### PR TITLE
Fix SSL offloading support for Nuts Network

### DIFF
--- a/docs/pages/production-configuration.rst
+++ b/docs/pages/production-configuration.rst
@@ -1,4 +1,4 @@
-.. _prodruction-configuration:
+.. _production-configuration:
 
 Configuring for Production
 ##########################
@@ -49,3 +49,48 @@ secure subnets. This is done through the `http` configuration:
         # The following binds all endpoints starting with `/status` to all interfaces on `:80`
         status:
           address: :80
+
+Nuts Network SSL/TLS Deployment Layouts
+***************************************
+
+This section describes which deployment layouts are supported regarding SSL/TLS. In all layouts there should be
+X.509 server and client certificates issued by a Certificate Authority trusted by the network, if the node operator wants
+other Nuts nodes to be able to connect to the node and vice versa.
+
+Direct WAN Connection
+---------------------
+
+This is the simplest layout where the Nuts node is directly accessible from the internet:
+
+.. raw:: html
+    :file: ../../_static/images/network_layouts_directwan.svg
+
+This layout has the following requirements:
+
+* X.509 server certificate and private key must be configured on the Nuts node.
+* SSL/TLS terminator must use the trust anchors as specified by the network as root CA trust bundle.
+
+SSL/TLS Offloading
+------------------
+
+In this layout incoming TLS traffic is decrypted on a SSL/TLS terminator and then being forwarded to the Nuts node.
+This is layout is typically used to provide layer 7 load balancing and/or securing traffic "at the gates":
+
+.. raw:: html
+    :file: ../../_static/images/network_layouts_tlsoffloading.svg
+
+This layout has the following requirements:
+
+* X.509 server certificate and private key must be present on the SSL/TLS terminator.
+* X.509 client certificate must be configured on the Nuts node.
+* SSL/TLS terminator must use the trust anchors as specified by the network as root CA trust bundle.
+
+SSL/TLS Pass-through
+--------------------
+
+In this layout incoming TLS traffic is forwarded to the Nuts node without being decrypted:
+
+.. raw:: html
+    :file: ../../_static/images/network_layouts_tlspassthrough.svg
+
+Requirements are the same as for the Direct WAN Connection layout.

--- a/network/network.go
+++ b/network/network.go
@@ -22,6 +22,7 @@ import (
 	crypto2 "crypto"
 	"crypto/tls"
 	"fmt"
+	"github.com/pkg/errors"
 	"os"
 	"path"
 	"path/filepath"
@@ -35,7 +36,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/network/log"
 	"github.com/nuts-foundation/nuts-node/network/p2p"
 	"github.com/nuts-foundation/nuts-node/network/proto"
-	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
 )
 
@@ -92,14 +92,17 @@ func (n *Network) Configure(config core.ServerConfig) error {
 	return n.p2pNetwork.Configure(*networkConfig)
 }
 
+// Name returns the module name.
 func (n *Network) Name() string {
 	return moduleName
 }
 
+// ConfigKey returns the config key for the module.
 func (n *Network) ConfigKey() string {
 	return configKey
 }
 
+// Config returns a pointer to the actual config of the module.
 func (n *Network) Config() interface{} {
 	return &n.config
 }
@@ -203,18 +206,19 @@ func (n *Network) buildP2PConfig(peerID p2p.PeerID) (*p2p.P2PNetworkConfig, erro
 		BootstrapNodes: n.config.parseBootstrapNodes(),
 		PeerID:         peerID,
 	}
-	var err error
-	if cfg.TrustStore, err = n.config.loadTrustStore(); err != nil {
-		return nil, err
-	}
 	clientCertificate, err := tls.LoadX509KeyPair(n.config.CertFile, n.config.CertKeyFile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to load node TLS client certificate (certFile=%s,certKeyFile=%s)", n.config.CertFile, n.config.CertKeyFile)
 	}
 	cfg.ClientCert = clientCertificate
-	// Load TLS server certificate, only if enableTLS=true and gRPC server should be started.
-	if n.config.GrpcAddr != "" && n.config.EnableTLS {
-		cfg.ServerCert = cfg.ClientCert
+	if n.config.EnableTLS {
+		if cfg.TrustStore, err = n.config.loadTrustStore(); err != nil {
+			return nil, err
+		}
+		// Load TLS server certificate, only if enableTLS=true and gRPC server should be started.
+		if n.config.GrpcAddr != "" {
+			cfg.ServerCert = cfg.ClientCert
+		}
 	}
 	return &cfg, nil
 }

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -59,6 +59,20 @@ func TestNetwork_ListDocuments(t *testing.T) {
 	})
 }
 
+
+func TestNetwork_Name(t *testing.T) {
+	assert.Equal(t, "Network", (&Network{}).Name())
+}
+
+func TestNetwork_ConfigKey(t *testing.T) {
+	assert.Equal(t, "network", (&Network{}).ConfigKey())
+}
+
+func TestNetwork_Config(t *testing.T) {
+	n := &Network{}
+	assert.Same(t, &n.config, n.Config())
+}
+
 func TestNetwork_GetDocument(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -115,14 +129,24 @@ func TestNetwork_Configure(t *testing.T) {
 			return
 		}
 	})
-	t.Run("offline mode", func(t *testing.T) {
+	t.Run("certs not configured (offline mode)", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		cxt := createNetwork(ctrl)
+		cxt.protocol.EXPECT().Configure(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+		cxt.network.config.CertKeyFile = ""
+		cxt.network.config.CertFile = ""
+		err := cxt.network.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
+		if !assert.NoError(t, err) {
+			return
+		}
+	})
+	t.Run("truststore not configured (offline mode)", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		cxt := createNetwork(ctrl)
 		cxt.protocol.EXPECT().Configure(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 		cxt.network.config.TrustStoreFile = ""
-		cxt.network.config.CertKeyFile = ""
-		cxt.network.config.CertFile = ""
 		err := cxt.network.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
 		if !assert.NoError(t, err) {
 			return
@@ -298,6 +322,7 @@ func createNetwork(ctrl *gomock.Controller) *networkTestContext {
 	networkConfig.CertFile = "test/certificate-and-key.pem"
 	networkConfig.CertKeyFile = "test/certificate-and-key.pem"
 	networkConfig.PublicAddr = "foo:8080"
+	networkConfig.EnableTLS = true
 	keyStore := crypto.NewMockKeyStore(ctrl)
 	network := NewNetworkInstance(networkConfig, keyStore)
 	network.p2pNetwork = p2pNetwork

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -128,6 +128,19 @@ func TestNetwork_Configure(t *testing.T) {
 			return
 		}
 	})
+	t.Run("disable TLS for incoming connections (SSL offloading)", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		cxt := createNetwork(ctrl)
+		cxt.protocol.EXPECT().Configure(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+		cxt.p2pNetwork.EXPECT().Configure(gomock.Any())
+		cxt.network.config.TrustStoreFile = ""
+		cxt.network.config.EnableTLS = false
+		err := cxt.network.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
+		if !assert.NoError(t, err) {
+			return
+		}
+	})
 	t.Run("unable to create datadir", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()

--- a/network/p2p/impl.go
+++ b/network/p2p/impl.go
@@ -195,9 +195,6 @@ func (n *p2pNetwork) Configure(config P2PNetworkConfig) error {
 	if config.PeerID == "" {
 		return errors.New("PeerID is empty")
 	}
-	if config.TrustStore == nil {
-		return errors.New("TrustStore is nil")
-	}
 	n.config = config
 	n.configured = true
 	for _, bootstrapNode := range n.config.BootstrapNodes {

--- a/network/p2p/impl_test.go
+++ b/network/p2p/impl_test.go
@@ -41,6 +41,18 @@ func Test_p2pNetwork_Configure(t *testing.T) {
 		}
 		assert.Len(t, network.(*p2pNetwork).connectorAddChannel, 2)
 	})
+	t.Run("ok - ssl offloading", func(t *testing.T) {
+		network := NewP2PNetwork()
+		err := network.Configure(P2PNetworkConfig{
+			PeerID:         "foo",
+			ListenAddress:  "0.0.0.0:555",
+			BootstrapNodes: []string{"foo:555", "bar:5554"},
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Len(t, network.(*p2pNetwork).connectorAddChannel, 2)
+	})
 }
 
 func Test_p2pNetwork_Start(t *testing.T) {


### PR DESCRIPTION
While fixing the end-to-end test for the new implementation, found out that SSL offloading (for incoming Nuts Network connections) was broken.