### PR TITLE
Also include the public claims in token introspection

### DIFF
--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -355,11 +355,19 @@ func (s *service) IntrospectAccessToken(accessToken string) (*services.NutsAcces
 	if err != nil {
 		return nil, err
 	}
-	var result services.NutsAccessToken
+
+	result := &services.NutsAccessToken{}
+
 	if err := result.FromMap(token.PrivateClaims()); err != nil {
 		return nil, err
 	}
-	return &result, err
+
+	result.Subject = token.Subject()
+	result.Issuer = token.Issuer()
+	result.IssuedAt = token.IssuedAt().Unix()
+	result.Expiration = token.Expiration().Unix()
+
+	return result, err
 }
 
 // todo split this func for easier testing

--- a/auth/services/oauth/oauth_test.go
+++ b/auth/services/oauth/oauth_test.go
@@ -698,6 +698,11 @@ func TestOAuthService_IntrospectAccessToken(t *testing.T) {
 		if !assert.NoError(t, err) || !assert.NotNil(t, claims) {
 			t.FailNow()
 		}
+
+		assert.Equal(t, tokenCtx.jwtBearerToken.Subject(), claims.Subject)
+		assert.Equal(t, tokenCtx.jwtBearerToken.Issuer(), claims.Issuer)
+		assert.Equal(t, tokenCtx.jwtBearerToken.IssuedAt().Unix(), claims.IssuedAt)
+		assert.Equal(t, tokenCtx.jwtBearerToken.Expiration().Unix(), claims.Expiration)
 	})
 
 	t.Run("private key not present", func(t *testing.T) {


### PR DESCRIPTION
We need this in the demo EHR (specifically the `subject`). We could parse it from the JWT in the demo EHR but why would we if we already introspect the token to retrieve the `NutsAuthorizationCredential`s ?