### PR TITLE
Updated go-did library (large refactor)

### DIFF
--- a/auth/api/experimental/api.go
+++ b/auth/api/experimental/api.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/core"
 	"net/http"
 	"time"

--- a/auth/services/contract/notary.go
+++ b/auth/services/contract/notary.go
@@ -21,14 +21,13 @@ package contract
 import (
 	"errors"
 	"fmt"
-	"time"
-
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/auth/services/validator"
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/vcr"
 	"github.com/nuts-foundation/nuts-node/vcr/concept"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
+	"time"
 
 	"github.com/nuts-foundation/nuts-node/auth/services"
 

--- a/auth/services/irma/validator.go
+++ b/auth/services/irma/validator.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/lestrrat-go/jwx/jwt"
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/vdr"
 	"github.com/nuts-foundation/nuts-node/vdr/types"

--- a/auth/services/mock.go
+++ b/auth/services/mock.go
@@ -10,7 +10,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-	go_did "github.com/nuts-foundation/go-did"
+	did "github.com/nuts-foundation/go-did/did"
 	contract "github.com/nuts-foundation/nuts-node/auth/contract"
 )
 
@@ -224,7 +224,7 @@ func (m *MockContractNotary) EXPECT() *MockContractNotaryMockRecorder {
 }
 
 // DrawUpContract mocks base method.
-func (m *MockContractNotary) DrawUpContract(template contract.Template, orgID go_did.DID, validFrom time.Time, validDuration time.Duration) (*contract.Contract, error) {
+func (m *MockContractNotary) DrawUpContract(template contract.Template, orgID did.DID, validFrom time.Time, validDuration time.Duration) (*contract.Contract, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DrawUpContract", template, orgID, validFrom, validDuration)
 	ret0, _ := ret[0].(*contract.Contract)

--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/lestrrat-go/jwx/jwt"
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/vcr"
 	"github.com/nuts-foundation/nuts-node/vcr/concept"

--- a/auth/services/oauth/oauth_test.go
+++ b/auth/services/oauth/oauth_test.go
@@ -26,13 +26,14 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	ssi "github.com/nuts-foundation/go-did"
 	"testing"
 	"time"
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jws"
 	"github.com/lestrrat-go/jwx/jwt"
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/vcr"
 	"github.com/nuts-foundation/nuts-node/vcr/concept"
@@ -55,28 +56,28 @@ var actorSigningKeyID = getActorSigningKey()
 var custodianSigningKeyID = getCustodianSigningKey()
 var orgConceptName = concept.Concept{"organization": concept.Concept{"name": "Carebears"}}
 
-func getActorSigningKey() *did.URI {
-	serviceID, _ := did.ParseURI(actorDID.String() + "#signing-key")
+func getActorSigningKey() *ssi.URI {
+	serviceID, _ := ssi.ParseURI(actorDID.String() + "#signing-key")
 
 	return serviceID
 }
 
-func getCustodianSigningKey() *did.URI {
-	keyID, _ := did.ParseURI(custodianDID.String() + "#signing-key")
+func getCustodianSigningKey() *ssi.URI {
+	keyID, _ := ssi.ParseURI(custodianDID.String() + "#signing-key")
 
 	return keyID
 }
 
 func getCustodianDIDDocument() *did.Document {
 	id := *vdr.TestDIDB
-	serviceID, _ := did.ParseURI(id.String() + "#service-id")
+	serviceID, _ := ssi.ParseURI(id.String() + "#service-id")
 
 	doc := did.Document{
 		ID: id,
 	}
 	signingKeyID := id
 	signingKeyID.Fragment = "signing-key"
-	key, err := did.NewVerificationMethod(signingKeyID, did.JsonWebKey2020, id, custodianSigningKey.Public())
+	key, err := did.NewVerificationMethod(signingKeyID, ssi.JsonWebKey2020, id, custodianSigningKey.Public())
 	if err != nil {
 		panic(err)
 	}

--- a/auth/services/services.go
+++ b/auth/services/services.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 
 	"github.com/nuts-foundation/nuts-node/auth/contract"
 )

--- a/auth/services/util.go
+++ b/auth/services/util.go
@@ -1,10 +1,10 @@
 package services
 
 import (
-	"time"
-
-	"github.com/nuts-foundation/go-did"
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
+	"time"
 )
 
 // ResolveEndpointURL finds the endpoint with the given type of the given holder and unmarshals it as single URL.
@@ -13,10 +13,10 @@ import (
 // - service with given type doesn't exist,
 // - multiple services match,
 // - serviceEndpoint isn't a string.
-func ResolveEndpointURL(resolver types.DocResolver, holder did.DID, endpointType string, validAt *time.Time) (endpointID did.URI, endpointURL string, err error) {
+func ResolveEndpointURL(resolver types.DocResolver, holder did.DID, endpointType string, validAt *time.Time) (endpointID ssi.URI, endpointURL string, err error) {
 	doc, _, err := resolver.Resolve(holder, &types.ResolveMetadata{ResolveTime: validAt})
 	if err != nil {
-		return did.URI{}, "", err
+		return ssi.URI{}, "", err
 	}
 	return doc.ResolveEndpointURL(endpointType)
 }

--- a/auth/services/util_test.go
+++ b/auth/services/util_test.go
@@ -1,10 +1,11 @@
 package services
 
 import (
+	ssi "github.com/nuts-foundation/go-did"
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/vdr"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"github.com/stretchr/testify/assert"
@@ -17,7 +18,7 @@ func TestResolveEndpointURL(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		expectedURI, _ := did.ParseURI("http://nuts.nl")
+		expectedURI, _ := ssi.ParseURI("http://nuts.nl")
 		s := did.Service{Type: "oauth", ServiceEndpoint: expectedURI.String()}
 		resolver := types.NewMockDocResolver(ctrl)
 		resolver.EXPECT().Resolve(holder, gomock.Any()).Return(&did.Document{Service: []did.Service{s}}, nil, nil)

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/magiconair/properties v1.8.4
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
 	github.com/mdp/qrterminal/v3 v3.0.0
-	github.com/nuts-foundation/go-did v0.0.0-20210309101603-d2a97847ec54
+	github.com/nuts-foundation/go-did v0.0.0-20210322161533-d5dd217f4e2b
 	github.com/nuts-foundation/go-leia v0.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/privacybydesign/irmago v0.6.2-0.20210226102726-35c6768789c6

--- a/go.sum
+++ b/go.sum
@@ -452,6 +452,8 @@ github.com/nuts-foundation/go-did v0.0.0-20210309101603-d2a97847ec54 h1:fzQdSzYG
 github.com/nuts-foundation/go-did v0.0.0-20210309101603-d2a97847ec54 h1:fzQdSzYGDwJD/yE7sqzRPWVvm6SaK1Nf+Jyls8PTXz4=
 github.com/nuts-foundation/go-did v0.0.0-20210309101603-d2a97847ec54/go.mod h1:Xqmd6ILZj41nNovodxnb4F+JgcKmIz+XGpLw6m6fZnU=
 github.com/nuts-foundation/go-did v0.0.0-20210309101603-d2a97847ec54/go.mod h1:Xqmd6ILZj41nNovodxnb4F+JgcKmIz+XGpLw6m6fZnU=
+github.com/nuts-foundation/go-did v0.0.0-20210322161533-d5dd217f4e2b h1:hSwJZhPBmhi/Uiu+11V+UUsPIyHSJhYE/8LvUwfH+IY=
+github.com/nuts-foundation/go-did v0.0.0-20210322161533-d5dd217f4e2b/go.mod h1:Xqmd6ILZj41nNovodxnb4F+JgcKmIz+XGpLw6m6fZnU=
 github.com/nuts-foundation/go-leia v0.2.2 h1:E85e/vZlu9mqd/J6WqR25wh4IKAX8y6f5jpU92mJWDM=
 github.com/nuts-foundation/go-leia v0.2.2/go.mod h1:VMmOAg9I6kRUGY9eRNgeQqyj5vyx+oAteKWfVXzcTQs=
 github.com/nuts-foundation/go-leia v0.2.3 h1:zGoqqtqas8Y4qMQSVnXzcFazcM5we1hX9GWIoABdqrc=

--- a/makefile
+++ b/makefile
@@ -16,8 +16,8 @@ gen-mocks:
 	mockgen -destination=core/echo_mock.go -package=core -source core/echo.go -imports echo=github.com/labstack/echo/v4
 	mockgen -destination=crypto/mock.go -package=crypto -source=crypto/interface.go
 	mockgen -destination=crypto/storage/mock.go -package=storage -source=crypto/storage/storage.go
-	mockgen -destination=vdr/types/mock.go -package=types -source=vdr/types/interface.go -self_package github.com/nuts-foundation/nuts-node/vdr/types --imports did=github.com/nuts-foundation/go-did
-	mockgen -destination=vdr/mock.go -package=vdr -source=vdr/resolvers.go -self_package github.com/nuts-foundation/nuts-node/vdr --imports did=github.com/nuts-foundation/go-did
+	mockgen -destination=vdr/types/mock.go -package=types -source=vdr/types/interface.go -self_package github.com/nuts-foundation/nuts-node/vdr/types --imports did=github.com/nuts-foundation/go-did/did
+	mockgen -destination=vdr/mock.go -package=vdr -source=vdr/resolvers.go -self_package github.com/nuts-foundation/nuts-node/vdr --imports did=github.com/nuts-foundation/go-did/did
 	mockgen -destination=network/proto/mock.go -package=proto -source=network/proto/interface.go Protocol
 	mockgen -destination=network/p2p/mock.go -package=p2p -source=network/p2p/interface.go P2PNetwork
 	mockgen -destination=network/mock.go -package=network -source=network/interface.go

--- a/vcr/ambassador.go
+++ b/vcr/ambassador.go
@@ -21,8 +21,7 @@ package vcr
 
 import (
 	"encoding/json"
-
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/network"
 	"github.com/nuts-foundation/nuts-node/network/dag"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
@@ -57,17 +56,17 @@ func (n ambassador) Configure() {
 
 // vcCallback gets called when new Verifiable Credentials are received by the network. All checks on the signature are already performed.
 // The VCR is used to verify the contents of the credential.
-// payload should be a json encoded did.VerifiableCredential
+// payload should be a json encoded vc.VerifiableCredential
 func (n ambassador) vcCallback(tx dag.SubscriberTransaction, payload []byte) error {
 	logging.Log().Debugf("Processing Verifiable Credential received from Nuts Network: ref=%s", tx.Ref())
 
-	vc := did.VerifiableCredential{}
-	if err := json.Unmarshal(payload, &vc); err != nil {
+	target := vc.VerifiableCredential{}
+	if err := json.Unmarshal(payload, &target); err != nil {
 		return errors.Wrap(err, "credential processing failed")
 	}
 
 	// Verify and store
-	return n.writer.StoreCredential(vc)
+	return n.writer.StoreCredential(target)
 }
 
 // rCallback gets called when new credential revocations are received by the network. All checks on the signature are already performed.

--- a/vcr/ambassador_test.go
+++ b/vcr/ambassador_test.go
@@ -21,10 +21,10 @@ package vcr
 
 import (
 	"errors"
+	"github.com/nuts-foundation/go-did/vc"
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	did "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network"
 	"github.com/nuts-foundation/nuts-node/network/dag"
@@ -62,10 +62,10 @@ func TestAmbassador_vcCallback(t *testing.T) {
 		wMock := NewMockWriter(ctrl)
 		defer ctrl.Finish()
 
-		vc := did.VerifiableCredential{}
+		target := vc.VerifiableCredential{}
 		a := NewAmbassador(nil, wMock).(ambassador)
 		wMock.EXPECT().StoreCredential(gomock.Any()).DoAndReturn(func(f interface{}) error {
-			vc = f.(did.VerifiableCredential)
+			target = f.(vc.VerifiableCredential)
 			return nil
 		})
 
@@ -75,7 +75,7 @@ func TestAmbassador_vcCallback(t *testing.T) {
 			return
 		}
 
-		assert.Equal(t, "did:nuts:1#123", vc.ID.String())
+		assert.Equal(t, "did:nuts:1#123", target.ID.String())
 	})
 
 	t.Run("error", func(t *testing.T) {

--- a/vcr/api/v1/api.go
+++ b/vcr/api/v1/api.go
@@ -22,7 +22,7 @@ package v1
 import (
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/go-did"
+	ssi "github.com/nuts-foundation/go-did"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -85,7 +85,7 @@ func (w *Wrapper) Search(ctx echo.Context, conceptTemplate string) error {
 
 // Revoke a credential
 func (w *Wrapper) Revoke(ctx echo.Context, id string) error {
-	idURI, err := did.ParseURI(id)
+	idURI, err := ssi.ParseURI(id)
 
 	// return 400 for malformed input
 	if err != nil {
@@ -142,7 +142,7 @@ func (w *Wrapper) Create(ctx echo.Context) error {
 
 // Resolve a VC and return its content
 func (w *Wrapper) Resolve(ctx echo.Context, id string) error {
-	idURI, err := did.ParseURI(id)
+	idURI, err := ssi.ParseURI(id)
 	// return 400 for malformed input
 	if err != nil {
 		return ctx.String(http.StatusBadRequest, fmt.Sprintf("failed to parse credential ID: %s", err.Error()))
@@ -176,18 +176,18 @@ func (w *Wrapper) Resolve(ctx echo.Context, id string) error {
 }
 
 func (w *Wrapper) TrustIssuer(ctx echo.Context) error {
-	return changeTrust(ctx, func(cType did.URI, issuer did.URI) error {
+	return changeTrust(ctx, func(cType ssi.URI, issuer ssi.URI) error {
 		return w.R.Trust(cType, issuer)
 	})
 }
 
 func (w *Wrapper) UntrustIssuer(ctx echo.Context) error {
-	return changeTrust(ctx, func(cType did.URI, issuer did.URI) error {
+	return changeTrust(ctx, func(cType ssi.URI, issuer ssi.URI) error {
 		return w.R.Untrust(cType, issuer)
 	})
 }
 
-type trustChangeFunc func(did.URI, did.URI) error
+type trustChangeFunc func(ssi.URI, ssi.URI) error
 
 func changeTrust(ctx echo.Context, f trustChangeFunc) error {
 	var icc = new(CredentialIssuer)
@@ -196,12 +196,12 @@ func changeTrust(ctx echo.Context, f trustChangeFunc) error {
 		return ctx.String(http.StatusBadRequest, fmt.Sprintf("failed to parse request body: %s", err.Error()))
 	}
 
-	d, err := did.ParseURI(icc.Issuer)
+	d, err := ssi.ParseURI(icc.Issuer)
 	if err != nil {
 		return ctx.String(http.StatusBadRequest, fmt.Sprintf("failed to parse issuer: %s", err.Error()))
 	}
 
-	cType, err := did.ParseURI(icc.CredentialType)
+	cType, err := ssi.ParseURI(icc.CredentialType)
 	if err != nil {
 		return ctx.String(http.StatusBadRequest, fmt.Sprintf("failed to parse credential type: %s", err.Error()))
 	}

--- a/vcr/api/v1/types.go
+++ b/vcr/api/v1/types.go
@@ -20,18 +20,18 @@
 package v1
 
 import (
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 )
 
 // VerifiableCredential is an alias to use from within the API
-type VerifiableCredential = did.VerifiableCredential
+type VerifiableCredential = vc.VerifiableCredential
 
 // CredentialSubject is an alias to use from within the API
 type CredentialSubject = interface{}
 
 // IssueVCRequest is an alias to use from within the API for issuing VCs.
-type IssueVCRequest = did.VerifiableCredential
+type IssueVCRequest = vc.VerifiableCredential
 
 // Revocation is an alias to use from within the API
 type Revocation = credential.Revocation

--- a/vcr/concept/mock.go
+++ b/vcr/concept/mock.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	go_did "github.com/nuts-foundation/go-did"
+	vc "github.com/nuts-foundation/go-did/vc"
 )
 
 // MockRegistry is a mock of Registry interface.
@@ -78,7 +78,7 @@ func (mr *MockRegistryMockRecorder) QueryFor(concept interface{}) *gomock.Call {
 }
 
 // Transform mocks base method.
-func (m *MockRegistry) Transform(concept string, VC go_did.VerifiableCredential) (Concept, error) {
+func (m *MockRegistry) Transform(concept string, VC vc.VerifiableCredential) (Concept, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Transform", concept, VC)
 	ret0, _ := ret[0].(Concept)

--- a/vcr/concept/registry.go
+++ b/vcr/concept/registry.go
@@ -20,7 +20,7 @@
 package concept
 
 import (
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 )
 
 // Registry defines the interface for accessing loaded concepts and using the templates
@@ -35,7 +35,7 @@ type Registry interface {
 	// It returns ErrUnknownConcept if the concept is not found
 	QueryFor(concept string) (Query, error)
 	// Transform a VerifiableCredential to concept format.
-	Transform(concept string, VC did.VerifiableCredential) (Concept, error)
+	Transform(concept string, VC vc.VerifiableCredential) (Concept, error)
 }
 
 const (
@@ -105,7 +105,7 @@ func (r *registry) Add(conceptTemplate *Template) error {
 }
 
 // Transform a raw VC to a Concept
-func (r *registry) Transform(concept string, VC did.VerifiableCredential) (Concept, error) {
+func (r *registry) Transform(concept string, VC vc.VerifiableCredential) (Concept, error) {
 	if !r.hasConcept(concept) {
 		return nil, ErrUnknownConcept
 	}

--- a/vcr/concept/registry_test.go
+++ b/vcr/concept/registry_test.go
@@ -20,10 +20,10 @@
 package concept
 
 import (
-	"testing"
-
-	"github.com/nuts-foundation/go-did"
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestRegistry_AddFromString(t *testing.T) {
@@ -127,9 +127,9 @@ func TestRegistry_Transform(t *testing.T) {
 	})
 
 	t.Run("error - unknown type", func(t *testing.T) {
-		vcType, _ := did.ParseURI("unknownType")
-		vc := did.VerifiableCredential{
-			Type: []did.URI{*vcType},
+		vcType, _ := ssi.ParseURI("unknownType")
+		vc := vc.VerifiableCredential{
+			Type: []ssi.URI{*vcType},
 		}
 
 		_, err = r.Transform("human", vc)
@@ -142,7 +142,7 @@ func TestRegistry_Transform(t *testing.T) {
 	})
 
 	t.Run("error - unknown concept", func(t *testing.T) {
-		_, err = r.Transform("unknown", did.VerifiableCredential{})
+		_, err = r.Transform("unknown", vc.VerifiableCredential{})
 
 		if !assert.Error(t, err) {
 			return

--- a/vcr/concept/template.go
+++ b/vcr/concept/template.go
@@ -23,11 +23,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/nuts-foundation/go-did/vc"
 	"regexp"
 	"strconv"
 	"strings"
 
-	"github.com/nuts-foundation/go-did"
 	errors2 "github.com/pkg/errors"
 )
 
@@ -200,7 +200,7 @@ func (ct *Template) addIndex(lvl1 int, lvl2 int, jsonPath string) {
 }
 
 // transform a VC to a concept given the template mapping
-func (ct *Template) transform(VC did.VerifiableCredential) (Concept, error) {
+func (ct *Template) transform(VC vc.VerifiableCredential) (Concept, error) {
 	// remove type as this will be hardcoded later
 	VC.Type = nil
 

--- a/vcr/concept/template_test.go
+++ b/vcr/concept/template_test.go
@@ -21,12 +21,11 @@ package concept
 
 import (
 	"encoding/json"
+	"github.com/nuts-foundation/go-did/vc"
+	"github.com/stretchr/testify/assert"
 	"sort"
 	"strings"
 	"testing"
-
-	"github.com/nuts-foundation/go-did"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestTemplateString_isValid(t *testing.T) {
@@ -105,7 +104,7 @@ func TestTemplate_transform(t *testing.T) {
 	}
 
 	t.Run("ok", func(t *testing.T) {
-		testVC := did.VerifiableCredential{}
+		testVC := vc.VerifiableCredential{}
 		if !assert.NoError(t, json.Unmarshal([]byte(TestCredential), &testVC)) {
 			return
 		}
@@ -139,7 +138,7 @@ func TestTemplate_transform(t *testing.T) {
 	"type": ["VerifiableCredential", "ExampleCredential"]
 }
 `
-		testVC := did.VerifiableCredential{}
+		testVC := vc.VerifiableCredential{}
 		if !assert.NoError(t, json.Unmarshal([]byte(testCredential), &testVC)) {
 			return
 		}

--- a/vcr/concept/test.go
+++ b/vcr/concept/test.go
@@ -20,8 +20,7 @@ package concept
 
 import (
 	"encoding/json"
-
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 )
 
 const ExampleConcept = "human"
@@ -66,10 +65,10 @@ const TestRevocation = `
 }
 `
 
-func TestVC() did.VerifiableCredential {
-	vc := did.VerifiableCredential{}
+func TestVC() vc.VerifiableCredential {
+	credential := vc.VerifiableCredential{}
 
-	json.Unmarshal([]byte(TestCredential), &vc)
+	json.Unmarshal([]byte(TestCredential), &credential)
 
-	return vc
+	return credential
 }

--- a/vcr/credential/builder.go
+++ b/vcr/credential/builder.go
@@ -21,10 +21,11 @@ package credential
 
 import (
 	"fmt"
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/nuts-foundation/go-did"
 )
 
 // Builder is an abstraction for extending a partial VC into a fully valid VC
@@ -32,7 +33,7 @@ type Builder interface {
 	// Type returns the matching Verifiable Credential type
 	Type() string
 	// Fill sets the defaults for common fields
-	Fill(vc *did.VerifiableCredential)
+	Fill(vc *vc.VerifiableCredential)
 }
 
 // defaultBuilder fills in the type, issuanceDate and context
@@ -42,20 +43,20 @@ type defaultBuilder struct {
 
 var nowFunc = time.Now
 
-func (d defaultBuilder) Fill(vc *did.VerifiableCredential) {
-	vc.Context = []did.URI{did.VCContextV1URI(), *NutsContextURI}
+func (d defaultBuilder) Fill(credential *vc.VerifiableCredential) {
+	credential.Context = []ssi.URI{vc.VCContextV1URI(), *NutsContextURI}
 
-	defaultType := did.VerifiableCredentialTypeV1URI()
-	if !vc.IsType(defaultType) {
-		vc.Type = append(vc.Type, defaultType)
+	defaultType := vc.VerifiableCredentialTypeV1URI()
+	if !credential.IsType(defaultType) {
+		credential.Type = append(credential.Type, defaultType)
 	}
 
-	builderType, _ := did.ParseURI(d.vcType)
-	if !vc.IsType(*builderType) {
-		vc.Type = append(vc.Type, *builderType)
+	builderType, _ := ssi.ParseURI(d.vcType)
+	if !credential.IsType(*builderType) {
+		credential.Type = append(credential.Type, *builderType)
 	}
-	vc.IssuanceDate = nowFunc()
-	vc.ID = generateID(vc.Issuer)
+	credential.IssuanceDate = nowFunc()
+	credential.ID = generateID(credential.Issuer)
 
 	return
 }
@@ -64,8 +65,8 @@ func (d defaultBuilder) Type() string {
 	return d.vcType
 }
 
-func generateID(issuer did.URI) *did.URI {
+func generateID(issuer ssi.URI) *ssi.URI {
 	id := fmt.Sprintf("%s#%s", issuer.String(), uuid.New().String())
-	u, _ := did.ParseURI(id)
+	u, _ := ssi.ParseURI(id)
 	return u
 }

--- a/vcr/credential/builder_test.go
+++ b/vcr/credential/builder_test.go
@@ -20,17 +20,18 @@
 package credential
 
 import (
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/nuts-node/vdr"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateID(t *testing.T) {
-	issuer, _ := did.ParseURI(vdr.TestDIDA.String())
+	issuer, _ := ssi.ParseURI(vdr.TestDIDA.String())
 	id := generateID(*issuer)
 
 	if !assert.NotNil(t, id) {
@@ -52,8 +53,8 @@ func TestDefaultBuilder_Type(t *testing.T) {
 
 func TestDefaultBuilder_Fill(t *testing.T) {
 	b := defaultBuilder{vcType: "type"}
-	issuer, _ := did.ParseURI(vdr.TestDIDA.String())
-	vc := &did.VerifiableCredential{
+	issuer, _ := ssi.ParseURI(vdr.TestDIDA.String())
+	subject := &vc.VerifiableCredential{
 		Issuer: *issuer,
 	}
 	defer func() {
@@ -64,37 +65,37 @@ func TestDefaultBuilder_Fill(t *testing.T) {
 		return checkTime
 	}
 
-	b.Fill(vc)
+	b.Fill(subject)
 
 	t.Run("adds context", func(t *testing.T) {
-		assert.True(t, vc.ContainsContext(did.VCContextV1URI()))
-		assert.True(t, vc.ContainsContext(*NutsContextURI))
+		assert.True(t, subject.ContainsContext(vc.VCContextV1URI()))
+		assert.True(t, subject.ContainsContext(*NutsContextURI))
 	})
 
 	t.Run("adds type", func(t *testing.T) {
-		vcType, _ := did.ParseURI("type")
-		assert.True(t, vc.IsType(did.VerifiableCredentialTypeV1URI()))
-		assert.True(t, vc.IsType(*vcType))
+		vcType, _ := ssi.ParseURI("type")
+		assert.True(t, subject.IsType(vc.VerifiableCredentialTypeV1URI()))
+		assert.True(t, subject.IsType(*vcType))
 	})
 
 	t.Run("adds issuanceDate", func(t *testing.T) {
-		assert.NotEqual(t, time.Time{}, vc.IssuanceDate)
+		assert.NotEqual(t, time.Time{}, subject.IssuanceDate)
 	})
 
 	t.Run("adds ID", func(t *testing.T) {
-		assert.NotNil(t, vc.ID)
+		assert.NotNil(t, subject.ID)
 	})
 
 	t.Run("sets time", func(t *testing.T) {
-		assert.Equal(t, checkTime, vc.IssuanceDate)
+		assert.Equal(t, checkTime, subject.IssuanceDate)
 	})
 
 	t.Run("default VC type is not added twice if already present", func(t *testing.T) {
-		vc := &did.VerifiableCredential{
-			Type:   []did.URI{did.VerifiableCredentialTypeV1URI()},
+		subject := &vc.VerifiableCredential{
+			Type:   []ssi.URI{vc.VerifiableCredentialTypeV1URI()},
 			Issuer: *issuer,
 		}
-		b.Fill(vc)
-		assert.Len(t, vc.Type, 2)
+		b.Fill(subject)
+		assert.Len(t, subject.Type, 2)
 	})
 }

--- a/vcr/credential/resolver.go
+++ b/vcr/credential/resolver.go
@@ -20,13 +20,13 @@
 package credential
 
 import (
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 )
 
 // FindValidatorAndBuilder finds the Validator and Builder for the credential Type
 // It returns nils when not found.
 // It only supports VCs with one additional type next to the default VerifiableCredential type.
-func FindValidatorAndBuilder(credential did.VerifiableCredential) (Validator, Builder) {
+func FindValidatorAndBuilder(credential vc.VerifiableCredential) (Validator, Builder) {
 	if vcTypes := ExtractTypes(credential); len(vcTypes) > 0 {
 		for _, t := range vcTypes {
 			if t == NutsOrganizationCredentialType {
@@ -39,11 +39,11 @@ func FindValidatorAndBuilder(credential did.VerifiableCredential) (Validator, Bu
 }
 
 // ExtractTypes extract additional VC types from the VC as strings
-func ExtractTypes(credential did.VerifiableCredential) []string {
+func ExtractTypes(credential vc.VerifiableCredential) []string {
 	var vcTypes []string
 
 	for _, t := range credential.Type {
-		if t != did.VerifiableCredentialTypeV1URI() {
+		if t != vc.VerifiableCredentialTypeV1URI() {
 			vcTypes = append(vcTypes, t.String())
 		}
 	}

--- a/vcr/credential/resolver_test.go
+++ b/vcr/credential/resolver_test.go
@@ -20,15 +20,15 @@
 package credential
 
 import (
-	"testing"
-
-	"github.com/nuts-foundation/go-did"
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestFindValidatorAndBuilder(t *testing.T) {
 	t.Run("nothing found", func(t *testing.T) {
-		v, b := FindValidatorAndBuilder(did.VerifiableCredential{})
+		v, b := FindValidatorAndBuilder(vc.VerifiableCredential{})
 
 		assert.Nil(t, v)
 		assert.Nil(t, b)
@@ -44,11 +44,11 @@ func TestFindValidatorAndBuilder(t *testing.T) {
 }
 
 func TestExtractTypes(t *testing.T) {
-	vc := did.VerifiableCredential{
-		Type: []did.URI{did.VerifiableCredentialTypeV1URI(), *NutsOrganizationCredentialTypeURI},
+	v := vc.VerifiableCredential{
+		Type: []ssi.URI{vc.VerifiableCredentialTypeV1URI(), *NutsOrganizationCredentialTypeURI},
 	}
 
-	types := ExtractTypes(vc)
+	types := ExtractTypes(v)
 
 	assert.Len(t, types, 1)
 	assert.Equal(t, NutsOrganizationCredentialType, types[0])

--- a/vcr/credential/revocation.go
+++ b/vcr/credential/revocation.go
@@ -20,30 +20,30 @@
 package credential
 
 import (
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 	"time"
-
-	"github.com/nuts-foundation/go-did"
 )
 
 // Revocation defines a proof that a VC has been revoked by it's issuer.
 type Revocation struct {
 	// Issuer refers to the party that issued the credential
-	Issuer did.URI `json:"issuer"`
+	Issuer ssi.URI `json:"issuer"`
 	// Subject refers to the VC that is revoked
-	Subject did.URI `json:"subject"`
+	Subject ssi.URI `json:"subject"`
 	// Reason describes why the VC has been revoked
 	Reason string `json:"reason,omitempty"`
 	// Date is a rfc3339 formatted datetime.
 	Date time.Time `json:"date"`
 	// Proof contains the cryptographic proof(s). It must be extracted using the Proofs method or UnmarshalProofValue method for non-generic proof fields.
-	Proof *did.JSONWebSignature2020Proof `json:"proof,omitempty"`
+	Proof *vc.JSONWebSignature2020Proof `json:"proof,omitempty"`
 }
 
 // BuildRevocation generates a revocation based on the credential
-func BuildRevocation(vc did.VerifiableCredential) Revocation {
+func BuildRevocation(credential vc.VerifiableCredential) Revocation {
 	return Revocation{
-		Issuer:  vc.Issuer,
-		Subject: *vc.ID,
+		Issuer:  credential.Issuer,
+		Subject: *credential.ID,
 		Date:    nowFunc(),
 	}
 }

--- a/vcr/credential/revocation_test.go
+++ b/vcr/credential/revocation_test.go
@@ -21,18 +21,18 @@ package credential
 
 import (
 	"encoding/json"
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 	"time"
-
-	"github.com/nuts-foundation/go-did"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildRevocation(t *testing.T) {
-	vc := did.VerifiableCredential{}
+	target := vc.VerifiableCredential{}
 	vcData, _ := os.ReadFile("../test/vc.json")
-	json.Unmarshal(vcData, &vc)
+	json.Unmarshal(vcData, &target)
 
 	at := time.Now()
 	nowFunc = func() time.Time {
@@ -42,10 +42,10 @@ func TestBuildRevocation(t *testing.T) {
 		nowFunc = time.Now
 	}()
 
-	r := BuildRevocation(vc)
+	r := BuildRevocation(target)
 
-	assert.Equal(t, *vc.ID, r.Subject)
-	assert.Equal(t, vc.Issuer, r.Issuer)
+	assert.Equal(t, *target.ID, r.Subject)
+	assert.Equal(t, target.Issuer, r.Issuer)
 	assert.Equal(t, at, r.Date)
 }
 
@@ -60,7 +60,7 @@ func TestValidateRevocation(t *testing.T) {
 
 	t.Run("error - empty subject", func(t *testing.T) {
 		r := revocation
-		r.Subject = did.URI{}
+		r.Subject = ssi.URI{}
 
 		err := ValidateRevocation(r)
 		assert.Error(t, err)
@@ -78,7 +78,7 @@ func TestValidateRevocation(t *testing.T) {
 
 	t.Run("error - issuer is required", func(t *testing.T) {
 		r := revocation
-		r.Issuer = did.URI{}
+		r.Issuer = ssi.URI{}
 
 		err := ValidateRevocation(r)
 		assert.Error(t, err)

--- a/vcr/credential/types.go
+++ b/vcr/credential/types.go
@@ -19,7 +19,9 @@
 
 package credential
 
-import "github.com/nuts-foundation/go-did"
+import (
+	ssi "github.com/nuts-foundation/go-did"
+)
 
 const (
 	// NutsOrganizationCredentialType is the VC type for a NutsOrganizationCredentialType
@@ -30,9 +32,9 @@ const (
 
 var (
 	// NutsOrganizationCredentialTypeURI is the VC type for a NutsOrganizationCredentialType as URI
-	NutsOrganizationCredentialTypeURI, _ = did.ParseURI(NutsOrganizationCredentialType)
+	NutsOrganizationCredentialTypeURI, _ = ssi.ParseURI(NutsOrganizationCredentialType)
 	// NutsContextURI is the nuts specific json-ld context as URI
-	NutsContextURI, _ = did.ParseURI(NutsContext)
+	NutsContextURI, _ = ssi.ParseURI(NutsContext)
 )
 
 // NutsOrganizationCredentialSubject defines the CredentialSubject struct for the NutsOrganizationCredentialType

--- a/vcr/credential/validator.go
+++ b/vcr/credential/validator.go
@@ -22,16 +22,15 @@ package credential
 import (
 	"errors"
 	"fmt"
+	"github.com/nuts-foundation/go-did/vc"
 	"strings"
-
-	"github.com/nuts-foundation/go-did"
 )
 
 // Validator is the interface specific VC verification.
 // Every VC will have it's own rules of verification.
 type Validator interface {
 	// Validate the given credential according to the rules of the VC type.
-	Validate(credential did.VerifiableCredential) error
+	Validate(credential vc.VerifiableCredential) error
 }
 
 // ErrValidation is a common error indicating validation failed
@@ -56,13 +55,13 @@ func failure(err string) error {
 }
 
 // validate the default fields
-func validate(credential did.VerifiableCredential) error {
+func validate(credential vc.VerifiableCredential) error {
 
-	if !credential.IsType(did.VerifiableCredentialTypeV1URI()) {
+	if !credential.IsType(vc.VerifiableCredentialTypeV1URI()) {
 		return failure("'VerifiableCredential' is required")
 	}
 
-	if !credential.ContainsContext(did.VCContextV1URI()) {
+	if !credential.ContainsContext(vc.VCContextV1URI()) {
 		return failure("default context is required")
 	}
 
@@ -88,7 +87,7 @@ func validate(credential did.VerifiableCredential) error {
 // nutsOrganizationCredentialValidator checks if there's a 'name' and 'city' in the 'organization' struct
 type nutsOrganizationCredentialValidator struct{}
 
-func (d nutsOrganizationCredentialValidator) Validate(credential did.VerifiableCredential) error {
+func (d nutsOrganizationCredentialValidator) Validate(credential vc.VerifiableCredential) error {
 	var target = make([]NutsOrganizationCredentialSubject, 0)
 
 	if err := validate(credential); err != nil {

--- a/vcr/credential/validator_test.go
+++ b/vcr/credential/validator_test.go
@@ -20,182 +20,182 @@
 package credential
 
 import (
-	"testing"
-	"time"
-
-	"github.com/nuts-foundation/go-did"
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/vdr"
 	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
 )
 
 func TestNutsOrganizationCredentialValidator_Validate(t *testing.T) {
 	validator := nutsOrganizationCredentialValidator{}
 
 	t.Run("ok", func(t *testing.T) {
-		vc := validNutsOrganizationCredential()
+		v := validNutsOrganizationCredential()
 
-		err := validator.Validate(*vc)
+		err := validator.Validate(*v)
 
 		assert.NoError(t, err)
 	})
 
 	t.Run("failed - missing custom type", func(t *testing.T) {
-		vc := validNutsOrganizationCredential()
-		vc.Type = []did.URI{did.VerifiableCredentialTypeV1URI()}
+		v := validNutsOrganizationCredential()
+		v.Type = []ssi.URI{vc.VerifiableCredentialTypeV1URI()}
 
-		err := validator.Validate(*vc)
+		err := validator.Validate(*v)
 
 		assert.Error(t, err)
 	})
 
 	t.Run("failed - missing default type", func(t *testing.T) {
-		vc := validNutsOrganizationCredential()
-		vc.Type = []did.URI{stringToURI(NutsOrganizationCredentialType)}
+		v := validNutsOrganizationCredential()
+		v.Type = []ssi.URI{stringToURI(NutsOrganizationCredentialType)}
 
-		err := validator.Validate(*vc)
+		err := validator.Validate(*v)
 
 		assert.Error(t, err)
 	})
 
 	t.Run("failed - missing credential subject", func(t *testing.T) {
-		vc := validNutsOrganizationCredential()
-		vc.CredentialSubject = []interface{}{}
+		v := validNutsOrganizationCredential()
+		v.CredentialSubject = []interface{}{}
 
-		err := validator.Validate(*vc)
+		err := validator.Validate(*v)
 
 		assert.Error(t, err)
 	})
 
 	t.Run("failed - missing organization", func(t *testing.T) {
-		vc := validNutsOrganizationCredential()
+		v := validNutsOrganizationCredential()
 		var credentialSubject = make(map[string]interface{})
 		credentialSubject["id"] = vdr.TestDIDB.String()
-		vc.CredentialSubject = []interface{}{credentialSubject}
+		v.CredentialSubject = []interface{}{credentialSubject}
 
-		err := validator.Validate(*vc)
+		err := validator.Validate(*v)
 
 		assert.Error(t, err)
 	})
 
 	t.Run("failed - missing organization name", func(t *testing.T) {
-		vc := validNutsOrganizationCredential()
+		v := validNutsOrganizationCredential()
 		var credentialSubject = make(map[string]interface{})
 		credentialSubject["id"] = vdr.TestDIDB.String()
 		credentialSubject["organization"] = map[string]interface{}{
 			"city": "EIbergen",
 		}
-		vc.CredentialSubject = []interface{}{credentialSubject}
+		v.CredentialSubject = []interface{}{credentialSubject}
 
-		err := validator.Validate(*vc)
+		err := validator.Validate(*v)
 
 		assert.Error(t, err)
 	})
 
 	t.Run("failed - missing organization city", func(t *testing.T) {
-		vc := validNutsOrganizationCredential()
+		v := validNutsOrganizationCredential()
 		var credentialSubject = make(map[string]interface{})
 		credentialSubject["id"] = vdr.TestDIDB.String()
 		credentialSubject["organization"] = map[string]interface{}{
 			"name": "Because we care B.V.",
 		}
-		vc.CredentialSubject = []interface{}{credentialSubject}
+		v.CredentialSubject = []interface{}{credentialSubject}
 
-		err := validator.Validate(*vc)
+		err := validator.Validate(*v)
 
 		assert.Error(t, err)
 	})
 
 	t.Run("failed - empty organization city", func(t *testing.T) {
-		vc := validNutsOrganizationCredential()
+		v := validNutsOrganizationCredential()
 		var credentialSubject = make(map[string]interface{})
 		credentialSubject["id"] = vdr.TestDIDB.String()
 		credentialSubject["organization"] = map[string]interface{}{
 			"name": "Because we care B.V.",
 			"city": " ",
 		}
-		vc.CredentialSubject = []interface{}{credentialSubject}
+		v.CredentialSubject = []interface{}{credentialSubject}
 
-		err := validator.Validate(*vc)
+		err := validator.Validate(*v)
 
 		assert.Error(t, err)
 	})
 
 	t.Run("failed - empty organization name", func(t *testing.T) {
-		vc := validNutsOrganizationCredential()
+		v := validNutsOrganizationCredential()
 		var credentialSubject = make(map[string]interface{})
 		credentialSubject["id"] = vdr.TestDIDB.String()
 		credentialSubject["organization"] = map[string]interface{}{
 			"name": " ",
 			"city": "EIbergen",
 		}
-		vc.CredentialSubject = []interface{}{credentialSubject}
+		v.CredentialSubject = []interface{}{credentialSubject}
 
-		err := validator.Validate(*vc)
+		err := validator.Validate(*v)
 
 		assert.Error(t, err)
 	})
 
 	t.Run("failed - missing credentialSubject.ID", func(t *testing.T) {
-		vc := validNutsOrganizationCredential()
+		v := validNutsOrganizationCredential()
 		var credentialSubject = make(map[string]interface{})
 		credentialSubject["organization"] = map[string]interface{}{
 			"name": "Because we care B.V.",
 			"city": "EIbergen",
 		}
-		vc.CredentialSubject = []interface{}{credentialSubject}
+		v.CredentialSubject = []interface{}{credentialSubject}
 
-		err := validator.Validate(*vc)
+		err := validator.Validate(*v)
 
 		assert.Error(t, err)
 	})
 
 	t.Run("failed - missing ID", func(t *testing.T) {
-		vc := validNutsOrganizationCredential()
-		vc.ID = nil
+		v := validNutsOrganizationCredential()
+		v.ID = nil
 
-		err := validator.Validate(*vc)
+		err := validator.Validate(*v)
 
 		assert.Error(t, err)
 	})
 
 	t.Run("failed - missing default context", func(t *testing.T) {
-		vc := validNutsOrganizationCredential()
-		vc.Context = []did.URI{stringToURI(NutsContext)}
+		v := validNutsOrganizationCredential()
+		v.Context = []ssi.URI{stringToURI(NutsContext)}
 
-		err := validator.Validate(*vc)
+		err := validator.Validate(*v)
 
 		assert.Error(t, err)
 	})
 
 	t.Run("failed - missing nuts context", func(t *testing.T) {
-		vc := validNutsOrganizationCredential()
-		vc.Context = []did.URI{did.VerifiableCredentialTypeV1URI()}
+		v := validNutsOrganizationCredential()
+		v.Context = []ssi.URI{vc.VerifiableCredentialTypeV1URI()}
 
-		err := validator.Validate(*vc)
+		err := validator.Validate(*v)
 
 		assert.Error(t, err)
 	})
 
 	t.Run("failed - missing issuanceDate", func(t *testing.T) {
-		vc := validNutsOrganizationCredential()
-		vc.IssuanceDate = time.Time{}
+		v := validNutsOrganizationCredential()
+		v.IssuanceDate = time.Time{}
 
-		err := validator.Validate(*vc)
+		err := validator.Validate(*v)
 
 		assert.Error(t, err)
 	})
 
 	t.Run("failed - missing proof", func(t *testing.T) {
-		vc := validNutsOrganizationCredential()
-		vc.Proof = nil
+		v := validNutsOrganizationCredential()
+		v.Proof = nil
 
-		err := validator.Validate(*vc)
+		err := validator.Validate(*v)
 
 		assert.Error(t, err)
 	})
 }
 
-func validNutsOrganizationCredential() *did.VerifiableCredential {
+func validNutsOrganizationCredential() *vc.VerifiableCredential {
 	var credentialSubject = make(map[string]interface{})
 	credentialSubject["id"] = vdr.TestDIDB.String()
 	credentialSubject["organization"] = map[string]interface{}{
@@ -203,18 +203,18 @@ func validNutsOrganizationCredential() *did.VerifiableCredential {
 		"city": "EIbergen",
 	}
 
-	return &did.VerifiableCredential{
-		Context:           []did.URI{did.VCContextV1URI(), *NutsContextURI},
-		ID:                &did.URI{},
-		Type:              []did.URI{*NutsOrganizationCredentialTypeURI, did.VerifiableCredentialTypeV1URI()},
+	return &vc.VerifiableCredential{
+		Context:           []ssi.URI{vc.VCContextV1URI(), *NutsContextURI},
+		ID:                &ssi.URI{},
+		Type:              []ssi.URI{*NutsOrganizationCredentialTypeURI, vc.VerifiableCredentialTypeV1URI()},
 		Issuer:            stringToURI(vdr.TestDIDA.String()),
 		IssuanceDate:      time.Now(),
 		CredentialSubject: []interface{}{credentialSubject},
-		Proof:             []interface{}{did.Proof{}},
+		Proof:             []interface{}{vc.Proof{}},
 	}
 }
 
-func stringToURI(input string) did.URI {
-	u, _ := did.ParseURI(input)
+func stringToURI(input string) ssi.URI {
+	u, _ := ssi.ParseURI(input)
 	return *u
 }

--- a/vcr/interface.go
+++ b/vcr/interface.go
@@ -22,11 +22,11 @@ package vcr
 import (
 	"embed"
 	"errors"
-	"time"
-
-	"github.com/nuts-foundation/go-did"
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/vcr/concept"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
+	"time"
 )
 
 //go:embed assets/*
@@ -63,7 +63,7 @@ type ConceptFinder interface {
 // Writer is the interface that groups al the VC write methods
 type Writer interface {
 	// StoreCredential writes a VC to storage. Before writing, it calls Verify!
-	StoreCredential(vc did.VerifiableCredential) error
+	StoreCredential(vc vc.VerifiableCredential) error
 	// StoreRevocation writes a revocation to storage.
 	StoreRevocation(r credential.Revocation) error
 }
@@ -73,27 +73,27 @@ type VCR interface {
 	// Issue creates and publishes a new VC.
 	// An optional expirationDate can be given.
 	// VCs are stored when the network has successfully published them.
-	Issue(vc did.VerifiableCredential) (*did.VerifiableCredential, error)
+	Issue(vcToIssue vc.VerifiableCredential) (*vc.VerifiableCredential, error)
 	// Search for matching credentials based upon a query. It returns an empty list if no matches have been found.
-	Search(query concept.Query) ([]did.VerifiableCredential, error)
+	Search(query concept.Query) ([]vc.VerifiableCredential, error)
 	// Resolve returns a credential based on its ID.
 	// The credential will still be returned in the case of ErrRevoked and ErrUntrusted.
 	// For other errors, nil is returned
-	Resolve(ID did.URI) (*did.VerifiableCredential, error)
+	Resolve(ID ssi.URI) (*vc.VerifiableCredential, error)
 	// Verify checks if a credential is valid and trusted at the given time.
 	// The time check is optional, so credentials can be issued that will become valid.
 	// If valid no error is returned.
-	Verify(vc did.VerifiableCredential, at *time.Time) error
+	Verify(vcToVerify vc.VerifiableCredential, at *time.Time) error
 	// Revoke a credential based on its ID, the Issuer will be resolved automatically.
 	// The statusDate will be set to the current time.
 	// It returns an error if the credential, issuer or private key can not be found.
-	Revoke(ID did.URI) (*credential.Revocation, error)
+	Revoke(ID ssi.URI) (*credential.Revocation, error)
 	// Registry returns the concept registry
 	Registry() concept.Registry
 	// Trust adds trust for a Issuer/CredentialType combination. The added trust is persisted to disk.
-	Trust(credentialType did.URI, issuer did.URI) error
+	Trust(credentialType ssi.URI, issuer ssi.URI) error
 	// Untrust removes trust for a Issuer/CredentialType combination. The result is persisted to disk.
-	Untrust(credentialType did.URI, issuer did.URI) error
+	Untrust(credentialType ssi.URI, issuer ssi.URI) error
 
 	ConceptFinder
 

--- a/vcr/mock.go
+++ b/vcr/mock.go
@@ -9,7 +9,8 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-	did "github.com/nuts-foundation/go-did"
+	ssi "github.com/nuts-foundation/go-did"
+	vc "github.com/nuts-foundation/go-did/vc"
 	concept "github.com/nuts-foundation/nuts-node/vcr/concept"
 	credential "github.com/nuts-foundation/nuts-node/vcr/credential"
 )
@@ -76,7 +77,7 @@ func (m *MockWriter) EXPECT() *MockWriterMockRecorder {
 }
 
 // StoreCredential mocks base method.
-func (m *MockWriter) StoreCredential(vc did.VerifiableCredential) error {
+func (m *MockWriter) StoreCredential(vc vc.VerifiableCredential) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StoreCredential", vc)
 	ret0, _ := ret[0].(error)
@@ -142,18 +143,18 @@ func (mr *MockVCRMockRecorder) Get(conceptName, subject interface{}) *gomock.Cal
 }
 
 // Issue mocks base method.
-func (m *MockVCR) Issue(vc did.VerifiableCredential) (*did.VerifiableCredential, error) {
+func (m *MockVCR) Issue(vcToIssue vc.VerifiableCredential) (*vc.VerifiableCredential, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Issue", vc)
-	ret0, _ := ret[0].(*did.VerifiableCredential)
+	ret := m.ctrl.Call(m, "Issue", vcToIssue)
+	ret0, _ := ret[0].(*vc.VerifiableCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Issue indicates an expected call of Issue.
-func (mr *MockVCRMockRecorder) Issue(vc interface{}) *gomock.Call {
+func (mr *MockVCRMockRecorder) Issue(vcToIssue interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Issue", reflect.TypeOf((*MockVCR)(nil).Issue), vc)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Issue", reflect.TypeOf((*MockVCR)(nil).Issue), vcToIssue)
 }
 
 // Registry mocks base method.
@@ -171,10 +172,10 @@ func (mr *MockVCRMockRecorder) Registry() *gomock.Call {
 }
 
 // Resolve mocks base method.
-func (m *MockVCR) Resolve(ID did.URI) (*did.VerifiableCredential, error) {
+func (m *MockVCR) Resolve(ID ssi.URI) (*vc.VerifiableCredential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Resolve", ID)
-	ret0, _ := ret[0].(*did.VerifiableCredential)
+	ret0, _ := ret[0].(*vc.VerifiableCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -186,7 +187,7 @@ func (mr *MockVCRMockRecorder) Resolve(ID interface{}) *gomock.Call {
 }
 
 // Revoke mocks base method.
-func (m *MockVCR) Revoke(ID did.URI) (*credential.Revocation, error) {
+func (m *MockVCR) Revoke(ID ssi.URI) (*credential.Revocation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Revoke", ID)
 	ret0, _ := ret[0].(*credential.Revocation)
@@ -201,10 +202,10 @@ func (mr *MockVCRMockRecorder) Revoke(ID interface{}) *gomock.Call {
 }
 
 // Search mocks base method.
-func (m *MockVCR) Search(query concept.Query) ([]did.VerifiableCredential, error) {
+func (m *MockVCR) Search(query concept.Query) ([]vc.VerifiableCredential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Search", query)
-	ret0, _ := ret[0].([]did.VerifiableCredential)
+	ret0, _ := ret[0].([]vc.VerifiableCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -216,7 +217,7 @@ func (mr *MockVCRMockRecorder) Search(query interface{}) *gomock.Call {
 }
 
 // StoreCredential mocks base method.
-func (m *MockVCR) StoreCredential(vc did.VerifiableCredential) error {
+func (m *MockVCR) StoreCredential(vc vc.VerifiableCredential) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StoreCredential", vc)
 	ret0, _ := ret[0].(error)
@@ -244,7 +245,7 @@ func (mr *MockVCRMockRecorder) StoreRevocation(r interface{}) *gomock.Call {
 }
 
 // Trust mocks base method.
-func (m *MockVCR) Trust(credentialType, issuer did.URI) error {
+func (m *MockVCR) Trust(credentialType, issuer ssi.URI) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Trust", credentialType, issuer)
 	ret0, _ := ret[0].(error)
@@ -258,7 +259,7 @@ func (mr *MockVCRMockRecorder) Trust(credentialType, issuer interface{}) *gomock
 }
 
 // Untrust mocks base method.
-func (m *MockVCR) Untrust(credentialType, issuer did.URI) error {
+func (m *MockVCR) Untrust(credentialType, issuer ssi.URI) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Untrust", credentialType, issuer)
 	ret0, _ := ret[0].(error)
@@ -272,15 +273,15 @@ func (mr *MockVCRMockRecorder) Untrust(credentialType, issuer interface{}) *gomo
 }
 
 // Verify mocks base method.
-func (m *MockVCR) Verify(vc did.VerifiableCredential, at *time.Time) error {
+func (m *MockVCR) Verify(vcToVerify vc.VerifiableCredential, at *time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Verify", vc, at)
+	ret := m.ctrl.Call(m, "Verify", vcToVerify, at)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Verify indicates an expected call of Verify.
-func (mr *MockVCRMockRecorder) Verify(vc, at interface{}) *gomock.Call {
+func (mr *MockVCRMockRecorder) Verify(vcToVerify, at interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockVCR)(nil).Verify), vc, at)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockVCR)(nil).Verify), vcToVerify, at)
 }

--- a/vcr/store.go
+++ b/vcr/store.go
@@ -21,28 +21,28 @@ package vcr
 
 import (
 	"encoding/json"
+	"github.com/nuts-foundation/go-did/vc"
 
-	"github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-leia"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 )
 
 const revocationCollection = "_revocation"
 
-func (c *vcr) StoreCredential(vc did.VerifiableCredential) error {
+func (c *vcr) StoreCredential(credential vc.VerifiableCredential) error {
 	// verify first
-	if err := c.Verify(vc, nil); err != nil {
+	if err := c.Verify(credential, nil); err != nil {
 		return err
 	}
 
-	return c.writeCredential(vc)
+	return c.writeCredential(credential)
 }
 
-func (c *vcr) writeCredential(vc did.VerifiableCredential) error {
+func (c *vcr) writeCredential(subject vc.VerifiableCredential) error {
 	// validation has made sure there's exactly one!
-	vcType := credential.ExtractTypes(vc)[0]
+	vcType := credential.ExtractTypes(subject)[0]
 
-	doc, _ := json.Marshal(vc)
+	doc, _ := json.Marshal(subject)
 
 	collection := c.store.Collection(vcType)
 

--- a/vcr/store_test.go
+++ b/vcr/store_test.go
@@ -22,11 +22,11 @@ package vcr
 import (
 	"crypto/ecdsa"
 	"encoding/json"
+	"github.com/nuts-foundation/go-did/vc"
 	"io/ioutil"
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/crypto/storage"
 	"github.com/nuts-foundation/nuts-node/test/io"
@@ -36,9 +36,9 @@ import (
 
 func TestVcr_StoreCredential(t *testing.T) {
 	// load VC
-	vc := did.VerifiableCredential{}
+	target := vc.VerifiableCredential{}
 	vcJSON, _ := ioutil.ReadFile("test/vc.json")
-	json.Unmarshal(vcJSON, &vc)
+	json.Unmarshal(vcJSON, &target)
 
 	// load pub key
 	pke := storage.PublicKeyEntry{}
@@ -55,7 +55,7 @@ func TestVcr_StoreCredential(t *testing.T) {
 		ctx.vcr.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
 		ctx.vdr.EXPECT().ResolveSigningKey(gomock.Any(), nil).Return(pk, nil)
 
-		err := ctx.vcr.StoreCredential(vc)
+		err := ctx.vcr.StoreCredential(target)
 
 		assert.NoError(t, err)
 	})
@@ -67,7 +67,7 @@ func TestVcr_StoreCredential(t *testing.T) {
 		ctx.tx.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(2)
 		ctx.vcr.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
 
-		err := ctx.vcr.StoreCredential(did.VerifiableCredential{})
+		err := ctx.vcr.StoreCredential(vc.VerifiableCredential{})
 
 		assert.Error(t, err)
 	})

--- a/vcr/trust/trust.go
+++ b/vcr/trust/trust.go
@@ -21,11 +21,10 @@ package trust
 
 import (
 	"errors"
+	ssi "github.com/nuts-foundation/go-did"
+	"gopkg.in/yaml.v2"
 	"os"
 	"sync"
-
-	"github.com/nuts-foundation/go-did"
-	"gopkg.in/yaml.v2"
 )
 
 // Config holds the trusted issuers per credential type
@@ -82,7 +81,7 @@ func (tc *Config) save() error {
 }
 
 // IsTrusted returns true when the given issuer is in the trusted issuers list of the given credentialType
-func (tc *Config) IsTrusted(credentialType did.URI, issuer did.URI) bool {
+func (tc *Config) IsTrusted(credentialType ssi.URI, issuer ssi.URI) bool {
 	issuerString := issuer.String()
 	for _, i := range tc.issuersPerType[credentialType.String()] {
 		if i == issuerString {
@@ -95,7 +94,7 @@ func (tc *Config) IsTrusted(credentialType did.URI, issuer did.URI) bool {
 
 // AddTrust adds trust in a specific Issuer for a credential type.
 // It returns an error if the Save fails
-func (tc *Config) AddTrust(credentialType did.URI, issuer did.URI) error {
+func (tc *Config) AddTrust(credentialType ssi.URI, issuer ssi.URI) error {
 	tc.mutex.Lock()
 	defer tc.mutex.Unlock()
 
@@ -112,7 +111,7 @@ func (tc *Config) AddTrust(credentialType did.URI, issuer did.URI) error {
 
 // RemoveTrust removes trust in a specific Issuer for a credential type.
 // It returns an error if the Save fails
-func (tc *Config) RemoveTrust(credentialType did.URI, issuer did.URI) error {
+func (tc *Config) RemoveTrust(credentialType ssi.URI, issuer ssi.URI) error {
 	tc.mutex.Lock()
 	defer tc.mutex.Unlock()
 	tString := credentialType.String()

--- a/vcr/trust/trust_test.go
+++ b/vcr/trust/trust_test.go
@@ -20,12 +20,12 @@
 package trust
 
 import (
-	"path"
-	"testing"
-
-	"github.com/nuts-foundation/go-did"
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/test/io"
 	"github.com/stretchr/testify/assert"
+	"path"
+	"testing"
 )
 
 const nutsTestCredential = "NutsOrganizationCredential"
@@ -89,16 +89,16 @@ func TestTrustConfig_IsTrusted(t *testing.T) {
 		return
 	}
 
-	c, _ := did.ParseURI(nutsTestCredential)
+	c, _ := ssi.ParseURI(nutsTestCredential)
 
 	t.Run("true", func(t *testing.T) {
-		d, _ := did.ParseURI("did:nuts:t1DVVAs5fmNba8fdKoTSQNtiGcH49vicrkjZW2KRqpv")
+		d, _ := ssi.ParseURI("did:nuts:t1DVVAs5fmNba8fdKoTSQNtiGcH49vicrkjZW2KRqpv")
 
 		assert.True(t, tc.IsTrusted(*c, *d))
 	})
 
 	t.Run("false", func(t *testing.T) {
-		d, _ := did.ParseURI("did:nuts:1")
+		d, _ := ssi.ParseURI("did:nuts:1")
 
 		assert.False(t, tc.IsTrusted(*c, *d))
 	})
@@ -107,14 +107,14 @@ func TestTrustConfig_IsTrusted(t *testing.T) {
 func TestConfig_AddTrust(t *testing.T) {
 	testDir := io.TestDirectory(t)
 	tc := NewConfig(path.Join(testDir, "test.yaml"))
-	issuer, _ := did.ParseURI("did:nuts:1")
+	issuer, _ := ssi.ParseURI("did:nuts:1")
 
 	t.Run("ok - already present", func(t *testing.T) {
-		err := tc.AddTrust(did.VerifiableCredentialTypeV1URI(), *issuer)
+		err := tc.AddTrust(vc.VerifiableCredentialTypeV1URI(), *issuer)
 
 		assert.NoError(t, err)
 
-		err = tc.AddTrust(did.VerifiableCredentialTypeV1URI(), *issuer)
+		err = tc.AddTrust(vc.VerifiableCredentialTypeV1URI(), *issuer)
 
 		assert.NoError(t, err)
 	})
@@ -123,49 +123,49 @@ func TestConfig_AddTrust(t *testing.T) {
 func TestConfig_RemoveTrust(t *testing.T) {
 	testDir := io.TestDirectory(t)
 	tc := NewConfig(path.Join(testDir, "test.yaml"))
-	issuer, _ := did.ParseURI("did:nuts:1")
+	issuer, _ := ssi.ParseURI("did:nuts:1")
 
 	t.Run("ok - not present", func(t *testing.T) {
-		isTrusted := tc.IsTrusted(did.VerifiableCredentialTypeV1URI(), *issuer)
+		isTrusted := tc.IsTrusted(vc.VerifiableCredentialTypeV1URI(), *issuer)
 
 		assert.False(t, isTrusted)
-		err := tc.RemoveTrust(did.VerifiableCredentialTypeV1URI(), *issuer)
+		err := tc.RemoveTrust(vc.VerifiableCredentialTypeV1URI(), *issuer)
 
 		assert.NoError(t, err)
 		assert.False(t, isTrusted)
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		err := tc.AddTrust(did.VerifiableCredentialTypeV1URI(), *issuer)
+		err := tc.AddTrust(vc.VerifiableCredentialTypeV1URI(), *issuer)
 		if !assert.NoError(t, err) {
 			return
 		}
 
-		assert.True(t, tc.IsTrusted(did.VerifiableCredentialTypeV1URI(), *issuer))
-		err = tc.RemoveTrust(did.VerifiableCredentialTypeV1URI(), *issuer)
+		assert.True(t, tc.IsTrusted(vc.VerifiableCredentialTypeV1URI(), *issuer))
+		err = tc.RemoveTrust(vc.VerifiableCredentialTypeV1URI(), *issuer)
 
 		if !assert.NoError(t, err) {
 			return
 		}
-		assert.False(t, tc.IsTrusted(did.VerifiableCredentialTypeV1URI(), *issuer))
+		assert.False(t, tc.IsTrusted(vc.VerifiableCredentialTypeV1URI(), *issuer))
 	})
 
 	t.Run("ok - with multiple entries", func(t *testing.T) {
 		testDir := io.TestDirectory(t)
 		tc := NewConfig(path.Join(testDir, "test.yaml"))
 
-		issuer2, _ := did.ParseURI("did:nuts:2")
-		issuer3, _ := did.ParseURI("did:nuts:3")
+		issuer2, _ := ssi.ParseURI("did:nuts:2")
+		issuer3, _ := ssi.ParseURI("did:nuts:3")
 
-		tc.AddTrust(did.VerifiableCredentialTypeV1URI(), *issuer)
-		tc.AddTrust(did.VerifiableCredentialTypeV1URI(), *issuer2)
-		tc.AddTrust(did.VerifiableCredentialTypeV1URI(), *issuer3)
+		tc.AddTrust(vc.VerifiableCredentialTypeV1URI(), *issuer)
+		tc.AddTrust(vc.VerifiableCredentialTypeV1URI(), *issuer2)
+		tc.AddTrust(vc.VerifiableCredentialTypeV1URI(), *issuer3)
 
-		err := tc.RemoveTrust(did.VerifiableCredentialTypeV1URI(), *issuer)
+		err := tc.RemoveTrust(vc.VerifiableCredentialTypeV1URI(), *issuer)
 
 		if !assert.NoError(t, err) {
 			return
 		}
-		assert.True(t, tc.IsTrusted(did.VerifiableCredentialTypeV1URI(), *issuer3))
+		assert.True(t, tc.IsTrusted(vc.VerifiableCredentialTypeV1URI(), *issuer3))
 	})
 }

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -25,10 +25,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	ssi "github.com/nuts-foundation/go-did"
 	"time"
 
 	"github.com/lestrrat-go/jwx/jwk"
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/network"
 	"github.com/nuts-foundation/nuts-node/network/dag"
@@ -295,14 +296,16 @@ func checkSubscriberTransactionIntegrity(transaction dag.SubscriberTransaction) 
 }
 
 // checkDIDDocumentIntegrity checks for inconsistencies in the the DID Document:
-// - it checks validationMethods for the following conditions:
-//  - every validationMethod id must have a fragment
-//  - every validationMethod id should have the DID prefix
-//  - every validationMethod id must be unique
-// - it checks services for the following conditions:
-//  - every service id must have a fragment
-//  - every service id should have the DID prefix
-//  - every service id must be unique
+// - validate it according to the W3C DID Core Data Model specification
+// - validate is according to the Nuts DID Method specification:
+//  - it checks validationMethods for the following conditions:
+//   - every validationMethod id must have a fragment
+//   - every validationMethod id should have the DID prefix
+//   - every validationMethod id must be unique
+//  - it checks services for the following conditions:
+//   - every service id must have a fragment
+//   - every service id should have the DID prefix
+//   - every service id must be unique
 func checkDIDDocumentIntegrity(doc did.Document) error {
 	// Verification methods
 	knownKeyIds := make(map[string]bool, 0)
@@ -321,7 +324,7 @@ func checkDIDDocumentIntegrity(doc did.Document) error {
 	return nil
 }
 
-func verifyDocumentEntryID(owner did.DID, entryID did.URI, knownIDs map[string]bool) error {
+func verifyDocumentEntryID(owner did.DID, entryID ssi.URI, knownIDs map[string]bool) error {
 	// Check theID has a fragment
 	if len(entryID.Fragment) == 0 {
 		return fmt.Errorf("ID must have a fragment")

--- a/vdr/ambassador_test.go
+++ b/vdr/ambassador_test.go
@@ -7,12 +7,13 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+	ssi "github.com/nuts-foundation/go-did"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/lestrrat-go/jwx/jwk"
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nuts-foundation/nuts-node/crypto"
@@ -946,7 +947,7 @@ func Test_checkDIDDocumentIntegrity(t *testing.T) {
 		}, errors.New("invalid service: ID must have a fragment")},
 		{"nok - service ID has wrong prefix", func(t *testing.T, a *args) {
 			didDoc, _, _ := newDidDoc(t)
-			uri, _ := did.ParseURI("did:foo:123#foobar")
+			uri, _ := ssi.ParseURI("did:foo:123#foobar")
 			didDoc.Service[0].ID = *uri
 			a.doc = didDoc
 		}, errors.New("invalid service: ID must have document prefix")},
@@ -1005,7 +1006,7 @@ func Test_ambassador_updateKeysInStore(t *testing.T) {
 		proposed := did.Document{}
 		pair, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		timeNow := time.Now()
-		vm, err := did.NewVerificationMethod(did.DID{}, did.JsonWebKey2020, did.DID{}, pair.PublicKey)
+		vm, err := did.NewVerificationMethod(did.DID{}, ssi.JsonWebKey2020, did.DID{}, pair.PublicKey)
 		if !assert.NoError(t, err,
 			"unexpected error while generating a new verificationMethod") {
 			return
@@ -1031,7 +1032,7 @@ func Test_ambassador_updateKeysInStore(t *testing.T) {
 		current := did.Document{}
 		pair, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		timeNow := time.Now()
-		vm, err := did.NewVerificationMethod(did.DID{}, did.JsonWebKey2020, did.DID{}, pair.PublicKey)
+		vm, err := did.NewVerificationMethod(did.DID{}, ssi.JsonWebKey2020, did.DID{}, pair.PublicKey)
 		if !assert.NoError(t, err,
 			"unexpected error while generating a new verificationMethod") {
 			return
@@ -1058,7 +1059,7 @@ func Test_ambassador_updateKeysInStore(t *testing.T) {
 		proposed := did.Document{}
 		pair, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		timeNow := time.Now()
-		vm, err := did.NewVerificationMethod(did.DID{}, did.JsonWebKey2020, did.DID{}, pair.PublicKey)
+		vm, err := did.NewVerificationMethod(did.DID{}, ssi.JsonWebKey2020, did.DID{}, pair.PublicKey)
 		if !assert.NoError(t, err,
 			"unexpected error while generating a new verificationMethod") {
 			return
@@ -1082,7 +1083,7 @@ func Test_ambassador_updateKeysInStore(t *testing.T) {
 		current := did.Document{}
 		pair, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		timeNow := time.Now()
-		vm, err := did.NewVerificationMethod(did.DID{}, did.JsonWebKey2020, did.DID{}, pair.PublicKey)
+		vm, err := did.NewVerificationMethod(did.DID{}, ssi.JsonWebKey2020, did.DID{}, pair.PublicKey)
 		if !assert.NoError(t, err,
 			"unexpected error while generating a new verificationMethod") {
 			return

--- a/vdr/api/v1/api.go
+++ b/vdr/api/v1/api.go
@@ -22,11 +22,10 @@ package v1
 import (
 	"errors"
 	"fmt"
+	"github.com/nuts-foundation/go-did/did"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
-	did2 "github.com/nuts-foundation/go-did"
-
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
@@ -54,8 +53,8 @@ func (a Wrapper) CreateDID(ctx echo.Context) error {
 }
 
 // GetDID returns a DID document and DID document metadata based on a DID.
-func (a Wrapper) GetDID(ctx echo.Context, did string) error {
-	d, err := did2.ParseDID(did)
+func (a Wrapper) GetDID(ctx echo.Context, targetDID string) error {
+	d, err := did.ParseDID(targetDID)
 	if err != nil {
 		return ctx.String(http.StatusBadRequest, fmt.Sprintf("given DID could not be parsed: %s", err.Error()))
 	}
@@ -78,8 +77,8 @@ func (a Wrapper) GetDID(ctx echo.Context, did string) error {
 }
 
 // UpdateDID updates a DID Document given a DID and DID Document body. It returns the updated DID Document.
-func (a Wrapper) UpdateDID(ctx echo.Context, did string) error {
-	d, err := did2.ParseDID(did)
+func (a Wrapper) UpdateDID(ctx echo.Context, targetDID string) error {
+	d, err := did.ParseDID(targetDID)
 	if err != nil {
 		return ctx.String(http.StatusBadRequest, fmt.Sprintf("given DID could not be parsed: %s", err.Error()))
 	}
@@ -103,8 +102,8 @@ func (a Wrapper) UpdateDID(ctx echo.Context, did string) error {
 
 // DeactivateDID deactivates a DID Document given a DID.
 // It returns a 200 and an empty body if the deactivation was successful.
-func (a *Wrapper) DeactivateDID(ctx echo.Context, did string) error {
-	id, err := did2.ParseDID(did)
+func (a *Wrapper) DeactivateDID(ctx echo.Context, targetDID string) error {
+	id, err := did.ParseDID(targetDID)
 	if err != nil {
 		return ctx.String(http.StatusBadRequest, fmt.Sprintf("given DID could not be parsed: %s", err.Error()))
 	}

--- a/vdr/api/v1/client.go
+++ b/vdr/api/v1/client.go
@@ -23,12 +23,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/nuts-foundation/go-did/did"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
-
-	"github.com/nuts-foundation/go-did"
 )
 
 // HTTPClient holds the server address and other basic settings for the http client

--- a/vdr/api/v1/client_test.go
+++ b/vdr/api/v1/client_test.go
@@ -22,16 +22,16 @@ import (
 	"testing"
 	"time"
 
-	did2 "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	http2 "github.com/nuts-foundation/nuts-node/test/http"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestHTTPClient_Create(t *testing.T) {
-	did, _ := did2.ParseDID("did:nuts:1")
-	didDoc := did2.Document{
-		ID: *did,
+	id, _ := did.ParseDID("did:nuts:1")
+	didDoc := did.Document{
+		ID: *id,
 	}
 
 	t.Run("ok", func(t *testing.T) {
@@ -60,9 +60,9 @@ func TestHTTPClient_Create(t *testing.T) {
 
 func TestHttpClient_Get(t *testing.T) {
 	didString := "did:nuts:1"
-	did, _ := did2.ParseDID(didString)
-	didDoc := did2.Document{
-		ID: *did,
+	id, _ := did.ParseDID(didString)
+	didDoc := did.Document{
+		ID: *id,
 	}
 	meta := types.DocumentMetadata{}
 
@@ -108,9 +108,9 @@ func TestHttpClient_Get(t *testing.T) {
 
 func TestHTTPClient_Update(t *testing.T) {
 	didString := "did:nuts:1"
-	did, _ := did2.ParseDID(didString)
-	didDoc := did2.Document{
-		ID: *did,
+	id, _ := did.ParseDID(didString)
+	didDoc := did.Document{
+		ID: *id,
 	}
 	hash := "0000000000000000000000000000000000000000"
 

--- a/vdr/api/v1/types.go
+++ b/vdr/api/v1/types.go
@@ -16,7 +16,7 @@
 package v1
 
 import (
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 )
 

--- a/vdr/cmd/cmd.go
+++ b/vdr/cmd/cmd.go
@@ -23,14 +23,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"os"
-	"strings"
-
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"io/ioutil"
+	"os"
+	"strings"
 
 	"github.com/nuts-foundation/nuts-node/core"
 	api "github.com/nuts-foundation/nuts-node/vdr/api/v1"

--- a/vdr/cmd/cmd_test.go
+++ b/vdr/cmd/cmd_test.go
@@ -21,14 +21,13 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
-
-	"github.com/nuts-foundation/go-did"
-	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/nuts-foundation/nuts-node/core"
 	http2 "github.com/nuts-foundation/nuts-node/test/http"

--- a/vdr/doc-creator.go
+++ b/vdr/doc-creator.go
@@ -7,13 +7,13 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	ssi "github.com/nuts-foundation/go-did"
 
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/shengdoushi/base58"
 
+	"github.com/nuts-foundation/go-did/did"
 	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
-
-	"github.com/nuts-foundation/go-did"
 )
 
 // NutsDIDMethodName is the DID method name used by Nuts
@@ -82,13 +82,13 @@ func (n NutsDocCreator) Create() (*did.Document, error) {
 	didID.Fragment = ""
 
 	// Build the AuthenticationMethod and add it to the document
-	verificationMethod, err := did.NewVerificationMethod(*keyID, did.JsonWebKey2020, did.DID{}, key)
+	verificationMethod, err := did.NewVerificationMethod(*keyID, ssi.JsonWebKey2020, did.DID{}, key)
 	if err != nil {
 		return nil, err
 	}
 
 	doc := &did.Document{
-		Context: []did.URI{did.DIDContextV1URI()},
+		Context: []ssi.URI{did.DIDContextV1URI()},
 		ID:      didID,
 	}
 

--- a/vdr/doc-updater.go
+++ b/vdr/doc-updater.go
@@ -3,10 +3,10 @@ package vdr
 import (
 	"crypto"
 	"errors"
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 
 	"github.com/lestrrat-go/jwx/jwk"
-	"github.com/nuts-foundation/go-did"
-
 	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
 )
 
@@ -49,7 +49,7 @@ func (u NutsDocUpdater) CreateNewAuthenticationMethodForDocument(doc *did.Docume
 	if err != nil {
 		return err
 	}
-	method, err := did.NewVerificationMethod(*keyID, did.JsonWebKey2020, did.DID{}, key)
+	method, err := did.NewVerificationMethod(*keyID, ssi.JsonWebKey2020, did.DID{}, key)
 	if err != nil {
 		return err
 	}

--- a/vdr/doc-updater_test.go
+++ b/vdr/doc-updater_test.go
@@ -4,10 +4,10 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"testing"
-
-	"github.com/nuts-foundation/go-did"
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func Test_newNamingFnForExistingDID(t *testing.T) {
@@ -49,7 +49,7 @@ func TestNutsDocUpdater_RemoveVerificationMethod(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		doc := &did.Document{ID: *id123}
 		publicKey, _ := jwkToPublicKey(t, jwkString)
-		vm, _ := did.NewVerificationMethod(*id123Method, did.JsonWebKey2020, did.DID{}, publicKey)
+		vm, _ := did.NewVerificationMethod(*id123Method, ssi.JsonWebKey2020, did.DID{}, publicKey)
 		doc.AddAuthenticationMethod(vm)
 		assert.Equal(t, vm, doc.Authentication[0].VerificationMethod)
 		assert.Equal(t, vm, doc.VerificationMethod[0])
@@ -83,7 +83,7 @@ func TestNutsDocUpdater_CreateNewAuthenticationMethodForDocument(t *testing.T) {
 		// Prepare a document with an authenticationMethod:
 		document := &did.Document{ID: *id123}
 		keyPair, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		vMethod, err := did.NewVerificationMethod(*id123Method, did.JsonWebKey2020, did.DID{}, keyPair.PublicKey)
+		vMethod, err := did.NewVerificationMethod(*id123Method, ssi.JsonWebKey2020, did.DID{}, keyPair.PublicKey)
 		if !assert.NoError(t, err) {
 			return
 		}

--- a/vdr/integration_test.go
+++ b/vdr/integration_test.go
@@ -1,15 +1,15 @@
 package vdr
 
 import (
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/url"
 	"os"
 	"testing"
 	"time"
-
-	"github.com/nuts-foundation/go-did"
-	log "github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/nuts-foundation/nuts-node/core"
 	crypto "github.com/nuts-foundation/nuts-node/crypto"
@@ -83,7 +83,7 @@ func TestVDRIntegration_Test(t *testing.T) {
 	// Try to update the document with a service
 	serviceID, _ := url.Parse(docA.ID.String() + "#service-1")
 	newService := did.Service{
-		ID:              did.URI{URL: *serviceID},
+		ID:              ssi.URI{URL: *serviceID},
 		Type:            "service",
 		ServiceEndpoint: []interface{}{"http://example.com/service"},
 	}
@@ -149,7 +149,7 @@ func TestVDRIntegration_Test(t *testing.T) {
 	// Update and check DocumentA with a new service:
 	serviceID, _ = url.Parse(docA.ID.String() + "#service-2")
 	newService = did.Service{
-		ID:              did.URI{URL: *serviceID},
+		ID:              ssi.URI{URL: *serviceID},
 		Type:            "service-2",
 		ServiceEndpoint: []interface{}{"http://example.com/service2"},
 	}

--- a/vdr/resolvers.go
+++ b/vdr/resolvers.go
@@ -3,10 +3,10 @@ package vdr
 import (
 	"crypto"
 	"fmt"
-	"time"
-
-	"github.com/nuts-foundation/go-did"
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
+	"time"
 )
 
 func (r *VDR) ResolveSigningKeyID(holder did.DID, validAt *time.Time) (string, error) {
@@ -47,20 +47,20 @@ func (r *VDR) ResolveSigningKey(keyID string, validAt *time.Time) (crypto.Public
 	return result.PublicKey()
 }
 
-func (r *VDR) ResolveAssertionKey(id did.DID) (did.URI, error) {
+func (r *VDR) ResolveAssertionKey(id did.DID) (ssi.URI, error) {
 	doc, _, err := r.Resolve(id, nil)
 	if err != nil {
-		return did.URI{}, err
+		return ssi.URI{}, err
 	}
 
 	keys := doc.AssertionMethod
 	for _, key := range keys {
 		kid := key.ID.String()
 		if r.keyStore.PrivateKeyExists(kid) {
-			u, _ := did.ParseURI(kid)
+			u, _ := ssi.ParseURI(kid)
 			return *u, nil
 		}
 	}
 
-	return did.URI{}, types.ErrKeyNotFound
+	return ssi.URI{}, types.ErrKeyNotFound
 }

--- a/vdr/resolvers_test.go
+++ b/vdr/resolvers_test.go
@@ -20,13 +20,12 @@
 package vdr
 
 import (
-	"testing"
-
-	"github.com/nuts-foundation/go-did"
+	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/test/io"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 var holder = *TestDIDA
@@ -51,7 +50,7 @@ func TestResolveSigningKey(t *testing.T) {
 	})
 
 	t.Run("unable to resolve", func(t *testing.T) {
-		fakeDID, _ := did.ParseURI("did:nuts:fake")
+		fakeDID, _ := ssi.ParseURI("did:nuts:fake")
 
 		_, err := resolver.ResolveSigningKey(fakeDID.String(), nil)
 

--- a/vdr/store/memory.go
+++ b/vdr/store/memory.go
@@ -17,10 +17,9 @@ package store
 
 import (
 	"encoding/json"
-	"sync"
-
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	vdr "github.com/nuts-foundation/nuts-node/vdr/types"
+	"sync"
 
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 )

--- a/vdr/store/memory_test.go
+++ b/vdr/store/memory_test.go
@@ -16,13 +16,12 @@
 package store
 
 import (
-	"testing"
-	"time"
-
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
 )
 
 func TestMemory_Write(t *testing.T) {

--- a/vdr/test.go
+++ b/vdr/test.go
@@ -1,7 +1,7 @@
 package vdr
 
 import (
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/network"
 )

--- a/vdr/types/interface.go
+++ b/vdr/types/interface.go
@@ -20,9 +20,10 @@ package types
 
 import (
 	"crypto"
+	ssi "github.com/nuts-foundation/go-did"
 	"time"
 
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 )
 
@@ -85,7 +86,7 @@ type KeyResolver interface {
 	ResolveSigningKey(keyID string, validAt *time.Time) (crypto.PublicKey, error)
 	// ResolveAssertionKey look for a valid assertion key for the give DID. If multiple keys are valid, the first one is returned.
 	// An ErrKeyNotFound is returned when no key is found.
-	ResolveAssertionKey(id did.DID) (did.URI, error)
+	ResolveAssertionKey(id did.DID) (ssi.URI, error)
 }
 
 // Store is the interface that groups all low level VDR DID storage operations.

--- a/vdr/types/mock.go
+++ b/vdr/types/mock.go
@@ -11,6 +11,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	go_did "github.com/nuts-foundation/go-did"
+	did "github.com/nuts-foundation/go-did/did"
 	hash "github.com/nuts-foundation/nuts-node/crypto/hash"
 )
 
@@ -38,10 +39,10 @@ func (m *MockDocResolver) EXPECT() *MockDocResolverMockRecorder {
 }
 
 // Resolve mocks base method.
-func (m *MockDocResolver) Resolve(id go_did.DID, metadata *ResolveMetadata) (*go_did.Document, *DocumentMetadata, error) {
+func (m *MockDocResolver) Resolve(id did.DID, metadata *ResolveMetadata) (*did.Document, *DocumentMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Resolve", id, metadata)
-	ret0, _ := ret[0].(*go_did.Document)
+	ret0, _ := ret[0].(*did.Document)
 	ret1, _ := ret[1].(*DocumentMetadata)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -77,10 +78,10 @@ func (m *MockDocCreator) EXPECT() *MockDocCreatorMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockDocCreator) Create() (*go_did.Document, error) {
+func (m *MockDocCreator) Create() (*did.Document, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create")
-	ret0, _ := ret[0].(*go_did.Document)
+	ret0, _ := ret[0].(*did.Document)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -115,7 +116,7 @@ func (m *MockDocWriter) EXPECT() *MockDocWriterMockRecorder {
 }
 
 // Write mocks base method.
-func (m *MockDocWriter) Write(document go_did.Document, metadata DocumentMetadata) error {
+func (m *MockDocWriter) Write(document did.Document, metadata DocumentMetadata) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", document, metadata)
 	ret0, _ := ret[0].(error)
@@ -152,7 +153,7 @@ func (m *MockDocUpdater) EXPECT() *MockDocUpdaterMockRecorder {
 }
 
 // Update mocks base method.
-func (m *MockDocUpdater) Update(id go_did.DID, current hash.SHA256Hash, next go_did.Document, metadata *DocumentMetadata) error {
+func (m *MockDocUpdater) Update(id did.DID, current hash.SHA256Hash, next did.Document, metadata *DocumentMetadata) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", id, current, next, metadata)
 	ret0, _ := ret[0].(error)
@@ -189,7 +190,7 @@ func (m *MockDocDeactivator) EXPECT() *MockDocDeactivatorMockRecorder {
 }
 
 // Deactivate mocks base method.
-func (m *MockDocDeactivator) Deactivate(id go_did.DID) error {
+func (m *MockDocDeactivator) Deactivate(id did.DID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Deactivate", id)
 	ret0, _ := ret[0].(error)
@@ -226,7 +227,7 @@ func (m *MockKeyResolver) EXPECT() *MockKeyResolverMockRecorder {
 }
 
 // ResolveAssertionKey mocks base method.
-func (m *MockKeyResolver) ResolveAssertionKey(id go_did.DID) (go_did.URI, error) {
+func (m *MockKeyResolver) ResolveAssertionKey(id did.DID) (go_did.URI, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveAssertionKey", id)
 	ret0, _ := ret[0].(go_did.URI)
@@ -256,7 +257,7 @@ func (mr *MockKeyResolverMockRecorder) ResolveSigningKey(keyID, validAt interfac
 }
 
 // ResolveSigningKeyID mocks base method.
-func (m *MockKeyResolver) ResolveSigningKeyID(holder go_did.DID, validAt *time.Time) (string, error) {
+func (m *MockKeyResolver) ResolveSigningKeyID(holder did.DID, validAt *time.Time) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveSigningKeyID", holder, validAt)
 	ret0, _ := ret[0].(string)
@@ -294,10 +295,10 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 }
 
 // Resolve mocks base method.
-func (m *MockStore) Resolve(id go_did.DID, metadata *ResolveMetadata) (*go_did.Document, *DocumentMetadata, error) {
+func (m *MockStore) Resolve(id did.DID, metadata *ResolveMetadata) (*did.Document, *DocumentMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Resolve", id, metadata)
-	ret0, _ := ret[0].(*go_did.Document)
+	ret0, _ := ret[0].(*did.Document)
 	ret1, _ := ret[1].(*DocumentMetadata)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -310,7 +311,7 @@ func (mr *MockStoreMockRecorder) Resolve(id, metadata interface{}) *gomock.Call 
 }
 
 // Update mocks base method.
-func (m *MockStore) Update(id go_did.DID, current hash.SHA256Hash, next go_did.Document, metadata *DocumentMetadata) error {
+func (m *MockStore) Update(id did.DID, current hash.SHA256Hash, next did.Document, metadata *DocumentMetadata) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", id, current, next, metadata)
 	ret0, _ := ret[0].(error)
@@ -324,7 +325,7 @@ func (mr *MockStoreMockRecorder) Update(id, current, next, metadata interface{})
 }
 
 // Write mocks base method.
-func (m *MockStore) Write(document go_did.Document, metadata DocumentMetadata) error {
+func (m *MockStore) Write(document did.Document, metadata DocumentMetadata) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", document, metadata)
 	ret0, _ := ret[0].(error)
@@ -361,10 +362,10 @@ func (m *MockVDR) EXPECT() *MockVDRMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockVDR) Create() (*go_did.Document, error) {
+func (m *MockVDR) Create() (*did.Document, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create")
-	ret0, _ := ret[0].(*go_did.Document)
+	ret0, _ := ret[0].(*did.Document)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -376,7 +377,7 @@ func (mr *MockVDRMockRecorder) Create() *gomock.Call {
 }
 
 // Deactivate mocks base method.
-func (m *MockVDR) Deactivate(id go_did.DID) error {
+func (m *MockVDR) Deactivate(id did.DID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Deactivate", id)
 	ret0, _ := ret[0].(error)
@@ -390,10 +391,10 @@ func (mr *MockVDRMockRecorder) Deactivate(id interface{}) *gomock.Call {
 }
 
 // Resolve mocks base method.
-func (m *MockVDR) Resolve(id go_did.DID, metadata *ResolveMetadata) (*go_did.Document, *DocumentMetadata, error) {
+func (m *MockVDR) Resolve(id did.DID, metadata *ResolveMetadata) (*did.Document, *DocumentMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Resolve", id, metadata)
-	ret0, _ := ret[0].(*go_did.Document)
+	ret0, _ := ret[0].(*did.Document)
 	ret1, _ := ret[1].(*DocumentMetadata)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -406,7 +407,7 @@ func (mr *MockVDRMockRecorder) Resolve(id, metadata interface{}) *gomock.Call {
 }
 
 // ResolveAssertionKey mocks base method.
-func (m *MockVDR) ResolveAssertionKey(id go_did.DID) (go_did.URI, error) {
+func (m *MockVDR) ResolveAssertionKey(id did.DID) (go_did.URI, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveAssertionKey", id)
 	ret0, _ := ret[0].(go_did.URI)
@@ -436,7 +437,7 @@ func (mr *MockVDRMockRecorder) ResolveSigningKey(keyID, validAt interface{}) *go
 }
 
 // ResolveSigningKeyID mocks base method.
-func (m *MockVDR) ResolveSigningKeyID(holder go_did.DID, validAt *time.Time) (string, error) {
+func (m *MockVDR) ResolveSigningKeyID(holder did.DID, validAt *time.Time) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveSigningKeyID", holder, validAt)
 	ret0, _ := ret[0].(string)
@@ -451,7 +452,7 @@ func (mr *MockVDRMockRecorder) ResolveSigningKeyID(holder, validAt interface{}) 
 }
 
 // Update mocks base method.
-func (m *MockVDR) Update(id go_did.DID, current hash.SHA256Hash, next go_did.Document, metadata *DocumentMetadata) error {
+func (m *MockVDR) Update(id did.DID, current hash.SHA256Hash, next did.Document, metadata *DocumentMetadata) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", id, current, next, metadata)
 	ret0, _ := ret[0].(error)
@@ -488,10 +489,10 @@ func (m *MockResolver) EXPECT() *MockResolverMockRecorder {
 }
 
 // Resolve mocks base method.
-func (m *MockResolver) Resolve(id go_did.DID, metadata *ResolveMetadata) (*go_did.Document, *DocumentMetadata, error) {
+func (m *MockResolver) Resolve(id did.DID, metadata *ResolveMetadata) (*did.Document, *DocumentMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Resolve", id, metadata)
-	ret0, _ := ret[0].(*go_did.Document)
+	ret0, _ := ret[0].(*did.Document)
 	ret1, _ := ret[1].(*DocumentMetadata)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -504,7 +505,7 @@ func (mr *MockResolverMockRecorder) Resolve(id, metadata interface{}) *gomock.Ca
 }
 
 // ResolveAssertionKey mocks base method.
-func (m *MockResolver) ResolveAssertionKey(id go_did.DID) (go_did.URI, error) {
+func (m *MockResolver) ResolveAssertionKey(id did.DID) (go_did.URI, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveAssertionKey", id)
 	ret0, _ := ret[0].(go_did.URI)
@@ -534,7 +535,7 @@ func (mr *MockResolverMockRecorder) ResolveSigningKey(keyID, validAt interface{}
 }
 
 // ResolveSigningKeyID mocks base method.
-func (m *MockResolver) ResolveSigningKeyID(holder go_did.DID, validAt *time.Time) (string, error) {
+func (m *MockResolver) ResolveSigningKeyID(holder did.DID, validAt *time.Time) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveSigningKeyID", holder, validAt)
 	ret0, _ := ret[0].(string)

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -27,15 +27,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	ssi "github.com/nuts-foundation/go-did"
 	"time"
 
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/network"
 	"github.com/nuts-foundation/nuts-node/network/dag"
 	"github.com/nuts-foundation/nuts-node/vdr/store"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
-
-	"github.com/nuts-foundation/go-did"
 	"github.com/sirupsen/logrus"
 
 	"github.com/nuts-foundation/nuts-node/vdr/logging"
@@ -183,7 +183,7 @@ func (r *VDR) Deactivate(id did.DID) error {
 	}
 	// A deactivated DID resolves to an empty DID document.
 	emptyDoc := did.Document{
-		Context: []did.URI{did.DIDContextV1URI()},
+		Context: []ssi.URI{did.DIDContextV1URI()},
 		ID:      id,
 	}
 	return r.Update(id, meta.Hash, emptyDoc, nil)

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+	ssi "github.com/nuts-foundation/go-did"
 	"reflect"
 	"testing"
 
@@ -15,7 +16,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/crypto"
 
 	"github.com/golang/mock/gomock"
-	"github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nuts-foundation/nuts-node/network"
@@ -142,7 +143,7 @@ func TestVDR_Create(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	vm, err := did.NewVerificationMethod(*keyID, did.JsonWebKey2020, did.DID{}, privateKey.PublicKey)
+	vm, err := did.NewVerificationMethod(*keyID, ssi.JsonWebKey2020, did.DID{}, privateKey.PublicKey)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -170,7 +171,7 @@ func TestVDR_Deactivate(t *testing.T) {
 		network: networkMock,
 	}
 
-	expectedDocument := did.Document{ID: *id, Context: []did.URI{did.DIDContextV1URI()}}
+	expectedDocument := did.Document{ID: *id, Context: []ssi.URI{did.DIDContextV1URI()}}
 	expectedPayload, _ := json.Marshal(expectedDocument)
 
 	currentDIDDocument := did.Document{ID: *id, Controller: []did.DID{*id}}


### PR DESCRIPTION
- Everything DID related now resides in `go-did/did`
- Everything VC related now resides in `go-did/vc`
- Everything else (shared stuff) now resides in `go-did` which is the `ssi` package

PR only updates references/imports.