### PR TITLE
Fix error message of drawup contract call

### DIFF
--- a/auth/services/contract/notary.go
+++ b/auth/services/contract/notary.go
@@ -61,7 +61,7 @@ func (s *contractNotaryService) DrawUpContract(template contract.Template, orgID
 	// Test if the org in managed by this node:
 	signingKeyID, err := s.keyResolver.ResolveSigningKeyID(orgID, &validFrom)
 	if errors.Is(err, types.ErrNotFound) {
-		return nil, fmt.Errorf("could not draw up contract: organization not found")
+		return nil, fmt.Errorf("could not draw up contract: no valid organization credential at provided validFrom date")
 	} else if err != nil {
 		return nil, fmt.Errorf("could not draw up contract: %w", err)
 	}

--- a/auth/services/contract/notary_test.go
+++ b/auth/services/contract/notary_test.go
@@ -120,7 +120,7 @@ func Test_contractNotaryService_DrawUpContract(t *testing.T) {
 
 		drawnUpContract, err := ctx.notary.DrawUpContract(template, orgID, validFrom, duration)
 		if assert.Error(t, err) {
-			assert.Equal(t, "could not draw up contract: organization not found", err.Error())
+			assert.Equal(t, "could not draw up contract: no valid organization credential at provided validFrom date", err.Error())
 		}
 		assert.Nil(t, drawnUpContract)
 	})


### PR DESCRIPTION
When the wrong date is used, the error is misleading.