### PR TITLE
Fix oauth flow without identity

### DIFF
--- a/auth/api/v1/api.go
+++ b/auth/api/v1/api.go
@@ -258,6 +258,14 @@ func (w Wrapper) DrawUpContract(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, response)
 }
 
+func makeStringPointer(input string) *string {
+	if input == "" {
+		return nil
+	}
+
+	return &input
+}
+
 // CreateJwtGrant handles the http request (from the vendor's EPD/XIS) for creating a JWT bearer token which can be used to retrieve an access token from a remote Nuts node.
 func (w Wrapper) CreateJwtGrant(ctx echo.Context) error {
 	requestBody := &CreateJwtGrantRequest{}
@@ -268,11 +276,12 @@ func (w Wrapper) CreateJwtGrant(ctx echo.Context) error {
 	request := services.CreateJwtGrantRequest{
 		Actor:         requestBody.Actor,
 		Custodian:     requestBody.Custodian,
-		IdentityToken: &requestBody.Identity,
+		IdentityToken: makeStringPointer(requestBody.Identity),
 		Service:       requestBody.Service,
 		Subject:       requestBody.Subject,
 		Credentials:   requestBody.Credentials,
 	}
+
 	response, err := w.Auth.OAuthClient().CreateJwtGrant(request)
 	if err != nil {
 		return core.InvalidInputError(err.Error())
@@ -291,7 +300,7 @@ func (w Wrapper) RequestAccessToken(ctx echo.Context) error {
 	request := services.CreateJwtGrantRequest{
 		Actor:         requestBody.Actor,
 		Custodian:     requestBody.Custodian,
-		IdentityToken: &requestBody.Identity,
+		IdentityToken: makeStringPointer(requestBody.Identity),
 		Service:       requestBody.Service,
 		Subject:       requestBody.Subject,
 		Credentials:   requestBody.Credentials,

--- a/auth/api/v1/api_test.go
+++ b/auth/api/v1/api_test.go
@@ -755,7 +755,6 @@ func TestWrapper_CreateAccessToken(t *testing.T) {
 		err := ctx.wrapper.CreateAccessToken(ctx.echoMock)
 
 		assert.Nil(t, err)
-
 	})
 }
 

--- a/auth/contract/template.go
+++ b/auth/contract/template.go
@@ -111,14 +111,5 @@ func (c Template) Render(vars map[string]string, validFrom time.Time, validDurat
 	return contract, nil
 }
 
-// ErrUnknownContractFormat is returned when the contract format is unknown
-var ErrUnknownContractFormat = errors.New("unknown contract format")
-
-// ErrInvalidContractFormat indicates tha a contract format is unknown.
-var ErrInvalidContractFormat = errors.New("unknown contract type")
-
-// ErrContractNotFound is used when a certain combination of type, language and version cannot resolve to a contract
-var ErrContractNotFound = errors.New("contract not found")
-
 // ErrInvalidContractText is used when contract texts cannot be parsed or contain invalid values
 var ErrInvalidContractText = errors.New("invalid contract text")

--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -147,9 +147,6 @@ func (s *service) CreateAccessToken(request services.CreateAccessTokenRequest) (
 	return &services.AccessTokenResult{AccessToken: accessToken}, nil
 }
 
-// ErrLegalEntityNotProvided indicates that the legalEntity is missing
-var ErrLegalEntityNotProvided = errors.New("legalEntity not provided")
-
 // checks if the name from the login contract matches with the registered name of the issuer.
 func (s *service) validateActor(context *validationContext) error {
 	if context.contractVerificationResult.ContractAttributes[contract.LegalEntityAttr] != context.actorName || context.contractVerificationResult.ContractAttributes[contract.LegalEntityCityAttr] != context.actorCity {

--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -112,21 +112,26 @@ func (s *service) CreateAccessToken(request services.CreateAccessTokenRequest) (
 
 	// Validate the AuthTokenContainer, according to RFC003 §5.2.1.5
 	var err error
+
 	if context.jwtBearerTokenClaims.UserIdentity != nil {
 		var decoded []byte
+
 		if decoded, err = base64.StdEncoding.DecodeString(*context.jwtBearerTokenClaims.UserIdentity); err != nil {
 			return nil, fmt.Errorf("failed to decode base64 usi field: %w", err)
 		}
+
 		if context.contractVerificationResult, err = s.contractClient.VerifyVP(decoded, nil); err != nil {
 			return nil, fmt.Errorf("identity verification failed: %w", err)
 		}
-	}
-	if context.contractVerificationResult.Validity == contract.Invalid {
-		return nil, errors.New("identity validation failed")
-	}
-	// checks if the name from the login contract matches with the registered name of the issuer.
-	if err := s.validateActor(&context); err != nil {
-		return nil, err
+
+		if context.contractVerificationResult.Validity != contract.Valid {
+			return nil, errors.New("identity validation failed")
+		}
+
+		// checks if the name from the login contract matches with the registered name of the issuer.
+		if err := s.validateActor(&context); err != nil {
+			return nil, err
+		}
 	}
 
 	// validate the endpoint in aud, according to RFC003 §5.2.1.6
@@ -367,46 +372,52 @@ func (s *service) IntrospectAccessToken(accessToken string) (*services.NutsAcces
 // BuildAccessToken builds an access token based on the oauth claims and the identity of the user provided by the identityValidationResult
 // The token gets signed with the custodians private key and returned as a string.
 func (s *service) buildAccessToken(context *validationContext) (string, error) {
-	identityValidationResult := context.contractVerificationResult
-	bearerTokenClaims := context.jwtBearerTokenClaims
-	bearerToken := context.jwtBearerToken
-
-	if identityValidationResult.Validity != contract.Valid {
-		return "", fmt.Errorf("could not build accessToken: %w", errors.New("invalid contract"))
+	if context.contractVerificationResult != nil {
+		if context.contractVerificationResult.Validity != contract.Valid {
+			return "", fmt.Errorf("could not build accessToken: %w", errors.New("invalid contract"))
+		}
 	}
 
-	if bearerToken.Subject() == "" {
+	if context.jwtBearerToken.Subject() == "" {
 		return "", fmt.Errorf("could not build accessToken: %w", errors.New("subject is missing"))
 	}
 
-	issuer, err := did.ParseDID(bearerToken.Subject())
+	issuer, err := did.ParseDID(context.jwtBearerToken.Subject())
 	if err != nil {
-		return "", fmt.Errorf("could not build accessToken, subject is invalid (subject=%s): %w", bearerToken.Subject(), err)
+		return "", fmt.Errorf("could not build accessToken, subject is invalid (subject=%s): %w", context.jwtBearerToken.Subject(), err)
 	}
 
-	disclosedAttributes := identityValidationResult.DisclosedAttributes
 	issueTime := time.Now()
+
 	at := services.NutsAccessToken{
-		SubjectID: bearerTokenClaims.SubjectID,
-		Service:   bearerTokenClaims.Service,
+		SubjectID:  context.jwtBearerTokenClaims.SubjectID,
+		Service:    context.jwtBearerTokenClaims.Service,
+		Expiration: time.Now().Add(time.Minute * 15).UTC().Unix(), // Expires in 15 minutes
+		IssuedAt:   issueTime.UTC().Unix(),
+		Issuer:     issuer.String(),
+		Subject:    context.jwtBearerToken.Issuer(),
+	}
+
+	if context.contractVerificationResult != nil {
+		disclosedAttributes := context.contractVerificationResult.DisclosedAttributes
+
 		// based on
 		// https://privacybydesign.foundation/attribute-index/en/pbdf.gemeente.personalData.html
 		// https://privacybydesign.foundation/attribute-index/en/pbdf.pbdf.email.html
 		// and
 		// https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims
-		FamilyName: disclosedAttributes["gemeente.personalData.familyname"],
-		GivenName:  disclosedAttributes["gemeente.personalData.firstnames"],
-		Prefix:     disclosedAttributes["gemeente.personalData.prefix"],
-		Name:       disclosedAttributes["gemeente.personalData.fullname"],
-		Email:      disclosedAttributes["sidn-pbdf.email.email"],
-		Expiration: time.Now().Add(time.Minute * 15).UTC().Unix(), // Expires in 15 minutes
-		IssuedAt:   issueTime.UTC().Unix(),
-		Issuer:     issuer.String(),
-		Subject:    bearerToken.Issuer(),
+		at.FamilyName = disclosedAttributes["gemeente.personalData.familyname"]
+		at.GivenName = disclosedAttributes["gemeente.personalData.firstnames"]
+		at.Prefix = disclosedAttributes["gemeente.personalData.prefix"]
+		at.Name = disclosedAttributes["gemeente.personalData.fullname"]
+		at.Email = disclosedAttributes["sidn-pbdf.email.email"]
 	}
+
 	var keyVals map[string]interface{}
-	inrec, _ := json.Marshal(at)
-	if err := json.Unmarshal(inrec, &keyVals); err != nil {
+
+	data, _ := json.Marshal(at)
+
+	if err := json.Unmarshal(data, &keyVals); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
Currently, the oath flow doesn't work without user identity because of two bugs:

1. In the OpenAPI spec the identity is a string but in our code it's a string pointer. Before this fix the empty string would be converted into an empty string pointer instead of `nil`
2. No identity means no contract validation (if I understand it correctly) this wasn't taken into account when creating the access token