### PR TITLE
Network: expose graphviz DAG visitor in API for visualization/analytical purposes

### DIFF
--- a/docs/_static/network/v1.yaml
+++ b/docs/_static/network/v1.yaml
@@ -70,3 +70,19 @@ paths:
               example:
         "404":
           description: "Transaction (or payload) wasn't found"
+  /internal/network/v1/diagnostics/graph:
+    get:
+      summary: "Visualizes the DAG as a graph"
+      description: >
+        Walks the DAG as subscribers of the DAG do, rendering it as graph. By default it renders in Graphviz format,
+        which can be rendered to an image using `dot`.
+      operationId: "renderGraph"
+      tags:
+        - transactions
+      responses:
+        "200":
+          description: "Graph successfully rendered"
+          content:
+            text/vnd.graphviz:
+              schema:
+                type: string

--- a/docs/pages/monitoring.rst
+++ b/docs/pages/monitoring.rst
@@ -195,3 +195,16 @@ The Nuts service executable exports the following metrics by default. These cove
     promhttp_metric_handler_requests_total{code="200"} 0
     promhttp_metric_handler_requests_total{code="500"} 0
     promhttp_metric_handler_requests_total{code="503"} 0
+
+
+Network DAG Visualization
+=========================
+
+All network transactions form a directed acyclic graph (DAG) which helps achieving consistency and data completeness.
+Since it's a hard to debug, complex structure, the network API provides a visualization which can be queried
+from `/internal/network/v1/diagnostics/graph`. It is returned in the `dot` format which can then be rendered to an image using
+`dot` or `graphviz` (given you saved the output to `input.dot`):
+
+.. code-block:: shell
+
+    dot -T png -o output.png input.dot

--- a/network/api/v1/api.go
+++ b/network/api/v1/api.go
@@ -19,6 +19,7 @@
 package v1
 
 import (
+	"github.com/nuts-foundation/nuts-node/network/dag"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -88,4 +89,16 @@ func (a Wrapper) GetTransactionPayload(ctx echo.Context, hashAsString string) er
 	ctx.Response().WriteHeader(http.StatusOK)
 	_, err = ctx.Response().Writer.Write(data)
 	return err
+}
+
+// RenderGraph visualizes the DAG as Graphviz/dot graph
+func (a Wrapper) RenderGraph(ctx echo.Context) error {
+	visitor := dag.NewDotGraphVisitor(dag.ShowShortRefLabelStyle)
+	err := a.Service.Walk(visitor.Accept)
+	if err != nil {
+		log.Logger().Errorf("Error while rendering graph: %v", err)
+		return ctx.String(http.StatusInternalServerError, err.Error())
+	}
+	ctx.Response().Header().Set(echo.HeaderContentType, "text/vnd.graphviz")
+	return ctx.String(http.StatusOK, visitor.Render())
 }

--- a/network/api/v1/api_test.go
+++ b/network/api/v1/api_test.go
@@ -92,6 +92,28 @@ func TestApiWrapper_GetTransaction(t *testing.T) {
 	})
 }
 
+func TestApiWrapper_RenderGraph(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	t.Run("ok", func(t *testing.T) {
+		var networkClient = network.NewMockTransactions(mockCtrl)
+		e, wrapper := initMockEcho(networkClient)
+		networkClient.EXPECT().Walk(gomock.Any())
+
+		req := httptest.NewRequest(echo.GET, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/graph")
+
+		err := wrapper.RenderGraph(c)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "text/vnd.graphviz", rec.Header().Get("Content-Type"))
+		assert.NotEmpty(t, rec.Body.String())
+	})
+}
+
 func TestApiWrapper_GetTransactionPayload(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/network/dag/dotviz.go
+++ b/network/dag/dotviz.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2021. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package dag
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DotGraphVisitor is a graph visitor that outputs the walked path as "dot" diagram.
+// The is currently unused, but can be used to debug the DAG to see how transactions relate to each other. The output
+// can be viewed using a DOT plugin or when rendering the DOT file to SVG/PNG, etc.
+type DotGraphVisitor struct {
+	aliases    map[string]string
+	counter    int
+	labelStyle LabelStyle
+
+	nodes []string
+	edges []string
+}
+
+// LabelStyle defines node label styles for DotGraphVisitor.
+type LabelStyle int
+
+const (
+	// ShowAliasLabelStyle is a style that uses integer aliases for node labels.
+	ShowAliasLabelStyle LabelStyle = iota
+	// ShowRefLabelStyle is a style that uses the references of nodes as label.
+	ShowRefLabelStyle LabelStyle = iota
+	// ShowShortRefLabelStyle is a style that uses a shorter version of the references of nodes as label.
+	ShowShortRefLabelStyle LabelStyle = iota
+)
+
+// NewDotGraphVisitor creates a new DotGraphVisitor
+func NewDotGraphVisitor(labelStyle LabelStyle) *DotGraphVisitor {
+	return &DotGraphVisitor{
+		aliases:    map[string]string{},
+		labelStyle: labelStyle,
+	}
+}
+
+// Accept adds a transaction to the dot graph. Should be called by the DAG walker.
+func (d *DotGraphVisitor) Accept(transaction Transaction) bool {
+	d.counter++
+	d.nodes = append(d.nodes, fmt.Sprintf("  \"%s\"[label=\"%s (%d)\"]", transaction.Ref().String(), d.label(transaction), d.counter))
+	for _, prev := range transaction.Previous() {
+		d.edges = append(d.edges, fmt.Sprintf("  \"%s\" -> \"%s\"", prev.String(), transaction.Ref().String()))
+	}
+	return true
+}
+
+// Render returns the walked DAG visualized as dot graph.
+func (d *DotGraphVisitor) Render() string {
+	var lines []string
+	lines = append(lines, "digraph {")
+	lines = append(lines, d.nodes...)
+	lines = append(lines, d.edges...)
+	lines = append(lines, "}")
+	return strings.Join(lines, "\n")
+}
+
+func (d *DotGraphVisitor) label(transaction Transaction) string {
+	ref := transaction.Ref().String()
+	switch d.labelStyle {
+	case ShowAliasLabelStyle:
+		return d.getAlias(ref, func(ref string) string {
+			return fmt.Sprintf("%d", len(d.aliases)+1)
+		})
+	case ShowShortRefLabelStyle:
+		return d.getAlias(ref, func(ref string) string {
+			return fmt.Sprintf("%s..%s", ref[:4], ref[len(ref)-4:])
+		})
+	case ShowRefLabelStyle:
+		fallthrough
+	default:
+		return ref
+	}
+}
+
+func (d *DotGraphVisitor) getAlias(ref string, aliaser func(ref string) string) string {
+	alias, _ := d.aliases[ref]
+	if alias == "" {
+		alias = aliaser(ref)
+		d.aliases[ref] = alias
+	}
+	return alias
+}

--- a/network/dag/dotviz_test.go
+++ b/network/dag/dotviz_test.go
@@ -1,90 +1,32 @@
-/*
- * Copyright (C) 2021. Nuts community
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
- */
-
 package dag
 
 import (
 	"fmt"
-	"strings"
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
-// DotGraphVisitor is a graph visitor that outputs the walked path as "dot" diagram.
-// The is currently unused, but can be used to debug the DAG to see how transactions relate to each other. The output
-// can be viewed using a DOT plugin or when rendering the DOT file to SVG/PNG, etc.
-type DotGraphVisitor struct {
-	output      string
-	aliases     map[string]string
-	counter     int
-	labelStyle  LabelStyle
-	showAliases bool
-	showContent bool
-
-	nodes []string
-	edges []string
-}
-
-// LabelStyle defines node label styles for DotGraphVisitor.
-type LabelStyle int
-
-const (
-	// ShowAliasLabelStyle is a style that uses integer aliases for node labels.
-	ShowAliasLabelStyle LabelStyle = iota
-	// ShowAliasLabelStyle is a style that uses the references of nodes as label.
-	ShowRefLabelStyle LabelStyle = iota
-)
-
-func NewDotGraphVisitor(labelStyle LabelStyle) *DotGraphVisitor {
-	return &DotGraphVisitor{
-		aliases:    map[string]string{},
-		labelStyle: labelStyle,
+func TestDotGraphVisitor(t *testing.T) {
+	doTest := func(style LabelStyle) {
+		t.Run(fmt.Sprintf("%d", style), func(t *testing.T) {
+			visitor := NewDotGraphVisitor(style)
+			txA, _, _ := CreateTestTransaction(1)
+			txB, _, _ := CreateTestTransaction(2, txA.Ref())
+			txC, _, _ := CreateTestTransaction(3, txA.Ref())
+			visitor.Accept(txA)
+			visitor.Accept(txB)
+			visitor.Accept(txC)
+			actual := visitor.Render()
+			// Since visualization changes now and then and the TX references differ every time the test is run, just do some sanity checks
+			assert.Contains(t, actual, "digraph {")
+			assert.Contains(t, actual, "}")
+			assert.Contains(t, actual, txA.Ref().String())
+			assert.Contains(t, actual, txB.Ref().String())
+			assert.Contains(t, actual, txC.Ref().String())
+			assert.Contains(t, actual, "->")
+		})
 	}
-}
-
-func (d *DotGraphVisitor) Accept(transaction Transaction) {
-	d.counter++
-	d.nodes = append(d.nodes, fmt.Sprintf("  \"%s\"[label=\"%s (%d)\"]", transaction.Ref().String(), d.label(transaction), d.counter))
-	for _, prev := range transaction.Previous() {
-		d.edges = append(d.edges, fmt.Sprintf("  \"%s\" -> \"%s\"", prev.String(), transaction.Ref().String()))
-	}
-}
-
-func (d *DotGraphVisitor) Render() string {
-	var lines []string
-	lines = append(lines, "digraph {")
-	lines = append(lines, d.nodes...)
-	lines = append(lines, d.edges...)
-	lines = append(lines, "}")
-	return strings.Join(lines, "\n")
-}
-
-func (d *DotGraphVisitor) label(transaction Transaction) string {
-	switch d.labelStyle {
-	case ShowAliasLabelStyle:
-		if alias, ok := d.aliases[transaction.Ref().String()]; ok {
-			return alias
-		} else {
-			alias = fmt.Sprintf("%d", len(d.aliases)+1)
-			d.aliases[transaction.Ref().String()] = alias
-			return alias
-		}
-	case ShowRefLabelStyle:
-		fallthrough
-	default:
-		return transaction.Ref().String()
-	}
+	doTest(ShowShortRefLabelStyle)
+	doTest(ShowRefLabelStyle)
+	doTest(ShowAliasLabelStyle)
 }

--- a/network/interface.go
+++ b/network/interface.go
@@ -41,4 +41,6 @@ type Transactions interface {
 	CreateTransaction(payloadType string, payload []byte, signingKeyID string, attachKey crypto2.PublicKey, timestamp time.Time, fieldsOpts ...dag.FieldOpt) (dag.Transaction, error)
 	// ListTransactions returns all transactions known to this Network instance.
 	ListTransactions() ([]dag.Transaction, error)
+	// Walk walks the DAG starting at the root, calling `visitor` for every transaction.
+	Walk(visitor dag.Visitor) error
 }

--- a/network/mock.go
+++ b/network/mock.go
@@ -113,3 +113,17 @@ func (mr *MockTransactionsMockRecorder) Subscribe(payloadType, receiver interfac
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockTransactions)(nil).Subscribe), payloadType, receiver)
 }
+
+// Walk mocks base method.
+func (m *MockTransactions) Walk(visitor dag.Visitor) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Walk", visitor)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Walk indicates an expected call of Walk.
+func (mr *MockTransactionsMockRecorder) Walk(visitor interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Walk", reflect.TypeOf((*MockTransactions)(nil).Walk), visitor)
+}

--- a/network/network.go
+++ b/network/network.go
@@ -61,6 +61,15 @@ type Network struct {
 	keyResolver  types.KeyResolver
 }
 
+// Walk walks the DAG starting at the root, passing every transaction to `visitor`.
+func (n *Network) Walk(visitor dag.Visitor) error {
+	root, err := n.graph.Root()
+	if err != nil {
+		return err
+	}
+	return n.graph.Walk(dag.NewBFSWalkerAlgorithm(), visitor, root)
+}
+
 // NewNetworkInstance creates a new Network engine instance.
 func NewNetworkInstance(config Config, jwsSigner crypto.JWSSigner, keyResolver types.KeyResolver) *Network {
 	result := &Network{


### PR DESCRIPTION
Goal is to visualize it in Nuts Explorer.