### PR TITLE
changed VPVerificationResult to interface and streamlined attributes

### DIFF
--- a/auth/api/v1/api.go
+++ b/auth/api/v1/api.go
@@ -100,22 +100,22 @@ func (w Wrapper) VerifySignature(ctx echo.Context) error {
 	}
 	// Convert internal validationResult to api SignatureVerificationResponse
 	response := SignatureVerificationResponse{}
-	if validationResult.Validity == contract.Valid {
+	if validationResult.Validity() == contract.Valid {
 		response.Validity = true
 
 		credentials := map[string]interface{}{}
-		for key, val := range validationResult.ContractAttributes {
+		for key, val := range validationResult.ContractAttributes() {
 			credentials[key] = val
 		}
 		response.Credentials = &credentials
 
 		issuerAttributes := map[string]interface{}{}
-		for key, val := range validationResult.DisclosedAttributes {
+		for key, val := range validationResult.DisclosedAttributes() {
 			issuerAttributes[key] = val
 		}
 		response.IssuerAttributes = &issuerAttributes
 
-		vpType := string(validationResult.VPType)
+		vpType := string(validationResult.VPType())
 		response.VpType = &vpType
 	} else {
 		response.Validity = false
@@ -440,8 +440,7 @@ func (w Wrapper) IntrospectAccessToken(ctx echo.Context) error {
 		Iat:        &iat,
 		Sid:        claims.SubjectID,
 		Service:    &claims.Service,
-		Name:       claims.Name,
-		GivenName:  claims.GivenName,
+		Initials:   claims.Initials,
 		Prefix:     claims.Prefix,
 		FamilyName: claims.FamilyName,
 		Email:      claims.Email,

--- a/auth/api/v1/api_test.go
+++ b/auth/api/v1/api_test.go
@@ -987,11 +987,11 @@ func TestWrapper_VerifySignature(t *testing.T) {
 
 		bindPostBody(ctx, postParams)
 
-		verificationResult := &contract.VPVerificationResult{
-			Validity:            contract.Valid,
-			VPType:              "AVPType",
-			DisclosedAttributes: map[string]string{"name": "John"},
-			ContractAttributes:  map[string]string{"validTo": "now"},
+		verificationResult := services.TestVPVerificationResult{
+			Val:         contract.Valid,
+			Type:        "AVPType",
+			DAttributes: map[string]string{"name": "John"},
+			CAttributes: map[string]string{"validTo": "now"},
 		}
 
 		vpType := "AVPType"
@@ -1021,8 +1021,8 @@ func TestWrapper_VerifySignature(t *testing.T) {
 
 		bindPostBody(ctx, postParams)
 
-		verificationResult := &contract.VPVerificationResult{
-			Validity: contract.Invalid,
+		verificationResult := services.TestVPVerificationResult{
+			Val: contract.Invalid,
 		}
 
 		expectedResponse := SignatureVerificationResponse{
@@ -1051,8 +1051,8 @@ func TestWrapper_VerifySignature(t *testing.T) {
 
 		bindPostBody(ctx, postParams)
 
-		verificationResult := &contract.VPVerificationResult{
-			Validity: contract.Valid,
+		verificationResult := services.TestVPVerificationResult{
+			Val: contract.Valid,
 		}
 
 		vpType := ""

--- a/auth/api/v1/generated.go
+++ b/auth/api/v1/generated.go
@@ -290,16 +290,13 @@ type TokenIntrospectionResponse struct {
 
 	// Surname(s) or last name(s) of the End-User.
 	FamilyName *string `json:"family_name,omitempty"`
+	Iat        *int    `json:"iat,omitempty"`
 
-	// Given name(s) or first name(s) of the End-User.
-	GivenName *string `json:"given_name,omitempty"`
-	Iat       *int    `json:"iat,omitempty"`
+	// Initials of the End-User.
+	Initials *string `json:"initials,omitempty"`
 
 	// The subject (not a Nuts subject) contains the DID of the authorizer.
 	Iss *string `json:"iss,omitempty"`
-
-	// End-User's full name in displayable form including all name parts, possibly including titles and suffixes, ordered according to the End-User's locale and preferences.
-	Name *string `json:"name,omitempty"`
 
 	// encoded ops signature. (TBD)
 	Osi *string `json:"osi,omitempty"`

--- a/auth/contract/verifier.go
+++ b/auth/contract/verifier.go
@@ -37,7 +37,7 @@ type VerifierType string
 type VPVerifier interface {
 	// VerifyVP validates a verifiable presentation.
 	// When the verifier could not handle the verifiable presentation, an error should be thrown.
-	VerifyVP(rawVerifiablePresentation []byte, checkTime *time.Time) (*VPVerificationResult, error)
+	VerifyVP(rawVerifiablePresentation []byte, checkTime *time.Time) (VPVerificationResult, error)
 }
 
 // VPType holds the type of the Verifiable Presentation. Based on the format an appropriate validator can be selected.
@@ -78,19 +78,25 @@ type Proof struct {
 	Type string `json:"type"`
 }
 
-// VPVerificationResult contains the result of a contract validation
-type VPVerificationResult struct {
+// VPVerificationResult describes the result of a contract validation
+// it abstracts the name of the disclosed attributes from the means.
+// the access token for example uses "initials", "family_name", "prefix" and "email"
+type VPVerificationResult interface {
 	// Validity indicates if the Presentation is valid
 	// It can contains the "VALID" or "INVALID" status.
 	// Validators must only set the Validity to "VALID" if the whole VP, including the embedded
 	// contract are valid at the given moment in time.
-	Validity State
-	// VPType contains the the VP type like "NutsUziPresentation".
-	VPType VPType
-	// ContractID contains the identifier string of the signed contract message like: "EN:PractitionerLogin:v3"
-	ContractID string
-	// DisclosedAttributes contain the attributes used to sign this contract
-	DisclosedAttributes map[string]string
-	// ContractAttributes contain the attributes used to fill the contract
-	ContractAttributes map[string]string
+	Validity() State
+	// VPType returns the the VP type like "NutsUziPresentation".
+	VPType() VPType
+	// DisclosedAttribute returns the attribute value used to sign this contract
+	// returns empty string when not found
+	DisclosedAttribute(key string) string
+	// ContractAttribute returns the attribute value used to fill the contract
+	// returns empty string when not found
+	ContractAttribute(key string) string
+	// DisclosedAttributes returns the attributes used to sign this contract
+	DisclosedAttributes() map[string]string
+	// ContractAttributes returns the attributes used to fill the contract
+	ContractAttributes() map[string]string
 }

--- a/auth/services/dummy/dummy_test.go
+++ b/auth/services/dummy/dummy_test.go
@@ -168,12 +168,12 @@ func TestDummy_VerifyVP(t *testing.T) {
 				Type:    []contract.VPType{contract.VerifiablePresentationType, VerifiablePresentationType},
 			},
 			Proof: Proof{
-				Type:      NoSignatureType,
-				Initials:  "I",
-				Lastname:  "Tester",
-				Birthdate: "1980-01-01",
-				Email:     "tester@example.com",
-				Contract:  "EN:PractitionerLogin:v3 I hereby declare to act on behalf of care org located in Caretown. This declaration is valid from maandag 1 oktober 12:00:00 until maandag 1 oktober 13:00:00.",
+				Type:       NoSignatureType,
+				Initials:   "I",
+				FamilyName: "Tester",
+				Prefix:     "von",
+				Email:      "tester@example.com",
+				Contract:   "EN:PractitionerLogin:v3 I hereby declare to act on behalf of care org located in Caretown. This declaration is valid from maandag 1 oktober 12:00:00 until maandag 1 oktober 13:00:00.",
 			},
 		}
 
@@ -181,8 +181,8 @@ func TestDummy_VerifyVP(t *testing.T) {
 		vr, err := d.VerifyVP(j, nil)
 
 		assert.NoError(t, err)
-		assert.Equal(t, contract.Valid, vr.Validity)
-		assert.Equal(t, VerifiablePresentationType, vr.VPType)
+		assert.Equal(t, contract.Valid, vr.Validity())
+		assert.Equal(t, VerifiablePresentationType, vr.VPType())
 	})
 
 	t.Run("error - incorrect json", func(t *testing.T) {
@@ -240,10 +240,10 @@ func TestSigningSessionResult_VerifiablePresentation(t *testing.T) {
 		assert.Equal(t, []string{contract.VerifiableCredentialContext}, dvp.Context)
 		assert.Equal(t, []contract.VPType{contract.VerifiablePresentationType, VerifiablePresentationType}, dvp.Type)
 		assert.Equal(t, "", dvp.Proof.Contract)
-		assert.Equal(t, "1980-01-01", dvp.Proof.Birthdate)
 		assert.Equal(t, "tester@example.com", dvp.Proof.Email)
 		assert.Equal(t, "I", dvp.Proof.Initials)
-		assert.Equal(t, "Tester", dvp.Proof.Lastname)
+		assert.Equal(t, "von", dvp.Proof.Prefix)
+		assert.Equal(t, "Dummy", dvp.Proof.FamilyName)
 		assert.Equal(t, "NoSignature", dvp.Proof.Type)
 	})
 }

--- a/auth/services/irma/validator.go
+++ b/auth/services/irma/validator.go
@@ -83,9 +83,51 @@ type VPProof struct {
 	ProofValue string `json:"proofValue"`
 }
 
+type irmaVPVerificationResult struct {
+	validity            contract.State
+	vpType              contract.VPType
+	disclosedAttributes map[string]string
+	contractAttributes  map[string]string
+}
+
+func (I irmaVPVerificationResult) Validity() contract.State {
+	return I.validity
+}
+
+func (I irmaVPVerificationResult) VPType() contract.VPType {
+	return I.vpType
+}
+
+func (I irmaVPVerificationResult) DisclosedAttribute(key string) string {
+	var v string
+	switch key {
+	case "familyname":
+		v = I.disclosedAttributes["gemeente.personalData.familyname"]
+	case "prefix":
+		v = I.disclosedAttributes["gemeente.personalData.prefix"]
+	case "initials":
+		v = I.disclosedAttributes["gemeente.personalData.initials"]
+	case "email":
+		v = I.disclosedAttributes["sidn-pbdf.email.email"]
+	}
+	return v
+}
+
+func (I irmaVPVerificationResult) ContractAttribute(key string) string {
+	return I.contractAttributes[key]
+}
+
+func (I irmaVPVerificationResult) DisclosedAttributes() map[string]string {
+	return I.disclosedAttributes
+}
+
+func (I irmaVPVerificationResult) ContractAttributes() map[string]string {
+	return I.contractAttributes
+}
+
 // VerifyVP expects the given raw VerifiablePresentation to be of the correct type
 // todo: type check?
-func (v Service) VerifyVP(rawVerifiablePresentation []byte, checkTime *time.Time) (*contract.VPVerificationResult, error) {
+func (v Service) VerifyVP(rawVerifiablePresentation []byte, checkTime *time.Time) (contract.VPVerificationResult, error) {
 	// Extract the Irma message
 	vp := VerifiablePresentation{}
 	if err := json.Unmarshal(rawVerifiablePresentation, &vp); err != nil {
@@ -109,11 +151,11 @@ func (v Service) VerifyVP(rawVerifiablePresentation []byte, checkTime *time.Time
 		return nil, fmt.Errorf("could not verify vp: could not get signer attributes: %w", err)
 	}
 
-	return &contract.VPVerificationResult{
-		Validity:            contract.State(cvr.ValidationResult),
-		VPType:              contract.VPType(cvr.ContractFormat),
-		DisclosedAttributes: signerAttributes,
-		ContractAttributes:  signedContract.Contract().Params,
+	return irmaVPVerificationResult{
+		validity:            contract.State(cvr.ValidationResult),
+		vpType:              contract.VPType(cvr.ContractFormat),
+		disclosedAttributes: signerAttributes,
+		contractAttributes:  signedContract.Contract().Params,
 	}, nil
 }
 

--- a/auth/services/irma/validator.go
+++ b/auth/services/irma/validator.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/lestrrat-go/jwx/jwt"
+	"github.com/nuts-foundation/nuts-node/auth/services"
 
 	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
 
@@ -101,13 +102,13 @@ func (I irmaVPVerificationResult) VPType() contract.VPType {
 func (I irmaVPVerificationResult) DisclosedAttribute(key string) string {
 	var v string
 	switch key {
-	case "familyname":
+	case services.FamilyNameTokenClaim:
 		v = I.disclosedAttributes["gemeente.personalData.familyname"]
-	case "prefix":
+	case services.PrefixTokenClaim:
 		v = I.disclosedAttributes["gemeente.personalData.prefix"]
-	case "initials":
+	case services.InitialsTokenClaim:
 		v = I.disclosedAttributes["gemeente.personalData.initials"]
-	case "email":
+	case services.EmailTokenClaim:
 		v = I.disclosedAttributes["sidn-pbdf.email.email"]
 	}
 	return v

--- a/auth/services/irma/validator_test.go
+++ b/auth/services/irma/validator_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/nuts-foundation/nuts-node/auth/contract"
+	"github.com/nuts-foundation/nuts-node/auth/services"
 	"github.com/nuts-foundation/nuts-node/auth/test"
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/test/io"
@@ -152,6 +153,46 @@ func TestService_VerifyVP(t *testing.T) {
 		}
 		assert.Equal(t, "could not verify VP: unexpected end of JSON input", err.Error())
 
+	})
+}
+
+func TestIrmaVPVerificationResult(t *testing.T) {
+	vr := irmaVPVerificationResult{
+		validity:            contract.Valid,
+		vpType:              contract.VPType("type"),
+		disclosedAttributes: map[string]string{
+			"gemeente.personalData.familyname": "tester",
+			"gemeente.personalData.initials": "i",
+			"gemeente.personalData.prefix": "von",
+			"sidn-pbdf.email.email": "info@example.com",
+		},
+		contractAttributes:  map[string]string{
+			"a": "b",
+		},
+	}
+
+	t.Run("attribute mapping", func(t *testing.T) {
+		assert.Equal(t, "i", vr.DisclosedAttribute(services.InitialsTokenClaim))
+		assert.Equal(t, "tester", vr.DisclosedAttribute(services.FamilyNameTokenClaim))
+		assert.Equal(t, "von", vr.DisclosedAttribute(services.PrefixTokenClaim))
+		assert.Equal(t, "info@example.com", vr.DisclosedAttribute(services.EmailTokenClaim))
+	})
+
+	t.Run("validity", func(t *testing.T) {
+		assert.Equal(t, contract.Valid, vr.Validity())
+	})
+
+	t.Run("type", func(t *testing.T) {
+		assert.Equal(t, contract.VPType("type"), vr.VPType())
+	})
+
+	t.Run("DisclosedAttributes", func(t *testing.T) {
+		assert.NotNil(t, vr.DisclosedAttributes())
+	})
+
+	t.Run("ContractAttributes", func(t *testing.T) {
+		assert.NotNil(t, vr.ContractAttributes())
+		assert.Equal(t, "b", vr.ContractAttribute("a"))
 	})
 }
 

--- a/auth/services/messages.go
+++ b/auth/services/messages.go
@@ -53,8 +53,7 @@ type JwtBearerTokenResult struct {
 type NutsAccessToken struct {
 	SubjectID  *string `json:"sid,omitempty"`
 	Service    string  `json:"service"`
-	Name       *string `json:"name,omitempty"`
-	GivenName  *string `json:"given_name,omitempty"`
+	Initials   *string `json:"initials,omitempty"`
 	Prefix     *string `json:"prefix,omitempty"`
 	FamilyName *string `json:"family_name,omitempty"`
 	Email      *string `json:"email,omitempty"`

--- a/auth/services/mock.go
+++ b/auth/services/mock.go
@@ -336,10 +336,10 @@ func (mr *MockContractClientMockRecorder) SigningSessionStatus(sessionID interfa
 }
 
 // VerifyVP mocks base method.
-func (m *MockContractClient) VerifyVP(rawVerifiablePresentation []byte, checkTime *time.Time) (*contract.VPVerificationResult, error) {
+func (m *MockContractClient) VerifyVP(rawVerifiablePresentation []byte, checkTime *time.Time) (contract.VPVerificationResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyVP", rawVerifiablePresentation, checkTime)
-	ret0, _ := ret[0].(*contract.VPVerificationResult)
+	ret0, _ := ret[0].(contract.VPVerificationResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -55,12 +55,6 @@ const subjectIDClaim = "sid"
 const purposeOfUseClaim = "purposeOfUseClaim"
 const userIdentityClaim = "usi"
 
-// claims as used by openid
-const initialsTokenClaim = "initials"
-const familyNameTokenClaim = "familyname"
-const prefixTokenClaim = "prefix"
-const emailTokenClaim = "email"
-
 type service struct {
 	docResolver     types.DocResolver
 	conceptFinder   vcr.ConceptFinder
@@ -541,10 +535,10 @@ func (s *service) buildAccessToken(context *validationContext) (string, error) {
 		disclosedAttributeFn := context.contractVerificationResult.DisclosedAttribute
 
 		// based on https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims
-		at.Initials = toStrPtr(disclosedAttributeFn(initialsTokenClaim))
-		at.FamilyName = toStrPtr(disclosedAttributeFn(familyNameTokenClaim))
-		at.Prefix = toStrPtr(disclosedAttributeFn(prefixTokenClaim))
-		at.Email = toStrPtr(disclosedAttributeFn(emailTokenClaim))
+		at.Initials = toStrPtr(disclosedAttributeFn(services.InitialsTokenClaim))
+		at.FamilyName = toStrPtr(disclosedAttributeFn(services.FamilyNameTokenClaim))
+		at.Prefix = toStrPtr(disclosedAttributeFn(services.PrefixTokenClaim))
+		at.Email = toStrPtr(disclosedAttributeFn(services.EmailTokenClaim))
 	}
 
 	if len(context.credentialIDs) > 0 {

--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -55,6 +55,12 @@ const subjectIDClaim = "sid"
 const purposeOfUseClaim = "purposeOfUseClaim"
 const userIdentityClaim = "usi"
 
+// claims as used by openid
+const initialsTokenClaim = "initials"
+const familyNameTokenClaim = "familyname"
+const prefixTokenClaim = "prefix"
+const emailTokenClaim = "email"
+
 type service struct {
 	docResolver     types.DocResolver
 	conceptFinder   vcr.ConceptFinder
@@ -73,7 +79,7 @@ type validationContext struct {
 	requesterCity              string
 	purposeOfUse               string
 	credentialIDs              []string
-	contractVerificationResult *contract.VPVerificationResult
+	contractVerificationResult contract.VPVerificationResult
 }
 
 func (c validationContext) subjectID() *string {
@@ -196,7 +202,7 @@ func (s *service) CreateAccessToken(request services.CreateAccessTokenRequest) (
 			return nil, fmt.Errorf("identity verification failed: %w", err)
 		}
 
-		if context.contractVerificationResult.Validity != contract.Valid {
+		if context.contractVerificationResult.Validity() != contract.Valid {
 			return nil, errors.New("identity validation failed")
 		}
 
@@ -231,7 +237,7 @@ func (s *service) CreateAccessToken(request services.CreateAccessTokenRequest) (
 
 // checks if the name from the login contract matches with the registered name of the issuer.
 func (s *service) validateRequester(context *validationContext) error {
-	if context.contractVerificationResult.ContractAttributes[contract.LegalEntityAttr] != context.requesterName || context.contractVerificationResult.ContractAttributes[contract.LegalEntityCityAttr] != context.requesterCity {
+	if context.contractVerificationResult.ContractAttribute(contract.LegalEntityAttr) != context.requesterName || context.contractVerificationResult.ContractAttribute(contract.LegalEntityCityAttr) != context.requesterCity {
 		return errors.New("legal entity mismatch")
 	}
 	return nil
@@ -506,7 +512,7 @@ func (s *service) IntrospectAccessToken(accessToken string) (*services.NutsAcces
 // The token gets signed with the authorizers private key and returned as a string.
 func (s *service) buildAccessToken(context *validationContext) (string, error) {
 	if context.contractVerificationResult != nil {
-		if context.contractVerificationResult.Validity != contract.Valid {
+		if context.contractVerificationResult.Validity() != contract.Valid {
 			return "", fmt.Errorf("could not build accessToken: %w", errors.New("invalid contract"))
 		}
 	}
@@ -532,18 +538,13 @@ func (s *service) buildAccessToken(context *validationContext) (string, error) {
 	}
 
 	if context.contractVerificationResult != nil {
-		disclosedAttributes := context.contractVerificationResult.DisclosedAttributes
+		disclosedAttributeFn := context.contractVerificationResult.DisclosedAttribute
 
-		// based on
-		// https://privacybydesign.foundation/attribute-index/en/pbdf.gemeente.personalData.html
-		// https://privacybydesign.foundation/attribute-index/en/pbdf.pbdf.email.html
-		// and
-		// https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims
-		at.FamilyName = toStrPtr(disclosedAttributes["gemeente.personalData.familyname"])
-		at.GivenName = toStrPtr(disclosedAttributes["gemeente.personalData.firstnames"])
-		at.Prefix = toStrPtr(disclosedAttributes["gemeente.personalData.prefix"])
-		at.Name = toStrPtr(disclosedAttributes["gemeente.personalData.fullname"])
-		at.Email = toStrPtr(disclosedAttributes["sidn-pbdf.email.email"])
+		// based on https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims
+		at.Initials = toStrPtr(disclosedAttributeFn(initialsTokenClaim))
+		at.FamilyName = toStrPtr(disclosedAttributeFn(familyNameTokenClaim))
+		at.Prefix = toStrPtr(disclosedAttributeFn(prefixTokenClaim))
+		at.Email = toStrPtr(disclosedAttributeFn(emailTokenClaim))
 	}
 
 	if len(context.credentialIDs) > 0 {

--- a/auth/services/oauth/oauth_test.go
+++ b/auth/services/oauth/oauth_test.go
@@ -166,7 +166,7 @@ func TestAuth_CreateAccessToken(t *testing.T) {
 		ctx.privateKeyStore.EXPECT().Exists(authorizerSigningKeyID.String()).Return(true)
 		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(requesterSigningKey.Public(), nil)
 		ctx.keyResolver.EXPECT().ResolveSigningKeyID(authorizerDID, gomock.Any()).MinTimes(1).Return(authorizerSigningKeyID.String(), nil)
-		ctx.contractClientMock.EXPECT().VerifyVP(gomock.Any(), nil).Return(&contract.VPVerificationResult{Validity: contract.Invalid}, nil)
+		ctx.contractClientMock.EXPECT().VerifyVP(gomock.Any(), nil).Return(services.TestVPVerificationResult{Val: contract.Invalid}, nil)
 
 		tokenCtx := validContext()
 		signToken(tokenCtx)
@@ -213,10 +213,11 @@ func TestAuth_CreateAccessToken(t *testing.T) {
 		ctx.serviceResolver.EXPECT().GetCompoundServiceEndpoint(authorizerDID, expectedService, services.OAuthEndpointType, true).Return(expectedAudience, nil)
 		ctx.privateKeyStore.EXPECT().Exists(authorizerSigningKeyID.String()).Return(true)
 		ctx.privateKeyStore.EXPECT().SignJWT(gomock.Any(), authorizerSigningKeyID.String()).Return("expectedAT", nil)
-		ctx.contractClientMock.EXPECT().VerifyVP(gomock.Any(), nil).Return(&contract.VPVerificationResult{
-			Validity:            contract.Valid,
-			DisclosedAttributes: map[string]string{"name": "Henk de Vries"},
-			ContractAttributes:  map[string]string{"legal_entity": "Carebears", "legal_entity_city": "Caretown"},
+		ctx.contractClientMock.EXPECT().VerifyVP(gomock.Any(), nil).Return(services.TestVPVerificationResult{
+			Val:            contract.Valid,
+			DAttributes: map[string]string{"name": "Henk de Vries"},
+			CAttributes:  map[string]string{"legal_entity": "Carebears", "legal_entity_city": "Caretown"},
+
 		}, nil)
 		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, true, gomock.Any()).Return(nil)
 
@@ -579,7 +580,7 @@ func TestService_buildAccessToken(t *testing.T) {
 		defer ctx.ctrl.Finish()
 
 		tokenCtx := &validationContext{
-			contractVerificationResult: &contract.VPVerificationResult{Validity: contract.Valid},
+			contractVerificationResult: services.TestVPVerificationResult{Val: contract.Valid},
 			jwtBearerToken:             jwt.New(),
 		}
 
@@ -602,7 +603,7 @@ func TestService_buildAccessToken(t *testing.T) {
 		})
 
 		tokenCtx := &validationContext{
-			contractVerificationResult: &contract.VPVerificationResult{Validity: contract.Valid},
+			contractVerificationResult: services.TestVPVerificationResult{Val: contract.Valid},
 			jwtBearerToken:             jwt.New(),
 			credentialIDs:              []string{"credential"},
 		}

--- a/auth/services/test.go
+++ b/auth/services/test.go
@@ -1,0 +1,53 @@
+/*
+ * Nuts node
+ * Copyright (C) 2021 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package services
+
+import "github.com/nuts-foundation/nuts-node/auth/contract"
+
+type TestVPVerificationResult struct {
+	Val         contract.State
+	Type        contract.VPType
+	DAttributes map[string]string
+	CAttributes map[string]string
+}
+
+func (t TestVPVerificationResult) Validity() contract.State {
+	return t.Val
+}
+
+func (t TestVPVerificationResult) VPType() contract.VPType {
+	return t.Type
+}
+
+func (t TestVPVerificationResult) DisclosedAttribute(key string) string {
+	return t.DAttributes[key]
+}
+
+func (t TestVPVerificationResult) ContractAttribute(key string) string {
+	return t.CAttributes[key]
+}
+
+func (t TestVPVerificationResult) DisclosedAttributes() map[string]string {
+	return t.DAttributes
+}
+
+func (t TestVPVerificationResult) ContractAttributes() map[string]string {
+	return t.CAttributes
+}

--- a/auth/services/types.go
+++ b/auth/services/types.go
@@ -44,3 +44,15 @@ type ContractFormat string
 
 // OAuthEndpointType defines the type identifier for oauth endpoints (RFCtodo)
 const OAuthEndpointType = "oauth"
+
+// InitialsTokenClaim is the JWT claim for initials
+const InitialsTokenClaim = "initials"
+
+// v is the JWT claim for the family name
+const FamilyNameTokenClaim = "familyname"
+
+// PrefixTokenClaim is the JWT claim for the name prefix
+const PrefixTokenClaim = "prefix"
+
+// EmailTokenClaim is the JWT claim for email
+const EmailTokenClaim = "email"

--- a/auth/services/types.go
+++ b/auth/services/types.go
@@ -48,7 +48,7 @@ const OAuthEndpointType = "oauth"
 // InitialsTokenClaim is the JWT claim for initials
 const InitialsTokenClaim = "initials"
 
-// v is the JWT claim for the family name
+// FamilyNameTokenClaim is the JWT claim for the family name
 const FamilyNameTokenClaim = "familyname"
 
 // PrefixTokenClaim is the JWT claim for the name prefix

--- a/auth/services/uzi/validator.go
+++ b/auth/services/uzi/validator.go
@@ -51,10 +51,41 @@ type proof struct {
 	ProofValue string
 }
 
+type uziVPVerificationResult struct {
+	validity            contract.State
+	vpType              contract.VPType
+	disclosedAttributes map[string]string
+	contractAttributes  map[string]string
+}
+
+func (I uziVPVerificationResult) Validity() contract.State {
+	return I.validity
+}
+
+func (I uziVPVerificationResult) VPType() contract.VPType {
+	return I.vpType
+}
+
+func (I uziVPVerificationResult) DisclosedAttribute(key string) string {
+	return I.disclosedAttributes[key]
+}
+
+func (I uziVPVerificationResult) ContractAttribute(key string) string {
+	return I.contractAttributes[key]
+}
+
+func (I uziVPVerificationResult) DisclosedAttributes() map[string]string {
+	return I.disclosedAttributes
+}
+
+func (I uziVPVerificationResult) ContractAttributes() map[string]string {
+	return I.contractAttributes
+}
+
 // VerifyVP implements the verifiablePresentation Verifier interface. It can verify an Uzi VP.
 // It checks the signature, the attributes and the contract.
 // Returns the contract.VPVerificationResult or an error if something went wrong.
-func (u Verifier) VerifyVP(rawVerifiablePresentation []byte, _ *time.Time) (*contract.VPVerificationResult, error) {
+func (u Verifier) VerifyVP(rawVerifiablePresentation []byte, _ *time.Time) (contract.VPVerificationResult, error) {
 
 	presentation := verifiablePresentation{}
 	if err := json.Unmarshal(rawVerifiablePresentation, &presentation); err != nil {
@@ -81,8 +112,8 @@ func (u Verifier) VerifyVP(rawVerifiablePresentation []byte, _ *time.Time) (*con
 		return nil, fmt.Errorf("could not verify verifiable presentation: could not parse the proof: %w", err)
 	}
 	if err := u.UziValidator.Verify(signedToken); err != nil {
-		return &contract.VPVerificationResult{
-			Validity: contract.Invalid,
+		return uziVPVerificationResult{
+			validity: contract.Invalid,
 		}, nil
 	}
 
@@ -91,10 +122,10 @@ func (u Verifier) VerifyVP(rawVerifiablePresentation []byte, _ *time.Time) (*con
 		return nil, fmt.Errorf("could not get disclosed attributes from signed contract: %w", err)
 	}
 
-	return &contract.VPVerificationResult{
-		Validity:            contract.Valid,
-		VPType:              VerifiablePresentationType,
-		DisclosedAttributes: disclosedAttributes,
-		ContractAttributes:  signedToken.Contract().Params,
+	return uziVPVerificationResult{
+		validity:            contract.Valid,
+		vpType:              VerifiablePresentationType,
+		disclosedAttributes: disclosedAttributes,
+		contractAttributes:  signedToken.Contract().Params,
 	}, nil
 }

--- a/auth/services/uzi/validator_test.go
+++ b/auth/services/uzi/validator_test.go
@@ -21,8 +21,9 @@ package uzi
 import (
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/nuts-node/auth/services"
 	"testing"
+
+	"github.com/nuts-foundation/nuts-node/auth/services"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -61,9 +62,9 @@ func TestUziValidator_VerifyVP(t *testing.T) {
 			return
 		}
 		assert.NotNil(t, res)
-		assert.Equal(t, contract.Valid, res.Validity)
-		assert.Equal(t, "Henk de Vries", res.DisclosedAttributes["name"])
-		assert.Equal(t, "2020-12-10T13:57:00", res.ContractAttributes["validFrom"])
+		assert.Equal(t, contract.Valid, res.Validity())
+		assert.Equal(t, "Henk de Vries", res.DisclosedAttribute("name"))
+		assert.Equal(t, "2020-12-10T13:57:00", res.ContractAttribute("validFrom"))
 	})
 
 	t.Run("nok - garbage input", func(t *testing.T) {
@@ -178,8 +179,8 @@ func TestUziValidator_VerifyVP(t *testing.T) {
 			return
 		}
 		assert.NotNil(t, res)
-		assert.Equal(t, contract.Invalid, res.Validity)
-		assert.Empty(t, res.DisclosedAttributes)
-		assert.Empty(t, res.ContractAttributes)
+		assert.Equal(t, contract.Invalid, res.Validity())
+		assert.Empty(t, res.DisclosedAttributes())
+		assert.Empty(t, res.ContractAttributes())
 	})
 }

--- a/auth/services/validator/validator.go
+++ b/auth/services/validator/validator.go
@@ -142,7 +142,7 @@ func (s *service) Configure() (err error) {
 	return
 }
 
-func (s *service) VerifyVP(rawVerifiablePresentation []byte, checkTime *time.Time) (*contract.VPVerificationResult, error) {
+func (s *service) VerifyVP(rawVerifiablePresentation []byte, checkTime *time.Time) (contract.VPVerificationResult, error) {
 	vp := contract.BaseVerifiablePresentation{}
 	if err := json.Unmarshal(rawVerifiablePresentation, &vp); err != nil {
 		return nil, fmt.Errorf("unable to verifyVP: %w", err)

--- a/auth/services/validator/validator_test.go
+++ b/auth/services/validator/validator_test.go
@@ -86,7 +86,7 @@ func TestContract_VerifyVP(t *testing.T) {
 		}
 
 		mockVerifier := services.NewMockContractClient(ctrl)
-		mockVerifier.EXPECT().VerifyVP(rawVP, nil).Return(&contract.VPVerificationResult{Validity: contract.Valid}, nil)
+		mockVerifier.EXPECT().VerifyVP(rawVP, nil).Return(services.TestVPVerificationResult{Val: contract.Valid}, nil)
 
 		validator := service{verifiers: map[contract.VPType]contract.VPVerifier{"bar": mockVerifier}}
 
@@ -98,7 +98,7 @@ func TestContract_VerifyVP(t *testing.T) {
 		if !assert.NotNil(t, validationResult) {
 			return
 		}
-		assert.Equal(t, contract.Valid, validationResult.Validity)
+		assert.Equal(t, contract.Valid, validationResult.Validity())
 	})
 
 	t.Run("nok - unknown VerifiablePresentation", func(t *testing.T) {

--- a/docs/_static/auth/v1.yaml
+++ b/docs/_static/auth/v1.yaml
@@ -739,10 +739,6 @@ components:
           type: integer
         iat:
           type: integer
-        name:
-          type: string
-          description: End-User's full name in displayable form including all name parts, possibly including titles and suffixes, ordered according to the End-User's locale and preferences.
-          example: Willeke de Bruijn
         family_name:
           type: string
           description: Surname(s) or last name(s) of the End-User.
@@ -751,10 +747,10 @@ components:
           type: string
           description: Surname prefix
           example: de
-        given_name:
+        initials:
           type: string
-          description: Given name(s) or first name(s) of the End-User.
-          example: Willeke
+          description: Initials of the End-User.
+          example: I.
         email:
           type: string
           description: End-User's preferred e-mail address. Should be a personal email and can be used to uniquely identify a user. Just like the email used for an account.


### PR DESCRIPTION
closes #493 

made VPVerificationResult to an interface so we can use default claim names. The means used will then convert it from their own attribute names.