### PR TITLE
Bind echo to all network ifaces by default

### DIFF
--- a/core/client_config.go
+++ b/core/client_config.go
@@ -29,6 +29,7 @@ import (
 
 const defaultClientTimeout = 10 * time.Second
 const clientTimeoutFlag = "timeout"
+const defaultAddress = "localhost" + defaultHTTPInterface
 
 // ClientConfig has CLI client settings.
 type ClientConfig struct {

--- a/core/server_config.go
+++ b/core/server_config.go
@@ -38,7 +38,7 @@ const defaultConfigFile = "nuts.yaml"
 const configFileFlag = "configfile"
 const addressFlag = "address"
 const datadirFlag = "datadir"
-const defaultAddress = "localhost:1323"
+const defaultHTTPInterface = ":1323"
 const strictModeFlag = "strictmode"
 const defaultStrictMode = false
 const defaultDatadir = "./data"
@@ -78,7 +78,7 @@ func NewServerConfig() *ServerConfig {
 		Strictmode: defaultStrictMode,
 		Datadir:    defaultDatadir,
 		HTTP: GlobalHTTPConfig{
-			HTTPConfig: HTTPConfig{Address: defaultAddress},
+			HTTPConfig: HTTPConfig{Address: defaultHTTPInterface},
 			AltBinds:   map[string]HTTPConfig{},
 		},
 	}
@@ -136,7 +136,7 @@ func FlagSet() *pflag.FlagSet {
 	flagSet := pflag.NewFlagSet("server", pflag.ContinueOnError)
 	flagSet.String(configFileFlag, defaultConfigFile, "Nuts config file")
 	flagSet.String(loggerLevelFlag, defaultLogLevel, "Log level (trace, debug, info, warn, error)")
-	flagSet.String(addressFlag, defaultAddress, "Address and port the server will be listening to")
+	flagSet.String(addressFlag, defaultHTTPInterface, "Address and port the server will be listening to")
 	flagSet.Bool(strictModeFlag, defaultStrictMode, "When set, insecure settings are forbidden.")
 	flagSet.String(datadirFlag, defaultDatadir, "Directory where the node stores its files.")
 	return flagSet

--- a/core/server_config_test.go
+++ b/core/server_config_test.go
@@ -45,7 +45,7 @@ func TestNewNutsConfig_Load(t *testing.T) {
 
 		assert.Equal(t, defaultLogLevel, cfg.Verbosity)
 		assert.Equal(t, defaultStrictMode, cfg.Strictmode)
-		assert.Equal(t, defaultAddress, cfg.HTTP.Address)
+		assert.Equal(t, defaultHTTPInterface, cfg.HTTP.Address)
 		assert.Empty(t, cfg.HTTP.AltBinds)
 	})
 

--- a/docs/pages/production-configuration.rst
+++ b/docs/pages/production-configuration.rst
@@ -25,11 +25,16 @@ For production it is recommended to enable `strictmode` which blocks some of the
 HTTP Interface Binding
 **********************
 
-By default all HTTP endpoints get bound on `localhost:1323` which generally isn't usable for production, since there are
-endpoints which are required to be accessible by the public. For instance `auth` engine HTTP endpoints required for IRMA
-authentication flows. However, having all endpoints open to the public would be very unsafe, so it's advisable to bind
-public endpoints to publicly accessible interfaces or ports and have administrative endpoints only accessible from
-secure subnets. This is done through the `http` configuration:
+By default all HTTP endpoints get bound on `:1323` which generally isn't usable for production, since some endpoints
+are required to be accessible by the public and others only meant for administrator or your own XIS. You can determine
+the intended public by looking at the first part of the URL.
+
+* Endpoints that start with `/public` should be accessible by the general public,
+* `/internal` is meant for XIS application integration and administrators.
+
+It's advisable to make sure internal endpoints aren't reachable from public networks. The HTTP configuration facilitates
+this by allowing you to bind sets of endpoints to a different HTTP port.
+This can be done by This is done through the `http` configuration:
 
 .. code-block:: yaml
 
@@ -38,7 +43,7 @@ secure subnets. This is done through the `http` configuration:
       # which don't have an alternative bind specified under `alt`. Since it's a default it can be left out or
       # be used to override the default bind address.
       default:
-        address: localhost:1323
+        address: :1323
       alt:
         # The following binds all endpoints starting with `/internal` to `internal.lan:1111`
         internal:


### PR DESCRIPTION
Much more convenient, not much less safe.

Fixes #78 