### PR TITLE
Improve PublicKeyStore interface

### DIFF
--- a/crypto/api/v1/api.go
+++ b/crypto/api/v1/api.go
@@ -27,10 +27,10 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/lestrrat-go/jwx/jwk"
+
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/crypto/log"
-	"github.com/nuts-foundation/nuts-node/crypto/storage"
 	"github.com/nuts-foundation/nuts-node/crypto/util"
 )
 
@@ -94,7 +94,7 @@ func (w *Wrapper) PublicKey(ctx echo.Context, kid string, params PublicKeyParams
 
 	pubKey, err := w.C.GetPublicKey(kid, at)
 	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
+		if errors.Is(err, crypto.ErrKeyNotFound) {
 			return ctx.NoContent(http.StatusNotFound)
 		}
 		log.Logger().Error(err.Error())

--- a/crypto/api/v1/api_test.go
+++ b/crypto/api/v1/api_test.go
@@ -27,11 +27,11 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/nuts-foundation/nuts-node/crypto"
-	"github.com/nuts-foundation/nuts-node/crypto/storage"
 	"github.com/nuts-foundation/nuts-node/crypto/test"
 	"github.com/nuts-foundation/nuts-node/mock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestWrapper_SignJwt(t *testing.T) {
@@ -167,7 +167,7 @@ func TestWrapper_PublicKey(t *testing.T) {
 		defer ctx.ctrl.Finish()
 
 		ctx.echo.EXPECT().Request().Return(&http.Request{})
-		ctx.keyStore.EXPECT().GetPublicKey("kid", at).Return(nil, storage.ErrNotFound)
+		ctx.keyStore.EXPECT().GetPublicKey("kid", at).Return(nil, crypto.ErrKeyNotFound)
 		ctx.echo.EXPECT().NoContent(http.StatusNotFound)
 
 		_ = ctx.client.PublicKey(ctx.echo, "kid", params)

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -24,6 +24,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"path"
 	"time"
 
@@ -110,7 +111,7 @@ func (client *Crypto) New(namingFunc KIDNamingFunc) (crypto.PublicKey, string, e
 	}
 
 	// also save the public key for all time use, otherwise it can't be attached to a published doc
-	if err := client.SavePublicKey(kid, pkey, core.Period{Begin: time.Time{}}); err != nil {
+	if err := client.AddPublicKey(kid, pkey, time.Now()); err != nil {
 		return nil, "", err
 	}
 
@@ -129,13 +130,15 @@ func (client *Crypto) PrivateKeyExists(kid string) bool {
 // GetPublicKey loads the key from storage
 func (client *Crypto) GetPublicKey(kid string, validationTime time.Time) (crypto.PublicKey, error) {
 	pke, err := client.Storage.GetPublicKey(kid)
-
 	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, ErrKeyNotFound
+		}
 		return nil, err
 	}
 
 	if !pke.Period.Contains(validationTime) {
-		return nil, storage.ErrNotFound
+		return nil, ErrKeyNotFound
 	}
 
 	var unknown interface{}
@@ -146,18 +149,43 @@ func (client *Crypto) GetPublicKey(kid string, validationTime time.Time) (crypto
 }
 
 // SavePublicKey save the public key to storage
-func (client *Crypto) SavePublicKey(kid string, publicKey crypto.PublicKey, period core.Period) error {
+func (client *Crypto) AddPublicKey(kid string, publicKey crypto.PublicKey, validFrom time.Time) error {
 	key, err := jwk.New(publicKey)
 	if err != nil {
 		return err
 	}
+	// check if key already exists
+	pkeyEntry, err := client.Storage.GetPublicKey(kid)
+	if err != nil {
+		if !errors.Is(err, storage.ErrNotFound) {
+			return fmt.Errorf("unable to check key existance: %w", err)
+		}
+	}
+	if pkeyEntry.Key != nil {
+		return ErrKeyAlreadyExists
+	}
 
 	publicKeyEntry := storage.PublicKeyEntry{
-		Period: period,
+		Period: core.Period{Begin: validFrom},
 	}
 	if err := publicKeyEntry.FromJWK(key); err != nil {
 		return err
 	}
 
 	return client.Storage.SavePublicKey(kid, publicKeyEntry)
+}
+
+func (client *Crypto) RevokePublicKey(kid string, validTo time.Time) error {
+	pkeyEntry, err := client.Storage.GetPublicKey(kid)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return ErrKeyNotFound
+		}
+		return err
+	}
+	if pkeyEntry.Period.End != nil {
+		return ErrKeyRevoked
+	}
+	pkeyEntry.Period.End = &validTo
+	return client.Storage.SavePublicKey(kid, pkeyEntry)
 }

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -40,8 +40,9 @@ func TestCrypto_PublicKey(t *testing.T) {
 	ec := test.GenerateECKey()
 
 	now := time.Now()
-	period := core.Period{Begin: now}
-	client.SavePublicKey(kid, ec.Public(), period)
+	if !assert.NoError(t, client.AddPublicKey(kid, ec.Public(), now)) {
+		return
+	}
 
 	t.Run("Public key is returned from storage", func(t *testing.T) {
 		pub, err := client.GetPublicKey(kid, now)
@@ -54,21 +55,61 @@ func TestCrypto_PublicKey(t *testing.T) {
 		_, err := client.GetPublicKey("unknown", now)
 
 		if assert.Error(t, err) {
-			assert.True(t, errors.Is(err, storage.ErrNotFound))
+			assert.True(t, errors.Is(err, ErrKeyNotFound))
 		}
+	})
+
+	t.Run("error - key exists", func(t *testing.T) {
+		err := client.AddPublicKey(kid, ec.Public(), now)
+		if !assert.Error(t, err) {
+			return
+		}
+		assert.True(t, errors.Is(err, ErrKeyAlreadyExists))
 	})
 
 	t.Run("error - kid not valid at time", func(t *testing.T) {
 		_, err := client.GetPublicKey(kid, now.Add(-1))
 
 		if assert.Error(t, err) {
-			assert.True(t, errors.Is(err, storage.ErrNotFound))
+			assert.True(t, errors.Is(err, ErrKeyNotFound))
 		}
 	})
 
 	t.Run("error - saving an empty key", func(t *testing.T) {
-		err := client.SavePublicKey(kid, nil, period)
+		err := client.AddPublicKey(kid, nil, now)
 		assert.Error(t, err)
+	})
+
+	t.Run("revoke a key", func(t *testing.T) {
+		// Create a fresh key to prevent revocation of the shared test key
+		kid := "kid revoke a key"
+		if !assert.NoError(t, client.AddPublicKey(kid, ec.Public(), now)) {
+			return
+		}
+		if !assert.NoError(t, client.RevokePublicKey(kid, now)) {
+			return
+		}
+		key, err := client.GetPublicKey(kid, now.Add(10*time.Second))
+		if !assert.Error(t, err) {
+			return
+		}
+		assert.True(t, errors.Is(err, ErrKeyNotFound), "GetPublicKey should return ErrNotFound after revocation")
+		assert.Nil(t, key)
+	})
+
+	t.Run("error - revoke an already revoked key", func(t *testing.T) {
+		// Create a fresh key to prevent revocation of the shared test key
+		kid := "kid revoke a revoked key"
+		if !assert.NoError(t, client.AddPublicKey(kid, ec.Public(), now)) {
+			return
+		}
+
+		if !assert.NoError(t, client.RevokePublicKey(kid, now)) {
+			return
+		}
+
+		err := client.RevokePublicKey(kid, now)
+		assert.True(t, errors.Is(err, ErrKeyRevoked))
 	})
 }
 

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -111,6 +111,16 @@ func TestCrypto_PublicKey(t *testing.T) {
 		err := client.RevokePublicKey(kid, now)
 		assert.True(t, errors.Is(err, ErrKeyRevoked))
 	})
+
+	t.Run("error - revoke unknown key", func(t *testing.T) {
+		kid := "kid of unknown key"
+		err := client.RevokePublicKey(kid, now)
+		if !assert.Error(t, err) {
+			return
+		}
+		assert.True(t, errors.Is(err, ErrKeyNotFound), "it should return a ErrKeyNotFound")
+
+	})
 }
 
 func TestCrypto_KeyExistsFor(t *testing.T) {

--- a/crypto/interface.go
+++ b/crypto/interface.go
@@ -26,8 +26,10 @@ import (
 
 // ErrKeyNotFound is returned when the key should not exists but does
 var ErrKeyNotFound = errors.New("key not found")
+
 // ErrKeyRevoked is returned in situations that operations require an active key
 var ErrKeyRevoked = errors.New("key is revoked")
+
 // ErrKeyAlreadyExists is return in situations where a key should not exists but does
 var ErrKeyAlreadyExists = errors.New("key already exists")
 

--- a/crypto/interface.go
+++ b/crypto/interface.go
@@ -20,10 +20,16 @@ package crypto
 
 import (
 	"crypto"
+	"errors"
 	"time"
-
-	"github.com/nuts-foundation/nuts-node/core"
 )
+
+// ErrKeyNotFound is returned when the key should not exists but does
+var ErrKeyNotFound = errors.New("key not found")
+// ErrKeyRevoked is returned in situations that operations require an active key
+var ErrKeyRevoked = errors.New("key is revoked")
+// ErrKeyAlreadyExists is return in situations where a key should not exists but does
+var ErrKeyAlreadyExists = errors.New("key already exists")
 
 // KIDNamingFunc is a function passed to New() which generates the kid for the pub/priv key
 type KIDNamingFunc func(key crypto.PublicKey) (string, error)
@@ -38,7 +44,7 @@ type KeyCreator interface {
 // KeyResolver defines the functions for retrieving keys.
 type KeyResolver interface {
 	// GetPublicKey returns the PublicKey if it was valid on the given validationTime
-	// If a key is missing, a Storage.ErrNotFound is returned.
+	// If a key is missing, a ErrKeyNotFound is returned.
 	GetPublicKey(kid string, validationTime time.Time) (crypto.PublicKey, error)
 }
 
@@ -46,9 +52,16 @@ type KeyResolver interface {
 type PublicKeyStore interface {
 	KeyResolver
 
-	// SavePublicKey stores or overwrites a public key with a given kid.
-	// The validity period defines when the given key is valid.
-	SavePublicKey(kid string, publicKey crypto.PublicKey, period core.Period) error
+	// AddPublicKey stores a public key with a given kid and valid from date
+	// The valid from determines the start of the period this key is valid
+	// It returns an ErrKeyAlreadyExists if the key already exists
+	AddPublicKey(kid string, publicKey crypto.PublicKey, validFrom time.Time) error
+
+	// RevokePublicKey revokes a public key.
+	// The validTo time determines end of the period the key was valid
+	// It returns an ErrKeyNotFound when the key could not be found
+	// It returns an ErrKeyRevoked error when the key was already revoked
+	RevokePublicKey(kid string, validTo time.Time) error
 }
 
 // KeyStore defines the functions that can be called by a Cmd, Direct or via rest call.

--- a/crypto/jwx.go
+++ b/crypto/jwx.go
@@ -29,6 +29,8 @@ import (
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/lestrrat-go/jwx/jws"
 	"github.com/lestrrat-go/jwx/jwt"
+
+	"github.com/nuts-foundation/nuts-node/crypto/storage"
 )
 
 // ErrUnsupportedSigningKey is returned when an unsupported private key is used to sign. Currently only ecdsa and rsa keys are supported
@@ -39,6 +41,9 @@ func (client *Crypto) SignJWT(claims map[string]interface{}, kid string) (token 
 	privateKey, err := client.Storage.GetPrivateKey(kid)
 
 	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return "", ErrKeyNotFound
+		}
 		return "", err
 	}
 	key, err := jwkKey(privateKey)

--- a/crypto/jwx_test.go
+++ b/crypto/jwx_test.go
@@ -31,10 +31,10 @@ import (
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/lestrrat-go/jwx/jws"
-	"github.com/nuts-foundation/nuts-node/crypto/storage"
-	"github.com/nuts-foundation/nuts-node/crypto/test"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/nuts-foundation/nuts-node/crypto/test"
 )
 
 func TestSignJWT(t *testing.T) {
@@ -131,7 +131,7 @@ func TestCrypto_SignJWT(t *testing.T) {
 	t.Run("returns error for not found", func(t *testing.T) {
 		_, err := client.SignJWT(map[string]interface{}{"iss": "nuts"}, "unknown")
 
-		assert.True(t, errors.Is(err, storage.ErrNotFound))
+		assert.True(t, errors.Is(err, ErrKeyNotFound))
 	})
 }
 

--- a/crypto/mock.go
+++ b/crypto/mock.go
@@ -7,7 +7,6 @@ package crypto
 import (
 	crypto "crypto"
 	gomock "github.com/golang/mock/gomock"
-	core "github.com/nuts-foundation/nuts-node/core"
 	reflect "reflect"
 	time "time"
 )
@@ -127,18 +126,32 @@ func (mr *MockPublicKeyStoreMockRecorder) GetPublicKey(kid, validationTime inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicKey", reflect.TypeOf((*MockPublicKeyStore)(nil).GetPublicKey), kid, validationTime)
 }
 
-// SavePublicKey mocks base method
-func (m *MockPublicKeyStore) SavePublicKey(kid string, publicKey crypto.PublicKey, period core.Period) error {
+// AddPublicKey mocks base method
+func (m *MockPublicKeyStore) AddPublicKey(kid string, publicKey crypto.PublicKey, validFrom time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SavePublicKey", kid, publicKey, period)
+	ret := m.ctrl.Call(m, "AddPublicKey", kid, publicKey, validFrom)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SavePublicKey indicates an expected call of SavePublicKey
-func (mr *MockPublicKeyStoreMockRecorder) SavePublicKey(kid, publicKey, period interface{}) *gomock.Call {
+// AddPublicKey indicates an expected call of AddPublicKey
+func (mr *MockPublicKeyStoreMockRecorder) AddPublicKey(kid, publicKey, validFrom interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SavePublicKey", reflect.TypeOf((*MockPublicKeyStore)(nil).SavePublicKey), kid, publicKey, period)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPublicKey", reflect.TypeOf((*MockPublicKeyStore)(nil).AddPublicKey), kid, publicKey, validFrom)
+}
+
+// RevokePublicKey mocks base method
+func (m *MockPublicKeyStore) RevokePublicKey(kid string, validTo time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevokePublicKey", kid, validTo)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RevokePublicKey indicates an expected call of RevokePublicKey
+func (mr *MockPublicKeyStoreMockRecorder) RevokePublicKey(kid, validTo interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokePublicKey", reflect.TypeOf((*MockPublicKeyStore)(nil).RevokePublicKey), kid, validTo)
 }
 
 // MockKeyStore is a mock of KeyStore interface
@@ -195,18 +208,32 @@ func (mr *MockKeyStoreMockRecorder) GetPublicKey(kid, validationTime interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicKey", reflect.TypeOf((*MockKeyStore)(nil).GetPublicKey), kid, validationTime)
 }
 
-// SavePublicKey mocks base method
-func (m *MockKeyStore) SavePublicKey(kid string, publicKey crypto.PublicKey, period core.Period) error {
+// AddPublicKey mocks base method
+func (m *MockKeyStore) AddPublicKey(kid string, publicKey crypto.PublicKey, validFrom time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SavePublicKey", kid, publicKey, period)
+	ret := m.ctrl.Call(m, "AddPublicKey", kid, publicKey, validFrom)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SavePublicKey indicates an expected call of SavePublicKey
-func (mr *MockKeyStoreMockRecorder) SavePublicKey(kid, publicKey, period interface{}) *gomock.Call {
+// AddPublicKey indicates an expected call of AddPublicKey
+func (mr *MockKeyStoreMockRecorder) AddPublicKey(kid, publicKey, validFrom interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SavePublicKey", reflect.TypeOf((*MockKeyStore)(nil).SavePublicKey), kid, publicKey, period)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPublicKey", reflect.TypeOf((*MockKeyStore)(nil).AddPublicKey), kid, publicKey, validFrom)
+}
+
+// RevokePublicKey mocks base method
+func (m *MockKeyStore) RevokePublicKey(kid string, validTo time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevokePublicKey", kid, validTo)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RevokePublicKey indicates an expected call of RevokePublicKey
+func (mr *MockKeyStoreMockRecorder) RevokePublicKey(kid, validTo interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokePublicKey", reflect.TypeOf((*MockKeyStore)(nil).RevokePublicKey), kid, validTo)
 }
 
 // SignJWS mocks base method


### PR DESCRIPTION
SavePublicKey -> AddPublicKey which only accepts a creation time instead of period
Add RevokePublicKey method
Add ErrKeyNotFound on crypto level to prevent dependency on storage for error checking.
Add ErrKeyRevoked and ErrKeyAlreadyExists.