### PR TITLE
non-ambiguous return for GetCompoundServiceEndpoint

### DIFF
--- a/didman/api/v1/api.go
+++ b/didman/api/v1/api.go
@@ -195,6 +195,7 @@ func (w *Wrapper) AddCompoundService(ctx echo.Context, didStr string) error {
 
 // GetCompoundServiceEndpoint handles calls to read a specific endpoint of a compound service.
 func (w *Wrapper) GetCompoundServiceEndpoint(ctx echo.Context, didStr string, compoundServiceType string, endpointType string, params GetCompoundServiceEndpointParams) error {
+	acceptHeader := ctx.Request().Header.Get("Accept")
 	id, err := did.ParseDID(didStr)
 	if err != nil {
 		return err
@@ -207,7 +208,12 @@ func (w *Wrapper) GetCompoundServiceEndpoint(ctx echo.Context, didStr string, co
 	if err != nil {
 		return err
 	}
-	return ctx.JSON(http.StatusOK, endpoint)
+	if strings.Contains(acceptHeader, "text/plain") {
+		return ctx.String(http.StatusOK, endpoint)
+	}
+
+	// default json
+	return ctx.JSON(http.StatusOK, EndpointResponse{Endpoint: endpoint})
 }
 
 func interfaceToURI(input interface{}) (*ssi.URI, error) {

--- a/didman/api/v1/generated.go
+++ b/didman/api/v1/generated.go
@@ -57,6 +57,12 @@ type EndpointProperties struct {
 	Type string `json:"type"`
 }
 
+// EndpointResponse defines model for EndpointResponse.
+type EndpointResponse struct {
+	// The endpoint URL.
+	Endpoint string `json:"endpoint"`
+}
+
 // AddCompoundServiceJSONBody defines parameters for AddCompoundService.
 type AddCompoundServiceJSONBody CompoundServiceProperties
 
@@ -877,7 +883,7 @@ func (r AddCompoundServiceResponse) StatusCode() int {
 type GetCompoundServiceEndpointResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *string
+	JSON200      *EndpointResponse
 }
 
 // Status returns HTTPResponse.Status
@@ -1198,11 +1204,14 @@ func ParseGetCompoundServiceEndpointResponse(rsp *http.Response) (*GetCompoundSe
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest string
+		var dest EndpointResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case rsp.StatusCode == 200:
+		// Content-type (text/plain) unsupported
 
 	}
 

--- a/docs/_static/didman/v1.yaml
+++ b/docs/_static/didman/v1.yaml
@@ -248,10 +248,14 @@ paths:
         "200":
           description: |
             The endpoint of the given type and compound service is returned.
+            It returns JSON by default, text if requested through the accept header (text/plain)
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EndpointResponse'
         default:
           $ref: '../common/error_response.yaml'
   /internal/didman/v1/service/{id}:
@@ -417,3 +421,11 @@ components:
             See https://nuts-node.readthedocs.io/en/latest/pages/development/3-vc.html for examples on which concepts are supported and how they're structured.
         didDocument:
           $ref: '../vdr/v1.yaml#/components/schemas/DIDDocument'
+    EndpointResponse:
+      type: object
+      required:
+        - endpoint
+      properties:
+        endpoint:
+          type: string
+          description: The endpoint URL.


### PR DESCRIPTION
fixes #481 

You can now choose between json/text via the Accept header.
Default is JSON
JSON return now has a structure.