### PR TITLE
removed one-of from vdr spec

### DIFF
--- a/docs/_static/vdr/v1.yaml
+++ b/docs/_static/vdr/v1.yaml
@@ -345,9 +345,7 @@ components:
           type: string
         serviceEndpoint:
           description: Either a URI or a complex object.
-          oneOf:
-            - type: string
-            - type: object
+          type: object
     DIDUpdateRequest:
       required:
         - document


### PR DESCRIPTION
fixes #328 

`one-of` can cause problems for some open api spec code generators. Better to stick to a single type, eg `object`.