### PR TITLE
Regenerated code

### DIFF
--- a/auth/api/v1/generated.go
+++ b/auth/api/v1/generated.go
@@ -97,7 +97,7 @@ type ContractResponse struct {
 // Type of which contract to sign.
 type ContractType string
 
-// SoftwareVersion of the contract.
+// Version of the contract.
 type ContractVersion string
 
 // Request as described in RFC7523 section 2.1

--- a/network/p2p/connection_mock.go
+++ b/network/p2p/connection_mock.go
@@ -86,6 +86,18 @@ func (m *Mockconnection) EXPECT() *MockconnectionMockRecorder {
 	return m.recorder
 }
 
+// exchange mocks base method.
+func (m *Mockconnection) exchange(messageReceiver messageQueue) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "exchange", messageReceiver)
+}
+
+// exchange indicates an expected call of exchange.
+func (mr *MockconnectionMockRecorder) exchange(messageReceiver interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "exchange", reflect.TypeOf((*Mockconnection)(nil).exchange), messageReceiver)
+}
+
 // peer mocks base method.
 func (m *Mockconnection) peer() Peer {
 	m.ctrl.T.Helper()
@@ -112,16 +124,4 @@ func (m *Mockconnection) send(message *transport.NetworkMessage) error {
 func (mr *MockconnectionMockRecorder) send(message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "send", reflect.TypeOf((*Mockconnection)(nil).send), message)
-}
-
-// sendAndReceive mocks base method.
-func (m *Mockconnection) exchange(receivedMessages messageQueue) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "exchange", receivedMessages)
-}
-
-// sendAndReceive indicates an expected call of sendAndReceive.
-func (mr *MockconnectionMockRecorder) sendAndReceive(receivedMessages interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "exchange", reflect.TypeOf((*Mockconnection)(nil).exchange), receivedMessages)
 }


### PR DESCRIPTION
Apparentely it was out-of-date.