### PR TITLE
DIDMan: return ErrServiceNotFound when service to be deleted does not exist

### DIFF
--- a/didman/didman.go
+++ b/didman/didman.go
@@ -122,6 +122,9 @@ func (d *didman) DeleteService(serviceID ssi.URI) error {
 			j++
 		}
 	}
+	if j == len(doc.Service) {
+		return ErrServiceNotFound
+	}
 	doc.Service = doc.Service[:j]
 
 	err = d.vdr.Update(*id, meta.Hash, *doc, nil)


### PR DESCRIPTION
So the method complies to its interface.