### PR TITLE
Added logs to VDR and flags to print only the document or metadata

### DIFF
--- a/vdr/cmd/cmd.go
+++ b/vdr/cmd/cmd.go
@@ -65,10 +65,8 @@ func createCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("unable to create new DID: %v", err)
 			}
-
 			bytes, _ := json.MarshalIndent(doc, "", "  ")
-
-			cmd.Printf("Created DID document: %s\n", string(bytes))
+			cmd.Println(string(bytes))
 			return nil
 		},
 	}
@@ -117,7 +115,9 @@ func updateCmd() *cobra.Command {
 }
 
 func resolveCmd() *cobra.Command {
-	return &cobra.Command{
+	var printMetadata bool
+	var printDocument bool
+	result := &cobra.Command{
 		Use:   "resolve [DID]",
 		Short: "Resolve a DID document based on its DID",
 		Args:  cobra.ExactArgs(1),
@@ -127,7 +127,18 @@ func resolveCmd() *cobra.Command {
 				return fmt.Errorf("failed to resolve DID document: %v", err)
 			}
 
-			for _, o := range []interface{}{doc, meta} {
+			var toPrint []interface{}
+			if !printMetadata && !printDocument {
+				toPrint = append(toPrint, doc, meta)
+			} else {
+				if printDocument {
+					toPrint = append(toPrint, doc)
+				}
+				if printMetadata {
+					toPrint = append(toPrint, meta)
+				}
+			}
+			for _, o := range toPrint {
 				bytes, _ := json.MarshalIndent(o, "", "  ")
 				cmd.Printf("%s\n", string(bytes))
 			}
@@ -135,6 +146,9 @@ func resolveCmd() *cobra.Command {
 			return nil
 		},
 	}
+	result.Flags().BoolVar(&printMetadata, "metadata", false, "Pass 'true' to print the metadata.")
+	result.Flags().BoolVar(&printDocument, "document", false, "Pass 'true' to print the document.")
+	return result
 }
 
 func readFromStdin() ([]byte, error) {

--- a/vdr/cmd/cmd.go
+++ b/vdr/cmd/cmd.go
@@ -146,8 +146,8 @@ func resolveCmd() *cobra.Command {
 			return nil
 		},
 	}
-	result.Flags().BoolVar(&printMetadata, "metadata", false, "Pass 'true' to print the metadata.")
-	result.Flags().BoolVar(&printDocument, "document", false, "Pass 'true' to print the document.")
+	result.Flags().BoolVar(&printMetadata, "metadata", false, "Pass 'true' to only print the metadata (unless other flags are provided as well).")
+	result.Flags().BoolVar(&printDocument, "document", false, "Pass 'true' to only print the document (unless other flags are provided as well).")
 	return result
 }
 

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -99,6 +99,7 @@ func (r *VDR) Diagnostics() []core.DiagnosticResult {
 
 // Create generates a new DID Document
 func (r VDR) Create() (*did.Document, error) {
+	logging.Log().Debug("Creating new DID Document.")
 	doc, err := r.didDocCreator.Create()
 	if err != nil {
 		return nil, fmt.Errorf("could not create did document: %w", err)
@@ -119,6 +120,8 @@ func (r VDR) Create() (*did.Document, error) {
 		return nil, fmt.Errorf("could not store did document in network: %w", err)
 	}
 
+	logging.Log().Infof("New DID Document created: %s", doc.ID)
+
 	return doc, nil
 }
 
@@ -129,6 +132,7 @@ func (r VDR) Resolve(id did.DID, metadata *types.ResolveMetadata) (*did.Document
 
 // Update updates a DID Document based on the DID and current hash
 func (r VDR) Update(id did.DID, current hash.SHA256Hash, next did.Document, _ *types.DocumentMetadata) error {
+	logging.Log().Debugf("Updating DID Document: %s", id)
 	// TODO: check the integrity / validity of the proposed DID Document.
 	resolverMetada := &types.ResolveMetadata{
 		Hash:             &current,
@@ -146,10 +150,16 @@ func (r VDR) Update(id did.DID, current hash.SHA256Hash, next did.Document, _ *t
 	// TODO: look into the controller of the did for a signing key
 	keyID := currentDIDdocument.Authentication[0].ID.String()
 	_, err = r.network.CreateDocument(didDocumentType, payload, keyID, nil, time.Now(), dag.TimelineIDField(meta.TimelineID), dag.TimelineVersionField(meta.Version+1))
+
+	if err == nil {
+		logging.Log().Infof("DID Document updated: %s", id)
+	}
+
 	return err
 }
 
 // Deactivate updates the DID Document so it can no longer be updated
 func (r *VDR) Deactivate(DID did.DID, current hash.SHA256Hash) {
+	logging.Log().Debugf("Deactivating DID Document: %s", DID)
 	panic("implement me")
 }


### PR DESCRIPTION
Pointed out while fixing end-to-end tests.