### PR TITLE
Add generic way of checking relationship between node and DID

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -99,7 +99,7 @@ func (auth *Auth) Configure(config core.ServerConfig) error {
 	nameResolver := auth.vcr
 	keyResolver := vdr.KeyResolver{DocResolver: auth.registry}
 	auth.contractClient = validator.NewContractInstance(cfg, keyResolver, auth.vcr, auth.keyStore)
-	auth.contractNotary = contract.NewContractNotary(nameResolver, keyResolver, auth.keyStore, contractValidity)
+	auth.contractNotary = contract.NewContractNotary(nameResolver, contractValidity)
 	if err := auth.contractClient.Configure(); err != nil {
 		return err
 	}

--- a/auth/services/contract/notary_test.go
+++ b/auth/services/contract/notary_test.go
@@ -216,13 +216,7 @@ func Test_contractNotaryService_DrawUpContract(t *testing.T) {
 func TestNewContractNotary(t *testing.T) {
 	t.Run("adds all services", func(t *testing.T) {
 		testDir := io.TestDirectory(t)
-		vdrInstance := vdr.NewTestVDRInstance(testDir)
-		instance := NewContractNotary(
-			vcr.NewTestVCRInstance(testDir),
-			vdr.KeyResolver{DocResolver: vdrInstance},
-			crypto.NewTestCryptoInstance(testDir),
-			60*time.Minute,
-		)
+		instance := NewContractNotary(vcr.NewTestVCRInstance(testDir), 60*time.Minute)
 
 		if !assert.NotNil(t, instance) {
 			return
@@ -233,9 +227,7 @@ func TestNewContractNotary(t *testing.T) {
 			return
 		}
 
-		assert.NotNil(t, service.privateKeyStore)
 		assert.NotNil(t, service.conceptFinder)
-		assert.NotNil(t, service.keyResolver)
 		assert.NotNil(t, service.contractValidity)
 	})
 }
@@ -257,8 +249,6 @@ func buildContext(t *testing.T) *testContext {
 		privateKeyStore: crypto.NewMockPrivateKeyStore(ctrl),
 	}
 	notary := contractNotaryService{
-		keyResolver:      ctx.keyResolver,
-		privateKeyStore:  ctx.privateKeyStore,
 		conceptFinder:    ctx.nameResolver,
 		contractValidity: 15 * time.Minute,
 	}

--- a/crypto/interface.go
+++ b/crypto/interface.go
@@ -73,12 +73,15 @@ type PublicKeyStore interface {
 	RevokePublicKey(kid string, validTo time.Time) error
 }
 
-// PrivateKeyStore defines the functions for working with private keys.
-type PrivateKeyStore interface {
+type PrivateKeyChecker interface {
 	// PrivateKeyExists returns if the specified private key exists.
 	// If an error occurs, false is also returned
 	PrivateKeyExists(kid string) bool
+}
 
+// PrivateKeyStore defines the functions for working with private keys.
+type PrivateKeyStore interface {
+	PrivateKeyChecker
 	KeyCreator
 	JWSSigner
 	JWTSigner

--- a/vdr/ownership-checker.go
+++ b/vdr/ownership-checker.go
@@ -1,0 +1,25 @@
+package vdr
+
+import (
+	"github.com/nuts-foundation/go-did/did"
+
+	"github.com/nuts-foundation/nuts-node/crypto"
+	"github.com/nuts-foundation/nuts-node/vdr/types"
+)
+
+type OwnershipChecker struct {
+	KeyResolver KeyResolver
+	KeyChecker  crypto.PrivateKeyChecker
+}
+
+func (c OwnershipChecker) OwnedByThisNode(id did.DID) (error) {
+	key, err := c.KeyResolver.ResolveAssertionKeyID(id)
+	if err != nil {
+		return err
+	}
+
+	if !c.KeyChecker.PrivateKeyExists(key.String()) {
+		return types.ErrDIDNotManagedByThisNode
+	}
+	return nil
+}

--- a/vdr/types/interface.go
+++ b/vdr/types/interface.go
@@ -93,6 +93,12 @@ type VDR interface {
 	DocUpdater
 }
 
+type OwnershipChecker interface {
+	// Checks if the node manages the DID document by checking for the private key.
+	// Returns ErrDIDNotManagedByThisNode when the document is not managed by this node
+	OwnedByThisNode(id did.DID) error
+}
+
 // DocManipulator groups several higher level methods to alter the state of a DID document.
 type DocManipulator interface {
 	// Deactivate deactivates a DID document


### PR DESCRIPTION
This is currently a draft of a proof of concept.

It introdces a VDR.OwnershipChecker which can be used in every api or service which needs to check if a DID is owned by this node.
I applied this pattern already in auth/api and vdr/api so you can see how this looks like. If you agree this PR will apply it on every relevant api handler.