### PR TITLE
run gofmt on generated code

### DIFF
--- a/makefile
+++ b/makefile
@@ -29,12 +29,12 @@ gen-mocks:
 	mockgen -destination=auth/contract/signer_mock.go -package=contract -source=auth/contract/signer.go
 
 gen-api:
-	oapi-codegen -generate types,server,client -templates codegen/oapi/ -package v1 docs/_static/crypto/v1.yaml > crypto/api/v1/generated.go
-	oapi-codegen -generate types,server,client,skip-prune -templates codegen/oapi/ -package v1 -exclude-schemas DIDDocument,DIDDocumentMetadata,Service,VerificationMethod docs/_static/vdr/v1.yaml > vdr/api/v1/generated.go
-	oapi-codegen -generate types,server,client -templates codegen/oapi/ -package v1 docs/_static/network/v1.yaml > network/api/v1/generated.go
-	oapi-codegen -generate types,server,client,skip-prune -templates codegen/oapi/ -package v1 -exclude-schemas VerifiableCredential,CredentialSubject,IssueVCRequest,Revocation docs/_static/vcr/v1.yaml > vcr/api/v1/generated.go
-	oapi-codegen -generate types,server -templates codegen/oapi/ -package v0 docs/_static/auth/v0.yaml > auth/api/v0/generated.go
-	oapi-codegen -generate types,server -templates codegen/oapi/ -package experimental docs/_static/auth/experimental.yaml > auth/api/experimental/generated.go
+	oapi-codegen -generate types,server,client -templates codegen/oapi/ -package v1 docs/_static/crypto/v1.yaml | gofmt > crypto/api/v1/generated.go
+	oapi-codegen -generate types,server,client,skip-prune -templates codegen/oapi/ -package v1 -exclude-schemas DIDDocument,DIDDocumentMetadata,Service,VerificationMethod docs/_static/vdr/v1.yaml | gofmt > vdr/api/v1/generated.go
+	oapi-codegen -generate types,server,client -templates codegen/oapi/ -package v1 docs/_static/network/v1.yaml | gofmt > network/api/v1/generated.go
+	oapi-codegen -generate types,server,client,skip-prune -templates codegen/oapi/ -package v1 -exclude-schemas VerifiableCredential,CredentialSubject,IssueVCRequest,Revocation docs/_static/vcr/v1.yaml | gofmt > vcr/api/v1/generated.go
+	oapi-codegen -generate types,server -templates codegen/oapi/ -package v0 docs/_static/auth/v0.yaml | gofmt > auth/api/v0/generated.go
+	oapi-codegen -generate types,server -templates codegen/oapi/ -package experimental docs/_static/auth/experimental.yaml | gofmt > auth/api/experimental/generated.go
 
 gen-protobuf:
 	protoc --go_out=paths=source_relative:network -I network network/transport/network.proto

--- a/vdr/api/v1/generated.go
+++ b/vdr/api/v1/generated.go
@@ -702,4 +702,3 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.Add(http.MethodPut, baseURL+"/internal/vdr/v1/did/:did", wrapper.UpdateDID)
 
 }
-


### PR DESCRIPTION
This removes the diff between oapicodegen and gofmt output.