### PR TITLE
Fix p2p test

### DIFF
--- a/network/p2p/connection.go
+++ b/network/p2p/connection.go
@@ -243,8 +243,8 @@ func (mgr *connectionManager) get(peer PeerID) connection {
 func (mgr *connectionManager) close(peer PeerID) bool {
 	mgr.mux.Lock()
 	defer mgr.mux.Unlock()
-	conn := mgr.conns[peer]
-	if conn == nil {
+	conn, ok := mgr.conns[peer]
+	if !ok {
 		return false
 	}
 	conn.close()

--- a/network/p2p/impl.go
+++ b/network/p2p/impl.go
@@ -343,6 +343,7 @@ func (n *adapter) shouldConnectTo(address string, peerID PeerID) bool {
 		log.Logger().Tracef("Not connecting since it's localhost (address=%s)", address)
 		return false
 	}
+
 	alreadyConnected := n.conns.isConnected(normalizedAddress)
 	if alreadyConnected {
 		log.Logger().Tracef("Not connected since we're already connected to a peer on that address (address=%s)", address)
@@ -350,6 +351,7 @@ func (n *adapter) shouldConnectTo(address string, peerID PeerID) bool {
 		log.Logger().Tracef("Not connecting since we're already connected to a peer with that ID (peer=%s)", peerID)
 		alreadyConnected = true
 	}
+
 	return !alreadyConnected
 }
 


### PR DESCRIPTION
It looks like adding yourself as a peer works (sort of) but can have unexpected side-effects such as the connection being closed and re-tried many times. This doesn't really work out in the unittest so @gerardsn and I changed it to connect to another peer.