### PR TITLE
Fix IRMA directory configuration for development config

### DIFF
--- a/development/nuts.yaml
+++ b/development/nuts.yaml
@@ -1,3 +1,4 @@
+datadir: /opt/nuts
 network:
   trustStoreFile: /opt/nuts/truststore.pem
   certFile: /opt/nuts/certificate.pem
@@ -9,6 +10,5 @@ http:
       address: :8080
 auth:
   irma:
-    directory: /opt/nuts/irma
     schemeManager: empty
     autoUpdateSchemas: false


### PR DESCRIPTION
IRMA directory configuration was removed in favor of deriving it from the global datadir config. This change reflects that in the development config.