### PR TITLE
Network: ignore empty bootstrap addresses

### DIFF
--- a/network/p2p/impl.go
+++ b/network/p2p/impl.go
@@ -203,6 +203,9 @@ func (n *adapter) Configure(config AdapterConfig) error {
 	n.config = config
 	n.configured = true
 	for _, bootstrapNode := range n.config.BootstrapNodes {
+		if len(strings.TrimSpace(bootstrapNode)) == 0 {
+			continue
+		}
 		n.ConnectToPeer(bootstrapNode)
 	}
 	return nil

--- a/network/p2p/impl_test.go
+++ b/network/p2p/impl_test.go
@@ -74,6 +74,15 @@ func Test_adapter_Configure(t *testing.T) {
 		err := network.Configure(AdapterConfig{})
 		assert.Error(t, err)
 	})
+	t.Run("ok - empty bootstrap node address is skipped", func(t *testing.T) {
+		network := NewAdapter()
+		err := network.Configure(AdapterConfig{
+			BootstrapNodes: []string{"A", " ", "B"},
+			PeerID:         "foo",
+		})
+		assert.NoError(t, err)
+		assert.Len(t, network.(*adapter).connectorAddChannel, 2)
+	})
 }
 
 func Test_adapter_Start(t *testing.T) {


### PR DESCRIPTION
When the `NUTS_NETWORK_BOOTSTRAPNODES` env/config variable is set, but empty, it results in a single (empty) bootstrap node address. Empty entries should be ignored.