### PR TITLE
Fix flaky signing time verifier test

### DIFF
--- a/network/dag/verifier_test.go
+++ b/network/dag/verifier_test.go
@@ -99,7 +99,7 @@ func TestSigningTimeVerifier(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("error - signed a day in the future", func(t *testing.T) {
-		err := NewSigningTimeVerifier()(CreateSignedTestTransaction(1, time.Now().Add(time.Hour*24+time.Second), "test/test"), nil)
+		err := NewSigningTimeVerifier()(CreateSignedTestTransaction(1, time.Now().Add(time.Hour*24+time.Minute), "test/test"), nil)
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
It seems like the `TestSigningTimeVerifier` unittest (specifically the "error - signed a day in the future" one) can fail if creating a test transaction takes longer than one second. Doesn't happen often but as CircleCI is "relatively" slow (DAG tests take 15s instead of 6s on my machine) it can fail even though it works just fine.

This PR adds one minute instead of one second to the signingtime so in theory it could still fail if creating the test transaction takes longer than one minute however it's very unlikely that will ever happen.

See: https://app.circleci.com/pipelines/github/nuts-foundation/nuts-node/1349/workflows/a77d6022-c272-469e-83de-2189a4e9cb2a/jobs/1359