### PR TITLE
Config: allow multi-valued options to be configured through environment or flags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,8 @@ Config parameters for engines are prepended by the ``engine.ConfigKey`` by defau
 
 is equal to ``$ nuts --engine.nested.parameter X`` is equal to ``$ NUTS_ENGINE_NESTED_PARAMETER=X nuts``
 
+While most options are a single value, some are represented as a list (indicated with the square brackets in the table below).
+To provide multiple values through flags or environment variables you can separate them with a comma (``,``).
 
 Ordering
 ********

--- a/core/config.go
+++ b/core/config.go
@@ -30,12 +30,24 @@ import (
 
 const defaultPrefix = "NUTS_"
 const defaultDelimiter = "."
+const configValueListSeparator = ","
 
 func loadConfigIntoStruct(flags *pflag.FlagSet, target interface{}, configMap *koanf.Koanf) error {
 	// load env
-	e := env.Provider(defaultPrefix, defaultDelimiter, func(s string) string {
-		return strings.Replace(strings.ToLower(
-			strings.TrimPrefix(s, defaultPrefix)), "_", defaultDelimiter, -1)
+	e := env.ProviderWithValue(defaultPrefix, defaultDelimiter, func(rawKey string, rawValue string) (string, interface{}) {
+		key := strings.Replace(strings.ToLower(strings.TrimPrefix(rawKey, defaultPrefix)), "_", defaultDelimiter, -1)
+
+		// Support multiple values separated by a comma
+		if strings.Contains(rawValue, configValueListSeparator) {
+			values := strings.Split(rawValue, configValueListSeparator)
+			for i, value := range values {
+				values[i] = strings.TrimSpace(value)
+			}
+			return key, values
+		}
+
+		// Just a single value
+		return key, rawValue
 	})
 	// errors can't occur for this provider
 	_ = configMap.Load(e, nil)

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -28,17 +28,31 @@ import (
 )
 
 func Test_loadConfigIntoStruct(t *testing.T) {
-	os.Setenv("NUTS_E", "nvironment")
-	defer os.Unsetenv("NUTS_E")
-	flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	flagSet.String("f", "lag", "A great option")
-	type Target struct {
-		F string `koanf:"f"`
-		E string `koanf:"e"`
-	}
-	var target Target
-	err := loadConfigIntoStruct(flagSet, &target, koanf.New(defaultDelimiter))
-	assert.NoError(t, err)
-	assert.Equal(t, "lag", target.F)
-	assert.Equal(t, "nvironment", target.E)
+	t.Run("scalar values from env", func(t *testing.T) {
+		os.Setenv("NUTS_E", "nvironment")
+		defer os.Unsetenv("NUTS_E")
+		flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		flagSet.String("f", "lag", "A great option")
+		type Target struct {
+			F string `koanf:"f"`
+			E string `koanf:"e"`
+		}
+		var target Target
+		err := loadConfigIntoStruct(flagSet, &target, koanf.New(defaultDelimiter))
+		assert.NoError(t, err)
+		assert.Equal(t, "lag", target.F)
+		assert.Equal(t, "nvironment", target.E)
+	})
+	t.Run("support for listed values from env and CLI", func(t *testing.T) {
+		os.Setenv("NUTS_LIST", "a, b, c,d")
+		defer os.Unsetenv("NUTS_LIST")
+		flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		type Target struct {
+			List []string `koanf:"list"`
+		}
+		var target Target
+		err := loadConfigIntoStruct(flagSet, &target, koanf.New(defaultDelimiter))
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"a", "b", "c", "d"}, target.List)
+	})
 }

--- a/docs/pages/configuration/configuration.rst
+++ b/docs/pages/configuration/configuration.rst
@@ -29,6 +29,8 @@ Config parameters for engines are prepended by the ``engine.ConfigKey`` by defau
 
 is equal to ``$ nuts --engine.nested.parameter X`` is equal to ``$ NUTS_ENGINE_NESTED_PARAMETER=X nuts``
 
+While most options are a single value, some are represented as a list (indicated with the square brackets in the table below).
+To provide multiple values through flags or environment variables you can separate them with a comma (``,``).
 
 Ordering
 ********


### PR DESCRIPTION
By separating them with a comma.

Wasn't working before.