### PR TITLE
Allow exact matches in VCR search

### DIFF
--- a/vcr/assets/NutsOrganizationCredential.config.yaml
+++ b/vcr/assets/NutsOrganizationCredential.config.yaml
@@ -15,11 +15,11 @@ indices:
     parts:
       - path: credentialSubject.organization.name
         alias: organization.name
-        tokenizer: whitespace
+        tokenizer: whitespaceOrExact
         transformer: cologne
       - path: credentialSubject.organization.city
         alias: organization.city
-        tokenizer: whitespace
+        tokenizer: whitespaceOrExact
         transformer: cologne
 template: |
     {

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -139,6 +139,13 @@ func (c *vcr) loadTemplates() error {
 	return nil
 }
 
+func whitespaceOrExactTokenizer(text string) (tokens []string) {
+	tokens = leia.WhiteSpaceTokenizer(text)
+	tokens = append(tokens, text)
+
+	return
+}
+
 func (c *vcr) initIndices() error {
 	for _, config := range c.registry.Concepts() {
 		collection := c.store.Collection(config.CredentialType)
@@ -153,6 +160,8 @@ func (c *vcr) initIndices() error {
 				if iParts.Tokenizer != nil {
 					tokenizer := strings.ToLower(*iParts.Tokenizer)
 					switch tokenizer {
+					case "whitespaceorexact":
+						options = append(options, leia.TokenizerOption(whitespaceOrExactTokenizer))
 					case "whitespace":
 						options = append(options, leia.TokenizerOption(leia.WhiteSpaceTokenizer))
 					default:

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -1065,6 +1065,12 @@ func TestVcr_generateRevocationProof(t *testing.T) {
 	})
 }
 
+func TestWhitespaceOrExactTokenizer(t *testing.T) {
+	input := "a b c"
+
+	assert.Equal(t, []string{"a", "b", "c", "a b c"}, whitespaceOrExactTokenizer(input))
+}
+
 func validNutsOrganizationCredential() *vc.VerifiableCredential {
 	uri, _ := ssi.ParseURI(credential.NutsOrganizationCredentialType)
 	issuer, _ := ssi.ParseURI(vdr.TestDIDA.String())


### PR DESCRIPTION
Adds a `whitespaceOrExact` tokenizer which adds the input itself as a token as well to allow exact matches.

Closes: #386 