### PR TITLE
Network: fix racy behaviour on nil connection.messenger due to peers parallel reconnect

### DIFF
--- a/network/p2p/connection_test.go
+++ b/network/p2p/connection_test.go
@@ -125,7 +125,7 @@ func Test_connection_receiveMessages(t *testing.T) {
 	// Create connection, start message receiving goroutine
 	conn := newConnection(Peer{}, messenger)
 	defer conn.close()
-	c := conn.receiveMessages()
+	c := receiveMessages(conn.ID, conn.messenger)
 
 	// Wait for numMsg to arrive
 	wg := sync.WaitGroup{}
@@ -187,7 +187,7 @@ func Test_connectionManager_register(t *testing.T) {
 		// Now register second one, disconnect first
 		conn2 := mgr.register(Peer{ID: id, Address: addr + "2"}, nil).(*managedConnection)
 		assert.NotEmpty(t, conn1.closer) // assert first one disconnected
-		assert.Empty(t, conn2.closer) // assert second one connected
+		assert.Empty(t, conn2.closer)    // assert second one connected
 
 		assert.Len(t, mgr.peersByAddr, 1)
 	})

--- a/network/p2p/connection_test.go
+++ b/network/p2p/connection_test.go
@@ -65,6 +65,10 @@ func Test_connection_exchange(t *testing.T) {
 			t.Fatal("expected exchange() to return due to close()")
 		}
 	})
+	t.Run("messenger is nil", func(t *testing.T) {
+		conn := newConnection(Peer{}, nil)
+		conn.exchange(messageQueue{})
+	})
 }
 
 func Test_connection_send(t *testing.T) {


### PR DESCRIPTION
Access to `connection.messenger` was synchronized but could be nil, due to `receiveMessages()` using the messenger outside of the lock. Now it's checked for `nil` and if so, it indicates the connection is closed (or closing), so the function can simply return.

Fixes #346 