### PR TITLE
fix correct types for service

### DIFF
--- a/didman/didman.go
+++ b/didman/didman.go
@@ -82,7 +82,7 @@ func (d *didman) AddCompoundService(id did.DID, serviceType string, references m
 		return err
 	}
 
-	// transform ContactInformation to map[string]interface{}
+	// transform service references to map[string]interface{}
 	serviceEndpoint := map[string]interface{}{}
 	for k, v := range references {
 		serviceEndpoint[k] = v.String()

--- a/didman/didman.go
+++ b/didman/didman.go
@@ -81,7 +81,14 @@ func (d *didman) AddCompoundService(id did.DID, serviceType string, references m
 	if err := d.validateCompoundServiceEndpoint(references); err != nil {
 		return err
 	}
-	err := d.addService(id, serviceType, references, nil)
+
+	// transform ContactInformation to map[string]interface{}
+	serviceEndpoint := map[string]interface{}{}
+	for k, v := range references {
+		serviceEndpoint[k] = v.String()
+	}
+
+	err := d.addService(id, serviceType, serviceEndpoint, nil)
 	if err == nil {
 		logging.Log().Infof("Compound service added (did: %s, type: %s, references: %s)", id.String(), serviceType, references)
 	}
@@ -133,7 +140,16 @@ func (d *didman) DeleteService(serviceID ssi.URI) error {
 
 func (d *didman) UpdateContactInformation(id did.DID, information ContactInformation) (*ContactInformation, error) {
 	logging.Log().Debugf("Updating contact information service (did: %s, info: %v)", id.String(), information)
-	err := d.addService(id, ContactInformationServiceType, information, func(doc *did.Document) {
+
+	// transform ContactInformation to map[string]interface{}
+	serviceEndpoint := map[string]interface{}{
+		"name":    information.Name,
+		"email":   information.Email,
+		"phone":   information.Phone,
+		"website": information.Website,
+	}
+
+	err := d.addService(id, ContactInformationServiceType, serviceEndpoint, func(doc *did.Document) {
 		// check for existing contact information and remove it
 		i := 0
 		for _, s := range doc.Service {


### PR DESCRIPTION
inside a did.Document.service, an `endpoint` needs to be a `map[string]interface{}`, `[]interface{}` or `string`. In didman a `ContactInformation` struct is set as `endpoint`, this trips the validation. This only recently became a problem when validation was added before publishing.

an alternative would be to change the adding of a service.
It should then marshal/unmarshal which would always fool the validator....