### PR TITLE
VDR: Fix DocumentMetadata Copy() returning an actual deepcopy

### DIFF
--- a/vdr/types/common.go
+++ b/vdr/types/common.go
@@ -82,6 +82,7 @@ func (m DocumentMetadata) Copy() DocumentMetadata {
 		updated := *m.Updated
 		m.Updated = &updated
 	}
+	m.SourceTransactions = append(m.SourceTransactions[:0:0], m.SourceTransactions...)
 	return m
 }
 

--- a/vdr/types/common_test.go
+++ b/vdr/types/common_test.go
@@ -39,7 +39,7 @@ func TestCopy(t *testing.T) {
 		Updated:            &timeNow,
 		Hash:               h,
 		Deactivated:        false,
-		SourceTransactions: []hash.SHA256Hash{hash.EmptyHash()},
+		SourceTransactions: []hash.SHA256Hash{h},
 	}
 	numFields := 5
 
@@ -53,12 +53,18 @@ func TestCopy(t *testing.T) {
 		// Updated
 		metaCopy = meta.Copy()
 		*metaCopy.Updated = timeLater
-		metaCopy.SourceTransactions = []hash.SHA256Hash{}
 		assert.False(t, reflect.DeepEqual(meta, metaCopy))
+
+		// Hash
+		metaCopy.Hash[0] = 0
+		assert.NotEqual(t, metaCopy.Hash, meta.Hash, "Hash is not deep-copied")
+
+		// SourceTransactions
+		metaCopy.SourceTransactions[0] = hash.SHA256Hash{20}
+		assert.NotEqual(t, metaCopy.SourceTransactions, meta.SourceTransactions, "SourceTransactions is not deep-copied")
 
 		// if this test fails, please make sure the Copy() method is updated as well!
 		assert.Equal(t, numFields, reflect.TypeOf(DocumentMetadata{}).NumField())
-
 	})
 }
 


### PR DESCRIPTION
Incomplete copies returned by `memoryStore` causes race conditions when VDR is access/operated concurrently.