### PR TITLE
Temporarily fixes case when 2 versions of the same DID doc have the same signingTime where one removes a key

### DIFF
--- a/vdr/store/memory.go
+++ b/vdr/store/memory.go
@@ -156,7 +156,7 @@ func timeSelectionFilter(metadata vdr.ResolveMetadata) filterFunc {
 		if e.next != nil {
 			// a next must always have an updated field
 			// the next version is created later, indicating this version is valid
-			return e.next.metadata.Updated.After(*metadata.ResolveTime)
+			return e.next.metadata.Updated.After(*metadata.ResolveTime) || e.next.metadata.Updated.Equal(*metadata.ResolveTime)
 		}
 
 		// last record in line


### PR DESCRIPTION
Development network is now broken, this makes it functional again.

Problem is still not fixed permanently though, since ultimately the 2 versions (in time) must be merged.