### PR TITLE
Auth: typo

### DIFF
--- a/auth/services/x509/uzi_validator.go
+++ b/auth/services/x509/uzi_validator.go
@@ -48,7 +48,7 @@ func getUziAttributeNames() []string {
 		"uziNr",
 		"cardType",
 		"orgID",
-		"rollCode",
+		"roleCode",
 		"agbCode",
 	}
 }

--- a/auth/services/x509/uzi_validator_test.go
+++ b/auth/services/x509/uzi_validator_test.go
@@ -59,7 +59,7 @@ func TestUziValidator(t *testing.T) {
 			"cardType": "N",
 			"oidCa":    "2.16.528.1.1007.99.218", // CIBG.Uzi test identifiers
 			"orgID":    "90000382",
-			"rollCode": "00.000",
+			"roleCode": "00.000",
 			"uziNr":    "900021219",
 			"version":  "1",
 		}


### PR DESCRIPTION
Correct UZI attribute name to `roleCode`

https://github.com/nuts-foundation/nuts-specification/pull/102