### PR TITLE
fix correct kid extraction from parsing bearer token

### DIFF
--- a/auth/services/messages.go
+++ b/auth/services/messages.go
@@ -69,7 +69,7 @@ type NutsJwtBearerToken struct {
 	UserIdentity *string `json:"usi,omitempty"`
 	SubjectID    *string `json:"sid,omitempty"`
 	Scope        string  `json:"scope"`
-	KeyID        string  `json:"kid"`
+	KeyID        string  `json:"-"`
 }
 
 // NutsAccessToken is a OAuth 2.0 access token which provides context to a request.
@@ -84,7 +84,7 @@ type NutsAccessToken struct {
 	FamilyName string  `json:"family_name"`
 	Email      string  `json:"email"`
 
-	KeyID      string `json:"kid"`
+	KeyID      string `json:"-"`
 	Expiration int64  `json:"exp"`
 	IssuedAt   int64  `json:"iat"`
 	Issuer     string `json:"iss"`

--- a/auth/services/messages_test.go
+++ b/auth/services/messages_test.go
@@ -21,7 +21,7 @@ func TestNutsAccessToken_FromMap(t *testing.T) {
 }
 
 func TestNutsJwtBearerToken_FromMap(t *testing.T) {
-	expected := NutsJwtBearerToken{KeyID: "kid"}
+	expected := NutsJwtBearerToken{Scope: "scope"}
 	m, _ := expected.AsMap()
 	var actual NutsJwtBearerToken
 	err := actual.FromMap(m)

--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -262,7 +262,9 @@ func claimsFromRequest(request services.CreateJwtBearerTokenRequest, audience st
 
 // parseAndValidateJwtBearerToken validates the jwt signature and returns the containing claims
 func (s *service) parseAndValidateJwtBearerToken(context *validationContext) error {
+	var kidHdr string
 	token, err := nutsCrypto.ParseJWT(context.rawJwtBearerToken, func(kid string) (crypto.PublicKey, error) {
+		kidHdr = kid
 		return s.didResolver.ResolveSigningKey(kid, nil)
 	})
 	if err != nil {
@@ -271,7 +273,7 @@ func (s *service) parseAndValidateJwtBearerToken(context *validationContext) err
 
 	// this should be ok since it has already succeeded before
 	context.jwtBearerToken = token
-	context.jwtBearerTokenClaims = &services.NutsJwtBearerToken{}
+	context.jwtBearerTokenClaims = &services.NutsJwtBearerToken{KeyID: kidHdr}
 	return context.jwtBearerTokenClaims.FromMap(token.PrivateClaims())
 }
 

--- a/auth/services/oauth/oauth_test.go
+++ b/auth/services/oauth/oauth_test.go
@@ -324,6 +324,7 @@ func TestOAuthService_parseAndValidateJwtBearerToken(t *testing.T) {
 		err := ctx.oauthService.parseAndValidateJwtBearerToken(tokenCtx)
 		assert.NoError(t, err)
 		assert.Equal(t, actorDID.String(), tokenCtx.jwtBearerToken.Issuer())
+		assert.Equal(t, actorSigningKeyID.String(), tokenCtx.jwtBearerTokenClaims.KeyID)
 	})
 }
 


### PR DESCRIPTION
part fix for #163 

`kid` was put as claim in bearer token. When creating the access token it was expected to be there instead of the header.