### PR TITLE
Return DID.controller as object

### DIFF
--- a/docs/_static/vdr/v1.yaml
+++ b/docs/_static/vdr/v1.yaml
@@ -204,10 +204,8 @@ components:
           items:
             type: string
         controller:
-          description: List of DIDs that have control over the DID document
-          type: array
-          items:
-            type: string
+          description: Single DID (as string) or List of DIDs that have control over the DID document
+          type: object
         id:
           description: DID according to Nuts specification
           example: "did:nuts:1"

--- a/docs/_static/vdr/v1.yaml
+++ b/docs/_static/vdr/v1.yaml
@@ -205,7 +205,6 @@ components:
             type: string
         controller:
           description: Single DID (as string) or List of DIDs that have control over the DID document
-          type: object
         id:
           description: DID according to Nuts specification
           example: "did:nuts:1"

--- a/vdr/api/v1/generated.go
+++ b/vdr/api/v1/generated.go
@@ -570,7 +570,6 @@ type ClientWithResponsesInterface interface {
 type CreateDIDResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON400      *string
 }
 
 // Status returns HTTPResponse.Status
@@ -779,13 +778,6 @@ func ParseCreateDIDResponse(rsp *http.Response) (*CreateDIDResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
-		var dest string
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON400 = &dest
-
 	}
 
 	return response, nil


### PR DESCRIPTION
Fixes #365 

Returning document.controller as object is the quickest and simplest way to fix this. 
The API returns a DIDDocument according to the go-did library not according to spec.