### PR TITLE
DIDMan: GetCompoundServiceEndpoint should resolve reference to compound service as well

### DIFF
--- a/auth/services/oauth/oauth_test.go
+++ b/auth/services/oauth/oauth_test.go
@@ -356,12 +356,6 @@ func TestService_validateSubject(t *testing.T) {
 	})
 }
 
-func TestParseURL(t *testing.T) {
-	l, err := url.Parse("https://nodeA:443/n2n/auth/v1/accesstoken")
-	assert.NoError(t, err)
-	println(l)
-}
-
 func TestService_validateAud(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		ctx := createContext(t)

--- a/auth/services/oauth/oauth_test.go
+++ b/auth/services/oauth/oauth_test.go
@@ -356,6 +356,12 @@ func TestService_validateSubject(t *testing.T) {
 	})
 }
 
+func TestParseURL(t *testing.T) {
+	l, err := url.Parse("https://nodeA:443/n2n/auth/v1/accesstoken")
+	assert.NoError(t, err)
+	println(l)
+}
+
 func TestService_validateAud(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		ctx := createContext(t)

--- a/didman/didman_test.go
+++ b/didman/didman_test.go
@@ -601,6 +601,10 @@ func TestDidman_GetCompoundServiceEndpoint(t *testing.T) {
 			},
 		},
 		{
+			Type: "csRefType",
+			ServiceEndpoint: id.String() + "/serviceEndpoint?type=csType",
+		},
+		{
 			Type:            "url",
 			ServiceEndpoint: expectedURL,
 		},
@@ -613,10 +617,17 @@ func TestDidman_GetCompoundServiceEndpoint(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURL, actual)
 	})
-	t.Run("ok - resolve references", func(t *testing.T) {
+	t.Run("ok - resolve references - top level is compound service", func(t *testing.T) {
 		ctx := newMockContext(t)
 		ctx.docResolver.EXPECT().Resolve(*id, nil).Return(didDoc, nil, nil)
 		actual, err := ctx.instance.GetCompoundServiceEndpoint(*id, "csType", "eType", false)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedRef, actual)
+	})
+	t.Run("ok - resolve references - top level is reference", func(t *testing.T) {
+		ctx := newMockContext(t)
+		ctx.docResolver.EXPECT().Resolve(*id, nil).Return(didDoc, nil, nil)
+		actual, err := ctx.instance.GetCompoundServiceEndpoint(*id, "csRefType", "eType", false)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedRef, actual)
 	})
@@ -631,7 +642,7 @@ func TestDidman_GetCompoundServiceEndpoint(t *testing.T) {
 		ctx := newMockContext(t)
 		ctx.docResolver.EXPECT().Resolve(*id, nil).Return(didDoc, nil, nil)
 		actual, err := ctx.instance.GetCompoundServiceEndpoint(*id, "non-existent", "eType", false)
-		assert.ErrorIs(t, err, ErrServiceNotFound)
+		assert.Contains(t, err.Error(), ErrServiceNotFound.Error())
 		assert.Empty(t, actual)
 	})
 	t.Run("error - unknown endpoint", func(t *testing.T) {


### PR DESCRIPTION
Before it only resolved references from the endpoints specified by the compound service, not a reference to the compound service itself (the latter is how Nuts Registry Admin Demo currently registers endpoints).