### PR TITLE
Network: solve desync of historic block and omnihashes being all zeroed

### DIFF
--- a/network/dag/verifier.go
+++ b/network/dag/verifier.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jws"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
+	"time"
 )
 
 // ErrPreviousTransactionMissing indicates one or more of the previous transactions (which the transaction refers to)
@@ -51,6 +52,17 @@ func NewPrevTransactionsVerifier() Verifier {
 			if !present {
 				return ErrPreviousTransactionMissing
 			}
+		}
+		return nil
+	}
+}
+
+// NewSigningTimeVerifier creates a transaction verifier that asserts that signing time of transactions aren't
+// further than 1 day in the future, since that complicates head calculation.
+func NewSigningTimeVerifier() Verifier {
+	return func(tx Transaction, _ DAG) error {
+		if time.Now().Add(24 * time.Hour).Before(tx.SigningTime()) {
+			return fmt.Errorf("transaction signing time too far in the future: %s", tx.SigningTime())
 		}
 		return nil
 	}

--- a/network/network.go
+++ b/network/network.go
@@ -89,7 +89,7 @@ func (n *Network) Configure(config core.ServerConfig) error {
 	if bboltErr != nil {
 		return fmt.Errorf("unable to create BBolt database: %w", bboltErr)
 	}
-	n.graph = dag.NewBBoltDAG(db, dag.NewPrevTransactionsVerifier(), dag.NewTransactionSignatureVerifier(n.keyResolver))
+	n.graph = dag.NewBBoltDAG(db, dag.NewSigningTimeVerifier(), dag.NewPrevTransactionsVerifier(), dag.NewTransactionSignatureVerifier(n.keyResolver))
 	n.payloadStore = dag.NewBBoltPayloadStore(db)
 	n.publisher = dag.NewReplayingDAGPublisher(n.payloadStore, n.graph)
 	peerID := p2p.PeerID(uuid.New().String())

--- a/network/proto/handlers_test.go
+++ b/network/proto/handlers_test.go
@@ -87,7 +87,7 @@ func TestProtocol_HandleAdvertedHashes(t *testing.T) {
 		msg := createAdvertHashesMessage(blocks)
 		err := ctx.handle(msg)
 		assert.NoError(t, err)
-		ctx.assertNoNewOmnihashes()
+		ctx.assertNewOmnihash()
 	})
 }
 
@@ -148,7 +148,7 @@ func TestProtocol_HandleTransactionList(t *testing.T) {
 	t.Run("remove from slice", func(t *testing.T) {
 		slice := []string{"a"}
 		idx := 0
-		slice = append(slice[:idx], slice[idx + 1:]...)
+		slice = append(slice[:idx], slice[idx+1:]...)
 		fmt.Printf("%v\n", slice)
 	})
 	t.Run("non-empty list, processing error", func(t *testing.T) {


### PR DESCRIPTION
Fixes #289 

- Calculate peer omnihash even when historic block differs (solves all-zeroes omnihashes)
- Reject transactions with a signing time further than 1 day in the future (makes determining heads much easier, if we keep it we should put it in the spec)
- Fix marking new transaction as head instead of the previous transaction if they're in the same block

The time-based blocks are complicated and I discovered more issues with it (next TX being in an older block). Should probably be rethought. (even if it's fixed for now)