### PR TITLE
VDR: Validate DID Documents using W3C spec validator

### DIFF
--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -307,6 +307,10 @@ func checkSubscriberTransactionIntegrity(transaction dag.SubscriberTransaction) 
 //   - every service id should have the DID prefix
 //   - every service id must be unique
 func checkDIDDocumentIntegrity(doc did.Document) error {
+	if err := (did.W3CSpecValidator{}).Validate(doc); err != nil {
+		return err
+	}
+
 	// Verification methods
 	knownKeyIds := make(map[string]bool, 0)
 	for _, method := range doc.VerificationMethod {


### PR DESCRIPTION
The development network now shows some invalid DID documents since they're considered valid (without context for example). After this change they won't be considered valid any more.

Based on https://github.com/nuts-foundation/nuts-node/pull/176