### PR TITLE
Network: fix incorrect timezone used in blockdate

### DIFF
--- a/network/proto/blocks.go
+++ b/network/proto/blocks.go
@@ -262,7 +262,8 @@ func (b blockTracker) String() string {
 }
 
 func startOfDay(now time.Time) time.Time {
-	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	nowUTC := now.In(time.UTC)
+	return time.Date(nowUTC.Year(), nowUTC.Month(), nowUTC.Day(), 0, 0, 0, 0, time.UTC)
 }
 
 func xor(dest *hash.SHA256Hash, left, right hash.SHA256Hash) {

--- a/network/proto/blocks_test.go
+++ b/network/proto/blocks_test.go
@@ -253,6 +253,13 @@ func TestBlocks(t *testing.T) {
 		assert.Len(t, actual[2].heads, 1)
 		assert.Equal(t, tx2.Ref(), actual[2].heads[0])
 	})
+	t.Run("empty DAG", func(t *testing.T) {
+		blocks := newDAGBlocks().(*trackingDAGBlocks)
+		blocks.internalUpdate(time.Date(2021, 10, 10, 10, 11,0, 0, time.FixedZone("Europe/Amsterdam", 5)))
+		actual := blocks.internalGet()
+		assert.Len(t, actual, numberOfBlocks)
+		assert.Equal(t, "2021-10-10 00:00:00 +0000 UTC", getCurrentBlock(actual).start.String())
+	})
 }
 
 func TestDAGBlock_XORHeads(t *testing.T) {


### PR DESCRIPTION
Getting the block date uses `getStartOfDay()` which should've taken the start of day in UTC, instead of the local timezone. Since otherwise they aren't comparable to the start of day timestamps of other peers in other timezones.