### PR TITLE
also push to ghcr for a merge/push

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -46,7 +46,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64
-          push: ${{ github.event_name == 'pull_request' }}
+          push: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
           tags: ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}
           secrets: |
             "github_token=${{ secrets.PACKAGE_SECRET }}"


### PR DESCRIPTION
for the e2e tests, the docker image was only pushed for PRs, thus the master build was always broken...