### PR TITLE
Iss351 vc resolve period validation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -159,7 +159,7 @@ func CreateSystem() *core.System {
 
 	networkInstance := network.NewNetworkInstance(network.DefaultConfig(), keyResolver)
 	vdrInstance := vdr.NewVDR(vdr.DefaultConfig(), cryptoInstance, networkInstance, store)
-	credentialInstance := vcr.NewVCRInstance(cryptoInstance, keyResolver, networkInstance)
+	credentialInstance := vcr.NewVCRInstance(cryptoInstance, docResolver, keyResolver, networkInstance)
 	statusEngine := status.NewStatusEngine(system)
 	metricsEngine := core.NewMetricsEngine()
 	authInstance := auth.NewAuthInstance(auth.DefaultConfig(), store, credentialInstance, cryptoInstance)

--- a/docs/_static/vcr/v1.yaml
+++ b/docs/_static/vcr/v1.yaml
@@ -54,7 +54,7 @@ paths:
         * 500 - An error occurred while processing the request
       operationId: "resolve"
       parameters:
-        - name: at
+        - name: resolveTime
           in: query
           description: a rfc3339 time string for resolving a VC at a specific moment in time
           example: "2012-01-02T12:00:00Z"

--- a/docs/_static/vcr/v1.yaml
+++ b/docs/_static/vcr/v1.yaml
@@ -57,6 +57,7 @@ paths:
         - name: at
           in: query
           description: a rfc3339 time string for resolving a VC at a specific moment in time
+          example: "2012-01-02T12:00:00Z"
           schema:
             type: string
       tags:

--- a/docs/_static/vcr/v1.yaml
+++ b/docs/_static/vcr/v1.yaml
@@ -53,6 +53,12 @@ paths:
         * 404 - Corresponding credential could not be found
         * 500 - An error occurred while processing the request
       operationId: "resolve"
+      parameters:
+        - name: at
+          in: query
+          description: a rfc3339 time string for resolving a VC at a specific moment in time
+          schema:
+            type: string
       tags:
         - credential
       responses:

--- a/vcr/api/v1/api.go
+++ b/vcr/api/v1/api.go
@@ -144,16 +144,17 @@ func (w *Wrapper) Resolve(ctx echo.Context, id string, params ResolveParams) err
 	}
 
 	// resolve time
-	at := time.Now()
-	if params.At != nil {
-		at, err = time.Parse(time.RFC3339, *params.At)
+	var at *time.Time
+	if params.ResolveTime != nil {
+		parsedTime, err := time.Parse(time.RFC3339, *params.ResolveTime)
 		if err != nil {
 			return core.InvalidInputError("failed to parse query parameter 'at': %w", err)
 		}
+		at = &parsedTime
 	}
 
 	// id is given with fragment
-	vc, err := w.R.Resolve(*idURI, &at)
+	vc, err := w.R.Resolve(*idURI, at)
 	if vc == nil && err != nil {
 		return err
 	}

--- a/vcr/api/v1/api_test.go
+++ b/vcr/api/v1/api_test.go
@@ -21,9 +21,10 @@ package v1
 
 import (
 	"errors"
-	"github.com/nuts-foundation/nuts-node/core"
 	"net/http"
 	"testing"
+
+	"github.com/nuts-foundation/nuts-node/core"
 
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/vdr"
@@ -127,16 +128,14 @@ func TestWrapper_Resolve(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		ctx := newMockContext(t)
-		defer ctx.ctrl.Finish()
-
 		var resolutionResult ResolutionResult
-		ctx.vcr.EXPECT().Resolve(*id).Return(&v, nil)
+		ctx.vcr.EXPECT().Resolve(*id, gomock.Any()).Return(&v, nil)
 		ctx.echo.EXPECT().JSON(http.StatusOK, gomock.Any()).DoAndReturn(func(f interface{}, f2 interface{}) error {
 			resolutionResult = f2.(ResolutionResult)
 			return nil
 		})
 
-		err := ctx.client.Resolve(ctx.echo, idString)
+		err := ctx.client.Resolve(ctx.echo, idString, ResolveParams{})
 
 		if !assert.NoError(t, err) {
 			return
@@ -147,11 +146,10 @@ func TestWrapper_Resolve(t *testing.T) {
 
 	t.Run("error - not found", func(t *testing.T) {
 		ctx := newMockContext(t)
-		defer ctx.ctrl.Finish()
 
-		ctx.vcr.EXPECT().Resolve(*id).Return(nil, vcr.ErrNotFound)
+		ctx.vcr.EXPECT().Resolve(*id, gomock.Any()).Return(nil, vcr.ErrNotFound)
 
-		err := ctx.client.Resolve(ctx.echo, idString)
+		err := ctx.client.Resolve(ctx.echo, idString, ResolveParams{})
 
 		assert.ErrorIs(t, err, vcr.ErrNotFound)
 		assert.Equal(t, http.StatusNotFound, ctx.client.ResolveStatusCode(err))
@@ -159,27 +157,25 @@ func TestWrapper_Resolve(t *testing.T) {
 
 	t.Run("error - other", func(t *testing.T) {
 		ctx := newMockContext(t)
-		defer ctx.ctrl.Finish()
 
-		ctx.vcr.EXPECT().Resolve(*id).Return(nil, errors.New("b00m!"))
+		ctx.vcr.EXPECT().Resolve(*id, gomock.Any()).Return(nil, errors.New("b00m!"))
 
-		err := ctx.client.Resolve(ctx.echo, idString)
+		err := ctx.client.Resolve(ctx.echo, idString, ResolveParams{})
 
 		assert.Error(t, err)
 	})
 
 	t.Run("error - revoked", func(t *testing.T) {
 		ctx := newMockContext(t)
-		defer ctx.ctrl.Finish()
 
 		var resolutionResult ResolutionResult
-		ctx.vcr.EXPECT().Resolve(*id).Return(&v, vcr.ErrRevoked)
+		ctx.vcr.EXPECT().Resolve(*id, gomock.Any()).Return(&v, vcr.ErrRevoked)
 		ctx.echo.EXPECT().JSON(http.StatusOK, gomock.Any()).DoAndReturn(func(f interface{}, f2 interface{}) error {
 			resolutionResult = f2.(ResolutionResult)
 			return nil
 		})
 
-		err := ctx.client.Resolve(ctx.echo, idString)
+		err := ctx.client.Resolve(ctx.echo, idString, ResolveParams{})
 
 		if !assert.NoError(t, err) {
 			return
@@ -188,24 +184,33 @@ func TestWrapper_Resolve(t *testing.T) {
 		assert.Equal(t, ResolutionResultCurrentStatusRevoked, resolutionResult.CurrentStatus)
 	})
 
-	t.Run("error - revoked", func(t *testing.T) {
+	t.Run("error - untrusted", func(t *testing.T) {
 		ctx := newMockContext(t)
-		defer ctx.ctrl.Finish()
 
 		var resolutionResult ResolutionResult
-		ctx.vcr.EXPECT().Resolve(*id).Return(&v, vcr.ErrUntrusted)
+		ctx.vcr.EXPECT().Resolve(*id, gomock.Any()).Return(&v, vcr.ErrUntrusted)
 		ctx.echo.EXPECT().JSON(http.StatusOK, gomock.Any()).DoAndReturn(func(f interface{}, f2 interface{}) error {
 			resolutionResult = f2.(ResolutionResult)
 			return nil
 		})
 
-		err := ctx.client.Resolve(ctx.echo, idString)
+		err := ctx.client.Resolve(ctx.echo, idString, ResolveParams{})
 
 		if !assert.NoError(t, err) {
 			return
 		}
 		assert.Equal(t, id, resolutionResult.VerifiableCredential.ID)
 		assert.Equal(t, ResolutionResultCurrentStatusUntrusted, resolutionResult.CurrentStatus)
+	})
+
+	t.Run("error - incorrect at param", func(t *testing.T) {
+		ctx := newMockContext(t)
+		at := "b00m!"
+
+		err := ctx.client.Resolve(ctx.echo, idString, ResolveParams{At: &at})
+
+		assert.Error(t, err)
+		assert.EqualError(t, err, "failed to parse query parameter 'at': parsing time \"b00m!\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"b00m!\" as \"2006\"")
 	})
 }
 
@@ -233,7 +238,7 @@ func TestWrapper_Search(t *testing.T) {
 			*sr = searchRequest
 			return nil
 		})
-		ctx.vcr.EXPECT().Search(gomock.Any()).Return([]vc.VerifiableCredential{concept.TestVC()}, nil)
+		ctx.vcr.EXPECT().Search(gomock.Any(), nil).Return([]vc.VerifiableCredential{concept.TestVC()}, nil)
 		ctx.echo.EXPECT().JSON(http.StatusOK, gomock.Any()).DoAndReturn(func(f interface{}, f2 interface{}) error {
 			capturedConcept = f2.([]concept.Concept)
 			return nil
@@ -280,7 +285,7 @@ func TestWrapper_Search(t *testing.T) {
 		defer ctx.ctrl.Finish()
 
 		ctx.echo.EXPECT().Bind(gomock.Any())
-		ctx.vcr.EXPECT().Search(gomock.Any()).Return(nil, errors.New("b00m!"))
+		ctx.vcr.EXPECT().Search(gomock.Any(), nil).Return(nil, errors.New("b00m!"))
 
 		err := ctx.client.Search(ctx.echo, "human")
 

--- a/vcr/api/v1/generated.go
+++ b/vcr/api/v1/generated.go
@@ -87,7 +87,7 @@ type CreateJSONBody IssueVCRequest
 type ResolveParams struct {
 
 	// a rfc3339 time string for resolving a VC at a specific moment in time
-	At *string `json:"at,omitempty"`
+	ResolveTime *string `json:"resolveTime,omitempty"`
 }
 
 // SearchJSONBody defines parameters for Search.
@@ -537,9 +537,9 @@ func NewResolveRequest(server string, id string, params *ResolveParams) (*http.R
 
 	queryValues := queryURL.Query()
 
-	if params.At != nil {
+	if params.ResolveTime != nil {
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "at", runtime.ParamLocationQuery, *params.At); err != nil {
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "resolveTime", runtime.ParamLocationQuery, *params.ResolveTime); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err
@@ -1291,11 +1291,11 @@ func (w *ServerInterfaceWrapper) Resolve(ctx echo.Context) error {
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params ResolveParams
-	// ------------- Optional query parameter "at" -------------
+	// ------------- Optional query parameter "resolveTime" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "at", ctx.QueryParams(), &params.At)
+	err = runtime.BindQueryParameter("form", true, false, "resolveTime", ctx.QueryParams(), &params.ResolveTime)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter at: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter resolveTime: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshalled arguments

--- a/vcr/api/v1/generated.go
+++ b/vcr/api/v1/generated.go
@@ -83,6 +83,13 @@ type TrustIssuerJSONBody CredentialIssuer
 // CreateJSONBody defines parameters for Create.
 type CreateJSONBody IssueVCRequest
 
+// ResolveParams defines parameters for Resolve.
+type ResolveParams struct {
+
+	// a rfc3339 time string for resolving a VC at a specific moment in time
+	At *string `json:"at,omitempty"`
+}
+
 // SearchJSONBody defines parameters for Search.
 type SearchJSONBody SearchRequest
 
@@ -190,7 +197,7 @@ type ClientInterface interface {
 	Revoke(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// Resolve request
-	Resolve(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	Resolve(ctx context.Context, id string, params *ResolveParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// Search request  with any body
 	SearchWithBody(ctx context.Context, concept string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -288,8 +295,8 @@ func (c *Client) Revoke(ctx context.Context, id string, reqEditors ...RequestEdi
 	return c.Client.Do(req)
 }
 
-func (c *Client) Resolve(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewResolveRequest(c.Server, id)
+func (c *Client) Resolve(ctx context.Context, id string, params *ResolveParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewResolveRequest(c.Server, id, params)
 	if err != nil {
 		return nil, err
 	}
@@ -503,7 +510,7 @@ func NewRevokeRequest(server string, id string) (*http.Request, error) {
 }
 
 // NewResolveRequest generates requests for Resolve
-func NewResolveRequest(server string, id string) (*http.Request, error) {
+func NewResolveRequest(server string, id string, params *ResolveParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -527,6 +534,26 @@ func NewResolveRequest(server string, id string) (*http.Request, error) {
 	}
 
 	queryURL := serverURL.ResolveReference(&operationURL)
+
+	queryValues := queryURL.Query()
+
+	if params.At != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "at", runtime.ParamLocationQuery, *params.At); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
@@ -713,7 +740,7 @@ type ClientWithResponsesInterface interface {
 	RevokeWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*RevokeResponse, error)
 
 	// Resolve request
-	ResolveWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ResolveResponse, error)
+	ResolveWithResponse(ctx context.Context, id string, params *ResolveParams, reqEditors ...RequestEditorFn) (*ResolveResponse, error)
 
 	// Search request  with any body
 	SearchWithBodyWithResponse(ctx context.Context, concept string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SearchResponse, error)
@@ -959,8 +986,8 @@ func (c *ClientWithResponses) RevokeWithResponse(ctx context.Context, id string,
 }
 
 // ResolveWithResponse request returning *ResolveResponse
-func (c *ClientWithResponses) ResolveWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ResolveResponse, error) {
-	rsp, err := c.Resolve(ctx, id, reqEditors...)
+func (c *ClientWithResponses) ResolveWithResponse(ctx context.Context, id string, params *ResolveParams, reqEditors ...RequestEditorFn) (*ResolveResponse, error) {
+	rsp, err := c.Resolve(ctx, id, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -1191,7 +1218,7 @@ type ServerInterface interface {
 	Revoke(ctx echo.Context, id string) error
 	// Resolves a verifiable credential
 	// (GET /internal/vcr/v1/vc/{id})
-	Resolve(ctx echo.Context, id string) error
+	Resolve(ctx echo.Context, id string, params ResolveParams) error
 	// Search for a concept. A concept is backed by 1 or more VCs
 	// (POST /internal/vcr/v1/{concept})
 	Search(ctx echo.Context, concept string) error
@@ -1262,8 +1289,17 @@ func (w *ServerInterfaceWrapper) Resolve(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ResolveParams
+	// ------------- Optional query parameter "at" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "at", ctx.QueryParams(), &params.At)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter at: %s", err))
+	}
+
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.Resolve(ctx, id)
+	err = w.Handler.Resolve(ctx, id, params)
 	return err
 }
 

--- a/vcr/concept/test.go
+++ b/vcr/concept/test.go
@@ -46,6 +46,8 @@ const TestCredential = `
 {
 	"id": "did:nuts:B8PUHs2AUHbFF1xLLK4eZjgErEcMXHxs68FteY7NDtCY#123",
 	"issuer": "did:nuts:B8PUHs2AUHbFF1xLLK4eZjgErEcMXHxs68FteY7NDtCY",
+	"issuanceDate": "1970-01-01T12:00:00Z",
+	"expirationDate": "2030-01-01T12:00:00Z",
 	"type": ["VerifiableCredential", "HumanCredential"],
 	"credentialSubject": {
 		"id": "did:nuts:GvkzxsezHvEc8nGhgz6Xo3jbqkHwswLmWw3CYtCm7hAW",

--- a/vcr/interface.go
+++ b/vcr/interface.go
@@ -51,6 +51,9 @@ var ErrUntrusted = errors.New("credential issuer is untrusted")
 // ErrInvalidCredential is returned when validation failed
 var ErrInvalidCredential = errors.New("invalid credential")
 
+// ErrInvalidPeriod is returned when the credential is not valid at the given time.
+var ErrInvalidPeriod = errors.New("credential not valid at given time")
+
 var vcDocumentType = "application/vc+json"
 
 var revocationDocumentType = "application/vc+json;type=revocation"

--- a/vcr/interface.go
+++ b/vcr/interface.go
@@ -22,6 +22,7 @@ package vcr
 import (
 	"embed"
 	"errors"
+	"time"
 
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/vc"
@@ -87,9 +88,9 @@ type Resolver interface {
 	// Resolve returns a credential based on its ID.
 	// The credential will still be returned in the case of ErrRevoked and ErrUntrusted.
 	// For other errors, nil is returned
-	Resolve(ID ssi.URI) (*vc.VerifiableCredential, error)
+	Resolve(ID ssi.URI, resolveTime *time.Time) (*vc.VerifiableCredential, error)
 	// Search for matching credentials based upon a query. It returns an empty list if no matches have been found.
-	Search(query concept.Query) ([]vc.VerifiableCredential, error)
+	Search(query concept.Query, resolveTime *time.Time) ([]vc.VerifiableCredential, error)
 }
 
 // VCR is the interface that covers all functionality of the vcr store.

--- a/vcr/interface.go
+++ b/vcr/interface.go
@@ -89,10 +89,12 @@ type Resolver interface {
 	// Registry returns the concept registry as read-only
 	Registry() concept.Reader
 	// Resolve returns a credential based on its ID.
+	// The optional resolveTime will resolve the credential at that point in time.
 	// The credential will still be returned in the case of ErrRevoked and ErrUntrusted.
 	// For other errors, nil is returned
 	Resolve(ID ssi.URI, resolveTime *time.Time) (*vc.VerifiableCredential, error)
 	// Search for matching credentials based upon a query. It returns an empty list if no matches have been found.
+	// The optional resolveTime will search for credentials at that point in time.
 	Search(query concept.Query, resolveTime *time.Time) ([]vc.VerifiableCredential, error)
 }
 

--- a/vcr/mock.go
+++ b/vcr/mock.go
@@ -6,6 +6,7 @@ package vcr
 
 import (
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	ssi "github.com/nuts-foundation/go-did"
@@ -222,33 +223,33 @@ func (mr *MockResolverMockRecorder) Registry() *gomock.Call {
 }
 
 // Resolve mocks base method.
-func (m *MockResolver) Resolve(ID ssi.URI) (*vc.VerifiableCredential, error) {
+func (m *MockResolver) Resolve(ID ssi.URI, resolveTime *time.Time) (*vc.VerifiableCredential, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Resolve", ID)
+	ret := m.ctrl.Call(m, "Resolve", ID, resolveTime)
 	ret0, _ := ret[0].(*vc.VerifiableCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Resolve indicates an expected call of Resolve.
-func (mr *MockResolverMockRecorder) Resolve(ID interface{}) *gomock.Call {
+func (mr *MockResolverMockRecorder) Resolve(ID, resolveTime interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockResolver)(nil).Resolve), ID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockResolver)(nil).Resolve), ID, resolveTime)
 }
 
 // Search mocks base method.
-func (m *MockResolver) Search(query concept.Query) ([]vc.VerifiableCredential, error) {
+func (m *MockResolver) Search(query concept.Query, resolveTime *time.Time) ([]vc.VerifiableCredential, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Search", query)
+	ret := m.ctrl.Call(m, "Search", query, resolveTime)
 	ret0, _ := ret[0].([]vc.VerifiableCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Search indicates an expected call of Search.
-func (mr *MockResolverMockRecorder) Search(query interface{}) *gomock.Call {
+func (mr *MockResolverMockRecorder) Search(query, resolveTime interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockResolver)(nil).Search), query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockResolver)(nil).Search), query, resolveTime)
 }
 
 // MockVCR is a mock of VCR interface.
@@ -319,18 +320,18 @@ func (mr *MockVCRMockRecorder) Registry() *gomock.Call {
 }
 
 // Resolve mocks base method.
-func (m *MockVCR) Resolve(ID ssi.URI) (*vc.VerifiableCredential, error) {
+func (m *MockVCR) Resolve(ID ssi.URI, resolveTime *time.Time) (*vc.VerifiableCredential, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Resolve", ID)
+	ret := m.ctrl.Call(m, "Resolve", ID, resolveTime)
 	ret0, _ := ret[0].(*vc.VerifiableCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Resolve indicates an expected call of Resolve.
-func (mr *MockVCRMockRecorder) Resolve(ID interface{}) *gomock.Call {
+func (mr *MockVCRMockRecorder) Resolve(ID, resolveTime interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockVCR)(nil).Resolve), ID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockVCR)(nil).Resolve), ID, resolveTime)
 }
 
 // Revoke mocks base method.
@@ -349,18 +350,18 @@ func (mr *MockVCRMockRecorder) Revoke(ID interface{}) *gomock.Call {
 }
 
 // Search mocks base method.
-func (m *MockVCR) Search(query concept.Query) ([]vc.VerifiableCredential, error) {
+func (m *MockVCR) Search(query concept.Query, resolveTime *time.Time) ([]vc.VerifiableCredential, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Search", query)
+	ret := m.ctrl.Call(m, "Search", query, resolveTime)
 	ret0, _ := ret[0].([]vc.VerifiableCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Search indicates an expected call of Search.
-func (mr *MockVCRMockRecorder) Search(query interface{}) *gomock.Call {
+func (mr *MockVCRMockRecorder) Search(query, resolveTime interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockVCR)(nil).Search), query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockVCR)(nil).Search), query, resolveTime)
 }
 
 // StoreCredential mocks base method.

--- a/vcr/store_test.go
+++ b/vcr/store_test.go
@@ -24,8 +24,11 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
+	"time"
 
+	did2 "github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
+	"github.com/nuts-foundation/nuts-node/vdr/types"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -41,6 +44,7 @@ func TestVcr_StoreCredential(t *testing.T) {
 	target := vc.VerifiableCredential{}
 	vcJSON, _ := os.ReadFile("test/vc.json")
 	json.Unmarshal(vcJSON, &target)
+	did, _ := did2.ParseDIDURL(target.Issuer.String())
 
 	// load pub key
 	pke := storage.PublicKeyEntry{}
@@ -51,10 +55,17 @@ func TestVcr_StoreCredential(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		ctx := newMockContext(t)
+		now := time.Now()
+		timeFunc = func() time.Time {
+			return now
+		}
+		defer func() {
+			timeFunc = time.Now
+		}()
 
 		ctx.vcr.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
 		ctx.keyResolver.EXPECT().ResolveSigningKey(gomock.Any(), nil).Return(pk, nil)
-		ctx.docResolver.EXPECT().Resolve(gomock.Any(), gomock.Any()).Return(nil, nil, nil)
+		ctx.docResolver.EXPECT().Resolve(*did, &types.ResolveMetadata{ResolveTime: &now}).Return(nil, nil, nil)
 
 		err := ctx.vcr.StoreCredential(target)
 

--- a/vcr/store_test.go
+++ b/vcr/store_test.go
@@ -52,7 +52,6 @@ func TestVcr_StoreCredential(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		ctx := newMockContext(t)
 
-		ctx.tx.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(2)
 		ctx.vcr.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
 		ctx.keyResolver.EXPECT().ResolveSigningKey(gomock.Any(), nil).Return(pk, nil)
 
@@ -64,7 +63,6 @@ func TestVcr_StoreCredential(t *testing.T) {
 	t.Run("error - validation", func(t *testing.T) {
 		ctx := newMockContext(t)
 
-		ctx.tx.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(2)
 		ctx.vcr.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
 
 		err := ctx.vcr.StoreCredential(vc.VerifiableCredential{})
@@ -89,7 +87,6 @@ func TestVcr_StoreRevocation(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		ctx := newMockContext(t)
 
-		ctx.tx.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(2)
 		ctx.vcr.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
 		ctx.keyResolver.EXPECT().ResolveSigningKey(gomock.Any(), gomock.Any()).Return(pk, nil)
 
@@ -101,7 +98,6 @@ func TestVcr_StoreRevocation(t *testing.T) {
 	t.Run("error - validation", func(t *testing.T) {
 		ctx := newMockContext(t)
 
-		ctx.tx.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(2)
 		ctx.vcr.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
 
 		err := ctx.vcr.StoreRevocation(credential.Revocation{})

--- a/vcr/store_test.go
+++ b/vcr/store_test.go
@@ -54,6 +54,7 @@ func TestVcr_StoreCredential(t *testing.T) {
 
 		ctx.vcr.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
 		ctx.keyResolver.EXPECT().ResolveSigningKey(gomock.Any(), nil).Return(pk, nil)
+		ctx.docResolver.EXPECT().Resolve(gomock.Any(), gomock.Any()).Return(nil, nil, nil)
 
 		err := ctx.vcr.StoreCredential(target)
 

--- a/vcr/test.go
+++ b/vcr/test.go
@@ -77,9 +77,6 @@ func newMockContext(t *testing.T) mockContext {
 	if err := vcr.Configure(core.ServerConfig{Datadir: testDir}); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		ctrl.Finish()
-	})
 
 	return mockContext{
 		ctrl:        ctrl,

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -46,6 +46,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var timeFunc = time.Now
+
 // NewVCRInstance creates a new vcr instance with default config and empty concept registry
 func NewVCRInstance(keyStore crypto.KeyStore, docResolver vdr.DocResolver, keyResolver vdr.KeyResolver, network network.Transactions) VCR {
 	r := &vcr{
@@ -330,7 +332,7 @@ func (c *vcr) validateForUse(credential vc.VerifiableCredential, validAt *time.T
 }
 
 func (c *vcr) validate(credential vc.VerifiableCredential, validAt *time.Time) error {
-	at := time.Now()
+	at := timeFunc()
 	if validAt != nil {
 		at = *validAt
 	}
@@ -584,7 +586,7 @@ func (c *vcr) Get(conceptName string, subject string) (concept.Concept, error) {
 
 	q.AddClause(concept.Eq(concept.SubjectField, subject))
 
-	// finding a VC that backs a concept is a runtime call, eg: usage is now
+	// finding a VC that backs a concept always occurs in the present, so no resolveTime needs to be passed.
 	vcs, err := c.Search(q, nil)
 	if err != nil {
 		return nil, err

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -121,9 +121,10 @@ func TestVCR_Search(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		ctx, q := testInstance(t)
 		ctx.vcr.Trust(vc.Type[0], vc.Issuer)
+		now := time.Now()
 		ctx.docResolver.EXPECT().Resolve(gomock.Any(), gomock.Any()).Return(nil, nil, nil)
 
-		creds, err := ctx.vcr.Search(q, nil)
+		creds, err := ctx.vcr.Search(q, &now)
 
 		if !assert.NoError(t, err) {
 			return
@@ -465,7 +466,8 @@ func TestVcr_Verify(t *testing.T) {
 		ctx := newMockContext(t)
 		instance := ctx.vcr
 
-		ctx.keyResolver.EXPECT().ResolveSigningKey(testKID, nil).Return(pk, nil)
+		ctx.keyResolver.EXPECT().ResolveSigningKey(testKID, gomock.Any()).Return(pk, nil)
+		ctx.docResolver.EXPECT().Resolve(gomock.Any(), gomock.Any()).Return(nil, nil, nil)
 
 		err := instance.Verify(subject, nil)
 

--- a/vdr/api/v1/generated.go
+++ b/vdr/api/v1/generated.go
@@ -570,7 +570,6 @@ type ClientWithResponsesInterface interface {
 type CreateDIDResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON400      *string
 }
 
 // Status returns HTTPResponse.Status
@@ -779,13 +778,6 @@ func ParseCreateDIDResponse(rsp *http.Response) (*CreateDIDResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
-		var dest string
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON400 = &dest
-
 	}
 
 	return response, nil


### PR DESCRIPTION
Closes #351 
Also part of nuts-foundation/nuts-specification#108, it solves the validity problem of VCs where the issuer has been deactivated.

This PR adds a `validate` and `validateForUse` private function to the vcr which does runtime checks.
The Resolve API now also has an optional `at` query param for resolving at a specific time.