### PR TITLE
VDR: Use TX's signing time when resolving a DID document's controllers when updating

### DIFF
--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -154,7 +154,8 @@ func (n *ambassador) handleUpdateDIDDocument(transaction dag.Transaction, propos
 	}
 
 	// Resolve controllers of current version (could be the same document)
-	didControllers, err := n.docResolver.ResolveControllers(*currentDIDDocument)
+	signingTime := transaction.SigningTime()
+	didControllers, err := n.docResolver.ResolveControllers(*currentDIDDocument, &types.ResolveMetadata{ResolveTime: &signingTime})
 	if err != nil {
 		return fmt.Errorf("unable to resolve DID document's controllers: %w", err)
 	}
@@ -168,7 +169,6 @@ func (n *ambassador) handleUpdateDIDDocument(transaction dag.Transaction, propos
 
 	// In an update, only the keyID is provided in the network document. Resolve the key from the key store
 	// This should succeed since the signature of the network document has already been verified.
-	signingTime := transaction.SigningTime()
 	pKey, err := n.keyResolver.ResolvePublicKey(transaction.SigningKeyID(), &signingTime)
 	if err != nil {
 		return fmt.Errorf("unable to resolve signingkey: %w", err)

--- a/vdr/ambassador_test.go
+++ b/vdr/ambassador_test.go
@@ -331,7 +331,7 @@ func Test_ambassador_callback(t *testing.T) {
 		signingKey.Raw(&pKey)
 
 		didStoreMock.EXPECT().Resolve(didDocument.ID, nil).Times(2).Return(&storedDocument, currentMetadata, nil)
-		resolverMock.EXPECT().ResolveControllers(storedDocument).Return([]did.Document{storedDocument}, nil)
+		resolverMock.EXPECT().ResolveControllers(storedDocument, &types.ResolveMetadata{ResolveTime: &subDoc.signingTime}).Return([]did.Document{storedDocument}, nil)
 		keyStoreMock.EXPECT().ResolvePublicKey(storedDocument.CapabilityInvocation[0].ID.String(), &subDoc.signingTime).Return(pKey, nil)
 		didStoreMock.EXPECT().Update(storedDocument.ID, currentMetadata.Hash, deactivatedDocument, &expectedNextMetadata)
 
@@ -387,7 +387,7 @@ func Test_ambassador_callback(t *testing.T) {
 		signingKey.Raw(&pKey)
 
 		didStoreMock.EXPECT().Resolve(didDocument.ID, nil).Times(2).Return(&expectedDocument, currentMetadata, nil)
-		resolverMock.EXPECT().ResolveControllers(expectedDocument).Return([]did.Document{expectedDocument}, nil)
+		resolverMock.EXPECT().ResolveControllers(expectedDocument, &types.ResolveMetadata{ResolveTime: &subDoc.signingTime}).Return([]did.Document{expectedDocument}, nil)
 		keyStoreMock.EXPECT().ResolvePublicKey(didDocument.CapabilityInvocation[0].ID.String(), &subDoc.signingTime).Return(pKey, nil)
 		didStoreMock.EXPECT().Update(didDocument.ID, currentMetadata.Hash, expectedDocument, &expectedNextMetadata)
 
@@ -439,7 +439,7 @@ func Test_ambassador_callback(t *testing.T) {
 		signingKey.Raw(&pKey)
 
 		didStoreMock.EXPECT().Resolve(didDocument.ID, nil).Times(2).Return(&expectedDocument, currentMetadata, nil)
-		resolverMock.EXPECT().ResolveControllers(expectedDocument).Return([]did.Document{controllerDoc}, nil)
+		resolverMock.EXPECT().ResolveControllers(expectedDocument, &types.ResolveMetadata{ResolveTime: &subDoc.signingTime}).Return([]did.Document{controllerDoc}, nil)
 		keyStoreMock.EXPECT().ResolvePublicKey(controllerDoc.CapabilityInvocation[0].ID.String(), &subDoc.signingTime).Return(pKey, nil)
 		didStoreMock.EXPECT().Update(didDocument.ID, currentMetadata.Hash, expectedDocument, &expectedNextMetadata)
 
@@ -490,7 +490,7 @@ func Test_ambassador_callback(t *testing.T) {
 		signingKey.Raw(&pKey)
 
 		didStoreMock.EXPECT().Resolve(currentDoc.ID, nil).Times(2).Return(&currentDoc, currentMetadata, nil)
-		resolverMock.EXPECT().ResolveControllers(currentDoc).Return([]did.Document{currentDoc}, nil)
+		resolverMock.EXPECT().ResolveControllers(currentDoc, &types.ResolveMetadata{ResolveTime: &subDoc.signingTime}).Return([]did.Document{currentDoc}, nil)
 		keyStoreMock.EXPECT().ResolvePublicKey(currentDoc.CapabilityInvocation[0].ID.String(), &subDoc.signingTime).Return(pKey, nil)
 		didStoreMock.EXPECT().Update(currentDoc.ID, currentMetadata.Hash, newDoc, &expectedNextMetadata)
 
@@ -568,7 +568,7 @@ func Test_ambassador_callback(t *testing.T) {
 		}
 
 		didStoreMock.EXPECT().Resolve(didDocument.ID, nil).Times(2).Return(&expectedDocument, currentMetadata, nil)
-		resolverMock.EXPECT().ResolveControllers(expectedDocument).Return([]did.Document{didDocumentController}, nil)
+		resolverMock.EXPECT().ResolveControllers(expectedDocument, &types.ResolveMetadata{ResolveTime: &subDoc.signingTime}).Return([]did.Document{didDocumentController}, nil)
 		keyStoreMock.EXPECT().ResolvePublicKey(didDocumentController.CapabilityInvocation[0].ID.String(), &subDoc.signingTime).Return(pKey, nil)
 		didStoreMock.EXPECT().Update(didDocument.ID, currentMetadata.Hash, expectedDocument, &expectedNextMetadata)
 
@@ -646,7 +646,7 @@ func Test_ambassador_callback(t *testing.T) {
 		// expect a resolve for previous versions of the DID document
 		didStoreMock.EXPECT().Resolve(didDocument.ID, nil).Times(2).Return(&expectedDocument, currentMetadata, nil)
 		// expect a resolve for the DID documents controller
-		resolverMock.EXPECT().ResolveControllers(expectedDocument).Return([]did.Document{didDocumentController}, nil)
+		resolverMock.EXPECT().ResolveControllers(expectedDocument, &types.ResolveMetadata{ResolveTime: &subDoc.signingTime}).Return([]did.Document{didDocumentController}, nil)
 
 		keyStoreMock.EXPECT().ResolvePublicKey(keyID, &subDoc.signingTime).Return(pKey, nil)
 
@@ -723,10 +723,10 @@ func Test_handleUpdateDIDDocument(t *testing.T) {
 		}
 
 		didDocument, _, _ := newDidDoc()
-		tx := testTransaction{}
+		tx := testTransaction{signingTime: time.Now()}
 
 		didStoreMock.EXPECT().Resolve(didDocument.ID, nil).Return(&didDocument, &types.DocumentMetadata{}, nil)
-		docResolverMock.EXPECT().ResolveControllers(didDocument).Return(nil, errors.New("failed"))
+		docResolverMock.EXPECT().ResolveControllers(didDocument, &types.ResolveMetadata{ResolveTime: &tx.signingTime}).Return(nil, errors.New("failed"))
 
 		err := am.handleUpdateDIDDocument(&tx, didDocument)
 		assert.EqualError(t, err, "unable to resolve DID document's controllers: failed")

--- a/vdr/doc/resolvers.go
+++ b/vdr/doc/resolvers.go
@@ -40,7 +40,7 @@ func (d Resolver) Resolve(id did.DID, metadata *types.ResolveMetadata) (*did.Doc
 	return d.Store.Resolve(id, metadata)
 }
 
-func (d Resolver) ResolveControllers(doc did.Document) ([]did.Document, error) {
+func (d Resolver) ResolveControllers(doc did.Document, metadata *types.ResolveMetadata) ([]did.Document, error) {
 	var leaves []did.Document
 	var refsToResolve []did.DID
 
@@ -63,7 +63,7 @@ func (d Resolver) ResolveControllers(doc did.Document) ([]did.Document, error) {
 
 	// resolve all unresolved docs
 	for _, ref := range refsToResolve {
-		node, _, err := d.Store.Resolve(ref, nil)
+		node, _, err := d.Store.Resolve(ref, metadata)
 		if err != nil {
 			return nil, fmt.Errorf("unable to resolve controllers: %w", err)
 		}

--- a/vdr/doc/resolvers.go
+++ b/vdr/doc/resolvers.go
@@ -40,6 +40,7 @@ func (d Resolver) Resolve(id did.DID, metadata *types.ResolveMetadata) (*did.Doc
 	return d.Store.Resolve(id, metadata)
 }
 
+// ResolveControllers finds the DID Document controllers
 func (d Resolver) ResolveControllers(doc did.Document, metadata *types.ResolveMetadata) ([]did.Document, error) {
 	var leaves []did.Document
 	var refsToResolve []did.DID

--- a/vdr/doc/resolvers_test.go
+++ b/vdr/doc/resolvers_test.go
@@ -186,7 +186,7 @@ func TestResolver_ResolveControllers(t *testing.T) {
 	id456Method1, _ := did.ParseDID("did:nuts:456#method-1")
 	t.Run("emtpy input", func(t *testing.T) {
 		resolver := Resolver{}
-		docs, err := resolver.ResolveControllers(did.Document{})
+		docs, err := resolver.ResolveControllers(did.Document{}, nil)
 		assert.NoError(t, err)
 		assert.Len(t, docs, 0,
 			"expected an empty list")
@@ -196,7 +196,7 @@ func TestResolver_ResolveControllers(t *testing.T) {
 		resolver := Resolver{}
 		doc := did.Document{ID: *id123}
 		doc.AddCapabilityInvocation(&did.VerificationMethod{ID: *id123Method1})
-		docs, err := resolver.ResolveControllers(doc)
+		docs, err := resolver.ResolveControllers(doc, nil)
 		assert.NoError(t, err)
 		assert.Len(t, docs, 1,
 			"expected the document")
@@ -206,7 +206,7 @@ func TestResolver_ResolveControllers(t *testing.T) {
 	t.Run("doc is deactivated", func(t *testing.T) {
 		resolver := Resolver{}
 		doc := did.Document{ID: *id123}
-		docs, err := resolver.ResolveControllers(doc)
+		docs, err := resolver.ResolveControllers(doc, nil)
 		assert.NoError(t, err)
 		assert.Len(t, docs, 0,
 			"expected an empty list when the document is deactivated")
@@ -226,7 +226,7 @@ func TestResolver_ResolveControllers(t *testing.T) {
 
 		docB := did.Document{ID: *id456, Controller: []did.DID{*id123}}
 
-		docs, err := resolver.ResolveControllers(docB)
+		docs, err := resolver.ResolveControllers(docB, nil)
 		assert.NoError(t, err)
 		assert.Len(t, docs, 1)
 		assert.Equal(t, docA, docs[0],
@@ -248,7 +248,7 @@ func TestResolver_ResolveControllers(t *testing.T) {
 		docB := did.Document{ID: *id456, Controller: []did.DID{*id123, *id456}}
 		docB.AddCapabilityInvocation(&did.VerificationMethod{ID: *id456Method1})
 
-		docs, err := resolver.ResolveControllers(docB)
+		docs, err := resolver.ResolveControllers(docB, nil)
 		assert.NoError(t, err)
 		assert.Len(t, docs, 2)
 		assert.Equal(t, []did.Document{docB, docA}, docs,
@@ -283,7 +283,7 @@ func TestResolver_ResolveControllers(t *testing.T) {
 		docA.Controller = []did.DID{docA.ID, docB.ID, docC.ID}
 		docA.AddCapabilityInvocation(&did.VerificationMethod{ID: docAIDCapInv})
 
-		docs, err := resolver.ResolveControllers(docA)
+		docs, err := resolver.ResolveControllers(docA, nil)
 		assert.NoError(t, err)
 		assert.Len(t, docs, 2)
 		assert.Contains(t, docs, docA, "expected docA to be resolved as controller of docA")
@@ -304,7 +304,7 @@ func TestResolver_ResolveControllers(t *testing.T) {
 
 		docB := did.Document{ID: *id456, Controller: []did.DID{*id123}}
 
-		docs, err := resolver.ResolveControllers(docB)
+		docs, err := resolver.ResolveControllers(docB, nil)
 		assert.NoError(t, err)
 		assert.Len(t, docs, 1)
 		assert.Equal(t, docA, docs[0],
@@ -322,7 +322,7 @@ func TestResolver_ResolveControllers(t *testing.T) {
 
 		docB := did.Document{ID: *id456, Controller: []did.DID{*id123}}
 
-		docs, err := resolver.ResolveControllers(docB)
+		docs, err := resolver.ResolveControllers(docB, nil)
 		assert.EqualError(t, err, "unable to resolve controllers: unable to find the DID document")
 		assert.Len(t, docs, 0)
 	})

--- a/vdr/doc/resolvers_test.go
+++ b/vdr/doc/resolvers_test.go
@@ -20,13 +20,13 @@
 package doc
 
 import (
-	"testing"
-
 	"github.com/golang/mock/gomock"
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/vdr/store"
 	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
 
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 )
@@ -222,11 +222,13 @@ func TestResolver_ResolveControllers(t *testing.T) {
 		docA := did.Document{ID: *id123}
 		docA.AddCapabilityInvocation(&did.VerificationMethod{ID: *id123Method1})
 
-		store.EXPECT().Resolve(*id123, gomock.Any()).Return(&docA, &types.DocumentMetadata{}, nil)
+		resolveTime := time.Date(2010, 1, 1, 1, 1, 1, 0, time.UTC)
+		resolveMD := &types.ResolveMetadata{ResolveTime: &resolveTime}
+		store.EXPECT().Resolve(*id123, resolveMD).Return(&docA, &types.DocumentMetadata{}, nil)
 
 		docB := did.Document{ID: *id456, Controller: []did.DID{*id123}}
 
-		docs, err := resolver.ResolveControllers(docB, nil)
+		docs, err := resolver.ResolveControllers(docB, resolveMD)
 		assert.NoError(t, err)
 		assert.Len(t, docs, 1)
 		assert.Equal(t, docA, docs[0],

--- a/vdr/types/interface.go
+++ b/vdr/types/interface.go
@@ -36,7 +36,7 @@ type DocResolver interface {
 	// It returns ErrNotFound if there are no corresponding DID documents or when the DID Documents are disjoint with the provided ResolveMetadata
 	Resolve(id did.DID, metadata *ResolveMetadata) (*did.Document, *DocumentMetadata, error)
 	// ResolveControllers finds the DID Document controllers
-	ResolveControllers(input did.Document) ([]did.Document, error)
+	ResolveControllers(input did.Document, metadata *ResolveMetadata) ([]did.Document, error)
 }
 
 // DocCreator is the interface that wraps the Create method

--- a/vdr/types/mock.go
+++ b/vdr/types/mock.go
@@ -55,18 +55,18 @@ func (mr *MockDocResolverMockRecorder) Resolve(id, metadata interface{}) *gomock
 }
 
 // ResolveControllers mocks base method
-func (m *MockDocResolver) ResolveControllers(input did.Document) ([]did.Document, error) {
+func (m *MockDocResolver) ResolveControllers(input did.Document, metadata *ResolveMetadata) ([]did.Document, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveControllers", input)
+	ret := m.ctrl.Call(m, "ResolveControllers", input, metadata)
 	ret0, _ := ret[0].([]did.Document)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ResolveControllers indicates an expected call of ResolveControllers
-func (mr *MockDocResolverMockRecorder) ResolveControllers(input interface{}) *gomock.Call {
+func (mr *MockDocResolverMockRecorder) ResolveControllers(input, metadata interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveControllers", reflect.TypeOf((*MockDocResolver)(nil).ResolveControllers), input)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveControllers", reflect.TypeOf((*MockDocResolver)(nil).ResolveControllers), input, metadata)
 }
 
 // MockDocCreator is a mock of DocCreator interface

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -177,7 +177,7 @@ func (r VDR) Update(id did.DID, current hash.SHA256Hash, next did.Document, _ *t
 }
 
 func (r VDR) resolveControllerKey(doc did.Document) (crypto.Key, error) {
-	controllers, err := r.didDocResolver.ResolveControllers(doc)
+	controllers, err := r.didDocResolver.ResolveControllers(doc, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error while finding controllers for document: %w", err)
 	}


### PR DESCRIPTION
It currently resolves to the latest versions, which is incorrect.

Fixes #311 

