### PR TITLE
Network: temporarily fix freezing nodes due to full channels, caused by increasing DAG

### DIFF
--- a/network/p2p/impl.go
+++ b/network/p2p/impl.go
@@ -42,7 +42,7 @@ type dialer func(ctx context.Context, target string, opts ...grpc.DialOption) (c
 
 const connectingQueueChannelSize = 100
 const eventChannelSize = 100
-const messageBacklogChannelSize = 100
+const messageBacklogChannelSize = 1000 // TODO: Does this number make sense? Should also be configurable?
 const maxMessageSizeInBytes = 1024 * 512
 
 type adapter struct {


### PR DESCRIPTION
Part of #387, still needs to be solved definitively. This should make the development network working again.