### PR TITLE
Remove check for kid in jwk

### DIFF
--- a/network/dag/parser.go
+++ b/network/dag/parser.go
@@ -106,11 +106,6 @@ func parseContentType(document *document, headers jws.Headers, _ *jws.Message) e
 func parseSignatureParams(document *document, headers jws.Headers, _ *jws.Message) error {
 	if key, ok := headers.Get(jws.JWKKey); ok {
 		jwkKey := key.(jwk.Key)
-		// Check RFC004 3.1 kid constraints
-		// A embedded jwk must have a keyID
-		if jwkKey.KeyID() == "" {
-			return documentValidationError("when present, the `jwk` must contain a valid `kid`")
-		}
 		document.signingKey = jwkKey
 	}
 	// Get the keyID from the header (not to be confused with the keyID from the embedded key)

--- a/network/dag/parser_test.go
+++ b/network/dag/parser_test.go
@@ -124,15 +124,6 @@ func TestParseDocument(t *testing.T) {
 		assert.Nil(t, document)
 		assert.EqualError(t, err, "document validation failed: either `kid` or `jwk` header must be present (but not both)")
 	})
-	t.Run("error - jwk without keyid", func(t *testing.T) {
-		headers := makeJWSHeaders(key, "", true)
-		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
-
-		document, err := ParseDocument(signature)
-
-		assert.Nil(t, document)
-		assert.EqualError(t, err, "document validation failed: when present, the `jwk` must contain a valid `kid`")
-	})
 	t.Run("error - prevs header is missing", func(t *testing.T) {
 		headers := makeJWSHeaders(key, "123", true)
 		delete(headers.PrivateParams(), previousHeader)


### PR DESCRIPTION
Fix #73 

Remove faulty check for presence of `kid` in embedded key in network document.