### PR TITLE
Improved Instance/Engine naming and instantation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Requirements for running sphinx
 Configuration
 *************
 
-The Nuts library contains some configuration logic which allows for usage of configFiles, Environment variables and commandLine params transparently.
+The Nuts node can be configured using a YAML configuration file, environment variables and commandline params.
 
 The parameters follow the following convention:
 ``$ nuts --parameter X`` is equal to ``$ NUTS_PARAMETER=X nuts`` is equal to ``parameter: X`` in a yaml file.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -79,3 +79,13 @@ func Test_echoCreator(t *testing.T) {
 		assert.NotNil(t, echoCreator())
 	})
 }
+
+func Test_CreateSystem(t *testing.T) {
+	system := CreateSystem()
+	assert.NotNil(t, system)
+	numEngines := 0
+	system.VisitEngines(func(engine *core.Engine) {
+		numEngines++
+	})
+	assert.Equal(t,5, numEngines)
+}

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -20,6 +20,7 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 	"github.com/golang/mock/gomock"
 	"github.com/labstack/echo/v4"
@@ -109,6 +110,22 @@ func TestSystem_RegisterEngine(t *testing.T) {
 			t.Errorf("Expected 1 registered engine, Got %d", len(ctl.engines))
 		}
 	})
+}
+
+func TestSystem_VisitEnginesE(t *testing.T) {
+	ctl := System{
+		engines: []*Engine{},
+	}
+	ctl.RegisterEngine(&Engine{})
+	ctl.RegisterEngine(&Engine{})
+	expectedErr := errors.New("function should stop because an error occurred")
+	timesCalled := 0
+	actualErr := ctl.VisitEnginesE(func(engine *Engine) error {
+		timesCalled++
+		return expectedErr
+	})
+	assert.Equal(t, 1, timesCalled)
+	assert.Equal(t, expectedErr, actualErr)
 }
 
 func TestSystem_Load(t *testing.T) {

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -33,17 +33,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCryptoBackend(t *testing.T) {
-	t.Run("Instance always returns same instance", func(t *testing.T) {
-		client := Instance()
-		client2 := Instance()
-
-		if client != client2 {
-			t.Error("Expected instances to be the same")
-		}
-	})
-}
-
 func TestCrypto_PublicKey(t *testing.T) {
 	client := createCrypto(t)
 
@@ -118,17 +107,17 @@ func TestCrypto_New(t *testing.T) {
 	})
 }
 
-func TestCrypto_doConfigure(t *testing.T) {
+func TestCrypto_Configure(t *testing.T) {
 	directory := io.TestDirectory(t)
 	cfg := core.NutsConfig{Datadir: directory}
 	t.Run("ok", func(t *testing.T) {
 		e := createCrypto(t)
-		err := e.doConfigure(cfg)
+		err := e.Configure(cfg)
 		assert.NoError(t, err)
 	})
 	t.Run("ok - default = fs backend", func(t *testing.T) {
 		client := createCrypto(t)
-		err := client.doConfigure(cfg)
+		err := client.Configure(cfg)
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -138,37 +127,21 @@ func TestCrypto_doConfigure(t *testing.T) {
 	t.Run("error - unknown backend", func(t *testing.T) {
 		client := createCrypto(t)
 		client.Config.Storage = "unknown"
-		err := client.doConfigure(cfg)
+		err := client.Configure(cfg)
 		assert.EqualErrorf(t, err, "only fs backend available for now", "expected error")
 	})
 }
 
-func TestCrypto_Configure(t *testing.T) {
-	createCrypto(t)
-
-	t.Run("ok - configOnce", func(t *testing.T) {
-		directory := io.TestDirectory(t)
-		e := createCrypto(t)
-		assert.False(t, e.configDone)
-		err := e.Configure(core.NutsConfig{Datadir: directory})
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.True(t, e.configDone)
-		err = e.Configure(core.NutsConfig{Datadir: directory})
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.True(t, e.configDone)
-	})
+func TestNewCryptoInstance(t *testing.T) {
+	instance := NewCryptoInstance()
+	assert.NotNil(t, instance)
 }
 
 func createCrypto(t *testing.T) *Crypto {
 	dir := io.TestDirectory(t)
 	backend, _ := storage.NewFileSystemBackend(dir)
-	crypto := Crypto{
+	c := Crypto{
 		Storage: backend,
 	}
-
-	return &crypto
+	return &c
 }

--- a/crypto/engine/engine.go
+++ b/crypto/engine/engine.go
@@ -36,21 +36,18 @@ import (
 const ConfigStorage string = "crypto.storage"
 
 // NewCryptoEngine the engine configuration for nuts-go.
-func NewCryptoEngine() (*core.Engine, crypto2.KeyStore) {
-	cb := crypto2.Instance()
-
+func NewCryptoEngine(instance *crypto2.Crypto) *core.Engine {
 	return &core.Engine{
 		Cmd:          cmd(),
-		Config:       &cb.Config,
+		Config:       &instance.Config,
 		ConfigKey:    "crypto",
-		Configurable: cb,
+		Configurable: instance,
 		FlagSet:      flagSet(),
 		Name:         "Crypto",
 		Routes: func(router core.EchoRouter) {
-			api.RegisterHandlers(router, &api.Wrapper{C: cb})
+			api.RegisterHandlers(router, &api.Wrapper{C: instance})
 		},
-		Runnable: cb,
-	}, cb
+	}
 }
 
 // FlagSet returns the configuration flags for crypto

--- a/crypto/engine/engine_test.go
+++ b/crypto/engine/engine_test.go
@@ -38,7 +38,7 @@ import (
 
 func TestNewCryptoEngine(t *testing.T) {
 	t.Run("New returns an engine with Cmd and Routes", func(t *testing.T) {
-		engine, _ := NewCryptoEngine()
+		engine := NewCryptoEngine(crypto.NewTestCryptoInstance(io.TestDirectory(t)))
 
 		if engine.Cmd == nil {
 			t.Errorf("Expected Engine to have Cmd")
@@ -52,7 +52,7 @@ func TestNewCryptoEngine(t *testing.T) {
 
 func TestNewCryptoEngine_Routes(t *testing.T) {
 	t.Run("Registers the available routes", func(t *testing.T) {
-		ce, _ := NewCryptoEngine()
+		ce := NewCryptoEngine(crypto.NewTestCryptoInstance(io.TestDirectory(t)))
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		echo := mock.NewMockEchoRouter(ctrl)
@@ -86,7 +86,7 @@ func TestNewCryptoEngine_Cmd(t *testing.T) {
 	createCmd := func(t *testing.T) (*cobra.Command, *crypto.Crypto) {
 		testDirectory := io.TestDirectory(t)
 		instance := crypto.NewTestCryptoInstance(testDirectory)
-		engine, _ := NewCryptoEngine()
+		engine := NewCryptoEngine(crypto.NewTestCryptoInstance(io.TestDirectory(t)))
 		return engine.Cmd, instance
 	}
 
@@ -151,7 +151,7 @@ func TestNewCryptoEngine_Cmd(t *testing.T) {
 
 func TestNewCryptoEngine_FlagSet(t *testing.T) {
 	t.Run("Cobra help should list flags", func(t *testing.T) {
-		e, _ := NewCryptoEngine()
+		e := NewCryptoEngine(crypto.NewTestCryptoInstance(io.TestDirectory(t)))
 		cmd := newRootCommand()
 		cmd.Flags().AddFlagSet(e.FlagSet)
 		cmd.SetArgs([]string{"--help"})

--- a/crypto/test.go
+++ b/crypto/test.go
@@ -14,13 +14,10 @@ import (
 // NewTestCryptoInstance returns a new Crypto instance to be used for integration tests. Any data is stored in the
 // specified test directory.
 func NewTestCryptoInstance(testDirectory string) *Crypto {
-	newInstance := &Crypto{
-		Config: DefaultCryptoConfig(),
-	}
+	newInstance := NewCryptoInstance()
 	if err := newInstance.Configure(core.NutsConfig{Datadir: testDirectory}); err != nil {
 		logrus.Fatal(err)
 	}
-	instance = newInstance
 	return newInstance
 }
 

--- a/network/api/v1/api.go
+++ b/network/api/v1/api.go
@@ -27,12 +27,12 @@ import (
 )
 
 // ServerImplementation returns a server API implementation that uses the given network.
-func ServerImplementation(network network.Network) ServerInterface {
+func ServerImplementation(network network.Transactions) ServerInterface {
 	return &wrapper{Service: network}
 }
 
 type wrapper struct {
-	Service network.Network
+	Service network.Transactions
 }
 
 // ListDocuments lists all documents

--- a/network/api/v1/api_test.go
+++ b/network/api/v1/api_test.go
@@ -39,7 +39,7 @@ func TestApiWrapper_GetDocument(t *testing.T) {
 	path := "/document/:ref"
 
 	t.Run("ok", func(t *testing.T) {
-		var networkClient = network.NewMockNetwork(mockCtrl)
+		var networkClient = network.NewMockTransactions(mockCtrl)
 		e, wrapper := initMockEcho(networkClient)
 		networkClient.EXPECT().GetDocument(hash.EqHash(document.Ref())).Return(document, nil)
 
@@ -57,7 +57,7 @@ func TestApiWrapper_GetDocument(t *testing.T) {
 		assert.Equal(t, string(document.Data()), rec.Body.String())
 	})
 	t.Run("invalid hash", func(t *testing.T) {
-		var networkClient = network.NewMockNetwork(mockCtrl)
+		var networkClient = network.NewMockTransactions(mockCtrl)
 		e, wrapper := initMockEcho(networkClient)
 
 		req := httptest.NewRequest(echo.GET, "/", nil)
@@ -73,7 +73,7 @@ func TestApiWrapper_GetDocument(t *testing.T) {
 		assert.Equal(t, "incorrect hash length (2)", rec.Body.String())
 	})
 	t.Run("not found", func(t *testing.T) {
-		var networkClient = network.NewMockNetwork(mockCtrl)
+		var networkClient = network.NewMockTransactions(mockCtrl)
 		e, wrapper := initMockEcho(networkClient)
 		networkClient.EXPECT().GetDocument(gomock.Any()).Return(nil, nil)
 
@@ -98,7 +98,7 @@ func TestApiWrapper_GetDocumentPayload(t *testing.T) {
 	path := "/document/:ref/payload"
 
 	t.Run("ok", func(t *testing.T) {
-		var networkClient = network.NewMockNetwork(mockCtrl)
+		var networkClient = network.NewMockTransactions(mockCtrl)
 		e, wrapper := initMockEcho(networkClient)
 		networkClient.EXPECT().GetDocumentPayload(hash.EqHash(document.Ref())).Return(payload, nil)
 
@@ -115,7 +115,7 @@ func TestApiWrapper_GetDocumentPayload(t *testing.T) {
 		assert.Equal(t, string(payload), rec.Body.String())
 	})
 	t.Run("not found", func(t *testing.T) {
-		var networkClient = network.NewMockNetwork(mockCtrl)
+		var networkClient = network.NewMockTransactions(mockCtrl)
 		e, wrapper := initMockEcho(networkClient)
 		networkClient.EXPECT().GetDocumentPayload(gomock.Any()).Return(nil, nil)
 
@@ -132,7 +132,7 @@ func TestApiWrapper_GetDocumentPayload(t *testing.T) {
 		assert.Equal(t, "document or contents not found", rec.Body.String())
 	})
 	t.Run("invalid hash", func(t *testing.T) {
-		var networkClient = network.NewMockNetwork(mockCtrl)
+		var networkClient = network.NewMockTransactions(mockCtrl)
 		e, wrapper := initMockEcho(networkClient)
 
 		req := httptest.NewRequest(echo.GET, "/", nil)
@@ -156,7 +156,7 @@ func TestApiWrapper_ListDocuments(t *testing.T) {
 
 	t.Run("list documents", func(t *testing.T) {
 		t.Run("200", func(t *testing.T) {
-			var networkClient = network.NewMockNetwork(mockCtrl)
+			var networkClient = network.NewMockTransactions(mockCtrl)
 			e, wrapper := initMockEcho(networkClient)
 			networkClient.EXPECT().ListDocuments().Return([]dag.Document{document}, nil)
 
@@ -173,7 +173,7 @@ func TestApiWrapper_ListDocuments(t *testing.T) {
 	})
 }
 
-func initMockEcho(networkClient *network.MockNetwork) (*echo.Echo, *ServerInterfaceWrapper) {
+func initMockEcho(networkClient *network.MockTransactions) (*echo.Echo, *ServerInterfaceWrapper) {
 	e := echo.New()
 	stub := wrapper{Service: networkClient}
 	wrapper := &ServerInterfaceWrapper{

--- a/network/config.go
+++ b/network/config.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// Config holds the config for Network
+// Config holds the config for Transactions
 type Config struct {
 	// Socket address for gRPC to listen on
 	GrpcAddr string `koanf:"grpcAddr"`

--- a/network/engine/engine.go
+++ b/network/engine/engine.go
@@ -21,7 +21,6 @@ package engine
 import (
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/core"
-	"github.com/nuts-foundation/nuts-node/crypto"
 	hash2 "github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network"
 	"github.com/nuts-foundation/nuts-node/network/api/v1"
@@ -42,9 +41,7 @@ var clientCreator = func(cmd *cobra.Command) *v1.HTTPClient {
 }
 
 // NewNetworkEngine returns the core definition for the network
-func NewNetworkEngine(keyStore crypto.KeyStore) (*core.Engine, network.Network) {
-	config := network.DefaultConfig()
-	instance := network.NewNetworkInstance(config, keyStore)
+func NewNetworkEngine(instance *network.Network) *core.Engine {
 	return &core.Engine{
 		Cmd:          cmd(),
 		Configurable: instance,
@@ -57,7 +54,7 @@ func NewNetworkEngine(keyStore crypto.KeyStore) (*core.Engine, network.Network) 
 			v1.RegisterHandlers(router, v1.ServerImplementation(instance))
 		},
 		Name: network.ModuleName,
-	}, instance
+	}
 }
 
 func flagSet() *pflag.FlagSet {

--- a/network/engine/engine_test.go
+++ b/network/engine/engine_test.go
@@ -20,8 +20,8 @@ package engine
 
 import (
 	"github.com/nuts-foundation/nuts-node/core"
-	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	"github.com/nuts-foundation/nuts-node/network"
 	"github.com/nuts-foundation/nuts-node/network/dag"
 	http2 "github.com/nuts-foundation/nuts-node/test/http"
 	"github.com/nuts-foundation/nuts-node/test/io"
@@ -35,9 +35,8 @@ import (
 
 func TestNewEngine(t *testing.T) {
 	testDirectory := io.TestDirectory(t)
-	e, i := NewNetworkEngine(crypto.NewTestCryptoInstance(testDirectory))
+	e := NewNetworkEngine(network.NewTestNetworkInstance(testDirectory))
 	assert.NotNil(t, e)
-	assert.NotNil(t, i)
 }
 
 func TestFlagSet(t *testing.T) {
@@ -105,7 +104,6 @@ func TestCmd_Payload(t *testing.T) {
 func createCmd(t *testing.T) *cobra.Command {
 	core.NewNutsConfig().Load(&cobra.Command{})
 	testDirectory := io.TestDirectory(t)
-	cryptoInstance := crypto.NewTestCryptoInstance(testDirectory)
-	engine, _ := NewNetworkEngine(cryptoInstance)
+	engine := NewNetworkEngine(network.NewTestNetworkInstance(testDirectory))
 	return engine.Cmd
 }

--- a/network/interface.go
+++ b/network/interface.go
@@ -24,8 +24,8 @@ import (
 	"time"
 )
 
-// Network is the interface to be implemented by any remote or local client
-type Network interface {
+// Transactions is the interface that defines the API for creating, reading and subscribing to Nuts Network transactions.
+type Transactions interface {
 	// Subscribe makes a subscription for the specified document type. The receiver is called when a document
 	// is received for the specified type.
 	Subscribe(documentType string, receiver dag.Receiver)
@@ -37,6 +37,6 @@ type Network interface {
 	// CreateDocument creates a new document with the specified payload, and signs it using the specified key.
 	// If the key should be inside the document (instead of being referred to) `attachKey` should be true.
 	CreateDocument(payloadType string, payload []byte, signingKeyID string, attachKey bool, timestamp time.Time, fieldsOpts ...dag.FieldOpt) (dag.Document, error)
-	// ListDocuments returns all documents known to this NetworkEngine instance.
+	// ListDocuments returns all documents known to this Network instance.
 	ListDocuments() ([]dag.Document, error)
 }

--- a/network/mock.go
+++ b/network/mock.go
@@ -12,43 +12,43 @@ import (
 	time "time"
 )
 
-// MockNetwork is a mock of Network interface
-type MockNetwork struct {
+// MockTransactions is a mock of Transactions interface
+type MockTransactions struct {
 	ctrl     *gomock.Controller
-	recorder *MockNetworkMockRecorder
+	recorder *MockTransactionsMockRecorder
 }
 
-// MockNetworkMockRecorder is the mock recorder for MockNetwork
-type MockNetworkMockRecorder struct {
-	mock *MockNetwork
+// MockTransactionsMockRecorder is the mock recorder for MockTransactions
+type MockTransactionsMockRecorder struct {
+	mock *MockTransactions
 }
 
-// NewMockNetwork creates a new mock instance
-func NewMockNetwork(ctrl *gomock.Controller) *MockNetwork {
-	mock := &MockNetwork{ctrl: ctrl}
-	mock.recorder = &MockNetworkMockRecorder{mock}
+// NewMockTransactions creates a new mock instance
+func NewMockTransactions(ctrl *gomock.Controller) *MockTransactions {
+	mock := &MockTransactions{ctrl: ctrl}
+	mock.recorder = &MockTransactionsMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockNetwork) EXPECT() *MockNetworkMockRecorder {
+func (m *MockTransactions) EXPECT() *MockTransactionsMockRecorder {
 	return m.recorder
 }
 
 // Subscribe mocks base method
-func (m *MockNetwork) Subscribe(documentType string, receiver dag.Receiver) {
+func (m *MockTransactions) Subscribe(documentType string, receiver dag.Receiver) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Subscribe", documentType, receiver)
 }
 
 // Subscribe indicates an expected call of Subscribe
-func (mr *MockNetworkMockRecorder) Subscribe(documentType, receiver interface{}) *gomock.Call {
+func (mr *MockTransactionsMockRecorder) Subscribe(documentType, receiver interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockNetwork)(nil).Subscribe), documentType, receiver)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockTransactions)(nil).Subscribe), documentType, receiver)
 }
 
 // GetDocumentPayload mocks base method
-func (m *MockNetwork) GetDocumentPayload(documentRef hash.SHA256Hash) ([]byte, error) {
+func (m *MockTransactions) GetDocumentPayload(documentRef hash.SHA256Hash) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDocumentPayload", documentRef)
 	ret0, _ := ret[0].([]byte)
@@ -57,13 +57,13 @@ func (m *MockNetwork) GetDocumentPayload(documentRef hash.SHA256Hash) ([]byte, e
 }
 
 // GetDocumentPayload indicates an expected call of GetDocumentPayload
-func (mr *MockNetworkMockRecorder) GetDocumentPayload(documentRef interface{}) *gomock.Call {
+func (mr *MockTransactionsMockRecorder) GetDocumentPayload(documentRef interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDocumentPayload", reflect.TypeOf((*MockNetwork)(nil).GetDocumentPayload), documentRef)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDocumentPayload", reflect.TypeOf((*MockTransactions)(nil).GetDocumentPayload), documentRef)
 }
 
 // GetDocument mocks base method
-func (m *MockNetwork) GetDocument(documentRef hash.SHA256Hash) (dag.Document, error) {
+func (m *MockTransactions) GetDocument(documentRef hash.SHA256Hash) (dag.Document, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDocument", documentRef)
 	ret0, _ := ret[0].(dag.Document)
@@ -72,13 +72,13 @@ func (m *MockNetwork) GetDocument(documentRef hash.SHA256Hash) (dag.Document, er
 }
 
 // GetDocument indicates an expected call of GetDocument
-func (mr *MockNetworkMockRecorder) GetDocument(documentRef interface{}) *gomock.Call {
+func (mr *MockTransactionsMockRecorder) GetDocument(documentRef interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDocument", reflect.TypeOf((*MockNetwork)(nil).GetDocument), documentRef)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDocument", reflect.TypeOf((*MockTransactions)(nil).GetDocument), documentRef)
 }
 
 // CreateDocument mocks base method
-func (m *MockNetwork) CreateDocument(payloadType string, payload []byte, signingKeyID string, attachKey bool, timestamp time.Time, fieldsOpts ...dag.FieldOpt) (dag.Document, error) {
+func (m *MockTransactions) CreateDocument(payloadType string, payload []byte, signingKeyID string, attachKey bool, timestamp time.Time, fieldsOpts ...dag.FieldOpt) (dag.Document, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{payloadType, payload, signingKeyID, attachKey, timestamp}
 	for _, a := range fieldsOpts {
@@ -91,14 +91,14 @@ func (m *MockNetwork) CreateDocument(payloadType string, payload []byte, signing
 }
 
 // CreateDocument indicates an expected call of CreateDocument
-func (mr *MockNetworkMockRecorder) CreateDocument(payloadType, payload, signingKeyID, attachKey, timestamp interface{}, fieldsOpts ...interface{}) *gomock.Call {
+func (mr *MockTransactionsMockRecorder) CreateDocument(payloadType, payload, signingKeyID, attachKey, timestamp interface{}, fieldsOpts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{payloadType, payload, signingKeyID, attachKey, timestamp}, fieldsOpts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDocument", reflect.TypeOf((*MockNetwork)(nil).CreateDocument), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDocument", reflect.TypeOf((*MockTransactions)(nil).CreateDocument), varargs...)
 }
 
 // ListDocuments mocks base method
-func (m *MockNetwork) ListDocuments() ([]dag.Document, error) {
+func (m *MockTransactions) ListDocuments() ([]dag.Document, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListDocuments")
 	ret0, _ := ret[0].([]dag.Document)
@@ -107,21 +107,7 @@ func (m *MockNetwork) ListDocuments() ([]dag.Document, error) {
 }
 
 // ListDocuments indicates an expected call of ListDocuments
-func (mr *MockNetworkMockRecorder) ListDocuments() *gomock.Call {
+func (mr *MockTransactionsMockRecorder) ListDocuments() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDocuments", reflect.TypeOf((*MockNetwork)(nil).ListDocuments))
-}
-
-// Walk mocks base method
-func (m *MockNetwork) Walk(walker dag.WalkerAlgorithm, visitor dag.Visitor, startAt hash.SHA256Hash) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Walk", walker, visitor, startAt)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Walk indicates an expected call of Walk
-func (mr *MockNetworkMockRecorder) Walk(walker, visitor, startAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Walk", reflect.TypeOf((*MockNetwork)(nil).Walk), walker, visitor, startAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDocuments", reflect.TypeOf((*MockTransactions)(nil).ListDocuments))
 }

--- a/network/test.go
+++ b/network/test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// NewTestNetworkInstance creates a new Network instance that writes it data to a test directory.
-func NewTestNetworkInstance(testDirectory string) *NetworkEngine {
-	config := TestNetworkConfig(testDirectory)
+// NewTestNetworkInstance creates a new Transactions instance that writes it data to a test directory.
+func NewTestNetworkInstance(testDirectory string) *Network {
+	config := TestNetworkConfig()
 	newInstance := NewNetworkInstance(config, crypto.NewTestCryptoInstance(testDirectory))
 	if err := newInstance.Configure(core.NutsConfig{Datadir: testDirectory}); err != nil {
 		logrus.Fatal(err)
@@ -35,7 +35,7 @@ func NewTestNetworkInstance(testDirectory string) *NetworkEngine {
 }
 
 // NewTestNetworkInstance creates new network config with a test directory as data path.
-func TestNetworkConfig(testDirectory string) Config {
+func TestNetworkConfig() Config {
 	config := DefaultConfig()
 	config.GrpcAddr = ":5555"
 	config.EnableTLS = false

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -49,13 +49,13 @@ type Ambassador interface {
 }
 
 type ambassador struct {
-	networkClient network.Network
+	networkClient network.Transactions
 	didStore      types.Store
 	keyResolver   crypto2.KeyResolver
 }
 
 // NewAmbassador creates a new Ambassador,
-func NewAmbassador(networkClient network.Network, didStore types.Store, keyResolver crypto2.KeyResolver) Ambassador {
+func NewAmbassador(networkClient network.Transactions, didStore types.Store, keyResolver crypto2.KeyResolver) Ambassador {
 	return &ambassador{
 		networkClient: networkClient,
 		didStore:      didStore,

--- a/vdr/engine/engine.go
+++ b/vdr/engine/engine.go
@@ -24,8 +24,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/nuts-node/crypto"
-	"github.com/nuts-foundation/nuts-node/network"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -40,8 +38,7 @@ import (
 )
 
 // NewVDREngine returns the core definition for the VDR
-func NewVDREngine(keyStore crypto.KeyStore, networkInstance network.Network) *core.Engine {
-	instance := vdr.NewVDR(vdr.DefaultConfig(), keyStore, networkInstance)
+func NewVDREngine(instance *vdr.VDR) *core.Engine {
 	return &core.Engine{
 		Cmd:         cmd(),
 		Runnable:    instance,

--- a/vdr/engine/engine_test.go
+++ b/vdr/engine/engine_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/network"
 	"github.com/nuts-foundation/nuts-node/test/io"
+	"github.com/nuts-foundation/nuts-node/vdr"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -46,12 +47,13 @@ func TestNewRegistryEngine(t *testing.T) {
 	testDirectory := io.TestDirectory(t)
 	cryptoInstance := crypto.NewTestCryptoInstance(testDirectory)
 	networkInstance := network.NewTestNetworkInstance(testDirectory)
+	vdrInstance := vdr.NewVDR(vdr.DefaultConfig(), cryptoInstance, networkInstance)
 	t.Run("instance", func(t *testing.T) {
-		assert.NotNil(t, NewVDREngine(cryptoInstance, networkInstance))
+		assert.NotNil(t, NewVDREngine(vdrInstance))
 	})
 
 	t.Run("configuration", func(t *testing.T) {
-		e := NewVDREngine(cryptoInstance, networkInstance)
+		e := NewVDREngine(vdrInstance)
 		cfg := core.NewNutsConfig()
 		cfg.RegisterFlags(e.Cmd, e)
 		assert.NoError(t, cfg.InjectIntoEngine(e))
@@ -63,8 +65,9 @@ func TestEngine_Command(t *testing.T) {
 	testDirectory := io.TestDirectory(t)
 	cryptoInstance := crypto.NewTestCryptoInstance(testDirectory)
 	networkInstance := network.NewTestNetworkInstance(testDirectory)
+	vdrInstance := vdr.NewVDR(vdr.DefaultConfig(), cryptoInstance, networkInstance)
 	createCmd := func(t *testing.T) *cobra.Command {
-		return NewVDREngine(cryptoInstance, networkInstance).Cmd
+		return NewVDREngine(vdrInstance).Cmd
 	}
 
 	exampleID, _ := did.ParseDID("did:nuts:Fx8kamg7Bom4gyEzmJc9t9QmWTkCwSxu3mrp3CbkehR7")

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -28,14 +28,13 @@ import (
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/network"
 	"github.com/nuts-foundation/nuts-node/network/dag"
+	"github.com/nuts-foundation/nuts-node/vdr/store"
 
-	"sync"
 	"time"
 
 	"github.com/nuts-foundation/go-did"
 	"github.com/sirupsen/logrus"
 
-	"github.com/nuts-foundation/nuts-node/vdr/store"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 
 	"github.com/nuts-foundation/nuts-node/vdr/logging"
@@ -46,24 +45,20 @@ import (
 )
 
 // VDR stands for the Nuts Verifiable Data Registry. It is the public entrypoint to work with W3C DID documents.
-// It connects the Resolve, Create and Update DID methods to the Network, and receives events back from the network which are processed in the store.
+// It connects the Resolve, Create and Update DID methods to the network, and receives events back from the network which are processed in the store.
 // It is also a Runnable, Diagnosable and Configurable Nuts Engine.
 type VDR struct {
 	Config            Config
 	store             types.Store
-	network           network.Network
+	network           network.Transactions
 	OnChange          func(registry *VDR)
 	networkAmbassador Ambassador
-	configOnce        sync.Once
 	_logger           *logrus.Entry
 	didDocCreator     types.DocCreator
 }
 
-var instance *VDR
-var oneVDR sync.Once
-
 // NewVDR creates a new VDR with provided params
-func NewVDR(config Config, cryptoClient crypto.KeyStore, networkClient network.Network) *VDR {
+func NewVDR(config Config, cryptoClient crypto.KeyStore, networkClient network.Transactions) *VDR {
 	store := store.NewMemoryStore()
 	return &VDR{
 		Config:            config,

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -18,7 +18,7 @@ func TestVDR_Update(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	didStoreMock := types.NewMockStore(ctrl)
-	networkMock := network.NewMockNetwork(ctrl)
+	networkMock := network.NewMockTransactions(ctrl)
 	vdr := VDR{
 		store:   didStoreMock,
 		network: networkMock,
@@ -47,7 +47,7 @@ func TestVDR_Update(t *testing.T) {
 func TestVDR_Create(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	networkMock := network.NewMockNetwork(ctrl)
+	networkMock := network.NewMockTransactions(ctrl)
 	didCreator := types.NewMockDocCreator(ctrl)
 
 	vdr := VDR{


### PR DESCRIPTION
- `NetworkEngine` instance (which wasn't the actual engine) renamed to `Transactions`
- Made instance/network instantiation explicit in root command
- Removed last singletons and configOnce's
- Added previously missing tests