### PR TITLE
Docs: fix bootstrap nodes example config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,7 @@ crypto.storage                     fs                Storage to use, 'fs' for fi
 **Network**
 network.advertdiagnosticsinterval  5000              Interval (in milliseconds) that specifies how often the node should broadcast its diagnostic information to other nodes (specify 0 to disable).
 network.adverthashesinterval       2000              Interval (in milliseconds) that specifies how often the node should broadcast its last hashes to other nodes.
-network.bootstrapnodes             []                Comma-separated list of bootstrap nodes (`<host>:<port>`) which the node initially connect to.
+network.bootstrapnodes             []                List of bootstrap nodes (`<host>:<port>`) which the node initially connect to.
 network.certfile                                     PEM file containing the server certificate for the gRPC server. Required when `enableTLS` is `true`.
 network.certkeyfile                                  PEM file containing the private key of the server certificate. Required when `network.enabletls` is `true`.
 network.enabletls                  true              Whether to enable TLS for incoming and outgoing gRPC connections. If set to `true` (which is default) `certfile` and `certkeyfile` MUST be configured.

--- a/development/nuts.yaml
+++ b/development/nuts.yaml
@@ -1,9 +1,10 @@
-datadir: /opt/nuts
+  datadir: /opt/nuts
 network:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate.pem
   certkeyfile: /opt/nuts/certificate.pem
-  bootstrapnodes: node1:5555
+  bootstrapnodes:
+    - node1:5555
 http:
   default:
     address: :8080

--- a/development/nuts.yaml
+++ b/development/nuts.yaml
@@ -1,4 +1,4 @@
-  datadir: /opt/nuts
+datadir: /opt/nuts
 network:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate.pem

--- a/docs/pages/getting-started/1-running-docker.rst
+++ b/docs/pages/getting-started/1-running-docker.rst
@@ -44,7 +44,8 @@ This setup uses the following `nuts.yaml` configuration file:
     truststorefile: /opt/nuts/truststore.pem
     certfile: /opt/nuts/certificate-and-key.pem
     certkeyfile: /opt/nuts/certificate-and-key.pem
-    bootstrapnodes: example.com:5555
+    bootstrapnodes:
+      - example.com:5555
 
 .. note::
 

--- a/docs/pages/getting-started/3-configure-your-node.rst
+++ b/docs/pages/getting-started/3-configure-your-node.rst
@@ -43,7 +43,8 @@ If you're using a YAML file to configure your node, the following snippet shows 
     truststorefile: /path/to/truststore.pem
     certfile: /path/to/certificate-and-key.pem
     certkeyfile: /path/to/certificate-and-key.pem
-    bootstrapnodes: example.com:5555
+    bootstrapnodes:
+      - "example.com:5555"
 
 Node TLS Certificate
 ====================

--- a/docs/pages/getting-started/3-configure-your-node.rst
+++ b/docs/pages/getting-started/3-configure-your-node.rst
@@ -44,7 +44,7 @@ If you're using a YAML file to configure your node, the following snippet shows 
     certfile: /path/to/certificate-and-key.pem
     certkeyfile: /path/to/certificate-and-key.pem
     bootstrapnodes:
-      - "example.com:5555"
+      - example.com:5555
 
 Node TLS Certificate
 ====================


### PR DESCRIPTION
Changed quite a while ago, docs were out of date appearantely.