### PR TITLE
Fixed starting multiple Echo servers

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -102,7 +102,7 @@ func Test_serverCmd(t *testing.T) {
 		defer ctrl.Finish()
 
 		echoServer := core.NewMockEchoServer(ctrl)
-		echoServer.EXPECT().Start(gomock.Any()).Return(errors.New("unable to start"))
+		echoServer.EXPECT().Start(gomock.Any()).Return(errors.New("unable to start")).Times(2)
 
 		system := core.NewSystem()
 		system.EchoCreator = func() core.EchoServer {

--- a/core/echo_test.go
+++ b/core/echo_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"net/http"
@@ -18,6 +19,24 @@ func Test_MultiEcho_Bind(t *testing.T) {
 		}, cfg)
 		err := m.Bind("", cfg)
 		assert.EqualError(t, err, "http bind group already exists: ")
+	})
+}
+
+
+func Test_MultiEcho_Start(t *testing.T) {
+	t.Run("error while starting returns first error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		cfg := NewServerConfig().HTTP.HTTPConfig
+		m := NewMultiEcho(func() EchoServer {
+			server := NewMockEchoServer(ctrl)
+			server.EXPECT().Start(gomock.Any()).Return(fmt.Errorf("unable to start"))
+			return server
+		}, cfg)
+		m.Bind("group2", HTTPConfig{Address: ":8080"})
+		err := m.Start()
+		assert.EqualError(t, err, "unable to start")
 	})
 }
 

--- a/development/docker-compose.yaml
+++ b/development/docker-compose.yaml
@@ -5,6 +5,10 @@ services:
     environment:
       NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
       NUTS_NETWORK_PUBLICADDR: bootstrap:5555
+    ports:
+      - 8080:8080
+    healthcheck:
+      test: "curl -f http://localhost:8080/status || exit 1"
     volumes:
       - "./nuts.yaml:/opt/nuts/nuts.yaml"
       - "./truststore.pem:/opt/nuts/truststore.pem"
@@ -13,6 +17,8 @@ services:
     image: nutsfoundation/nuts:latest
     environment:
       NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
+    healthcheck:
+      test: "curl -f http://localhost:8080/status || exit 1"
     volumes:
       - "./nuts.yaml:/opt/nuts/nuts.yaml"
       - "./truststore.pem:/opt/nuts/truststore.pem"
@@ -21,6 +27,8 @@ services:
     image: nutsfoundation/nuts:latest
     environment:
       NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
+    healthcheck:
+      test: "curl -f http://localhost:8080/status || exit 1"
     volumes:
       - "./nuts.yaml:/opt/nuts/nuts.yaml"
       - "./truststore.pem:/opt/nuts/truststore.pem"

--- a/development/nuts.yaml
+++ b/development/nuts.yaml
@@ -3,3 +3,7 @@ network:
   certFile: /opt/nuts/certificate.pem
   certKeyFile: /opt/nuts/certificate.pem
   bootstrapNodes: bootstrap:5555
+http:
+  alt:
+    status:
+      address: :8080

--- a/docs/pages/production-configuration.rst
+++ b/docs/pages/production-configuration.rst
@@ -47,5 +47,5 @@ secure subnets. This is done through the `http` configuration:
         public:
           address: nuts.vendor.nl:443
         # The following binds all endpoints starting with `/status` to all interfaces on `:80`
-        public:
+        status:
           address: :80

--- a/docs/pages/production-configuration.rst
+++ b/docs/pages/production-configuration.rst
@@ -46,3 +46,6 @@ secure subnets. This is done through the `http` configuration:
         # The following binds all endpoints starting with `/public` to `nuts.vendor.nl:443`
         public:
           address: nuts.vendor.nl:443
+        # The following binds all endpoints starting with `/status` to all interfaces on `:80`
+        public:
+          address: :80


### PR DESCRIPTION
`Echo.Start()` is blocking, so only the first (default) echo server was started. Now it's using goroutines.