### PR TITLE
VCR: Trust CLI commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,14 +20,15 @@
 package cmd
 
 import (
+	"io"
+	"os"
+
 	"github.com/nuts-foundation/nuts-node/auth"
 	authExperimentalAPI "github.com/nuts-foundation/nuts-node/auth/api/experimental"
 	authIrmaAPI "github.com/nuts-foundation/nuts-node/auth/api/irma"
 	authV1API "github.com/nuts-foundation/nuts-node/auth/api/v0"
 	authCmd "github.com/nuts-foundation/nuts-node/auth/cmd"
 	"github.com/nuts-foundation/nuts-node/core/status"
-	"io"
-	"os"
 
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/crypto"
@@ -38,6 +39,7 @@ import (
 	networkCmd "github.com/nuts-foundation/nuts-node/network/cmd"
 	"github.com/nuts-foundation/nuts-node/vcr"
 	credApi "github.com/nuts-foundation/nuts-node/vcr/api/v1"
+	vcrCmd "github.com/nuts-foundation/nuts-node/vcr/cmd"
 	"github.com/nuts-foundation/nuts-node/vdr"
 	vdrApi "github.com/nuts-foundation/nuts-node/vdr/api/v1"
 	vdrCmd "github.com/nuts-foundation/nuts-node/vdr/cmd"
@@ -188,6 +190,7 @@ func addSubCommands(system *core.System, root *cobra.Command) {
 		status.Cmd(),
 		cryptoCmd.Cmd(),
 		networkCmd.Cmd(),
+		vcrCmd.Cmd(),
 		vdrCmd.Cmd(),
 	}
 	clientFlags := core.ClientConfigFlags()

--- a/core/http.go
+++ b/core/http.go
@@ -1,0 +1,35 @@
+/*
+ * Nuts node
+ * Copyright (C) 2021 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package core
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+func TestResponseCode(expectedStatusCode int, response *http.Response) error {
+	if response.StatusCode != expectedStatusCode {
+		responseData, _ := ioutil.ReadAll(response.Body)
+		return fmt.Errorf("server returned HTTP %d (expected: %d), response: %s",
+			response.StatusCode, expectedStatusCode, string(responseData))
+	}
+	return nil
+}

--- a/crypto/api/v1/client.go
+++ b/crypto/api/v1/client.go
@@ -22,13 +22,13 @@ package v1
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/lestrrat-go/jwx/jwk"
+	"github.com/nuts-foundation/nuts-node/core"
 )
 
 // HTTPClient holds the server address and other basic settings for the http client
@@ -73,7 +73,7 @@ func (hb HTTPClient) GetPublicKey(kid string, validAt *string) (jwk.Key, error) 
 	if err != nil {
 		return nil, err
 	}
-	if err := testResponseCode(http.StatusOK, response); err != nil {
+	if err := core.TestResponseCode(http.StatusOK, response); err != nil {
 		return nil, err
 	}
 	jwkSet, err := jwk.ParseReader(response.Body)
@@ -82,13 +82,4 @@ func (hb HTTPClient) GetPublicKey(kid string, validAt *string) (jwk.Key, error) 
 	}
 	key, _ := jwkSet.Get(0)
 	return key, nil
-}
-
-func testResponseCode(expectedStatusCode int, response *http.Response) error {
-	if response.StatusCode != expectedStatusCode {
-		responseData, _ := ioutil.ReadAll(response.Body)
-		return fmt.Errorf("server returned HTTP %d (expected: %d), response: %s",
-			response.StatusCode, expectedStatusCode, string(responseData))
-	}
-	return nil
 }

--- a/docs/_static/vcr/v1.yaml
+++ b/docs/_static/vcr/v1.yaml
@@ -215,6 +215,73 @@ paths:
             text/plain:
               schema:
                 type: string
+  /internal/vcr/v1/trusted/{credentialType}:
+    get:
+      summary: "List all trusted issuers for a given credential type"
+      description: "If an unknown credential is requested, an empty list will be returned"
+      operationId: "trusted"
+      tags:
+        - credential
+      parameters:
+        - name: credentialType
+          in: path
+          description: URL encoded Verifiable Credential Type.
+          required: true
+          example:
+            - "NutsOrganizationCredential"
+          schema:
+            type: string
+      responses:
+        "200":
+          description: List of trusted issuers is returned.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DID'
+        "400":
+          description: malformed credential type.
+          content:
+            text/plain:
+              schema:
+                type: string
+  /internal/vcr/v1/untrusted/{credentialType}:
+    get:
+      summary: "List all untrusted issuers for a given credential type"
+      operationId: "untrusted"
+      tags:
+        - credential
+      parameters:
+        - name: credentialType
+          in: path
+          description: URL encoded Verifiable Credential Type.
+          required: true
+          example:
+            - "NutsOrganizationCredential"
+          schema:
+            type: string
+      responses:
+        "200":
+          description: List of untrusted issuers is returned.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DID'
+        "400":
+          description: malformed credential type.
+          content:
+            text/plain:
+              schema:
+                type: string
+        "404":
+          description: unknown credential type.
+          content:
+            text/plain:
+              schema:
+                type: string
 components:
   schemas:
     CredentialSubject:
@@ -234,6 +301,10 @@ components:
           description: a credential type
           example: NutsOrganizationCredential
           type: string
+    DID:
+      type: string
+      description: DID according to Nuts specification
+      example: "did:nuts:B8PUHs2AUHbFF1xLLK4eZjgErEcMXHxs68FteY7NDtCY"
     KeyValuePair:
       type: object
       description: used search params
@@ -271,8 +342,7 @@ components:
         - date
       properties:
         issuer:
-          type: string
-          description: issuer refers to the party that issued the credential
+          $ref: '#/components/schemas/DID'
         subject:
           type: string
           description: subject refers to the credential identifier that is revoked
@@ -330,9 +400,7 @@ components:
           items:
             type: string
         issuer:
-          description: DID according to Nuts specification
-          example: "did:nuts:B8PUHs2AUHbFF1xLLK4eZjgErEcMXHxs68FteY7NDtCY"
-          type: string
+          $ref: '#/components/schemas/DID'
         issuanceDate:
           description: rfc3339 time string when the credential was issued.
           type: string

--- a/docs/_static/vcr/v1.yaml
+++ b/docs/_static/vcr/v1.yaml
@@ -215,11 +215,10 @@ paths:
             text/plain:
               schema:
                 type: string
-  /internal/vcr/v1/trusted/{credentialType}:
+  /internal/vcr/v1/{credentialType}/trusted:
     get:
       summary: "List all trusted issuers for a given credential type"
-      description: "If an unknown credential is requested, an empty list will be returned"
-      operationId: "trusted"
+      operationId: "listTrusted"
       tags:
         - credential
       parameters:
@@ -246,10 +245,16 @@ paths:
             text/plain:
               schema:
                 type: string
-  /internal/vcr/v1/untrusted/{credentialType}:
+        "404":
+          description: unknown credential type.
+          content:
+            text/plain:
+              schema:
+                type: string
+  /internal/vcr/v1/{credentialType}/untrusted:
     get:
       summary: "List all untrusted issuers for a given credential type"
-      operationId: "untrusted"
+      operationId: "listUntrusted"
       tags:
         - credential
       parameters:

--- a/docs/pages/technology/vc-concepts.rst
+++ b/docs/pages/technology/vc-concepts.rst
@@ -25,17 +25,17 @@ An example concept mapping template looks like this:
     {
         "id": "<<id>>",
         "issuer": "<<issuer>>",
-        "type": "ExampleCredential@{1_1},{2_1}",
+        "type": "ExampleCredential",
         "credentialSubject": {
-            "id": "<<subject>>@{2_2}",
+            "id": "<<subject>>@{2}",
             "company": {
-                "name": "<<company.name>>@{1_2}",
+                "name": "<<company.name>>@{1}",
                 "city": "<<company.city>>"
             }
         }
     }
 
-it follows the syntax of a Verifiable Credential. Only the parts of the credential that are mapped or have a fixed value are in the template.
+it follows the syntax of a Verifiable Credential. Only the parts of the credential that are mapped (and type) are in the template.
 The example template above introduces the `company` concept. That name must also be used in the APIs.
 A concept is automatically derived from any *conceptValue* with a `.` in it. Any field that is encapsulated between `<<` and `>>` is called a *conceptValue*.
 This *conceptValue* is also used in the APIs and CLI. It can be used as JSON like:
@@ -72,14 +72,6 @@ The following template only defines the generic fields. The generic fields are r
         }
     }
 
-Fixed values
-============
-
-The example also contains a field that is not encapsulated, the `type` field with `ExampleCredential` as value. For the `type` field this is always the case.
-When searching for a credential, the fixed value will always be added.
-So, if you search for `company.name=X` through the API, the underlying query to the DB will add `type=ExampleCredential` to that query.
-This will happen for all fixed values. This is important to know because it will influence which indexes are required.
-
 Indices
 =======
 
@@ -95,7 +87,6 @@ In the concept templates, we use the `@{1_1},{2_1}` syntax for this. The full re
 Every entry between `{` and `}` represents an index. It contains multiple numbers that it represents a compound index.
 The second number is the place in the compound index. Every combination of numbers must be unique.
 The indices are dependent on the use case. For example: revoking requires an index on `issuer` and `id` (to find all issued and to revoke).
-Searching requires an index on `type` combined with the fields that will be used in the search query (`company.name` in this example).
 
 Restrictions
 ============

--- a/go.mod
+++ b/go.mod
@@ -38,3 +38,5 @@ require (
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v2 v2.3.0
 )
+
+replace github.com/nuts-foundation/go-leia => ../go-leia

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
 	github.com/mdp/qrterminal/v3 v3.0.0
 	github.com/nuts-foundation/go-did v0.0.0-20210322161533-d5dd217f4e2b
-	github.com/nuts-foundation/go-leia v0.3.0
+	github.com/nuts-foundation/go-leia v0.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/privacybydesign/irmago v0.6.2-0.20210226102726-35c6768789c6
 	github.com/prometheus/client_golang v1.7.1
@@ -38,5 +38,3 @@ require (
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v2 v2.3.0
 )
-
-replace github.com/nuts-foundation/go-leia => ../go-leia

--- a/go.sum
+++ b/go.sum
@@ -462,6 +462,8 @@ github.com/nuts-foundation/go-leia v0.2.3 h1:zGoqqtqas8Y4qMQSVnXzcFazcM5we1hX9GW
 github.com/nuts-foundation/go-leia v0.2.3/go.mod h1:VMmOAg9I6kRUGY9eRNgeQqyj5vyx+oAteKWfVXzcTQs=
 github.com/nuts-foundation/go-leia v0.3.0 h1:WLUyR3ANhqU389mIZ7ZarBbtnOpRR/Bgq+2RLoVy64w=
 github.com/nuts-foundation/go-leia v0.3.0/go.mod h1:VMmOAg9I6kRUGY9eRNgeQqyj5vyx+oAteKWfVXzcTQs=
+github.com/nuts-foundation/go-leia v0.4.0 h1:BdjZ3k2Wi3d25TCJBWZlD0Il8ox3uHVWP1ECvSdd0BM=
+github.com/nuts-foundation/go-leia v0.4.0/go.mod h1:VMmOAg9I6kRUGY9eRNgeQqyj5vyx+oAteKWfVXzcTQs=
 github.com/ockam-network/did v0.1.3 h1:qJGdccOV4bLfsS/eFM+Aj+CdCRJKNMxbmJevQclw44k=
 github.com/ockam-network/did v0.1.3/go.mod h1:ZsbTIuVGt8OrQEbqWrSztUISN4joeMabdsinbLubbzw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/network/api/v1/client.go
+++ b/network/api/v1/client.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network/dag"
 )
@@ -49,7 +50,7 @@ func (hb HTTPClient) GetTransactionPayload(transactionRef hash.SHA256Hash) ([]by
 	if res.StatusCode == http.StatusNotFound {
 		return nil, nil
 	}
-	if err := testResponseCode(http.StatusOK, res); err != nil {
+	if err := core.TestResponseCode(http.StatusOK, res); err != nil {
 		return nil, err
 	}
 	return ioutil.ReadAll(res.Body)
@@ -74,7 +75,7 @@ func (hb HTTPClient) ListTransactions() ([]dag.Transaction, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := testResponseCode(http.StatusOK, res); err != nil {
+	if err := core.TestResponseCode(http.StatusOK, res); err != nil {
 		return nil, err
 	}
 	responseData, err := ioutil.ReadAll(res.Body)
@@ -114,7 +115,7 @@ func testAndParseTransactionResponse(response *http.Response) (dag.Transaction, 
 	if response.StatusCode == http.StatusNotFound {
 		return nil, nil
 	}
-	if err := testResponseCode(http.StatusOK, response); err != nil {
+	if err := core.TestResponseCode(http.StatusOK, response); err != nil {
 		return nil, err
 	}
 	responseData, err := ioutil.ReadAll(response.Body)
@@ -122,13 +123,4 @@ func testAndParseTransactionResponse(response *http.Response) (dag.Transaction, 
 		return nil, err
 	}
 	return dag.ParseTransaction(responseData)
-}
-
-func testResponseCode(expectedStatusCode int, response *http.Response) error {
-	if response.StatusCode != expectedStatusCode {
-		responseData, _ := ioutil.ReadAll(response.Body)
-		return fmt.Errorf("network returned HTTP %d (expected: %d), response: %s",
-			response.StatusCode, expectedStatusCode, string(responseData))
-	}
-	return nil
 }

--- a/network/cmd/cmd_test.go
+++ b/network/cmd/cmd_test.go
@@ -39,9 +39,9 @@ func TestFlagSet(t *testing.T) {
 }
 
 func TestCmd_List(t *testing.T) {
-	t1 := dag.CreateSignedTestTransaction(1, time.Now().Add(time.Duration(0) * time.Second), "zfoo/bar")
-	t2 := dag.CreateSignedTestTransaction(1, time.Now().Add(time.Duration(60) * time.Second), "bar/foo")
-	t3 := dag.CreateSignedTestTransaction(1, time.Now().Add(time.Duration(30) * time.Second), "1foo/bar")
+	t1 := dag.CreateSignedTestTransaction(1, time.Now().Add(time.Duration(0)*time.Second), "zfoo/bar")
+	t2 := dag.CreateSignedTestTransaction(1, time.Now().Add(time.Duration(60)*time.Second), "bar/foo")
+	t3 := dag.CreateSignedTestTransaction(1, time.Now().Add(time.Duration(30)*time.Second), "1foo/bar")
 	response := []interface{}{string(t1.Data()), string(t2.Data()), string(t3.Data())}
 	s := httptest.NewServer(http2.Handler{StatusCode: http.StatusOK, ResponseData: response})
 	defer s.Close()
@@ -57,7 +57,7 @@ func TestCmd_List(t *testing.T) {
 
 		err := cmd.Execute()
 		assert.NoError(t, err)
-		lines := strings.Split(outBuf.String(),"\n")
+		lines := strings.Split(outBuf.String(), "\n")
 		assert.Len(t, lines, 5)
 		hashStr1 := strings.Split(lines[1], "  ")[0]
 		hashStr2 := strings.Split(lines[2], "  ")[0]
@@ -77,7 +77,7 @@ func TestCmd_List(t *testing.T) {
 		cmd.SetArgs([]string{"list", "--sort", "type"})
 		err := cmd.Execute()
 		assert.NoError(t, err)
-		lines := strings.Split(outBuf.String(),"\n")
+		lines := strings.Split(outBuf.String(), "\n")
 		assert.Len(t, lines, 5)
 
 		hashStr1 := strings.Split(lines[1], "  ")[0]

--- a/vcr/ambassador.go
+++ b/vcr/ambassador.go
@@ -21,6 +21,7 @@ package vcr
 
 import (
 	"encoding/json"
+
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/network"
 	"github.com/nuts-foundation/nuts-node/network/dag"

--- a/vcr/ambassador_test.go
+++ b/vcr/ambassador_test.go
@@ -21,8 +21,9 @@ package vcr
 
 import (
 	"errors"
-	"github.com/nuts-foundation/go-did/vc"
 	"testing"
+
+	"github.com/nuts-foundation/go-did/vc"
 
 	"github.com/golang/mock/gomock"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"

--- a/vcr/api/v1/api.go
+++ b/vcr/api/v1/api.go
@@ -22,8 +22,9 @@ package v1
 import (
 	"errors"
 	"fmt"
-	ssi "github.com/nuts-foundation/go-did"
 	"net/http"
+
+	ssi "github.com/nuts-foundation/go-did"
 
 	"github.com/labstack/echo/v4"
 	"github.com/nuts-foundation/nuts-node/core"

--- a/vcr/api/v1/api.go
+++ b/vcr/api/v1/api.go
@@ -188,13 +188,19 @@ func (w *Wrapper) UntrustIssuer(ctx echo.Context) error {
 	})
 }
 
-func (w *Wrapper) Trusted(ctx echo.Context, credentialType string) error {
+func (w *Wrapper) ListTrusted(ctx echo.Context, credentialType string) error {
 	uri, err := ssi.ParseURI(credentialType)
 	if err != nil {
 		return ctx.String(http.StatusBadRequest, fmt.Sprintf("malformed credential type: %s", err.Error()))
 	}
 
-	trusted := w.R.Trusted(*uri)
+	trusted, err := w.R.Trusted(*uri)
+	if err != nil {
+		if errors.Is(err, vcr.ErrInvalidCredential) {
+			return ctx.NoContent(http.StatusNotFound)
+		}
+		return err
+	}
 	result := make([]string, len(trusted))
 	for i, t := range trusted {
 		result[i] = t.String()
@@ -203,7 +209,7 @@ func (w *Wrapper) Trusted(ctx echo.Context, credentialType string) error {
 	return ctx.JSON(http.StatusOK, result)
 }
 
-func (w *Wrapper) Untrusted(ctx echo.Context, credentialType string) error {
+func (w *Wrapper) ListUntrusted(ctx echo.Context, credentialType string) error {
 	uri, err := ssi.ParseURI(credentialType)
 	if err != nil {
 		return ctx.String(http.StatusBadRequest, fmt.Sprintf("malformed credential type: %s", err.Error()))

--- a/vcr/api/v1/api_test.go
+++ b/vcr/api/v1/api_test.go
@@ -22,9 +22,10 @@ package v1
 import (
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/go-did/vc"
 	"net/http"
 	"testing"
+
+	"github.com/nuts-foundation/go-did/vc"
 
 	"github.com/golang/mock/gomock"
 	ssi "github.com/nuts-foundation/go-did"

--- a/vcr/api/v1/api_test.go
+++ b/vcr/api/v1/api_test.go
@@ -471,6 +471,101 @@ func TestWrapper_TrustUntrust(t *testing.T) {
 	})
 }
 
+func TestWrapper_Trusted(t *testing.T) {
+	credentialType, _ := ssi.ParseURI("type")
+
+	t.Run("ok", func(t *testing.T) {
+		ctx := newMockContext(t)
+		defer ctx.ctrl.Finish()
+
+		var capturedList []string
+		ctx.vcr.EXPECT().Trusted(*credentialType).Return([]ssi.URI{*credentialType})
+		ctx.echo.EXPECT().JSON(http.StatusOK, gomock.Any()).DoAndReturn(func(f1 interface{}, f2 interface{}) error {
+			capturedList = f2.([]string)
+			return nil
+		})
+
+		err := ctx.client.Trusted(ctx.echo, credentialType.String())
+
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Len(t, capturedList, 1)
+		assert.Equal(t, credentialType.String(), capturedList[0])
+	})
+
+	t.Run("error", func(t *testing.T) {
+		ctx := newMockContext(t)
+		defer ctx.ctrl.Finish()
+
+		ctx.echo.EXPECT().String(http.StatusBadRequest, gomock.Any())
+
+		err := ctx.client.Trusted(ctx.echo, string([]byte{0}))
+
+		assert.NoError(t, err)
+	})
+}
+
+func TestWrapper_Untrusted(t *testing.T) {
+	credentialType, _ := ssi.ParseURI("type")
+
+	t.Run("ok", func(t *testing.T) {
+		ctx := newMockContext(t)
+		defer ctx.ctrl.Finish()
+
+		var capturedList []string
+		ctx.vcr.EXPECT().Untrusted(*credentialType).Return([]ssi.URI{*credentialType}, nil)
+		ctx.echo.EXPECT().JSON(http.StatusOK, gomock.Any()).DoAndReturn(func(f1 interface{}, f2 interface{}) error {
+			capturedList = f2.([]string)
+			return nil
+		})
+
+		err := ctx.client.Untrusted(ctx.echo, credentialType.String())
+
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Len(t, capturedList, 1)
+		assert.Equal(t, credentialType.String(), capturedList[0])
+	})
+
+	t.Run("error - malformed input", func(t *testing.T) {
+		ctx := newMockContext(t)
+		defer ctx.ctrl.Finish()
+
+		ctx.echo.EXPECT().String(http.StatusBadRequest, gomock.Any())
+
+		err := ctx.client.Untrusted(ctx.echo, string([]byte{0}))
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("error - not found", func(t *testing.T) {
+		ctx := newMockContext(t)
+		defer ctx.ctrl.Finish()
+
+		ctx.vcr.EXPECT().Untrusted(*credentialType).Return(nil, vcr.ErrInvalidCredential)
+		ctx.echo.EXPECT().NoContent(http.StatusNotFound)
+
+		err := ctx.client.Untrusted(ctx.echo, credentialType.String())
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("error - other", func(t *testing.T) {
+		ctx := newMockContext(t)
+		defer ctx.ctrl.Finish()
+
+		ctx.vcr.EXPECT().Untrusted(*credentialType).Return(nil, errors.New("b00m!"))
+
+		err := ctx.client.Untrusted(ctx.echo, credentialType.String())
+
+		assert.Error(t, err)
+	})
+}
+
 type mockContext struct {
 	ctrl     *gomock.Controller
 	echo     *mock.MockContext

--- a/vcr/api/v1/client.go
+++ b/vcr/api/v1/client.go
@@ -90,13 +90,7 @@ func (hb HTTPClient) Trusted(credentialType string) ([]string, error) {
 	ctx, cancel := hb.withTimeout()
 	defer cancel()
 
-	if response, err := hb.client().Trusted(ctx, credentialType); err != nil {
-		return nil, err
-	} else if err := testResponseCode(http.StatusOK, response); err != nil {
-		return nil, err
-	} else {
-		return readIssuers(response.Body)
-	}
+	return handleTrustedResponse(hb.client().Trusted(ctx, credentialType))
 }
 
 // Untrusted lists the untrusted issuers for the given credential type
@@ -104,7 +98,11 @@ func (hb HTTPClient) Untrusted(credentialType string) ([]string, error) {
 	ctx, cancel := hb.withTimeout()
 	defer cancel()
 
-	if response, err := hb.client().Trusted(ctx, credentialType); err != nil {
+	return handleTrustedResponse(hb.client().Untrusted(ctx, credentialType))
+}
+
+func handleTrustedResponse(response *http.Response, err error) ([]string, error) {
+	if err != nil {
 		return nil, err
 	} else if err := testResponseCode(http.StatusOK, response); err != nil {
 		return nil, err

--- a/vcr/api/v1/client_test.go
+++ b/vcr/api/v1/client_test.go
@@ -1,0 +1,135 @@
+/*
+ * Nuts node
+ * Copyright (C) 2021 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package v1
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	http2 "github.com/nuts-foundation/nuts-node/test/http"
+	"github.com/stretchr/testify/assert"
+)
+
+var didString = "did:nuts:1"
+var credentialType = "type"
+
+func TestHttpClient_Trust(t *testing.T) {
+
+	s := httptest.NewServer(http2.Handler{StatusCode: http.StatusNoContent})
+	c := &HTTPClient{ServerAddress: s.URL, Timeout: time.Second}
+	funcs := []func(string, string) error{
+		c.Trust,
+		c.Untrust,
+	}
+
+	for _, fn := range funcs {
+		t.Run("ok", func(t *testing.T) {
+			err := fn(credentialType, didString)
+
+			assert.NoError(t, err)
+		})
+
+		t.Run("error - other status code", func(t *testing.T) {
+			s.Config.Handler = http2.Handler{StatusCode: http.StatusInternalServerError}
+			defer func() {
+				s.Config.Handler = http2.Handler{StatusCode: http.StatusNoContent}
+			}()
+			err := fn(credentialType, didString)
+
+			assert.Error(t, err)
+		})
+	}
+
+	t.Run("trust - error - connection problem", func(t *testing.T) {
+		c := &HTTPClient{ServerAddress: "unknown", Timeout: time.Second}
+
+		err := c.Trust(credentialType, didString)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("untrust - error - connection problem", func(t *testing.T) {
+		c := &HTTPClient{ServerAddress: "unknown", Timeout: time.Second}
+
+		err := c.Untrust(credentialType, didString)
+
+		assert.Error(t, err)
+	})
+}
+
+func TestHttpClient_Trusted(t *testing.T) {
+
+	t.Run("ok", func(t *testing.T) {
+		result := []string{didString}
+		s := httptest.NewServer(http2.Handler{StatusCode: http.StatusOK, ResponseData: result})
+		c := HTTPClient{ServerAddress: s.URL, Timeout: time.Second}
+
+		dids, err := c.Trusted(credentialType)
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotNil(t, dids)
+	})
+
+	t.Run("error - not found", func(t *testing.T) {
+		s := httptest.NewServer(http2.Handler{StatusCode: http.StatusNotFound})
+		c := HTTPClient{ServerAddress: s.URL, Timeout: time.Second}
+
+		_, err := c.Trusted(credentialType)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("error - connection problem", func(t *testing.T) {
+		c := HTTPClient{ServerAddress: "unknown", Timeout: time.Second}
+
+		_, err := c.Trusted(credentialType)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("error - wrong content", func(t *testing.T) {
+		s := httptest.NewServer(http2.Handler{StatusCode: http.StatusOK, ResponseData: "}"})
+		c := HTTPClient{ServerAddress: s.URL, Timeout: time.Second}
+
+		_, err := c.Trusted(credentialType)
+
+		assert.Error(t, err)
+	})
+}
+
+func TestHttpClient_Untrusted(t *testing.T) {
+
+	t.Run("ok", func(t *testing.T) {
+		result := []string{didString}
+		s := httptest.NewServer(http2.Handler{StatusCode: http.StatusOK, ResponseData: result})
+		c := HTTPClient{ServerAddress: s.URL, Timeout: time.Second}
+
+		dids, err := c.Untrusted(credentialType)
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotNil(t, dids)
+	})
+}

--- a/vcr/api/v1/generated.go
+++ b/vcr/api/v1/generated.go
@@ -169,12 +169,6 @@ type ClientInterface interface {
 
 	TrustIssuer(ctx context.Context, body TrustIssuerJSONRequestBody) (*http.Response, error)
 
-	// Trusted request
-	Trusted(ctx context.Context, credentialType string) (*http.Response, error)
-
-	// Untrusted request
-	Untrusted(ctx context.Context, credentialType string) (*http.Response, error)
-
 	// Create request  with any body
 	CreateWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error)
 
@@ -190,6 +184,12 @@ type ClientInterface interface {
 	SearchWithBody(ctx context.Context, concept string, contentType string, body io.Reader) (*http.Response, error)
 
 	Search(ctx context.Context, concept string, body SearchJSONRequestBody) (*http.Response, error)
+
+	// ListTrusted request
+	ListTrusted(ctx context.Context, credentialType string) (*http.Response, error)
+
+	// ListUntrusted request
+	ListUntrusted(ctx context.Context, credentialType string) (*http.Response, error)
 }
 
 func (c *Client) UntrustIssuerWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error) {
@@ -239,36 +239,6 @@ func (c *Client) TrustIssuerWithBody(ctx context.Context, contentType string, bo
 
 func (c *Client) TrustIssuer(ctx context.Context, body TrustIssuerJSONRequestBody) (*http.Response, error) {
 	req, err := NewTrustIssuerRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if c.RequestEditor != nil {
-		err = c.RequestEditor(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) Trusted(ctx context.Context, credentialType string) (*http.Response, error) {
-	req, err := NewTrustedRequest(c.Server, credentialType)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if c.RequestEditor != nil {
-		err = c.RequestEditor(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) Untrusted(ctx context.Context, credentialType string) (*http.Response, error) {
-	req, err := NewUntrustedRequest(c.Server, credentialType)
 	if err != nil {
 		return nil, err
 	}
@@ -372,6 +342,36 @@ func (c *Client) Search(ctx context.Context, concept string, body SearchJSONRequ
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListTrusted(ctx context.Context, credentialType string) (*http.Response, error) {
+	req, err := NewListTrustedRequest(c.Server, credentialType)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListUntrusted(ctx context.Context, credentialType string) (*http.Response, error) {
+	req, err := NewListUntrustedRequest(c.Server, credentialType)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
 // NewUntrustIssuerRequest calls the generic UntrustIssuer builder with application/json body
 func NewUntrustIssuerRequest(server string, body UntrustIssuerJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -447,74 +447,6 @@ func NewTrustIssuerRequestWithBody(server string, contentType string, body io.Re
 	}
 
 	req.Header.Add("Content-Type", contentType)
-	return req, nil
-}
-
-// NewTrustedRequest generates requests for Trusted
-func NewTrustedRequest(server string, credentialType string) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParam("simple", false, "credentialType", credentialType)
-	if err != nil {
-		return nil, err
-	}
-
-	queryUrl, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/internal/vcr/v1/trusted/%s", pathParam0)
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryUrl, err = queryUrl.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryUrl.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewUntrustedRequest generates requests for Untrusted
-func NewUntrustedRequest(server string, credentialType string) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParam("simple", false, "credentialType", credentialType)
-	if err != nil {
-		return nil, err
-	}
-
-	queryUrl, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/internal/vcr/v1/untrusted/%s", pathParam0)
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryUrl, err = queryUrl.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryUrl.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
 	return req, nil
 }
 
@@ -671,6 +603,74 @@ func NewSearchRequestWithBody(server string, concept string, contentType string,
 	return req, nil
 }
 
+// NewListTrustedRequest generates requests for ListTrusted
+func NewListTrustedRequest(server string, credentialType string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "credentialType", credentialType)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/internal/vcr/v1/%s/trusted", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListUntrustedRequest generates requests for ListUntrusted
+func NewListUntrustedRequest(server string, credentialType string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "credentialType", credentialType)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/internal/vcr/v1/%s/untrusted", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // ClientWithResponses builds on ClientInterface to offer response payloads
 type ClientWithResponses struct {
 	ClientInterface
@@ -710,12 +710,6 @@ type ClientWithResponsesInterface interface {
 
 	TrustIssuerWithResponse(ctx context.Context, body TrustIssuerJSONRequestBody) (*TrustIssuerResponse, error)
 
-	// Trusted request
-	TrustedWithResponse(ctx context.Context, credentialType string) (*TrustedResponse, error)
-
-	// Untrusted request
-	UntrustedWithResponse(ctx context.Context, credentialType string) (*UntrustedResponse, error)
-
 	// Create request  with any body
 	CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*CreateResponse, error)
 
@@ -731,6 +725,12 @@ type ClientWithResponsesInterface interface {
 	SearchWithBodyWithResponse(ctx context.Context, concept string, contentType string, body io.Reader) (*SearchResponse, error)
 
 	SearchWithResponse(ctx context.Context, concept string, body SearchJSONRequestBody) (*SearchResponse, error)
+
+	// ListTrusted request
+	ListTrustedWithResponse(ctx context.Context, credentialType string) (*ListTrustedResponse, error)
+
+	// ListUntrusted request
+	ListUntrustedWithResponse(ctx context.Context, credentialType string) (*ListUntrustedResponse, error)
 }
 
 type UntrustIssuerResponse struct {
@@ -769,50 +769,6 @@ func (r TrustIssuerResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r TrustIssuerResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type TrustedResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *[]DID
-}
-
-// Status returns HTTPResponse.Status
-func (r TrustedResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r TrustedResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type UntrustedResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *[]DID
-}
-
-// Status returns HTTPResponse.Status
-func (r UntrustedResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r UntrustedResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -904,6 +860,50 @@ func (r SearchResponse) StatusCode() int {
 	return 0
 }
 
+type ListTrustedResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]DID
+}
+
+// Status returns HTTPResponse.Status
+func (r ListTrustedResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListTrustedResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListUntrustedResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]DID
+}
+
+// Status returns HTTPResponse.Status
+func (r ListUntrustedResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListUntrustedResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 // UntrustIssuerWithBodyWithResponse request with arbitrary body returning *UntrustIssuerResponse
 func (c *ClientWithResponses) UntrustIssuerWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*UntrustIssuerResponse, error) {
 	rsp, err := c.UntrustIssuerWithBody(ctx, contentType, body)
@@ -936,24 +936,6 @@ func (c *ClientWithResponses) TrustIssuerWithResponse(ctx context.Context, body 
 		return nil, err
 	}
 	return ParseTrustIssuerResponse(rsp)
-}
-
-// TrustedWithResponse request returning *TrustedResponse
-func (c *ClientWithResponses) TrustedWithResponse(ctx context.Context, credentialType string) (*TrustedResponse, error) {
-	rsp, err := c.Trusted(ctx, credentialType)
-	if err != nil {
-		return nil, err
-	}
-	return ParseTrustedResponse(rsp)
-}
-
-// UntrustedWithResponse request returning *UntrustedResponse
-func (c *ClientWithResponses) UntrustedWithResponse(ctx context.Context, credentialType string) (*UntrustedResponse, error) {
-	rsp, err := c.Untrusted(ctx, credentialType)
-	if err != nil {
-		return nil, err
-	}
-	return ParseUntrustedResponse(rsp)
 }
 
 // CreateWithBodyWithResponse request with arbitrary body returning *CreateResponse
@@ -1008,6 +990,24 @@ func (c *ClientWithResponses) SearchWithResponse(ctx context.Context, concept st
 	return ParseSearchResponse(rsp)
 }
 
+// ListTrustedWithResponse request returning *ListTrustedResponse
+func (c *ClientWithResponses) ListTrustedWithResponse(ctx context.Context, credentialType string) (*ListTrustedResponse, error) {
+	rsp, err := c.ListTrusted(ctx, credentialType)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListTrustedResponse(rsp)
+}
+
+// ListUntrustedWithResponse request returning *ListUntrustedResponse
+func (c *ClientWithResponses) ListUntrustedWithResponse(ctx context.Context, credentialType string) (*ListUntrustedResponse, error) {
+	rsp, err := c.ListUntrusted(ctx, credentialType)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListUntrustedResponse(rsp)
+}
+
 // ParseUntrustIssuerResponse parses an HTTP response from a UntrustIssuerWithResponse call
 func ParseUntrustIssuerResponse(rsp *http.Response) (*UntrustIssuerResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -1041,58 +1041,6 @@ func ParseTrustIssuerResponse(rsp *http.Response) (*TrustIssuerResponse, error) 
 	}
 
 	switch {
-	}
-
-	return response, nil
-}
-
-// ParseTrustedResponse parses an HTTP response from a TrustedWithResponse call
-func ParseTrustedResponse(rsp *http.Response) (*TrustedResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &TrustedResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []DID
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseUntrustedResponse parses an HTTP response from a UntrustedWithResponse call
-func ParseUntrustedResponse(rsp *http.Response) (*UntrustedResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &UntrustedResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []DID
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
 	}
 
 	return response, nil
@@ -1181,6 +1129,58 @@ func ParseSearchResponse(rsp *http.Response) (*SearchResponse, error) {
 	return response, nil
 }
 
+// ParseListTrustedResponse parses an HTTP response from a ListTrustedWithResponse call
+func ParseListTrustedResponse(rsp *http.Response) (*ListTrustedResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListTrustedResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []DID
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListUntrustedResponse parses an HTTP response from a ListUntrustedWithResponse call
+func ParseListUntrustedResponse(rsp *http.Response) (*ListUntrustedResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListUntrustedResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []DID
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
 	// Remove trust in an issuer/credentialType combination
@@ -1189,12 +1189,6 @@ type ServerInterface interface {
 	// Mark all the VCs of given type and issuer as 'trusted'.
 	// (POST /internal/vcr/v1/trust)
 	TrustIssuer(ctx echo.Context) error
-	// List all trusted issuers for a given credential type
-	// (GET /internal/vcr/v1/trusted/{credentialType})
-	Trusted(ctx echo.Context, credentialType string) error
-	// List all untrusted issuers for a given credential type
-	// (GET /internal/vcr/v1/untrusted/{credentialType})
-	Untrusted(ctx echo.Context, credentialType string) error
 	// Creates a new Verifiable Credential
 	// (POST /internal/vcr/v1/vc)
 	Create(ctx echo.Context) error
@@ -1207,6 +1201,12 @@ type ServerInterface interface {
 	// Search for a concept. A concept is backed by 1 or more VCs
 	// (POST /internal/vcr/v1/{concept})
 	Search(ctx echo.Context, concept string) error
+	// List all trusted issuers for a given credential type
+	// (GET /internal/vcr/v1/{credentialType}/trusted)
+	ListTrusted(ctx echo.Context, credentialType string) error
+	// List all untrusted issuers for a given credential type
+	// (GET /internal/vcr/v1/{credentialType}/untrusted)
+	ListUntrusted(ctx echo.Context, credentialType string) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -1229,38 +1229,6 @@ func (w *ServerInterfaceWrapper) TrustIssuer(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.TrustIssuer(ctx)
-	return err
-}
-
-// Trusted converts echo context to params.
-func (w *ServerInterfaceWrapper) Trusted(ctx echo.Context) error {
-	var err error
-	// ------------- Path parameter "credentialType" -------------
-	var credentialType string
-
-	err = runtime.BindStyledParameter("simple", false, "credentialType", ctx.Param("credentialType"), &credentialType)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter credentialType: %s", err))
-	}
-
-	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.Trusted(ctx, credentialType)
-	return err
-}
-
-// Untrusted converts echo context to params.
-func (w *ServerInterfaceWrapper) Untrusted(ctx echo.Context) error {
-	var err error
-	// ------------- Path parameter "credentialType" -------------
-	var credentialType string
-
-	err = runtime.BindStyledParameter("simple", false, "credentialType", ctx.Param("credentialType"), &credentialType)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter credentialType: %s", err))
-	}
-
-	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.Untrusted(ctx, credentialType)
 	return err
 }
 
@@ -1321,6 +1289,38 @@ func (w *ServerInterfaceWrapper) Search(ctx echo.Context) error {
 	return err
 }
 
+// ListTrusted converts echo context to params.
+func (w *ServerInterfaceWrapper) ListTrusted(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "credentialType" -------------
+	var credentialType string
+
+	err = runtime.BindStyledParameter("simple", false, "credentialType", ctx.Param("credentialType"), &credentialType)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter credentialType: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.ListTrusted(ctx, credentialType)
+	return err
+}
+
+// ListUntrusted converts echo context to params.
+func (w *ServerInterfaceWrapper) ListUntrusted(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "credentialType" -------------
+	var credentialType string
+
+	err = runtime.BindStyledParameter("simple", false, "credentialType", ctx.Param("credentialType"), &credentialType)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter credentialType: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.ListUntrusted(ctx, credentialType)
+	return err
+}
+
 // PATCH: This template file was taken from pkg/codegen/templates/register.tmpl
 
 // This is a simple interface which specifies echo.Route addition functions which
@@ -1345,11 +1345,11 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 
 	router.Add(http.MethodDelete, baseURL+"/internal/vcr/v1/trust", wrapper.UntrustIssuer)
 	router.Add(http.MethodPost, baseURL+"/internal/vcr/v1/trust", wrapper.TrustIssuer)
-	router.Add(http.MethodGet, baseURL+"/internal/vcr/v1/trusted/:credentialType", wrapper.Trusted)
-	router.Add(http.MethodGet, baseURL+"/internal/vcr/v1/untrusted/:credentialType", wrapper.Untrusted)
 	router.Add(http.MethodPost, baseURL+"/internal/vcr/v1/vc", wrapper.Create)
 	router.Add(http.MethodDelete, baseURL+"/internal/vcr/v1/vc/:id", wrapper.Revoke)
 	router.Add(http.MethodGet, baseURL+"/internal/vcr/v1/vc/:id", wrapper.Resolve)
 	router.Add(http.MethodPost, baseURL+"/internal/vcr/v1/:concept", wrapper.Search)
+	router.Add(http.MethodGet, baseURL+"/internal/vcr/v1/:credentialType/trusted", wrapper.ListTrusted)
+	router.Add(http.MethodGet, baseURL+"/internal/vcr/v1/:credentialType/untrusted", wrapper.ListUntrusted)
 
 }

--- a/vcr/assets/NutsOrganizationCredential.json.template
+++ b/vcr/assets/NutsOrganizationCredential.json.template
@@ -5,8 +5,8 @@
   "credentialSubject": {
     "id": "<<subject>>@{3}",
     "organization": {
-      "name": "<<organization.name>>@{2}",
-      "city": "<<organization.city>>"
+      "name": "<<organization.name>>@{2_1}",
+      "city": "<<organization.city>>@{2_2}"
     }
   }
 }

--- a/vcr/assets/NutsOrganizationCredential.json.template
+++ b/vcr/assets/NutsOrganizationCredential.json.template
@@ -1,11 +1,11 @@
 {
   "id": "<<id>>@{1}",
-  "issuer": "<<issuer>>",
-  "type": "NutsOrganizationCredential@{2_1},{3_1}",
+  "issuer": "<<issuer>>@{4}",
+  "type": "NutsOrganizationCredential",
   "credentialSubject": {
-    "id": "<<subject>>@{3_2}",
+    "id": "<<subject>>@{3}",
     "organization": {
-      "name": "<<organization.name>>@{2_2}",
+      "name": "<<organization.name>>@{2}",
       "city": "<<organization.city>>"
     }
   }

--- a/vcr/cmd/cmd.go
+++ b/vcr/cmd/cmd.go
@@ -101,12 +101,7 @@ func listTrustedCmd() *cobra.Command {
 				return fmt.Errorf("unable to get list of trusted issuers: %v", err)
 			}
 
-			builder := strings.Builder{}
-			builder.WriteString("Trusted issuers:")
-			builder.WriteString("\n\n")
-			builder.WriteString(strings.Join(issuers, "\n"))
-
-			cmd.Println(builder.String())
+			cmd.Println(strings.Join(issuers, "\n"))
 			return nil
 		},
 	}
@@ -125,12 +120,7 @@ func listUntrustedCmd() *cobra.Command {
 				return fmt.Errorf("unable to get list of untrusted issuers: %v", err)
 			}
 
-			builder := strings.Builder{}
-			builder.WriteString("Untrusted issuers:")
-			builder.WriteString("\n\n")
-			builder.WriteString(strings.Join(issuers, "\n"))
-
-			cmd.Println(builder.String())
+			cmd.Println(strings.Join(issuers, "\n"))
 			return nil
 		},
 	}

--- a/vcr/cmd/cmd.go
+++ b/vcr/cmd/cmd.go
@@ -1,0 +1,149 @@
+/*
+ * Nuts node
+ * Copyright (C) 2021. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/nuts-foundation/nuts-node/core"
+	api "github.com/nuts-foundation/nuts-node/vcr/api/v1"
+)
+
+// Cmd contains sub-commands for the remote client
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vcr",
+		Short: "Verifiable Credential Registry commands",
+	}
+
+	cmd.AddCommand(trustCmd())
+
+	cmd.AddCommand(untrustCmd())
+
+	cmd.AddCommand(listTrustedCmd())
+
+	cmd.AddCommand(listUntrustedCmd())
+
+	return cmd
+}
+
+func trustCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "trust [type] [DID]",
+		Short: "Trust a DID for given credential type",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cType := args[0]
+			issuer := args[1]
+
+			err := httpClient(cmd.Flags()).Trust(cType, issuer)
+
+			if err != nil {
+				return fmt.Errorf("unable to trust issuer: %v", err)
+			}
+			cmd.Println(fmt.Sprintf("%s is now trusted as issuer of %s", issuer, cType))
+			return nil
+		},
+	}
+}
+
+func untrustCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "untrust [type] [DID]",
+		Short: "Untrust a DID for given credential type",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cType := args[0]
+			issuer := args[1]
+
+			err := httpClient(cmd.Flags()).Untrust(cType, issuer)
+
+			if err != nil {
+				return fmt.Errorf("unable to untrust issuer: %v", err)
+			}
+			cmd.Println(fmt.Sprintf("%s is no longer trusted as issuer of %s", issuer, cType))
+			return nil
+		},
+	}
+}
+
+func listTrustedCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "trusted [type]",
+		Short: "List trusted issuers for given credential type",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cType := args[0]
+
+			issuers, err := httpClient(cmd.Flags()).Trusted(cType)
+			if err != nil {
+				return fmt.Errorf("unable to get list of trusted issuers: %v", err)
+			}
+
+			builder := strings.Builder{}
+			builder.WriteString("Trusted issuers:")
+			builder.WriteString("\n\n")
+			builder.WriteString(strings.Join(issuers, "\n"))
+
+			cmd.Println(builder.String())
+			return nil
+		},
+	}
+}
+
+func listUntrustedCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "untrusted [type]",
+		Short: "List untrusted issuers for given credential type",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cType := args[0]
+
+			issuers, err := httpClient(cmd.Flags()).Untrusted(cType)
+			if err != nil {
+				return fmt.Errorf("unable to get list of untrusted issuers: %v", err)
+			}
+
+			builder := strings.Builder{}
+			builder.WriteString("Untrusted issuers:")
+			builder.WriteString("\n\n")
+			builder.WriteString(strings.Join(issuers, "\n"))
+
+			cmd.Println(builder.String())
+			return nil
+		},
+	}
+}
+
+// httpClient creates a remote client
+func httpClient(set *pflag.FlagSet) api.HTTPClient {
+	config := core.NewClientConfig()
+	if err := config.Load(set); err != nil {
+		logrus.Fatal(err)
+	}
+	return api.HTTPClient{
+		ServerAddress: config.GetAddress(),
+		Timeout:       config.Timeout,
+	}
+}

--- a/vcr/cmd/cmd.go
+++ b/vcr/cmd/cmd.go
@@ -90,7 +90,7 @@ func untrustCmd() *cobra.Command {
 
 func listTrustedCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "trusted [type]",
+		Use:   "list-trusted [type]",
 		Short: "List trusted issuers for given credential type",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -109,7 +109,7 @@ func listTrustedCmd() *cobra.Command {
 
 func listUntrustedCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "untrusted [type]",
+		Use:   "list-untrusted [type]",
 		Short: "List untrusted issuers for given credential type",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/vcr/cmd/cmd.go
+++ b/vcr/cmd/cmd.go
@@ -50,8 +50,8 @@ func Cmd() *cobra.Command {
 
 func trustCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "trust [type] [DID]",
-		Short: "Trust a DID for given credential type",
+		Use:   "trust [type] [issuer DID]",
+		Short: "Trust VCs of a certain credential type when published by the given issuer.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cType := args[0]
@@ -70,8 +70,8 @@ func trustCmd() *cobra.Command {
 
 func untrustCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "untrust [type] [DID]",
-		Short: "Untrust a DID for given credential type",
+		Use:   "untrust [type] [issuer DID]",
+		Short: "Untrust VCs of a certain credential type when published by the given issuer.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cType := args[0]

--- a/vcr/cmd/cmd_test.go
+++ b/vcr/cmd/cmd_test.go
@@ -79,7 +79,7 @@ func TestCmd(t *testing.T) {
 					return
 				}
 
-				assert.Contains(t, err.Error(), "VCR returned HTTP 500")
+				assert.Contains(t, err.Error(), "server returned HTTP 500")
 			})
 
 			t.Run("error - not enough args", func(t *testing.T) {
@@ -127,7 +127,7 @@ func TestCmd(t *testing.T) {
 					return
 				}
 
-				assert.Contains(t, err.Error(), "VCR returned HTTP 500")
+				assert.Contains(t, err.Error(), "server returned HTTP 500")
 			})
 
 			t.Run("error - not enough args", func(t *testing.T) {

--- a/vcr/cmd/cmd_test.go
+++ b/vcr/cmd/cmd_test.go
@@ -1,0 +1,155 @@
+/*
+ * Nuts node
+ * Copyright (C) 2021 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/nuts-foundation/nuts-node/core"
+	http2 "github.com/nuts-foundation/nuts-node/test/http"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCmd(t *testing.T) {
+	didString := "did:nuts:1"
+	credentialType := "type"
+
+	buf := new(bytes.Buffer)
+
+	newCmd := func(t *testing.T) *cobra.Command {
+		t.Helper()
+		buf.Reset()
+		command := Cmd()
+		command.SetOut(buf)
+		return command
+	}
+
+	cmds := []string{
+		"list-trusted",
+		"list-untrusted",
+	}
+
+	for _, c := range cmds {
+		t.Run(c, func(t *testing.T) {
+			t.Run("ok", func(t *testing.T) {
+				cmd := newCmd(t)
+				s := setupServer(cmd, http.StatusOK, []string{didString})
+				defer reset(s)
+
+				cmd.SetArgs([]string{c, credentialType})
+				err := cmd.Execute()
+
+				if !assert.NoError(t, err) {
+					return
+				}
+				assert.Contains(t, buf.String(), didString)
+			})
+
+			t.Run("error - server error", func(t *testing.T) {
+				cmd := newCmd(t)
+				s := setupServer(cmd, http.StatusInternalServerError, nil)
+				defer reset(s)
+
+				cmd.SetArgs([]string{c, credentialType})
+				err := cmd.Execute()
+
+				if !assert.Error(t, err) {
+					return
+				}
+
+				assert.Contains(t, err.Error(), "VCR returned HTTP 500")
+			})
+
+			t.Run("error - not enough args", func(t *testing.T) {
+				cmd := newCmd(t)
+
+				cmd.SetArgs([]string{c})
+				err := cmd.Execute()
+
+				assert.Error(t, err)
+			})
+		})
+	}
+
+	cmds2 := []string{
+		"trust",
+		"untrust",
+	}
+
+	for _, c := range cmds2 {
+		t.Run(c, func(t *testing.T) {
+			t.Run("ok", func(t *testing.T) {
+				cmd := newCmd(t)
+				s := setupServer(cmd, http.StatusNoContent, nil)
+				defer reset(s)
+
+				cmd.SetArgs([]string{c, credentialType, didString})
+				err := cmd.Execute()
+
+				if !assert.NoError(t, err) {
+					return
+				}
+				assert.Contains(t, buf.String(), didString)
+				assert.Contains(t, buf.String(), credentialType)
+			})
+
+			t.Run("error - server error", func(t *testing.T) {
+				cmd := newCmd(t)
+				s := setupServer(cmd, http.StatusInternalServerError, nil)
+				defer reset(s)
+
+				cmd.SetArgs([]string{c, credentialType, didString})
+				err := cmd.Execute()
+
+				if !assert.Error(t, err) {
+					return
+				}
+
+				assert.Contains(t, err.Error(), "VCR returned HTTP 500")
+			})
+
+			t.Run("error - not enough args", func(t *testing.T) {
+				cmd := newCmd(t)
+
+				cmd.SetArgs([]string{c})
+				err := cmd.Execute()
+
+				assert.Error(t, err)
+			})
+		})
+	}
+}
+
+func setupServer(cmd *cobra.Command, statusCode int, responseData interface{}) *httptest.Server {
+	s := httptest.NewServer(http2.Handler{StatusCode: statusCode, ResponseData: responseData})
+	os.Setenv("NUTS_ADDRESS", s.URL)
+	core.NewClientConfig().Load(cmd.Flags())
+	return s
+}
+
+func reset(httpServer *httptest.Server) {
+	os.Unsetenv("NUTS_ADDRESS")
+	httpServer.Close()
+}

--- a/vcr/concept/query.go
+++ b/vcr/concept/query.go
@@ -50,14 +50,6 @@ func (q *query) addTemplate(template *Template) {
 		template: template,
 	}
 
-	// add all hardcoded values
-	for k, v := range template.fixedValues {
-		tq.Clauses = append(tq.Clauses, eq{
-			key:   k,
-			value: v,
-		})
-	}
-
 	q.parts = append(q.parts, &tq)
 }
 

--- a/vcr/concept/query_test.go
+++ b/vcr/concept/query_test.go
@@ -91,29 +91,16 @@ func TestQuery(t *testing.T) {
 		assert.Len(t, q.Parts(), 1)
 	})
 
-	t.Run("addTemplate - adds hardcoded values to query clause", func(t *testing.T) {
+	t.Run("AddClause", func(t *testing.T) {
 		tq := q.parts[0]
+
+		q.AddClause(eq{key: "key", value: "value"})
 
 		if !assert.Len(t, tq.Clauses, 1) {
 			return
 		}
 
 		crit := tq.Clauses[0]
-		assert.Equal(t, TypeField, crit.Key())
-		assert.Equal(t, ExampleType, crit.Seek())
-		assert.Equal(t, ExampleType, crit.Match())
-	})
-
-	t.Run("AddClause", func(t *testing.T) {
-		tq := q.parts[0]
-
-		q.AddClause(eq{key: "key", value: "value"})
-
-		if !assert.Len(t, tq.Clauses, 2) {
-			return
-		}
-
-		crit := tq.Clauses[1]
 		assert.Equal(t, "key", crit.Key())
 		assert.Equal(t, "value", crit.Seek())
 	})

--- a/vcr/concept/registry_test.go
+++ b/vcr/concept/registry_test.go
@@ -20,10 +20,11 @@
 package concept
 
 import (
+	"testing"
+
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestRegistry_AddFromString(t *testing.T) {

--- a/vcr/concept/registry_test.go
+++ b/vcr/concept/registry_test.go
@@ -172,25 +172,4 @@ func TestRegistry_QueryFor(t *testing.T) {
 
 		assert.Equal(t, ErrUnknownConcept, err)
 	})
-
-	t.Run("ok - adds fixed values", func(t *testing.T) {
-		q, err := r.QueryFor(ExampleConcept)
-
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		assert.Equal(t, ExampleConcept, q.Concept())
-		if !assert.Len(t, q.Parts(), 1) {
-			return
-		}
-
-		if !assert.Len(t, q.Parts()[0].Clauses, 1) {
-			return
-		}
-		crit := q.Parts()[0].Clauses[0]
-
-		assert.Equal(t, "type", crit.Key())
-		assert.Equal(t, ExampleType, crit.Seek())
-	})
 }

--- a/vcr/concept/template.go
+++ b/vcr/concept/template.go
@@ -23,10 +23,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/go-did/vc"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/nuts-foundation/go-did/vc"
 
 	errors2 "github.com/pkg/errors"
 )

--- a/vcr/concept/template_test.go
+++ b/vcr/concept/template_test.go
@@ -21,11 +21,12 @@ package concept
 
 import (
 	"encoding/json"
-	"github.com/nuts-foundation/go-did/vc"
-	"github.com/stretchr/testify/assert"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/nuts-foundation/go-did/vc"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTemplateString_isValid(t *testing.T) {

--- a/vcr/concept/template_test.go
+++ b/vcr/concept/template_test.go
@@ -76,12 +76,11 @@ func TestTemplate_parse(t *testing.T) {
 	})
 
 	t.Run("it adds the correct Indices", func(t *testing.T) {
-		assert.Len(t, ct.Indices(), 2)
+		assert.Len(t, ct.Indices(), 3)
 
-		assert.Equal(t, "type", ct.indices[0][0])
-		assert.Equal(t, "human.eyeColour", ct.indices[0][1])
-		assert.Equal(t, "type", ct.indices[1][0])
-		assert.Equal(t, "subject", ct.indices[1][1])
+		assert.Equal(t, "human.eyeColour", ct.indices[0][0])
+		assert.Equal(t, "subject", ct.indices[1][0])
+		assert.Equal(t, "issuer", ct.indices[2][0])
 	})
 
 	t.Run("error - incorrect syntax", func(t *testing.T) {

--- a/vcr/concept/test.go
+++ b/vcr/concept/test.go
@@ -29,12 +29,12 @@ const ExampleType = "HumanCredential"
 const ExampleTemplate = `
 {
 	"id": "<<id>>",
-	"issuer": "<<issuer>>",
-	"type": "HumanCredential@{1_1},{2_1}",
+	"issuer": "<<issuer>>@{3}",
+	"type": "HumanCredential",
 	"credentialSubject": {
-		"id": "<<subject>>@{2_2}",
+		"id": "<<subject>>@{2}",
 		"human": {
-			"eyeColour": "<<human.eyeColour>>@{1_2}",
+			"eyeColour": "<<human.eyeColour>>@{1}",
 			"hairColour": "<<human.hairColour>>"
 		}
 	}

--- a/vcr/concept/test.go
+++ b/vcr/concept/test.go
@@ -20,6 +20,7 @@ package concept
 
 import (
 	"encoding/json"
+
 	"github.com/nuts-foundation/go-did/vc"
 )
 

--- a/vcr/credential/builder.go
+++ b/vcr/credential/builder.go
@@ -21,9 +21,10 @@ package credential
 
 import (
 	"fmt"
+	"time"
+
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/vc"
-	"time"
 
 	"github.com/google/uuid"
 )

--- a/vcr/credential/builder_test.go
+++ b/vcr/credential/builder_test.go
@@ -20,10 +20,11 @@
 package credential
 
 import (
-	ssi "github.com/nuts-foundation/go-did"
-	"github.com/nuts-foundation/go-did/vc"
 	"testing"
 	"time"
+
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 
 	"github.com/google/uuid"
 	"github.com/nuts-foundation/nuts-node/vdr"

--- a/vcr/credential/resolver_test.go
+++ b/vcr/credential/resolver_test.go
@@ -20,10 +20,11 @@
 package credential
 
 import (
+	"testing"
+
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestFindValidatorAndBuilder(t *testing.T) {

--- a/vcr/credential/revocation.go
+++ b/vcr/credential/revocation.go
@@ -20,9 +20,10 @@
 package credential
 
 import (
+	"time"
+
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/vc"
-	"time"
 )
 
 // Revocation defines a proof that a VC has been revoked by it's issuer.

--- a/vcr/credential/revocation_test.go
+++ b/vcr/credential/revocation_test.go
@@ -21,12 +21,13 @@ package credential
 
 import (
 	"encoding/json"
-	ssi "github.com/nuts-foundation/go-did"
-	"github.com/nuts-foundation/go-did/vc"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 	"time"
+
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildRevocation(t *testing.T) {

--- a/vcr/credential/types_test.go
+++ b/vcr/credential/types_test.go
@@ -2,8 +2,9 @@ package credential
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNutsOrganizationCredentialSubject(t *testing.T) {

--- a/vcr/credential/validator.go
+++ b/vcr/credential/validator.go
@@ -22,8 +22,9 @@ package credential
 import (
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/go-did/vc"
 	"strings"
+
+	"github.com/nuts-foundation/go-did/vc"
 )
 
 // Validator is the interface specific VC verification.

--- a/vcr/credential/validator_test.go
+++ b/vcr/credential/validator_test.go
@@ -20,12 +20,13 @@
 package credential
 
 import (
+	"testing"
+	"time"
+
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/vdr"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestNutsOrganizationCredentialValidator_Validate(t *testing.T) {

--- a/vcr/interface.go
+++ b/vcr/interface.go
@@ -71,12 +71,12 @@ type Writer interface {
 
 // TrustManager bundles all trust related methods in one interface
 type TrustManager interface {
-	// Trust adds trust for a Issuer/CredentialType combination. The added trust is persisted to disk.
+	// Trust adds trust for a Issuer/CredentialType combination.
 	Trust(credentialType ssi.URI, issuer ssi.URI) error
-	// Untrust removes trust for a Issuer/CredentialType combination. The result is persisted to disk.
+	// Untrust removes trust for a Issuer/CredentialType combination.
 	Untrust(credentialType ssi.URI, issuer ssi.URI) error
 	// Trusted returns a list of trusted issuers for given credentialType
-	Trusted(credentialType ssi.URI) []ssi.URI
+	Trusted(credentialType ssi.URI) ([]ssi.URI, error)
 	// Untrusted returns a list of untrusted issuers based on known credentials
 	Untrusted(credentialType ssi.URI) ([]ssi.URI, error)
 }

--- a/vcr/interface.go
+++ b/vcr/interface.go
@@ -68,6 +68,18 @@ type Writer interface {
 	StoreRevocation(r credential.Revocation) error
 }
 
+// TrustManager bundles all trust related methods in one interface
+type TrustManager interface {
+	// Trust adds trust for a Issuer/CredentialType combination. The added trust is persisted to disk.
+	Trust(credentialType ssi.URI, issuer ssi.URI) error
+	// Untrust removes trust for a Issuer/CredentialType combination. The result is persisted to disk.
+	Untrust(credentialType ssi.URI, issuer ssi.URI) error
+	// Trusted returns a list of trusted issuers for given credentialType
+	Trusted(credentialType ssi.URI) []ssi.URI
+	// Untrusted returns a list of untrusted issuers based on known credentials
+	Untrusted(credentialType ssi.URI) ([]ssi.URI, error)
+}
+
 // VCR is the interface that covers all functionality of the vcr store.
 type VCR interface {
 	// Issue creates and publishes a new VC.
@@ -90,12 +102,8 @@ type VCR interface {
 	Revoke(ID ssi.URI) (*credential.Revocation, error)
 	// Registry returns the concept registry
 	Registry() concept.Registry
-	// Trust adds trust for a Issuer/CredentialType combination. The added trust is persisted to disk.
-	Trust(credentialType ssi.URI, issuer ssi.URI) error
-	// Untrust removes trust for a Issuer/CredentialType combination. The result is persisted to disk.
-	Untrust(credentialType ssi.URI, issuer ssi.URI) error
 
 	ConceptFinder
-
+	TrustManager
 	Writer
 }

--- a/vcr/interface.go
+++ b/vcr/interface.go
@@ -22,11 +22,12 @@ package vcr
 import (
 	"embed"
 	"errors"
+	"time"
+
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/vcr/concept"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
-	"time"
 )
 
 //go:embed assets/*

--- a/vcr/mock.go
+++ b/vcr/mock.go
@@ -142,11 +142,12 @@ func (mr *MockTrustManagerMockRecorder) Trust(credentialType, issuer interface{}
 }
 
 // Trusted mocks base method.
-func (m *MockTrustManager) Trusted(credentialType ssi.URI) []ssi.URI {
+func (m *MockTrustManager) Trusted(credentialType ssi.URI) ([]ssi.URI, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Trusted", credentialType)
 	ret0, _ := ret[0].([]ssi.URI)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Trusted indicates an expected call of Trusted.
@@ -339,11 +340,12 @@ func (mr *MockVCRMockRecorder) Trust(credentialType, issuer interface{}) *gomock
 }
 
 // Trusted mocks base method.
-func (m *MockVCR) Trusted(credentialType ssi.URI) []ssi.URI {
+func (m *MockVCR) Trusted(credentialType ssi.URI) ([]ssi.URI, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Trusted", credentialType)
 	ret0, _ := ret[0].([]ssi.URI)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Trusted indicates an expected call of Trusted.

--- a/vcr/mock.go
+++ b/vcr/mock.go
@@ -104,6 +104,86 @@ func (mr *MockWriterMockRecorder) StoreRevocation(r interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreRevocation", reflect.TypeOf((*MockWriter)(nil).StoreRevocation), r)
 }
 
+// MockTrustManager is a mock of TrustManager interface.
+type MockTrustManager struct {
+	ctrl     *gomock.Controller
+	recorder *MockTrustManagerMockRecorder
+}
+
+// MockTrustManagerMockRecorder is the mock recorder for MockTrustManager.
+type MockTrustManagerMockRecorder struct {
+	mock *MockTrustManager
+}
+
+// NewMockTrustManager creates a new mock instance.
+func NewMockTrustManager(ctrl *gomock.Controller) *MockTrustManager {
+	mock := &MockTrustManager{ctrl: ctrl}
+	mock.recorder = &MockTrustManagerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockTrustManager) EXPECT() *MockTrustManagerMockRecorder {
+	return m.recorder
+}
+
+// Trust mocks base method.
+func (m *MockTrustManager) Trust(credentialType, issuer ssi.URI) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Trust", credentialType, issuer)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Trust indicates an expected call of Trust.
+func (mr *MockTrustManagerMockRecorder) Trust(credentialType, issuer interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Trust", reflect.TypeOf((*MockTrustManager)(nil).Trust), credentialType, issuer)
+}
+
+// Trusted mocks base method.
+func (m *MockTrustManager) Trusted(credentialType ssi.URI) []ssi.URI {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Trusted", credentialType)
+	ret0, _ := ret[0].([]ssi.URI)
+	return ret0
+}
+
+// Trusted indicates an expected call of Trusted.
+func (mr *MockTrustManagerMockRecorder) Trusted(credentialType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Trusted", reflect.TypeOf((*MockTrustManager)(nil).Trusted), credentialType)
+}
+
+// Untrust mocks base method.
+func (m *MockTrustManager) Untrust(credentialType, issuer ssi.URI) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Untrust", credentialType, issuer)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Untrust indicates an expected call of Untrust.
+func (mr *MockTrustManagerMockRecorder) Untrust(credentialType, issuer interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Untrust", reflect.TypeOf((*MockTrustManager)(nil).Untrust), credentialType, issuer)
+}
+
+// Untrusted mocks base method.
+func (m *MockTrustManager) Untrusted(credentialType ssi.URI) ([]ssi.URI, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Untrusted", credentialType)
+	ret0, _ := ret[0].([]ssi.URI)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Untrusted indicates an expected call of Untrusted.
+func (mr *MockTrustManagerMockRecorder) Untrusted(credentialType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Untrusted", reflect.TypeOf((*MockTrustManager)(nil).Untrusted), credentialType)
+}
+
 // MockVCR is a mock of VCR interface.
 type MockVCR struct {
 	ctrl     *gomock.Controller
@@ -258,6 +338,20 @@ func (mr *MockVCRMockRecorder) Trust(credentialType, issuer interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Trust", reflect.TypeOf((*MockVCR)(nil).Trust), credentialType, issuer)
 }
 
+// Trusted mocks base method.
+func (m *MockVCR) Trusted(credentialType ssi.URI) []ssi.URI {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Trusted", credentialType)
+	ret0, _ := ret[0].([]ssi.URI)
+	return ret0
+}
+
+// Trusted indicates an expected call of Trusted.
+func (mr *MockVCRMockRecorder) Trusted(credentialType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Trusted", reflect.TypeOf((*MockVCR)(nil).Trusted), credentialType)
+}
+
 // Untrust mocks base method.
 func (m *MockVCR) Untrust(credentialType, issuer ssi.URI) error {
 	m.ctrl.T.Helper()
@@ -270,6 +364,21 @@ func (m *MockVCR) Untrust(credentialType, issuer ssi.URI) error {
 func (mr *MockVCRMockRecorder) Untrust(credentialType, issuer interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Untrust", reflect.TypeOf((*MockVCR)(nil).Untrust), credentialType, issuer)
+}
+
+// Untrusted mocks base method.
+func (m *MockVCR) Untrusted(credentialType ssi.URI) ([]ssi.URI, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Untrusted", credentialType)
+	ret0, _ := ret[0].([]ssi.URI)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Untrusted indicates an expected call of Untrusted.
+func (mr *MockVCRMockRecorder) Untrusted(credentialType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Untrusted", reflect.TypeOf((*MockVCR)(nil).Untrusted), credentialType)
 }
 
 // Verify mocks base method.

--- a/vcr/store.go
+++ b/vcr/store.go
@@ -21,6 +21,7 @@ package vcr
 
 import (
 	"encoding/json"
+
 	"github.com/nuts-foundation/go-did/vc"
 
 	"github.com/nuts-foundation/go-leia"

--- a/vcr/store_test.go
+++ b/vcr/store_test.go
@@ -22,9 +22,10 @@ package vcr
 import (
 	"crypto/ecdsa"
 	"encoding/json"
-	"github.com/nuts-foundation/go-did/vc"
 	"io/ioutil"
 	"testing"
+
+	"github.com/nuts-foundation/go-did/vc"
 
 	"github.com/golang/mock/gomock"
 	"github.com/nuts-foundation/nuts-node/core"

--- a/vcr/trust/trust.go
+++ b/vcr/trust/trust.go
@@ -80,6 +80,17 @@ func (tc *Config) save() error {
 	return os.WriteFile(tc.filename, data, 0644)
 }
 
+// List returns all trusted issuers for the given type
+func (tc *Config) List(credentialType ssi.URI) []ssi.URI {
+	stringList := tc.issuersPerType[credentialType.String()]
+	uriList := make([]ssi.URI, len(stringList))
+	for i, e := range stringList {
+		u, _ := ssi.ParseURI(e)
+		uriList[i] = *u
+	}
+	return uriList
+}
+
 // IsTrusted returns true when the given issuer is in the trusted issuers list of the given credentialType
 func (tc *Config) IsTrusted(credentialType ssi.URI, issuer ssi.URI) bool {
 	issuerString := issuer.String()

--- a/vcr/trust/trust.go
+++ b/vcr/trust/trust.go
@@ -21,10 +21,11 @@ package trust
 
 import (
 	"errors"
-	ssi "github.com/nuts-foundation/go-did"
-	"gopkg.in/yaml.v2"
 	"os"
 	"sync"
+
+	ssi "github.com/nuts-foundation/go-did"
+	"gopkg.in/yaml.v2"
 )
 
 // Config holds the trusted issuers per credential type

--- a/vcr/trust/trust_test.go
+++ b/vcr/trust/trust_test.go
@@ -20,12 +20,13 @@
 package trust
 
 import (
+	"path"
+	"testing"
+
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/test/io"
 	"github.com/stretchr/testify/assert"
-	"path"
-	"testing"
 )
 
 const nutsTestCredential = "NutsOrganizationCredential"

--- a/vcr/trust/trust_test.go
+++ b/vcr/trust/trust_test.go
@@ -104,6 +104,22 @@ func TestTrustConfig_IsTrusted(t *testing.T) {
 	})
 }
 
+func TestTrustConfig_List(t *testing.T) {
+	tc := NewConfig("../test/issuers.yaml")
+	d, _ := ssi.ParseURI("did:nuts:t1DVVAs5fmNba8fdKoTSQNtiGcH49vicrkjZW2KRqpv")
+	c, _ := ssi.ParseURI(nutsTestCredential)
+
+	err := tc.Load()
+	if !assert.NoError(t, err) {
+		return
+	}
+	trusted := tc.List(*c)
+
+	assert.Len(t, trusted, 1)
+	assert.Equal(t, *d, trusted[0])
+}
+
+
 func TestConfig_AddTrust(t *testing.T) {
 	testDir := io.TestDirectory(t)
 	tc := NewConfig(path.Join(testDir, "test.yaml"))

--- a/vcr/trust/trust_test.go
+++ b/vcr/trust/trust_test.go
@@ -119,7 +119,6 @@ func TestTrustConfig_List(t *testing.T) {
 	assert.Equal(t, *d, trusted[0])
 }
 
-
 func TestConfig_AddTrust(t *testing.T) {
 	testDir := io.TestDirectory(t)
 	tc := NewConfig(path.Join(testDir, "test.yaml"))

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -23,12 +23,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	ssi "github.com/nuts-foundation/go-did"
-	"github.com/nuts-foundation/go-did/vc"
 	"io/fs"
 	"path"
 	"strings"
 	"time"
+
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jws"

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -460,8 +460,25 @@ func (c *vcr) Untrust(credentialType ssi.URI, issuer ssi.URI) error {
 	return c.trustConfig.RemoveTrust(credentialType, issuer)
 }
 
-func (c *vcr) Trusted(credentialType ssi.URI) []ssi.URI {
-	return c.trustConfig.List(credentialType)
+func (c *vcr) Trusted(credentialType ssi.URI) ([]ssi.URI, error) {
+	templates := c.registry.ConceptTemplates()
+	found := false
+
+outer:
+	for _, vs := range templates {
+		for _, v := range vs {
+			if v.VCType() == credentialType.String() {
+				found = true
+				break outer
+			}
+		}
+	}
+
+	if !found {
+		return nil, ErrInvalidCredential
+	}
+
+	return c.trustConfig.List(credentialType), nil
 }
 
 func (c *vcr) Untrusted(credentialType ssi.URI) ([]ssi.URI, error) {

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -23,13 +23,14 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"errors"
-	ssi "github.com/nuts-foundation/go-did"
-	"github.com/nuts-foundation/go-did/vc"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 	"time"
+
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/vc"
 
 	"github.com/golang/mock/gomock"
 	"github.com/nuts-foundation/go-leia"

--- a/vdr/api/v1/client.go
+++ b/vdr/api/v1/client.go
@@ -24,6 +24,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/core"
+
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -53,7 +55,7 @@ func (hb HTTPClient) Create() (*did.Document, error) {
 
 	if response, err := hb.client().CreateDID(ctx); err != nil {
 		return nil, err
-	} else if err := testResponseCode(http.StatusOK, response); err != nil {
+	} else if err := core.TestResponseCode(http.StatusOK, response); err != nil {
 		return nil, err
 	} else {
 		return readDIDDocument(response.Body)
@@ -69,7 +71,7 @@ func (hb HTTPClient) Get(DID string) (*DIDDocument, *DIDDocumentMetadata, error)
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := testResponseCode(http.StatusOK, response); err != nil {
+	if err := core.TestResponseCode(http.StatusOK, response); err != nil {
 		return nil, nil, err
 	}
 
@@ -93,7 +95,7 @@ func (hb HTTPClient) Update(DID string, current string, next did.Document) (*did
 	if err != nil {
 		return nil, err
 	}
-	if err := testResponseCode(http.StatusOK, response); err != nil {
+	if err := core.TestResponseCode(http.StatusOK, response); err != nil {
 		return nil, err
 	}
 
@@ -109,7 +111,7 @@ func (hb HTTPClient) Deactivate(DID string) error {
 	if err != nil {
 		return err
 	}
-	if err := testResponseCode(http.StatusOK, response); err != nil {
+	if err := core.TestResponseCode(http.StatusOK, response); err != nil {
 		return err
 	}
 	return nil
@@ -117,15 +119,6 @@ func (hb HTTPClient) Deactivate(DID string) error {
 
 func (hb HTTPClient) withTimeout() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), hb.Timeout)
-}
-
-func testResponseCode(expectedStatusCode int, response *http.Response) error {
-	if response.StatusCode != expectedStatusCode {
-		responseData, _ := ioutil.ReadAll(response.Body)
-		return fmt.Errorf("VDR returned HTTP %d (expected: %d), response: %s",
-			response.StatusCode, expectedStatusCode, string(responseData))
-	}
-	return nil
 }
 
 func readDIDDocument(reader io.Reader) (*did.Document, error) {

--- a/vdr/cmd/cmd_test.go
+++ b/vdr/cmd/cmd_test.go
@@ -280,7 +280,7 @@ func TestEngine_Command(t *testing.T) {
 			if !assert.Error(t, err) {
 				return
 			}
-			assert.Contains(t, buf.String(), "failed to deactivate DID document: VDR returned HTTP 404 (expected: 200)")
+			assert.Contains(t, buf.String(), "failed to deactivate DID document: server returned HTTP 404 (expected: 200)")
 		})
 	})
 }


### PR DESCRIPTION
Closes #173

* Added CLI commands for (un)trusting issuers and for listing (un)trusted issuers per credential type.
* Added APIs for listing (un)trusted issuers per credential type.
* Removed hardcoded values from template: type was the only case and that was already covered by the store collections.