### PR TITLE
Network: Added diagnostic that returns the node's own Peer ID

### DIFF
--- a/network/p2p/impl.go
+++ b/network/p2p/impl.go
@@ -71,6 +71,7 @@ func (n p2pNetwork) Diagnostics() []core.DiagnosticResult {
 	return []core.DiagnosticResult{
 		NumberOfPeersStatistic{NumberOfPeers: len(peers)},
 		PeersStatistic{Peers: peers},
+		OwnPeerIDStatistic{peerID: n.config.PeerID},
 	}
 }
 
@@ -124,7 +125,7 @@ func (c *connector) connect(ownID PeerID, config *tls.Config) (*connection, erro
 	grpcConn, err := c.Dialer(dialContext, c.address,
 		grpc.WithBlock(),                                          // Dial should block until connection succeeded (or time-out expired)
 		grpc.WithTransportCredentials(credentials.NewTLS(config)), // TLS authentication
-		grpc.WithReturnConnectionError()) // This option causes underlying errors to be returned when connections fail, rather than just "context deadline exceeded"
+		grpc.WithReturnConnectionError()) 						   // This option causes underlying errors to be returned when connections fail, rather than just "context deadline exceeded"
 	if err != nil {
 		return nil, errors2.Wrap(err, "unable to connect")
 	}

--- a/network/p2p/impl.go
+++ b/network/p2p/impl.go
@@ -125,7 +125,7 @@ func (c *connector) connect(ownID PeerID, config *tls.Config) (*connection, erro
 	grpcConn, err := c.Dialer(dialContext, c.address,
 		grpc.WithBlock(),                                          // Dial should block until connection succeeded (or time-out expired)
 		grpc.WithTransportCredentials(credentials.NewTLS(config)), // TLS authentication
-		grpc.WithReturnConnectionError()) 						   // This option causes underlying errors to be returned when connections fail, rather than just "context deadline exceeded"
+		grpc.WithReturnConnectionError()) // This option causes underlying errors to be returned when connections fail, rather than just "context deadline exceeded"
 	if err != nil {
 		return nil, errors2.Wrap(err, "unable to connect")
 	}

--- a/network/p2p/stats.go
+++ b/network/p2p/stats.go
@@ -55,3 +55,16 @@ func (p PeersStatistic) String() string {
 	})
 	return strings.Join(addrs, " ")
 }
+
+type OwnPeerIDStatistic struct {
+	peerID PeerID
+}
+
+func (o OwnPeerIDStatistic) Name() string {
+	return "[P2P Network] Peer ID of local node"
+}
+
+func (o OwnPeerIDStatistic) String() string {
+	return o.peerID.String()
+}
+


### PR DESCRIPTION
Fixes #108 

Turned out while diagnosing the development network; peer ID is randomly generated at boot time and communicated to other nodes, but not logged or shown elsewhere. Add it to diagnostics so we can analyze the dev network better.