### PR TITLE
updated go-leia to v0.2.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
 	github.com/mdp/qrterminal/v3 v3.0.0
 	github.com/nuts-foundation/go-did v0.0.0-20210309101603-d2a97847ec54
-	github.com/nuts-foundation/go-leia v0.2.2
+	github.com/nuts-foundation/go-leia v0.2.3
 	github.com/pkg/errors v0.9.1
 	github.com/privacybydesign/irmago v0.6.2-0.20210226102726-35c6768789c6
 	github.com/prometheus/client_golang v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -454,6 +454,8 @@ github.com/nuts-foundation/go-did v0.0.0-20210309101603-d2a97847ec54/go.mod h1:X
 github.com/nuts-foundation/go-did v0.0.0-20210309101603-d2a97847ec54/go.mod h1:Xqmd6ILZj41nNovodxnb4F+JgcKmIz+XGpLw6m6fZnU=
 github.com/nuts-foundation/go-leia v0.2.2 h1:E85e/vZlu9mqd/J6WqR25wh4IKAX8y6f5jpU92mJWDM=
 github.com/nuts-foundation/go-leia v0.2.2/go.mod h1:VMmOAg9I6kRUGY9eRNgeQqyj5vyx+oAteKWfVXzcTQs=
+github.com/nuts-foundation/go-leia v0.2.3 h1:zGoqqtqas8Y4qMQSVnXzcFazcM5we1hX9GWIoABdqrc=
+github.com/nuts-foundation/go-leia v0.2.3/go.mod h1:VMmOAg9I6kRUGY9eRNgeQqyj5vyx+oAteKWfVXzcTQs=
 github.com/ockam-network/did v0.1.3 h1:qJGdccOV4bLfsS/eFM+Aj+CdCRJKNMxbmJevQclw44k=
 github.com/ockam-network/did v0.1.3/go.mod h1:ZsbTIuVGt8OrQEbqWrSztUISN4joeMabdsinbLubbzw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=


### PR DESCRIPTION
Fixes #153

Any change to a search clause in the vcr tests will now result in an error.