### PR TITLE
added check to vdr.Resolve for deactivated controller

### DIFF
--- a/docs/_static/vdr/v1.yaml
+++ b/docs/_static/vdr/v1.yaml
@@ -48,7 +48,7 @@ paths:
     get:
       summary: "Resolves a Nuts DID document"
       description: |
-        Resolves a Nuts DID document
+        Resolves a Nuts DID document. It also resolves deactivated documents.
 
         error returns:
           * 400 - Returned in case of malformed DID
@@ -75,7 +75,7 @@ paths:
           * 400 - DID document could not be updated because the DID param was malformed or the DID document is invalid
           * 403 - DID document could not be updated because the DID is not managed by this node
           * 404 - Corresponding DID document could not be found
-          * 409 - DID document could not be updated because the the document was already deactivated
+          * 409 - DID document could not be updated because the document is deactivated or its controllers are deactivated
           * 500 - An error occurred while processing the request
       operationId: "updateDID"
       tags:

--- a/vdr/api/v1/api.go
+++ b/vdr/api/v1/api.go
@@ -48,6 +48,7 @@ func (a *Wrapper) ResolveStatusCode(err error) int {
 		types.ErrNotFound:                http.StatusNotFound,
 		types.ErrDIDNotManagedByThisNode: http.StatusForbidden,
 		types.ErrDeactivated:             http.StatusConflict,
+		types.ErrNoActiveController:      http.StatusConflict,
 		types.ErrDuplicateService:        http.StatusBadRequest,
 		vdrDoc.ErrInvalidOptions:         http.StatusBadRequest,
 		did.ErrInvalidDID:                http.StatusBadRequest,
@@ -154,7 +155,7 @@ func (a Wrapper) GetDID(ctx echo.Context, targetDID string) error {
 	}
 
 	// no params in the API for now
-	doc, meta, err := a.DocResolver.Resolve(*d, nil)
+	doc, meta, err := a.DocResolver.Resolve(*d, &types.ResolveMetadata{AllowDeactivated: true})
 	if err != nil {
 		return err
 	}

--- a/vdr/api/v1/api_test.go
+++ b/vdr/api/v1/api_test.go
@@ -17,9 +17,10 @@ package v1
 
 import (
 	"errors"
-	"github.com/nuts-foundation/nuts-node/core"
 	"net/http"
 	"testing"
+
+	"github.com/nuts-foundation/nuts-node/core"
 
 	"github.com/golang/mock/gomock"
 	"github.com/nuts-foundation/go-did/did"
@@ -164,7 +165,7 @@ func TestWrapper_GetDID(t *testing.T) {
 			return nil
 		})
 
-		ctx.docResolver.EXPECT().Resolve(*id, nil).Return(didDoc, meta, nil)
+		ctx.docResolver.EXPECT().Resolve(*id, &types.ResolveMetadata{AllowDeactivated: true}).Return(didDoc, meta, nil)
 		err := ctx.client.GetDID(ctx.echo, id.String())
 
 		if !assert.NoError(t, err) {
@@ -185,7 +186,7 @@ func TestWrapper_GetDID(t *testing.T) {
 	t.Run("error - not found", func(t *testing.T) {
 		ctx := newMockContext(t)
 
-		ctx.docResolver.EXPECT().Resolve(*id, nil).Return(nil, nil, types.ErrNotFound)
+		ctx.docResolver.EXPECT().Resolve(*id, &types.ResolveMetadata{AllowDeactivated: true}).Return(nil, nil, types.ErrNotFound)
 		err := ctx.client.GetDID(ctx.echo, id.String())
 
 		assert.ErrorIs(t, err, types.ErrNotFound)
@@ -195,7 +196,7 @@ func TestWrapper_GetDID(t *testing.T) {
 	t.Run("error - other", func(t *testing.T) {
 		ctx := newMockContext(t)
 
-		ctx.docResolver.EXPECT().Resolve(*id, nil).Return(nil, nil, errors.New("b00m!"))
+		ctx.docResolver.EXPECT().Resolve(*id, &types.ResolveMetadata{AllowDeactivated: true}).Return(nil, nil, errors.New("b00m!"))
 		err := ctx.client.GetDID(ctx.echo, id.String())
 
 		assert.Error(t, err)

--- a/vdr/doc/resolvers.go
+++ b/vdr/doc/resolvers.go
@@ -65,7 +65,7 @@ func (d Resolver) resolve(id did.DID, metadata *types.ResolveMetadata, depth int
 			return nil, nil, err
 		}
 		if len(controllers) == 0 {
-			return nil, nil, types.ErrDeactivated
+			return nil, nil, types.ErrNoActiveController
 		}
 	}
 
@@ -102,7 +102,7 @@ func (d Resolver) resolveControllers(doc did.Document, metadata *types.ResolveMe
 	// resolve all unresolved docs
 	for _, ref := range refsToResolve {
 		node, _, err := d.resolve(ref, metadata, depth)
-		if errors.Is(err, types.ErrDeactivated) {
+		if errors.Is(err, types.ErrDeactivated) || errors.Is(err, types.ErrNoActiveController) {
 			continue
 		}
 		if errors.Is(err, ErrNestedDocumentsTooDeep) {

--- a/vdr/doc/resolvers_test.go
+++ b/vdr/doc/resolvers_test.go
@@ -198,7 +198,7 @@ func TestResolver_Resolve(t *testing.T) {
 		doc, _, err := resolver.Resolve(*id456, resolveMD)
 
 		assert.Error(t, err)
-		assert.Equal(t, types.ErrDeactivated, err)
+		assert.Equal(t, types.ErrNoActiveController, err)
 		assert.Nil(t, doc)
 	})
 

--- a/vdr/doc/resolvers_test.go
+++ b/vdr/doc/resolvers_test.go
@@ -227,7 +227,7 @@ func TestResolver_Resolve(t *testing.T) {
 		store := types.NewMockStore(ctrl)
 		resolver := Resolver{Store: store}
 		for i := 0; i < depth; i++ {
-			id, _ := did.ParseDID(fmt.Sprintf("did:nuts:%d",i))
+			id, _ := did.ParseDID(fmt.Sprintf("did:nuts:%d", i))
 			d := did.Document{ID: *id, Controller: []did.DID{*prevID}}
 			store.EXPECT().Resolve(*prevID, resolveMD).Return(&prevDoc, &types.DocumentMetadata{}, nil).AnyTimes()
 			dids[i] = id

--- a/vdr/types/common.go
+++ b/vdr/types/common.go
@@ -41,6 +41,9 @@ var ErrNotFound = errors.New("unable to find the DID document")
 // ErrDeactivated The DID supplied to the DID resolution function has been deactivated.
 var ErrDeactivated = errors.New("the DID document has been deactivated")
 
+// ErrNoActiveController The DID supplied to the DID resolution does not have any active controllers.
+var ErrNoActiveController = errors.New("no active controllers for DID Document")
+
 // ErrDIDAlreadyExists is returned when a DID already exists.
 var ErrDIDAlreadyExists = errors.New("DID document already exists in the store")
 

--- a/vdr/types/interface.go
+++ b/vdr/types/interface.go
@@ -34,6 +34,8 @@ type DocResolver interface {
 	// If metadata is not provided the latest version is returned.
 	// If metadata is provided then the result is filtered or scoped on that metadata.
 	// It returns ErrNotFound if there are no corresponding DID documents or when the DID Documents are disjoint with the provided ResolveMetadata
+	// It returns ErrDeactivated if the DID Document has been deactivated
+	// It returns ErrNoActiveController if all of the DID Documents controllers have been deactivated
 	Resolve(id did.DID, metadata *ResolveMetadata) (*did.Document, *DocumentMetadata, error)
 	// ResolveControllers finds the DID Document controllers
 	ResolveControllers(input did.Document, metadata *ResolveMetadata) ([]did.Document, error)


### PR DESCRIPTION
closes #372 

It now checks if the controller is not deactivated. If it is, it'll return an ErrDeactivated.
It still honours metadata.AllowDeactivated