### PR TITLE
added API for finding conflicting docs

### DIFF
--- a/docs/_static/vdr/v1.yaml
+++ b/docs/_static/vdr/v1.yaml
@@ -92,7 +92,7 @@ paths:
           content:
             application/json+did-document:
               schema:
-                 $ref: '#/components/schemas/DIDDocument'
+                $ref: '#/components/schemas/DIDDocument'
         default:
           $ref: '../common/error_response.yaml'
     delete:
@@ -112,6 +112,28 @@ paths:
       responses:
         "200":
           description: DID document has been deactivated.
+        default:
+          $ref: '../common/error_response.yaml'
+  /internal/vdr/v1/did/conflicted:
+    get:
+      summary: "Retrieve the list of conflicted DID documents"
+      description: |
+        Resolves DID documents with a conflict. It returns both the DID Document and metadata of the DID Document.
+
+        error returns:
+          * 500 - An error occurred while processing the request
+      operationId: "conflictedDIDs"
+      tags:
+        - DID
+      responses:
+        "200":
+          description: List of conflicting DID Documents. Empty list if there are none.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DIDResolutionResult'
         default:
           $ref: '../common/error_response.yaml'
   /internal/vdr/v1/did/{did}/verificationmethod:

--- a/vdr/api/v1/api.go
+++ b/vdr/api/v1/api.go
@@ -177,7 +177,7 @@ func (a *Wrapper) ConflictedDIDs(ctx echo.Context) error {
 
 	// []docs, []meta to [](doc, meta)
 	returnValues := make([]DIDResolutionResult, len(docs))
-	for i, _ := range docs {
+	for i := range docs {
 		returnValues[i] = DIDResolutionResult{
 			Document:         docs[i],
 			DocumentMetadata: metas[i],

--- a/vdr/api/v1/api.go
+++ b/vdr/api/v1/api.go
@@ -168,6 +168,25 @@ func (a Wrapper) GetDID(ctx echo.Context, targetDID string) error {
 	return ctx.JSON(http.StatusOK, resolutionResult)
 }
 
+func (a *Wrapper) ConflictedDIDs(ctx echo.Context) error {
+	docs, metas, err := a.VDR.ConflictedDocuments()
+	if err != nil {
+		// 500 internal server error
+		return err
+	}
+
+	// []docs, []meta to [](doc, meta)
+	returnValues := make([]DIDResolutionResult, len(docs))
+	for i, _ := range docs {
+		returnValues[i] = DIDResolutionResult{
+			Document:         docs[i],
+			DocumentMetadata: metas[i],
+		}
+	}
+
+	return ctx.JSON(http.StatusOK, returnValues)
+}
+
 // UpdateDID updates a DID Document given a DID and DID Document body. It returns the updated DID Document.
 func (a Wrapper) UpdateDID(ctx echo.Context, targetDID string) error {
 	d, err := did.ParseDID(targetDID)

--- a/vdr/types/interface.go
+++ b/vdr/types/interface.go
@@ -109,6 +109,9 @@ type Store interface {
 type VDR interface {
 	DocCreator
 	DocUpdater
+
+	// ConflictedDocuments returns the DID Document and metadata of all documents with a conflict.
+	ConflictedDocuments() ([]did.Document, []DocumentMetadata, error)
 }
 
 // DocManipulator groups several higher level methods to alter the state of a DID document.

--- a/vdr/types/mock.go
+++ b/vdr/types/mock.go
@@ -370,6 +370,22 @@ func (m *MockVDR) EXPECT() *MockVDRMockRecorder {
 	return m.recorder
 }
 
+// ConflictedDocuments mocks base method.
+func (m *MockVDR) ConflictedDocuments() ([]did.Document, []DocumentMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConflictedDocuments")
+	ret0, _ := ret[0].([]did.Document)
+	ret1, _ := ret[1].([]DocumentMetadata)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ConflictedDocuments indicates an expected call of ConflictedDocuments.
+func (mr *MockVDRMockRecorder) ConflictedDocuments() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConflictedDocuments", reflect.TypeOf((*MockVDR)(nil).ConflictedDocuments))
+}
+
 // Create mocks base method.
 func (m *MockVDR) Create(options DIDCreationOptions) (*did.Document, crypto0.Key, error) {
 	m.ctrl.T.Helper()

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -88,7 +88,7 @@ func (r *VDR) Configure(_ core.ServerConfig) error {
 	return nil
 }
 
-func  (r *VDR) ConflictedDocuments() ([]did.Document, []types.DocumentMetadata, error) {
+func (r *VDR) ConflictedDocuments() ([]did.Document, []types.DocumentMetadata, error) {
 	conflictedDocs := make([]did.Document, 0)
 	conflictedMeta := make([]types.DocumentMetadata, 0)
 

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -88,6 +88,20 @@ func (r *VDR) Configure(_ core.ServerConfig) error {
 	return nil
 }
 
+func  (r *VDR) ConflictedDocuments() ([]did.Document, []types.DocumentMetadata, error) {
+	conflictedDocs := make([]did.Document, 0)
+	conflictedMeta := make([]types.DocumentMetadata, 0)
+
+	err := r.store.Iterate(func(doc did.Document, metadata types.DocumentMetadata) error {
+		if metadata.IsConflicted() {
+			conflictedDocs = append(conflictedDocs, doc)
+			conflictedMeta = append(conflictedMeta, metadata)
+		}
+		return nil
+	})
+	return conflictedDocs, conflictedMeta, err
+}
+
 // Diagnostics returns the diagnostics for this engine
 func (r *VDR) Diagnostics() []core.DiagnosticResult {
 	// return # conflicted docs


### PR DESCRIPTION
closes #456 

Added API that returns all conflicting docs and metadata. This will reflect the conflicting docs count in the diagnostics.