### PR TITLE
fix missing credential IDs in access token

### DIFF
--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -217,7 +217,7 @@ func (s *service) CreateAccessToken(request services.CreateAccessTokenRequest) (
 	}
 
 	// validate the legal base, according to RFC003 §5.2.1.7
-	if err = s.validateAuthorizationCredentials(context); err != nil {
+	if err = s.validateAuthorizationCredentials(&context); err != nil {
 		return nil, err
 	}
 
@@ -317,7 +317,7 @@ func (s *service) validateSubject(context *validationContext) error {
 }
 
 // validate the authorization credentials according to §5.2.1.7
-func (s *service) validateAuthorizationCredentials(context validationContext) error {
+func (s *service) validateAuthorizationCredentials(context *validationContext) error {
 	// filter on authorization credentials
 	vcs, err := context.verifiableCredentials()
 	if err != nil {

--- a/auth/services/oauth/oauth_test.go
+++ b/auth/services/oauth/oauth_test.go
@@ -412,12 +412,27 @@ func TestService_validateAuthorizationCredentials(t *testing.T) {
 	ctx := createContext(t)
 	defer ctx.ctrl.Finish()
 
+	t.Run("ok", func(t *testing.T) {
+		tokenCtx := validContext()
+		signToken(tokenCtx)
+
+		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, gomock.Any()).Return(nil)
+		err := ctx.oauthService.validateAuthorizationCredentials(tokenCtx)
+
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.NotNil(t, tokenCtx.credentialIDs)
+		assert.Equal(t, "did:nuts:GvkzxsezHvEc8nGhgz6Xo3jbqkHwswLmWw3CYtCm7hAW#1", tokenCtx.credentialIDs[0])
+	})
+
 	t.Run("ok - no authorization credentials", func(t *testing.T) {
 		tokenCtx := validContext()
 		tokenCtx.jwtBearerToken.Remove(vcClaim)
 		signToken(tokenCtx)
 
-		err := ctx.oauthService.validateAuthorizationCredentials(*tokenCtx)
+		err := ctx.oauthService.validateAuthorizationCredentials(tokenCtx)
 
 		assert.NoError(t, err)
 	})
@@ -427,7 +442,7 @@ func TestService_validateAuthorizationCredentials(t *testing.T) {
 		tokenCtx.jwtBearerToken.Set(vcClaim, []interface{}{})
 		signToken(tokenCtx)
 
-		err := ctx.oauthService.validateAuthorizationCredentials(*tokenCtx)
+		err := ctx.oauthService.validateAuthorizationCredentials(tokenCtx)
 
 		assert.NoError(t, err)
 	})
@@ -437,7 +452,7 @@ func TestService_validateAuthorizationCredentials(t *testing.T) {
 		tokenCtx.jwtBearerToken.Set(vcClaim, "not a vc")
 		signToken(tokenCtx)
 
-		err := ctx.oauthService.validateAuthorizationCredentials(*tokenCtx)
+		err := ctx.oauthService.validateAuthorizationCredentials(tokenCtx)
 
 		if !assert.Error(t, err) {
 			return
@@ -450,7 +465,7 @@ func TestService_validateAuthorizationCredentials(t *testing.T) {
 		tokenCtx.jwtBearerToken.Set(vcClaim, []interface{}{"}"})
 		signToken(tokenCtx)
 
-		err := ctx.oauthService.validateAuthorizationCredentials(*tokenCtx)
+		err := ctx.oauthService.validateAuthorizationCredentials(tokenCtx)
 
 		if !assert.Error(t, err) {
 			return
@@ -464,7 +479,7 @@ func TestService_validateAuthorizationCredentials(t *testing.T) {
 		signToken(tokenCtx)
 		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, gomock.Any()).Return(nil)
 
-		err := ctx.oauthService.validateAuthorizationCredentials(*tokenCtx)
+		err := ctx.oauthService.validateAuthorizationCredentials(tokenCtx)
 
 		if !assert.Error(t, err) {
 			return
@@ -478,7 +493,7 @@ func TestService_validateAuthorizationCredentials(t *testing.T) {
 		signToken(tokenCtx)
 		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, gomock.Any()).Return(nil)
 
-		err := ctx.oauthService.validateAuthorizationCredentials(*tokenCtx)
+		err := ctx.oauthService.validateAuthorizationCredentials(tokenCtx)
 
 		if !assert.Error(t, err) {
 			return
@@ -492,7 +507,7 @@ func TestService_validateAuthorizationCredentials(t *testing.T) {
 		signToken(tokenCtx)
 		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, gomock.Any()).Return(vcr.ErrRevoked)
 
-		err := ctx.oauthService.validateAuthorizationCredentials(*tokenCtx)
+		err := ctx.oauthService.validateAuthorizationCredentials(tokenCtx)
 
 		if !assert.Error(t, err) {
 			return

--- a/crypto/jwx.go
+++ b/crypto/jwx.go
@@ -144,7 +144,7 @@ func ParseJWT(tokenString string, f PublicKeyFunc) (jwt.Token, error) {
 		return nil, fmt.Errorf("token signing algorithm is not supported: %s", alg)
 	}
 
-	return jwt.ParseString(tokenString, jwt.WithVerify(alg, key), jwt.WithValidate(true), jwt.WithAcceptableSkew(5 * time.Second))
+	return jwt.ParseString(tokenString, jwt.WithVerify(alg, key), jwt.WithValidate(true), jwt.WithAcceptableSkew(5*time.Second))
 }
 
 func SignJWS(payload []byte, protectedHeaders map[string]interface{}, privateKey crypto.Signer) (string, error) {

--- a/crypto/jwx_test.go
+++ b/crypto/jwx_test.go
@@ -130,7 +130,7 @@ func TestParseJWT(t *testing.T) {
 	t.Run("allow clock skew", func(t *testing.T) {
 		ecKey := test.GenerateECKey()
 		token := jwt.New()
-		err := token.Set(jwt.IssuedAtKey, time.Now().Add(4 * time.Second).Unix())
+		err := token.Set(jwt.IssuedAtKey, time.Now().Add(4*time.Second).Unix())
 		assert.NoError(t, err)
 		signature, _ := jwt.Sign(token, jwa.ES256, ecKey)
 		parsedToken, err := ParseJWT(string(signature), func(_ string) (crypto.PublicKey, error) {

--- a/network/proto/impl_test.go
+++ b/network/proto/impl_test.go
@@ -19,7 +19,7 @@ func Test_ProtocolLifecycle(t *testing.T) {
 	publisher := dag.NewMockPublisher(mockCtrl)
 	publisher.EXPECT().Subscribe("*", gomock.Any())
 
-	instance.Configure(p2p.NewAdapter(), dag.NewMockDAG(mockCtrl), publisher, dag.NewMockPayloadStore(mockCtrl), nil, time.Second*2, time.Second*5, 10 * time.Second, "local")
+	instance.Configure(p2p.NewAdapter(), dag.NewMockDAG(mockCtrl), publisher, dag.NewMockPayloadStore(mockCtrl), nil, time.Second*2, time.Second*5, 10*time.Second, "local")
 	instance.Start()
 	instance.Stop()
 }


### PR DESCRIPTION
fixes #495

credential IDs are now added to the token. 