### PR TITLE
renamed auth api model

### DIFF
--- a/auth/api/v1/api.go
+++ b/auth/api/v1/api.go
@@ -124,7 +124,7 @@ func (w Wrapper) VerifySignature(ctx echo.Context) error {
 
 // CreateSignSession handles the CreateSignSession http request. It parses the parameters, finds the means handler and returns a session pointer which can be used to monitor the session.
 func (w Wrapper) CreateSignSession(ctx echo.Context) error {
-	requestParams := new(CreateSignSessionRequest)
+	requestParams := new(SignSessionRequest)
 	if err := ctx.Bind(requestParams); err != nil {
 		err = fmt.Errorf("could not parse request body: %w", err)
 		logging.Log().WithError(err).Warn(problemTitleCreateSignSession)
@@ -149,9 +149,9 @@ func (w Wrapper) CreateSignSession(ctx echo.Context) error {
 		return core.NewProblem(problemTitleCreateSignSession, http.StatusBadRequest, err.Error())
 	}
 
-	response := CreateSignSessionResponse{
+	response := SignSessionResponse{
 		SessionID:  sessionPtr.SessionID(),
-		Means:      CreateSignSessionResponseMeans(requestParams.Means),
+		Means:      SignSessionResponseMeans(requestParams.Means),
 		SessionPtr: keyValPointer,
 	}
 	return ctx.JSON(http.StatusCreated, response)
@@ -185,7 +185,7 @@ func (w Wrapper) GetSignSessionStatus(ctx echo.Context, sessionID string) error 
 			return core.NewProblem(problemTitleSignSessionStatus, http.StatusInternalServerError, err.Error())
 		}
 	}
-	response := GetSignSessionStatusResponse{Status: sessionStatus.Status(), VerifiablePresentation: apiVp}
+	response := SignSessionStatusResponse{Status: sessionStatus.Status(), VerifiablePresentation: apiVp}
 	return ctx.JSON(http.StatusOK, response)
 }
 

--- a/auth/api/v1/api_test.go
+++ b/auth/api/v1/api_test.go
@@ -106,7 +106,7 @@ func TestWrapper_GetSignSessionStatus(t *testing.T) {
 
 		ctx.contractClientMock.EXPECT().SigningSessionStatus(signingSessionID).Return(signingSessionResult, nil)
 
-		response := GetSignSessionStatusResponse{
+		response := SignSessionStatusResponse{
 			Status:                 signingSessionStatus,
 			VerifiablePresentation: nil,
 		}
@@ -135,7 +135,7 @@ func TestWrapper_GetSignSessionStatus(t *testing.T) {
 
 		ctx.contractClientMock.EXPECT().SigningSessionStatus(signingSessionID).Return(signingSessionResult, nil)
 
-		response := GetSignSessionStatusResponse{
+		response := SignSessionStatusResponse{
 			Status:                 signingSessionStatus,
 			VerifiablePresentation: &VerifiablePresentation{Context: []string{"http://example.com"}},
 		}
@@ -645,7 +645,7 @@ func (s signSessionResponseMatcher) Matches(x interface{}) bool {
 		return false
 	}
 
-	return string(x.(CreateSignSessionResponse).Means) == s.means && x.(CreateSignSessionResponse).SessionPtr["sessionID"] != ""
+	return string(x.(SignSessionResponse).Means) == s.means && x.(SignSessionResponse).SessionPtr["sessionID"] != ""
 }
 
 func (s signSessionResponseMatcher) String() string {
@@ -653,7 +653,7 @@ func (s signSessionResponseMatcher) String() string {
 }
 
 func TestWrapper_CreateSignSession(t *testing.T) {
-	bindPostBody := func(ctx *TestContext, body CreateSignSessionRequest) {
+	bindPostBody := func(ctx *TestContext, body SignSessionRequest) {
 		jsonData, _ := json.Marshal(body)
 		ctx.echoMock.EXPECT().Bind(gomock.Any()).Do(func(f interface{}) {
 			_ = json.Unmarshal(jsonData, f)
@@ -675,7 +675,7 @@ func TestWrapper_CreateSignSession(t *testing.T) {
 				return dummyMeans.StartSigningSession(sessionRequest.Message)
 			})
 
-		postParams := CreateSignSessionRequest{
+		postParams := SignSessionRequest{
 			Means:   "dummy",
 			Payload: "this is the contract message to agree to",
 		}
@@ -690,7 +690,7 @@ func TestWrapper_CreateSignSession(t *testing.T) {
 		ctx := createContext(t)
 		defer ctx.ctrl.Finish()
 
-		postParams := CreateSignSessionRequest{}
+		postParams := SignSessionRequest{}
 		bindPostBody(ctx, postParams)
 
 		ctx.contractClientMock.EXPECT().CreateSigningSession(gomock.Any()).Return(nil, errors.New("some error"))

--- a/auth/api/v1/generated.go
+++ b/auth/api/v1/generated.go
@@ -20,18 +20,18 @@ const (
 	AccessTokenRequestFailedResponseErrorUnsupportedGrantType AccessTokenRequestFailedResponseError = "unsupported_grant_type"
 )
 
-// Defines values for CreateSignSessionRequestMeans.
+// Defines values for SignSessionRequestMeans.
 const (
-	CreateSignSessionRequestMeansDummy CreateSignSessionRequestMeans = "dummy"
+	SignSessionRequestMeansDummy SignSessionRequestMeans = "dummy"
 
-	CreateSignSessionRequestMeansIrma CreateSignSessionRequestMeans = "irma"
+	SignSessionRequestMeansIrma SignSessionRequestMeans = "irma"
 )
 
-// Defines values for CreateSignSessionResponseMeans.
+// Defines values for SignSessionResponseMeans.
 const (
-	CreateSignSessionResponseMeansDummy CreateSignSessionResponseMeans = "dummy"
+	SignSessionResponseMeansDummy SignSessionResponseMeans = "dummy"
 
-	CreateSignSessionResponseMeansIrma CreateSignSessionResponseMeans = "irma"
+	SignSessionResponseMeansIrma SignSessionResponseMeans = "irma"
 )
 
 // Error response when access token request fails as described in rfc6749 sectionn 5.2
@@ -123,36 +123,6 @@ type CreateJwtBearerTokenRequest struct {
 	Subject *string `json:"subject,omitempty"`
 }
 
-// CreateSignSessionRequest defines model for CreateSignSessionRequest.
-type CreateSignSessionRequest struct {
-	Means CreateSignSessionRequestMeans `json:"means"`
-
-	// Params are passed to the means. Should be documented in the means documentation.
-	Params map[string]interface{} `json:"params"`
-
-	// Base64 encoded payload what needs to be signed.
-	Payload string `json:"payload"`
-}
-
-// CreateSignSessionRequestMeans defines model for CreateSignSessionRequest.Means.
-type CreateSignSessionRequestMeans string
-
-// CreateSignSessionResponse defines model for CreateSignSessionResponse.
-type CreateSignSessionResponse struct {
-
-	// The means this session uses to sign.
-	Means CreateSignSessionResponseMeans `json:"means"`
-
-	// Unique identifier of this sign session.
-	SessionID string `json:"sessionID"`
-
-	// A pointer to a sign session. This is an opaque value which only has meaning in the context of the signing means. Can be an URL, base64 encoded image of a QRCode etc.
-	SessionPtr map[string]interface{} `json:"sessionPtr"`
-}
-
-// The means this session uses to sign.
-type CreateSignSessionResponseMeans string
-
 // DrawUpContractRequest defines model for DrawUpContractRequest.
 type DrawUpContractRequest struct {
 
@@ -175,16 +145,6 @@ type DrawUpContractRequest struct {
 	Version ContractVersion `json:"version"`
 }
 
-// GetSignSessionStatusResponse defines model for GetSignSessionStatusResponse.
-type GetSignSessionStatusResponse struct {
-
-	// Status indicates the status of the signing proces. Values depend on the implementation of the signing means.
-	Status string `json:"status"`
-
-	// If the signature session is completed, this property contains the signature embedded in an w3c verifiable presentation.
-	VerifiablePresentation *VerifiablePresentation `json:"verifiablePresentation,omitempty"`
-}
-
 // Response with a JWT Bearer Token. It contains a JWT, signed with the private key of the requestor software vendor.
 type JwtBearerTokenResponse struct {
 
@@ -195,6 +155,46 @@ type JwtBearerTokenResponse struct {
 
 // Identifier of the legalEntity as registered in the Nuts registry.
 type LegalEntity string
+
+// SignSessionRequest defines model for SignSessionRequest.
+type SignSessionRequest struct {
+	Means SignSessionRequestMeans `json:"means"`
+
+	// Params are passed to the means. Should be documented in the means documentation.
+	Params map[string]interface{} `json:"params"`
+
+	// Base64 encoded payload what needs to be signed.
+	Payload string `json:"payload"`
+}
+
+// SignSessionRequestMeans defines model for SignSessionRequest.Means.
+type SignSessionRequestMeans string
+
+// SignSessionResponse defines model for SignSessionResponse.
+type SignSessionResponse struct {
+
+	// The means this session uses to sign.
+	Means SignSessionResponseMeans `json:"means"`
+
+	// Unique identifier of this sign session.
+	SessionID string `json:"sessionID"`
+
+	// A pointer to a sign session. This is an opaque value which only has meaning in the context of the signing means. Can be an URL, base64 encoded image of a QRCode etc.
+	SessionPtr map[string]interface{} `json:"sessionPtr"`
+}
+
+// The means this session uses to sign.
+type SignSessionResponseMeans string
+
+// SignSessionStatusResponse defines model for SignSessionStatusResponse.
+type SignSessionStatusResponse struct {
+
+	// Status indicates the status of the signing proces. Values depend on the implementation of the signing means.
+	Status string `json:"status"`
+
+	// If the signature session is completed, this property contains the signature embedded in an w3c verifiable presentation.
+	VerifiablePresentation *VerifiablePresentation `json:"verifiablePresentation,omitempty"`
+}
 
 // SignatureVerificationRequest defines model for SignatureVerificationRequest.
 type SignatureVerificationRequest struct {
@@ -290,7 +290,7 @@ type CreateJwtBearerTokenJSONBody CreateJwtBearerTokenRequest
 type DrawUpContractJSONBody DrawUpContractRequest
 
 // CreateSignSessionJSONBody defines parameters for CreateSignSession.
-type CreateSignSessionJSONBody CreateSignSessionRequest
+type CreateSignSessionJSONBody SignSessionRequest
 
 // VerifySignatureJSONBody defines parameters for VerifySignature.
 type VerifySignatureJSONBody SignatureVerificationRequest

--- a/docs/_static/auth/v1.yaml
+++ b/docs/_static/auth/v1.yaml
@@ -18,14 +18,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateSignSessionRequest"
+              $ref: "#/components/schemas/SignSessionRequest"
       responses:
         201:
           description: When the signing session was successfully created.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CreateSignSessionResponse"
+                $ref: "#/components/schemas/SignSessionResponse"
         default:
           $ref: '../common/error_response.yaml'
 
@@ -51,7 +51,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GetSignSessionStatusResponse"
+                $ref: "#/components/schemas/SignSessionStatusResponse"
         default:
           $ref: '../common/error_response.yaml'
 
@@ -258,7 +258,7 @@ components:
     #
     # Everthing related to sessions and signing
     #
-    CreateSignSessionRequest:
+    SignSessionRequest:
       required:
         - means
         - payload
@@ -274,7 +274,7 @@ components:
         payload:
           type: string
           description: Base64 encoded payload what needs to be signed.
-    CreateSignSessionResponse:
+    SignSessionResponse:
       required:
         - sessionID
         - sessionPtr
@@ -291,7 +291,7 @@ components:
           type: string
           enum: [ irma, dummy ]
           example: irma
-    GetSignSessionStatusResponse:
+    SignSessionStatusResponse:
       required:
         - status
       properties:


### PR DESCRIPTION
codegen automatically generates models as `{operationName}Request` and `{operationName}Response`.
We also named our request and response JSON models that way. When generating client code, duplicates are created.
A simple rename does the trick