### PR TITLE
Docker: Reverted HEALTHCHECK port change 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN apk update \
 COPY --from=builder /opt/nuts/nuts /usr/bin/nuts
 
 HEALTHCHECK --start-period=30s --timeout=5s --interval=10s \
-    CMD curl -f http://localhost:8080/status || exit 1
+    CMD curl -f http://localhost:1323/status || exit 1
 
-EXPOSE 1323 4222 5555 8080
+EXPOSE 1323 5555
 ENTRYPOINT ["/usr/bin/nuts"]
 CMD ["server"]


### PR DESCRIPTION
Is now inconsistent with default bind address (1323). Broken by https://github.com/nuts-foundation/nuts-node/pull/120

Also removed unused port 4222 (artifact from old nuts node).