### PR TITLE
Auth: parse dates for contract as RFC3339

### DIFF
--- a/auth/api/v1/api.go
+++ b/auth/api/v1/api.go
@@ -219,7 +219,7 @@ func (w Wrapper) DrawUpContract(ctx echo.Context) error {
 		err           error
 	)
 	if params.ValidFrom != nil {
-		vf, err = time.Parse("2006-01-02T15:04:05-07:00", *params.ValidFrom)
+		vf, err = time.Parse(time.RFC3339, *params.ValidFrom)
 		if err != nil {
 			return core.InvalidInputError("could not parse validFrom: %w", err)
 		}

--- a/auth/api/v1/api_test.go
+++ b/auth/api/v1/api_test.go
@@ -286,7 +286,7 @@ func TestWrapper_DrawUpContract(t *testing.T) {
 
 			err := ctx.wrapper.DrawUpContract(ctx.echoMock)
 
-			assert.EqualError(t, err, "could not parse validFrom: parsing time \"02 Jan 2010\" as \"2006-01-02T15:04:05-07:00\": cannot parse \"an 2010\" as \"2006\"")
+			assert.EqualError(t, err, "could not parse validFrom: parsing time \"02 Jan 2010\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"an 2010\" as \"2006\"")
 			assert.ErrorIs(t, err, core.InvalidInputError(""))
 		})
 


### PR DESCRIPTION
Looks like the API originally intended to require RFC3339 but only supported numerical +/- timezones not separated by `Z`. RFC3339 format supports both.