### PR TITLE
check VC sig when creating access token

### DIFF
--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -346,8 +346,8 @@ func (s *service) validateAuthorizationCredentials(context *validationContext) e
 	sub := context.jwtBearerToken.Subject()
 
 	for _, authCred := range vcs {
-		// first check if the VC is valid
-		if err := s.vcValidator.Validate(authCred, true, &iat); err != nil {
+		// first check if the VC is valid and if the signature is correct
+		if err := s.vcValidator.Validate(authCred, true, true, &iat); err != nil {
 			return fmt.Errorf(errInvalidVCClaim, err)
 		}
 

--- a/auth/services/oauth/oauth_test.go
+++ b/auth/services/oauth/oauth_test.go
@@ -189,7 +189,7 @@ func TestAuth_CreateAccessToken(t *testing.T) {
 		ctx.serviceResolver.EXPECT().GetCompoundServiceEndpoint(authorizerDID, expectedService, services.OAuthEndpointType, true).Return(expectedAudience, nil)
 		ctx.privateKeyStore.EXPECT().Exists(authorizerSigningKeyID.String()).Return(true)
 		ctx.privateKeyStore.EXPECT().SignJWT(gomock.Any(), authorizerSigningKeyID.String()).Return("expectedAccessToken", nil)
-		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, gomock.Any()).Return(nil)
+		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, true, gomock.Any()).Return(nil)
 
 		tokenCtx := validContext()
 		tokenCtx.jwtBearerToken.Remove(userIdentityClaim)
@@ -218,7 +218,7 @@ func TestAuth_CreateAccessToken(t *testing.T) {
 			DisclosedAttributes: map[string]string{"name": "Henk de Vries"},
 			ContractAttributes:  map[string]string{"legal_entity": "Carebears", "legal_entity_city": "Caretown"},
 		}, nil)
-		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, gomock.Any()).Return(nil)
+		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, true, gomock.Any()).Return(nil)
 
 		tokenCtx := validContext()
 		signToken(tokenCtx)
@@ -416,7 +416,7 @@ func TestService_validateAuthorizationCredentials(t *testing.T) {
 		tokenCtx := validContext()
 		signToken(tokenCtx)
 
-		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, gomock.Any()).Return(nil)
+		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, true, gomock.Any()).Return(nil)
 		err := ctx.oauthService.validateAuthorizationCredentials(tokenCtx)
 
 		if !assert.NoError(t, err) {
@@ -477,7 +477,7 @@ func TestService_validateAuthorizationCredentials(t *testing.T) {
 		tokenCtx := validContext()
 		tokenCtx.jwtBearerToken.Set(jwt.IssuerKey, "unknown")
 		signToken(tokenCtx)
-		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, gomock.Any()).Return(nil)
+		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, true, gomock.Any()).Return(nil)
 
 		err := ctx.oauthService.validateAuthorizationCredentials(tokenCtx)
 
@@ -491,7 +491,7 @@ func TestService_validateAuthorizationCredentials(t *testing.T) {
 		tokenCtx := validContext()
 		tokenCtx.jwtBearerToken.Set(jwt.SubjectKey, "unknown")
 		signToken(tokenCtx)
-		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, gomock.Any()).Return(nil)
+		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, true, gomock.Any()).Return(nil)
 
 		err := ctx.oauthService.validateAuthorizationCredentials(tokenCtx)
 
@@ -505,7 +505,7 @@ func TestService_validateAuthorizationCredentials(t *testing.T) {
 		tokenCtx := validContext()
 		tokenCtx.jwtBearerToken.Set(jwt.SubjectKey, "unknown")
 		signToken(tokenCtx)
-		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, gomock.Any()).Return(vcr.ErrRevoked)
+		ctx.vcValidator.EXPECT().Validate(gomock.Any(), true, true, gomock.Any()).Return(vcr.ErrRevoked)
 
 		err := ctx.oauthService.validateAuthorizationCredentials(tokenCtx)
 

--- a/vcr/concept/test.go
+++ b/vcr/concept/test.go
@@ -72,6 +72,10 @@ var ExampleConfig = Config{
 
 const TestCredential = `
 {
+	"@context": [
+		"https://www.w3.org/2018/credentials/v1",
+		"https://nuts.nl/credentials/v1"
+	  ],
 	"id": "did:nuts:B8PUHs2AUHbFF1xLLK4eZjgErEcMXHxs68FteY7NDtCY#123",
 	"issuer": "did:nuts:B8PUHs2AUHbFF1xLLK4eZjgErEcMXHxs68FteY7NDtCY",
 	"issuanceDate": "1970-01-01T12:00:00Z",
@@ -83,7 +87,8 @@ const TestCredential = `
 			"eyeColour": "blue/grey",
 			"hairColour": "fair"
 		}
-	}
+	},
+	"proof": {}
 }
 `
 

--- a/vcr/credential/resolver.go
+++ b/vcr/credential/resolver.go
@@ -34,10 +34,11 @@ func FindValidatorAndBuilder(credential vc.VerifiableCredential) (Validator, Bui
 				return nutsOrganizationCredentialValidator{}, defaultBuilder{vcType: t}
 			case NutsAuthorizationCredentialType:
 				return nutsAuthorizationCredentialValidator{}, defaultBuilder{vcType: t}
+			default:
+				return defaultCredentialValidator{}, defaultBuilder{vcType: t}
 			}
 		}
 	}
-
 	return nil, nil
 }
 

--- a/vcr/credential/validator.go
+++ b/vcr/credential/validator.go
@@ -85,6 +85,15 @@ func Validate(credential vc.VerifiableCredential) error {
 	return nil
 }
 
+type defaultCredentialValidator struct{}
+
+func (d defaultCredentialValidator) Validate(credential vc.VerifiableCredential) error {
+	if err := Validate(credential); err != nil {
+		return err
+	}
+	return nil
+}
+
 // nutsOrganizationCredentialValidator checks if there's a 'name' and 'city' in the 'organization' struct
 type nutsOrganizationCredentialValidator struct{}
 

--- a/vcr/interface.go
+++ b/vcr/interface.go
@@ -75,9 +75,10 @@ type Validator interface {
 	// - is not revoked
 	// - is valid at the given time (or now if not give)
 	// - has a valid issuer
+	// - has a valid signature if checkSignature is true
 	// if allowUntrusted == false, the issuer must also be a trusted DID
 	// May return ErrRevoked, ErrUntrusted or ErrInvalidPeriod
-	Validate(credential vc.VerifiableCredential, allowUntrusted bool, validAt *time.Time) error
+	Validate(credential vc.VerifiableCredential, allowUntrusted bool, checkSignature bool, validAt *time.Time) error
 }
 
 // Writer is the interface that groups al the VC write methods

--- a/vcr/mock.go
+++ b/vcr/mock.go
@@ -92,17 +92,17 @@ func (m *MockValidator) EXPECT() *MockValidatorMockRecorder {
 }
 
 // Validate mocks base method.
-func (m *MockValidator) Validate(credential vc.VerifiableCredential, allowUntrusted bool, validAt *time.Time) error {
+func (m *MockValidator) Validate(credential vc.VerifiableCredential, allowUntrusted, checkSignature bool, validAt *time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Validate", credential, allowUntrusted, validAt)
+	ret := m.ctrl.Call(m, "Validate", credential, allowUntrusted, checkSignature, validAt)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Validate indicates an expected call of Validate.
-func (mr *MockValidatorMockRecorder) Validate(credential, allowUntrusted, validAt interface{}) *gomock.Call {
+func (mr *MockValidatorMockRecorder) Validate(credential, allowUntrusted, checkSignature, validAt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockValidator)(nil).Validate), credential, allowUntrusted, validAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockValidator)(nil).Validate), credential, allowUntrusted, checkSignature, validAt)
 }
 
 // MockWriter is a mock of Writer interface.
@@ -488,15 +488,15 @@ func (mr *MockVCRMockRecorder) Untrusted(credentialType interface{}) *gomock.Cal
 }
 
 // Validate mocks base method.
-func (m *MockVCR) Validate(credential vc.VerifiableCredential, allowUntrusted bool, validAt *time.Time) error {
+func (m *MockVCR) Validate(credential vc.VerifiableCredential, allowUntrusted, checkSignature bool, validAt *time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Validate", credential, allowUntrusted, validAt)
+	ret := m.ctrl.Call(m, "Validate", credential, allowUntrusted, checkSignature, validAt)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Validate indicates an expected call of Validate.
-func (mr *MockVCRMockRecorder) Validate(credential, allowUntrusted, validAt interface{}) *gomock.Call {
+func (mr *MockVCRMockRecorder) Validate(credential, allowUntrusted, checkSignature, validAt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockVCR)(nil).Validate), credential, allowUntrusted, validAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockVCR)(nil).Validate), credential, allowUntrusted, checkSignature, validAt)
 }


### PR DESCRIPTION
closes #494

The Validate method on the VCR now accepts an additional `checkSignature` param. VCs returned from local storage do not need this check, but VCs given via the API do.