### PR TITLE
Network: remove dead code tracking missing transactions

### DIFF
--- a/network/dag/bbolt_dag_test.go
+++ b/network/dag/bbolt_dag_test.go
@@ -192,28 +192,6 @@ func TestBBoltDAG_Walk(t *testing.T) {
 	})
 }
 
-func TestBBoltDAG_MissingTransactions(t *testing.T) {
-	A := CreateTestTransactionWithJWK(0)
-	B := CreateTestTransactionWithJWK(1, A.Ref())
-	C := CreateTestTransactionWithJWK(2, B.Ref())
-	t.Run("no missing transactions (empty graph)", func(t *testing.T) {
-		graph := CreateDAG(t)
-		assert.Empty(t, graph.MissingTransactions())
-	})
-	t.Run("no missing transactions (non-empty graph)", func(t *testing.T) {
-		graph := CreateDAG(t)
-		graph.Add(A, B, C)
-		assert.Empty(t, graph.MissingTransactions())
-	})
-	t.Run("missing transactions (non-empty graph)", func(t *testing.T) {
-		graph := CreateDAG(t)
-		graph.Add(A, C)
-		assert.Len(t, graph.MissingTransactions(), 1)
-		// Now add missing transaction B and assert there are no more missing transactions
-		graph.Add(B)
-		assert.Empty(t, graph.MissingTransactions())
-	})
-}
 func TestBBoltDAG_Observe(t *testing.T) {
 	graph := CreateDAG(t)
 	var actual interface{}

--- a/network/dag/interface.go
+++ b/network/dag/interface.go
@@ -36,8 +36,6 @@ type DAG interface {
 	Observable
 	// Add adds one or more transactions to the DAG. If it can't be added an error is returned. Nil entries are ignored.
 	Add(transactions ...Transaction) error
-	// MissingTransactions returns the hashes of the transactions we know we are missing and should still be resolved.
-	MissingTransactions() []hash.SHA256Hash
 	// Walk visits every node of the DAG, starting at the given hash working its way down each level until every leaf is visited.
 	// when startAt is an empty hash, the walker starts at the root node.
 	Walk(algo WalkerAlgorithm, visitor Visitor, startAt hash.SHA256Hash) error

--- a/network/dag/mock.go
+++ b/network/dag/mock.go
@@ -64,20 +64,6 @@ func (mr *MockDAGMockRecorder) Add(transactions ...interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockDAG)(nil).Add), transactions...)
 }
 
-// MissingTransactions mocks base method
-func (m *MockDAG) MissingTransactions() []hash.SHA256Hash {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MissingTransactions")
-	ret0, _ := ret[0].([]hash.SHA256Hash)
-	return ret0
-}
-
-// MissingTransactions indicates an expected call of MissingTransactions
-func (mr *MockDAGMockRecorder) MissingTransactions() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MissingTransactions", reflect.TypeOf((*MockDAG)(nil).MissingTransactions))
-}
-
 // Walk mocks base method
 func (m *MockDAG) Walk(algo WalkerAlgorithm, visitor Visitor, startAt hash.SHA256Hash) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Since https://github.com/nuts-foundation/nuts-node/pull/272 transaction with missing "prev's" are blocked from being added to the DAG, but there was some BBolt code for registration and analysis left. This PR removes it.

We're missing some coverage on BBolt operation error returns, but I have no idea how to test them (and it adds little value imo).