### PR TITLE
Network: fix reconnect loop for bootstrap nodes

### DIFF
--- a/network/p2p/backoff.go
+++ b/network/p2p/backoff.go
@@ -19,6 +19,7 @@
 package p2p
 
 import (
+	"math/rand"
 	"time"
 )
 
@@ -32,6 +33,12 @@ type Backoff interface {
 	Reset()
 	// Backoff returns the waiting time before the call should be retried, and should be called after a failed call.
 	Backoff() time.Duration
+}
+
+// RandomBackoff returns a random time.Duration which lies between the given (inclusive) min/max bounds.
+// It can be used to get a random, one-off backoff.
+func RandomBackoff(min, max time.Duration) time.Duration {
+	return time.Duration(rand.Int63n(int64(max-min)) + int64(min))
 }
 
 type backoff struct {

--- a/network/p2p/backoff_test.go
+++ b/network/p2p/backoff_test.go
@@ -50,3 +50,12 @@ func TestBackoffDefaultValues(t *testing.T) {
 	assert.Equal(t, time.Second, b.min)
 	assert.Equal(t, 30*time.Second, b.max)
 }
+
+func TestRandomBackoff(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		const min = time.Second
+		const max = 10 * time.Second
+		val := RandomBackoff(min, max)
+		assert.True(t, val >= min && val <= max)
+	}
+}


### PR DESCRIPTION
When 2 nodes configure each other as bootstrap node, a reconnect loop occurs because:

- They don't recognize an existing incoming connection from the configured bootstrap node as being from that node, because bootstrap nodes are configured with just their address, not their peer ID.
- When a connection to a bootstrap node closes it the local node immediately reconnects. When the remote node does the same, the result is racy: the second connection that succeeds will close the first, leading to a reconnection, etc.

Fix is 2-fold:

- When connecting to a bootstrap node, store its peer ID so we can check whether we're already connected (to a peer with that ID), before reconnecting.
- Wait a random duration before reconnecting to make the chance of simultaneously reconnecting to each other smaller.

Nodes (that have each other configured as bootstrap nodes) will still reconnect at least 2 times initially, because they have to discover each other's peer IDs. It will also still occur when the race condition is triggered: when the random reconnection delays are close enough to each other (in combination with network delay). This is not a problem: they will simply disconnect and reconnect after a new random delay (it can still be a problem when the network delay is longer than the max. reconnect delay, which is 5 seconds).

Good enough for now.

Ultimately I think bootstrap nodes should be configured with the peer IDs as wel, which eliminates the initial reconnections described above. It also makes it safer, because then you know the peer you're connecting to is actually the intended peer (and not a MITM). For this peer ID has to replaced with a cryptographic _node identity_ first.

Fixes #349 