### PR TITLE
Network: only use TXs as prev which' payload is present

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -178,7 +178,7 @@ func (n *Network) CreateTransaction(payloadType string, payload []byte, key cryp
 	for _, prev := range additionalPrevs {
 		isPresent, err := n.isPayloadPresent(prev)
 		if err != nil {
-			return nil ,err
+			return nil, err
 		}
 		if !isPresent {
 			return nil, fmt.Errorf("additional prev is unknown or missing payload (prev=%s)", prev)

--- a/network/network.go
+++ b/network/network.go
@@ -295,7 +295,7 @@ func (n *Network) isPayloadPresent(txRef hash.SHA256Hash) (bool, error) {
 // This works because the publisher only publishes transactions which' payloads are present.
 type lastTransactionTracker struct {
 	headRefs map[hash.SHA256Hash]bool
-	mux sync.Mutex
+	mux      sync.Mutex
 }
 
 func (l *lastTransactionTracker) process(transaction dag.Transaction, _ []byte) error {

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -158,6 +158,7 @@ func startNode(name string, directory string) (*Network, error) {
 			AdvertHashesInterval:      500,
 			AdvertDiagnosticsInterval: 5000,
 		},
+		lastTransactionTracker: lastTransactionTracker{headRefs: make(map[hash.SHA256Hash]bool, 0)},
 	}
 	if err := instance.Configure(core.ServerConfig{Datadir: directory}); err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes 2 situations:

- All additional prevs (specified by caller) MUST be present, including its payload.
- All calculated prevs (heads of DAG) TX's payload MUST be present. If we specify TXs which' payload we're missing as prev, we can't answer peers querying us for that payload.

We do this by using a subscriber to determine the heads, because the subscriber only publishes transactions which' payload is present.

Fixes #469 by not prev'-ing TXs with missing payload.