### PR TITLE
Network: log empty messages (peer sent empty envelope or might have different protocol version)

### DIFF
--- a/network/proto/handlers.go
+++ b/network/proto/handlers.go
@@ -55,6 +55,8 @@ func (p *protocol) handleMessage(peerMsg p2p.PeerMessage) error {
 		if msg.TransactionPayload != nil && msg.TransactionPayload.PayloadHash != nil && msg.TransactionPayload.Data != nil {
 			p.handleTransactionPayload(peer, msg.TransactionPayload)
 		}
+	default:
+		log.Logger().Infof("Envelope doesn't contain any (handleable) messages, peer sent an empty message or protocol version might differ? (peer=%s)", peerMsg)
 	}
 	return nil
 }

--- a/network/proto/handlers_test.go
+++ b/network/proto/handlers_test.go
@@ -292,6 +292,18 @@ func TestProtocol_HandleTransactionPayload(t *testing.T) {
 	})
 }
 
+func TestProtocol_handleMessage(t *testing.T) {
+	t.Run("unknown fields", func(t *testing.T) {
+		ctx := newContext(t)
+		envelope := createEnvelope()
+		err := ctx.instance.handleMessage(p2p.PeerMessage{
+			Peer:    peer,
+			Message: &envelope,
+		})
+		assert.NoError(t, err)
+	})
+}
+
 func Test_checkTransactionOnLocalNode(t *testing.T) {
 	tx, _, _ := dag.CreateTestTransaction(1)
 	t.Run("payload present (happy flow)", func(t *testing.T) {

--- a/network/proto/handlers_test.go
+++ b/network/proto/handlers_test.go
@@ -293,7 +293,7 @@ func TestProtocol_HandleTransactionPayload(t *testing.T) {
 }
 
 func TestProtocol_handleMessage(t *testing.T) {
-	t.Run("unknown fields", func(t *testing.T) {
+	t.Run("empty message", func(t *testing.T) {
 		ctx := newContext(t)
 		envelope := createEnvelope()
 		err := ctx.instance.handleMessage(p2p.PeerMessage{


### PR DESCRIPTION
Possible when a new message type is added but peers don't understand that message type (yet). Should not be possible when the gRPC interface enforces correct versions for peers, but might happen when we choose to support some degree of forward (and backward, in some cases) compatibility.

Other case might be that the peer actually sent an empty message.