### PR TITLE
Network: make sure startTime is set before P2P layer is started

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -129,6 +129,7 @@ func (n *Network) Config() interface{} {
 
 // Start initiates the Network subsystem
 func (n *Network) Start() error {
+	n.startTime.Store(time.Now())
 	if n.p2pNetwork.Configured() {
 		// It's possible that the Nuts node isn't bootstrapped (e.g. TLS configuration incomplete) but that shouldn't
 		// prevent it from starting. In that case the network will be in 'offline mode', meaning it can be read from
@@ -144,8 +145,6 @@ func (n *Network) Start() error {
 	if err := n.graph.Verify(); err != nil {
 		return err
 	}
-	n.startTime.Store(time.Now())
-
 	return nil
 }
 

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -258,6 +258,7 @@ func TestNetwork_Start(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
+		assert.NotNil(t, cxt.network.startTime.Load())
 	})
 	t.Run("ok - offline", func(t *testing.T) {
 		ctrl := gomock.NewController(t)


### PR DESCRIPTION
To avoid nil deref while collecting diagnostics.