### PR TITLE
Network: split TransactionList response message in pages 

### DIFF
--- a/network/dag/bbolt_dag_test.go
+++ b/network/dag/bbolt_dag_test.go
@@ -55,20 +55,20 @@ func (n trackingVisitor) JoinRefsAsString() string {
 func TestBBoltDAG_FindBetween(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		graph := CreateDAG(t)
-		tx := CreateTestTransactionWithJWK(1)
 
-		err := graph.Add(tx)
+		// tx1 and tx2's signing time are out-of-order
+		tx1 := CreateSignedTestTransaction(2, time.Now().AddDate(0, 0, 1), "unit/test")
+		tx2 := CreateSignedTestTransaction(1, time.Now(), "unit/test", tx1.Ref())
+		_ = graph.Add(tx1)
+		_ = graph.Add(tx2)
 
+		actual, err := graph.FindBetween(time.Now().AddDate(0, 0, -2), time.Now().AddDate(1, 0, 0))
 		if !assert.NoError(t, err) {
 			return
 		}
-
-		actual, err := graph.FindBetween(time.Now().AddDate(0, 0, -1), time.Now().AddDate(1, 0, 0))
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.Len(t, actual, 1)
-		assert.Equal(t, tx, actual[0])
+		assert.Len(t, actual, 2)
+		assert.Equal(t, tx1, actual[0])
+		assert.Equal(t, tx2, actual[1])
 	})
 }
 

--- a/network/dag/interface.go
+++ b/network/dag/interface.go
@@ -40,6 +40,7 @@ type DAG interface {
 	// when startAt is an empty hash, the walker starts at the root node.
 	Walk(algo WalkerAlgorithm, visitor Visitor, startAt hash.SHA256Hash) error
 	// FindBetween finds all transactions which signing time lies between startInclude and endExclusive.
+	// It returns the transactions in DAG walking order.
 	FindBetween(startInclusive time.Time, endExclusive time.Time) ([]Transaction, error)
 	// Root returns the root hash of the DAG. If there's no root an empty hash is returned. If an error occurs, it is returned.
 	Root() (hash.SHA256Hash, error)

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -48,7 +48,7 @@ var receivedTransactions = make(map[string][]dag.Transaction, 0)
 
 func TestNetworkIntegration_HappyFlow(t *testing.T) {
 	testDirectory := io.TestDirectory(t)
-	resetIntegrationTest(testDirectory)
+	resetIntegrationTest()
 	key := nutsCrypto.NewTestKey("key")
 	expectedDocLogSize := 0
 
@@ -113,7 +113,7 @@ func TestNetworkIntegration_HappyFlow(t *testing.T) {
 	fmt.Printf("%v\n", node2.Diagnostics())
 }
 
-func resetIntegrationTest(testDirectory string) {
+func resetIntegrationTest() {
 	receivedTransactions = make(map[string][]dag.Transaction, 0)
 }
 

--- a/network/network_pagination_test.go
+++ b/network/network_pagination_test.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2021 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package network
+
+import (
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	"github.com/nuts-foundation/nuts-node/network/p2p"
+	"github.com/stretchr/testify/assert"
+	"path"
+	"testing"
+	"time"
+
+	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
+	"github.com/nuts-foundation/nuts-node/test/io"
+)
+
+// TestNetworkIntegration_Pagination tests whether TransactionList messages are paginated when the transactions on the DAG
+// exceed Protobuf's max message size.
+func TestNetworkIntegration_Pagination(t *testing.T) {
+	p2p.MaxMessageSizeInBytes = 4 * 1024 // 4kb
+	const numberOfTransactions = 19  // 20 transactions equals +/- 12.6kb (which exceeds the set limit of 10kb)
+
+	resetIntegrationTest()
+	testDirectory := io.TestDirectory(t)
+	key := nutsCrypto.NewTestKey("key")
+
+	node1, err := startNode("node1", path.Join(testDirectory, "node1"))
+	if !assert.NoError(t, err) {
+		return
+	}
+	node2, err := startNode("node2", path.Join(testDirectory, "node2"))
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	t.Logf("Creating %d transactions...", numberOfTransactions)
+	for i := 0; i < numberOfTransactions; i++ {
+		_, err := node1.CreateTransaction(payloadType, []byte{1, 2, 3}, key, true, time.Now(), []hash.SHA256Hash{})
+		if !assert.NoError(t, err) {
+			return
+		}
+	}
+
+	node2.p2pNetwork.ConnectToPeer(nameToAddress("node1"))
+	// Wait until nodes are connected
+	if !waitFor(t, func() (bool, error) {
+		return len(node1.p2pNetwork.Peers()) == 1 && len(node2.p2pNetwork.Peers()) == 1, nil
+	}, defaultTimeout, "time-out while waiting for node 1 and 2 to have 2 peers") {
+		return
+	}
+
+	waitFor(t, func() (bool, error) {
+		mutex.Lock()
+		defer mutex.Unlock()
+		t.Logf("received %d transactions", len(receivedTransactions["node2"]))
+		return len(receivedTransactions["node2"]) == numberOfTransactions, nil
+	}, 10*time.Second, "node2 didn't receive all transactions")
+
+	defer func() {
+		node2.Shutdown()
+		node1.Shutdown()
+	}()
+}

--- a/network/network_pagination_test.go
+++ b/network/network_pagination_test.go
@@ -34,7 +34,7 @@ import (
 // exceed Protobuf's max message size.
 func TestNetworkIntegration_Pagination(t *testing.T) {
 	p2p.MaxMessageSizeInBytes = 4 * 1024 // 4kb
-	const numberOfTransactions = 19  // 20 transactions equals +/- 12.6kb (which exceeds the set limit of 10kb)
+	const numberOfTransactions = 19      // 20 transactions equals +/- 12.6kb (which exceeds the set limit of 10kb)
 
 	resetIntegrationTest()
 	testDirectory := io.TestDirectory(t)

--- a/network/p2p/impl.go
+++ b/network/p2p/impl.go
@@ -43,7 +43,10 @@ type dialer func(ctx context.Context, target string, opts ...grpc.DialOption) (c
 const connectingQueueChannelSize = 100
 const eventChannelSize = 100
 const messageBacklogChannelSize = 1000 // TODO: Does this number make sense? Should also be configurable?
-const maxMessageSizeInBytes = 1024 * 512
+const defaultMaxMessageSizeInBytes = 1024 * 512
+
+// MaxMessageSizeInBytes defines the maximum size of an in- or outbound gRPC/Protobuf message
+var MaxMessageSizeInBytes = defaultMaxMessageSizeInBytes
 
 type adapter struct {
 	config AdapterConfig
@@ -126,8 +129,8 @@ func (c *connector) doConnect(ownID PeerID, tlsConfig *tls.Config) (*Peer, trans
 		grpc.WithBlock(),                 // Dial should block until connection succeeded (or time-out expired)
 		grpc.WithReturnConnectionError(), // This option causes underlying errors to be returned when connections fail, rather than just "context deadline exceeded"
 		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(maxMessageSizeInBytes),
-			grpc.MaxCallSendMsgSize(maxMessageSizeInBytes),
+			grpc.MaxCallRecvMsgSize(MaxMessageSizeInBytes),
+			grpc.MaxCallSendMsgSize(MaxMessageSizeInBytes),
 		),
 	}
 	if tlsConfig != nil {
@@ -215,8 +218,8 @@ func (n *adapter) Start() error {
 	if n.config.ListenAddress != "" {
 		log.Logger().Debugf("Starting gRPC server on %s", n.config.ListenAddress)
 		serverOpts := []grpc.ServerOption{
-			grpc.MaxRecvMsgSize(maxMessageSizeInBytes),
-			grpc.MaxSendMsgSize(maxMessageSizeInBytes),
+			grpc.MaxRecvMsgSize(MaxMessageSizeInBytes),
+			grpc.MaxSendMsgSize(MaxMessageSizeInBytes),
 		}
 		var err error
 		n.listener, err = net.Listen("tcp", n.config.ListenAddress)

--- a/network/p2p/interface.go
+++ b/network/p2p/interface.go
@@ -38,7 +38,7 @@ type Adapter interface {
 	Start() error
 	// Stop stops the P2P network on the local node.
 	Stop() error
-	// AddRemoteNode adds a remote node to the local node's view of the network, so it can become one of our peers.
+	// ConnectToPeer adds a remote node to the local node's view of the network, so it can become one of our peers.
 	// If we'll try to connect to the remote node, true is returned, otherwise false.
 	ConnectToPeer(address string) bool
 	// ReceivedMessages returns a queue containing all messages received from our peers. It must be drained, because when its buffer is full the producer (Adapter) is blocked.

--- a/network/proto/handlers.go
+++ b/network/proto/handlers.go
@@ -173,7 +173,7 @@ func (p *protocol) handleTransactionPayloadQuery(peer p2p.PeerID, query *transpo
 }
 
 func (p *protocol) handleTransactionList(peer p2p.PeerID, transactionList *transport.TransactionList) error {
-	// TODO: Only process transaction list if we actually queried it
+	// TODO: Only process transaction list if we actually queried it (but be aware of pagination)
 	// TODO: Do something with blockDate
 	log.Logger().Tracef("Received transaction list from peer (peer=%s)", peer)
 	transactions := transactionList.Transactions

--- a/network/proto/impl.go
+++ b/network/proto/impl.go
@@ -101,7 +101,7 @@ func (p *protocol) Configure(p2pNetwork p2p.Adapter, graph dag.DAG, publisher da
 	p.advertDiagnosticsInterval = advertDiagnosticsInterval
 	p.diagnosticsProvider = diagnosticsProvider
 	p.peerID = peerID
-	p.sender = defaultMessageSender{p2p: p.p2pNetwork}
+	p.sender = defaultMessageSender{p2p: p.p2pNetwork, maxMessageSize: p2p.MaxMessageSizeInBytes}
 	publisher.Subscribe(dag.AnyPayloadType, p.blocks.addTransaction)
 }
 

--- a/network/proto/senders.go
+++ b/network/proto/senders.go
@@ -6,8 +6,14 @@ import (
 	"github.com/nuts-foundation/nuts-node/network/log"
 	"github.com/nuts-foundation/nuts-node/network/p2p"
 	"github.com/nuts-foundation/nuts-node/network/transport"
+	"google.golang.org/protobuf/proto"
+	"math"
 	"time"
 )
+
+// estimatedMessageSizeMargin defines the factor by which the message size is multiplied, as a safety measure to avoid
+// accidentally exceeding the max Protobuf message size.
+const estimatedMessageSizeMargin = 0.75
 
 // messageSender provides a domain-specific abstraction for sending messages to the network. It aids testing and
 // implementation of non-functional requirements like throttling.
@@ -21,7 +27,8 @@ type messageSender interface {
 }
 
 type defaultMessageSender struct {
-	p2p p2p.Adapter
+	p2p            p2p.Adapter
+	maxMessageSize int
 }
 
 func (s defaultMessageSender) doSend(peer p2p.PeerID, envelope *transport.NetworkMessage) {
@@ -63,10 +70,37 @@ func (s defaultMessageSender) sendTransactionListQuery(peer p2p.PeerID, blockDat
 }
 
 func (s defaultMessageSender) sendTransactionList(peer p2p.PeerID, transactions []dag.Transaction, blockDate time.Time) {
-	envelope := createEnvelope()
+	if len(transactions) == 0 {
+		envelope := createEnvelope()
+		envelope.Message = &transport.NetworkMessage_TransactionList{TransactionList: &transport.TransactionList{Transactions: toNetworkTransactions([]dag.Transaction{}), BlockDate: uint32(blockDate.Unix())}}
+		s.doSend(peer, &envelope)
+		return
+	}
+	// When the DAG grows it the transactions might not fit in 1 network message (defined by p2p.MaxMessageSizeInBytes),
+	// so we have to split it up in pages. Protobuf can calculate the size of a message, so we can check whether it will fit in the max. message size.
+	// However, this can be quite expensive since it will marshal the message to the wire format (thus, marshalling will happen twice).
+	// Furthermore, we'd have to do this for every transaction we add to the message to find the max. number of TXs that
+	// will fit in the message.
+	// Since this sounds all horribly inefficient, we just calculate the size of a network message with 1 transaction,
+	// and use that to guesstimate the number of transactions that will fit in a message, decreased by a safety margin.
+	// Since transactions just contain metadata of the transaction (and not the payload itself), all transactions should
+	// serialize to more or less the same number of bytes, making the calculation safe.
+	sizeMsg := createEnvelope()
+	sizeMsg.Message = &transport.NetworkMessage_TransactionList{TransactionList: &transport.TransactionList{Transactions: toNetworkTransactions([]dag.Transaction{transactions[0]}), BlockDate: uint32(blockDate.Unix())}}
+	messageSizePerTX := proto.Size(sizeMsg.ProtoReflect().Interface())
+	transactionsPerMessage := int(math.Floor(float64(s.maxMessageSize) * estimatedMessageSizeMargin / float64(messageSizePerTX)))
+	numberOfMessages := int(math.Ceil(float64(len(transactions)) / float64(transactionsPerMessage)))
 	tl := toNetworkTransactions(transactions)
-	envelope.Message = &transport.NetworkMessage_TransactionList{TransactionList: &transport.TransactionList{Transactions: tl, BlockDate: uint32(blockDate.Unix())}}
-	s.doSend(peer, &envelope)
+
+	for i := 0; i < numberOfMessages; i++ {
+		upper := (i + 1) * transactionsPerMessage
+		if upper > len(tl) {
+			upper = len(tl)
+		}
+		envelope := createEnvelope()
+		envelope.Message = &transport.NetworkMessage_TransactionList{TransactionList: &transport.TransactionList{Transactions: tl[i*transactionsPerMessage : upper], BlockDate: uint32(blockDate.Unix())}}
+		s.doSend(peer, &envelope)
+	}
 }
 
 func (s defaultMessageSender) sendTransactionPayloadQuery(peer p2p.PeerID, payloadHash hash.SHA256Hash) {

--- a/network/proto/senders_test.go
+++ b/network/proto/senders_test.go
@@ -1,14 +1,15 @@
 package proto
 
 import (
+	"testing"
+	"time"
+
 	"github.com/golang/mock/gomock"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network/dag"
 	"github.com/nuts-foundation/nuts-node/network/p2p"
 	"github.com/nuts-foundation/nuts-node/network/transport"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func createMessageSender(t *testing.T) (defaultMessageSender, *p2p.MockAdapter) {
@@ -106,12 +107,8 @@ func Test_defaultMessageSender_sendTransactionList(t *testing.T) {
 			}
 		}
 	})
-	t.Run("ok - no transactions sends empty message", func(t *testing.T) {
-		sender, mock := createMessageSender(t)
-		mock.EXPECT().Send(peer, &transport.NetworkMessage{Message: &transport.NetworkMessage_TransactionList{TransactionList: &transport.TransactionList{
-			BlockDate:    uint32(blockDate.Unix()),
-			Transactions: []*transport.Transaction{},
-		}}})
+	t.Run("ok - no transactions sends nothing", func(t *testing.T) {
+		sender, _ := createMessageSender(t)
 		sender.sendTransactionList(peer, []dag.Transaction{}, blockDate)
 	})
 }

--- a/network/proto/senders_test.go
+++ b/network/proto/senders_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/network/dag"
 	"github.com/nuts-foundation/nuts-node/network/p2p"
 	"github.com/nuts-foundation/nuts-node/network/transport"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 )
@@ -17,6 +18,7 @@ func createMessageSender(t *testing.T) (defaultMessageSender, *p2p.MockAdapter) 
 	})
 	p2pInterface := p2p.NewMockAdapter(ctrl)
 	sender := defaultMessageSender{p2p: p2pInterface}
+	sender.maxMessageSize = p2p.MaxMessageSizeInBytes
 	return sender, p2pInterface
 }
 
@@ -55,17 +57,63 @@ func Test_defaultMessageSender_broadcastDiagnostics(t *testing.T) {
 }
 
 func Test_defaultMessageSender_sendTransactionList(t *testing.T) {
-	sender, mock := createMessageSender(t)
 	blockDate := time.Date(2021, 4, 29, 0, 0, 0, 0, time.UTC)
-	tx := testTX{data: []byte{1, 2, 3}}
-	mock.EXPECT().Send(peer, &transport.NetworkMessage{Message: &transport.NetworkMessage_TransactionList{TransactionList: &transport.TransactionList{
-		BlockDate: uint32(blockDate.Unix()),
-		Transactions: []*transport.Transaction{{
-			Hash: tx.Ref().Slice(),
-			Data: tx.data,
-		}},
-	}}})
-	sender.sendTransactionList(peer, []dag.Transaction{tx}, blockDate)
+
+	t.Run("ok", func(t *testing.T) {
+		sender, mock := createMessageSender(t)
+		tx := testTX{data: []byte{1, 2, 3}}
+		mock.EXPECT().Send(peer, &transport.NetworkMessage{Message: &transport.NetworkMessage_TransactionList{TransactionList: &transport.TransactionList{
+			BlockDate: uint32(blockDate.Unix()),
+			Transactions: []*transport.Transaction{{
+				Hash: tx.Ref().Slice(),
+				Data: tx.data,
+			}},
+		}}})
+		sender.sendTransactionList(peer, []dag.Transaction{tx}, blockDate)
+	})
+	t.Run("ok - paginated", func(t *testing.T) {
+		// This test checks whether transaction list responses that exceed the maximum Protobuf message size are split into
+		// pages.
+		const numberOfTXs = 100     // number of transactions this test produces
+		const maxMessageSize = 6000 // max. message size in bytes
+		const dataSize = 100        // number of bytes added to the TX to make them a bit larger
+		const numberOfMessages = 4  // expected number of pages when the transaction list is sent
+
+		var txs []dag.Transaction
+		for i := 0; i < numberOfTXs; i++ {
+			data := make([]byte, dataSize)
+			txs = append(txs, &testTX{data: append([]byte{byte(i)}, data...)})
+		}
+
+		sender, mock := createMessageSender(t)
+		sender.maxMessageSize = maxMessageSize
+		sentMessages := map[byte]bool{}
+		mock.EXPECT().Send(peer, gomock.Any()).DoAndReturn(func(_ p2p.PeerID, msg *transport.NetworkMessage) error {
+			for _, tx := range msg.GetTransactionList().Transactions {
+				if sentMessages[tx.Data[0]] {
+					t.Fatalf("transaction sent twice (idx: %d)", tx.Data[0])
+				}
+				sentMessages[tx.Data[0]] = true
+			}
+			return nil
+		}).Times(numberOfMessages)
+		sender.sendTransactionList(peer, txs, blockDate)
+
+		assert.Len(t, sentMessages, numberOfTXs)
+		for i := 0; i < numberOfTXs; i++ {
+			if !sentMessages[byte(i)] {
+				t.Fatalf("Missing message (idx: %d)", i)
+			}
+		}
+	})
+	t.Run("ok - no transactions sends empty message", func(t *testing.T) {
+		sender, mock := createMessageSender(t)
+		mock.EXPECT().Send(peer, &transport.NetworkMessage{Message: &transport.NetworkMessage_TransactionList{TransactionList: &transport.TransactionList{
+			BlockDate:    uint32(blockDate.Unix()),
+			Transactions: []*transport.Transaction{},
+		}}})
+		sender.sendTransactionList(peer, []dag.Transaction{}, blockDate)
+	})
 }
 
 func Test_defaultMessageSender_sendTransactionListQuery(t *testing.T) {


### PR DESCRIPTION
When number of transactions exceeds the maximum Protobuf message size.

Fixes https://github.com/nuts-foundation/nuts-node/issues/416

Also altered the behaviour of `dag.FindBetween`, it now returns the transactions in DAG walking order, to prevent out-of-order transactions (signing time) to be in the from page, preventing the receiving peer from processing the transactions (because it's previous transaction(s) are sent in a succeeding page, because its signing time lies before them). (edge case)