### PR TITLE
Fix IRMA schema updating (os.Rename error)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nuts-foundation/go-did v0.0.0-20210223070344-61d177b1beb9
 	github.com/nuts-foundation/go-leia v0.1.0
 	github.com/pkg/errors v0.9.1
-	github.com/privacybydesign/irmago v0.6.0
+	github.com/privacybydesign/irmago v0.6.2-0.20210226102726-35c6768789c6
 	github.com/prometheus/client_golang v1.7.1
 	github.com/shengdoushi/base58 v1.0.0
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
@@ -497,6 +498,8 @@ github.com/privacybydesign/gabi v0.0.0-20200823153621-467696543652 h1:cglj/IsZVP
 github.com/privacybydesign/gabi v0.0.0-20200823153621-467696543652/go.mod h1:HQ6L5rKBY7qaqcheK6zpaVf7fhGWD0PvUAXJTDws+0M=
 github.com/privacybydesign/irmago v0.6.0 h1:DbaJWtSEVsULKnZaADusSTLdjODSBouQzWC2Lj9Y9lU=
 github.com/privacybydesign/irmago v0.6.0/go.mod h1:S5eKWg1bk0y8x3UBzDPqUNx3wweU/V6RG1JzK742kAc=
+github.com/privacybydesign/irmago v0.6.2-0.20210226102726-35c6768789c6 h1:lBnclne5t24aMqzrTe2oXjImUKW1qLbbWj9HXezp5aA=
+github.com/privacybydesign/irmago v0.6.2-0.20210226102726-35c6768789c6/go.mod h1:Vml9NoGIDVnFVbXd6tvyiHlB/dbqN2yfYYctKLlkQQE=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=


### PR DESCRIPTION
Fix IRMA schema updating when directory is mounted on different volume from tmp folder by updating to unreleased `irmago` commit. Tested it locally, it's fixed now.