### PR TITLE
DIDMan: fixed following ref to compound service endpoint with unmarshal instead of cast

### DIFF
--- a/didman/didman.go
+++ b/didman/didman.go
@@ -434,7 +434,9 @@ func (d *didman) resolveService(endpoint ssi.URI, depth int, maxDepth int, docum
 		return did.Service{}, ErrServiceNotFound
 	}
 
-	if endpointURL, isString := service.ServiceEndpoint.(string); isString {
+	var endpointURL string
+	if service.UnmarshalServiceEndpoint(&endpointURL) == nil {
+		// Service endpoint is a string, if it's a reference we need to resolve it
 		if isServiceReference(endpointURL) {
 			// Looks like a reference, recurse
 			resolvedEndpointURI, err := ssi.ParseURI(endpointURL)


### PR DESCRIPTION
Missed this test before because the unit tests create a DID Document using the Go structs, instead of unmarshaling one.  I added a test to exactely mimic the DID Document structure as registry-admin-demo does it.

Before I cast the `serviceEndpoint` to a string, which is plainly wrong because many DID elements are always an array under the hood, so I had to use the unmarshal endpoint func instead.