### PR TITLE
added protocolVersionHeader to grpc

### DIFF
--- a/network/p2p/impl.go
+++ b/network/p2p/impl.go
@@ -394,7 +394,7 @@ func (n adapter) Connect(stream transport.Network_ConnectServer) error {
 
 	peerID, err := readHeaders(md)
 	if err != nil {
-		return fmt.Errorf("client connection rejected: %w", err)
+		return fmt.Errorf("client connection (peer=%s) rejected: %w", peerCtx.Addr, err)
 	}
 
 	peer := Peer{

--- a/network/p2p/impl_test.go
+++ b/network/p2p/impl_test.go
@@ -209,13 +209,13 @@ func Test_adapter_Connect(t *testing.T) {
 				Addr: &net.IPAddr{
 					IP: net.IPv4(127, 0, 0, 1),
 				},
-			}), metadata.Pairs(peerIDHeader, peerID, protocolHeader, "v2"))
+			}), metadata.Pairs(peerIDHeader, peerID, protocolVersionHeader, "v2"))
 			conn.EXPECT().Context().AnyTimes().Return(ctx)
 			return conn
 		}
 
 		err := network.Connect(mockConnection())
-		assert.EqualError(t, err, "client connection rejected: peer uses incorrect protocol version: v2")
+		assert.EqualError(t, err, "client connection (peer=127.0.0.1) rejected: peer uses incorrect protocol version: v2")
 	})
 
 	t.Run("second connection from same peer, disconnect first (uses actual in-memory gRPC connection)", func(t *testing.T) {

--- a/network/p2p/util.go
+++ b/network/p2p/util.go
@@ -27,7 +27,7 @@ import (
 )
 
 const protocolVersionV1 = "v1"
-const protocolHeader = "version"
+const protocolVersionHeader = "version"
 const peerIDHeader = "peerID"
 
 func normalizeAddress(addr string) string {
@@ -61,19 +61,19 @@ func peerIDFromMetadata(md metadata.MD) (PeerID, error) {
 }
 
 func protocolVersionFromMetadata(md metadata.MD) (string, error) {
-	values := md.Get(protocolHeader)
+	values := md.Get(protocolVersionHeader)
 	if len(values) == 0 {
 		// no version means v1 for backwards compatibility
 		return protocolVersionV1, nil
 	} else if len(values) > 1 {
-		return "", fmt.Errorf("peer sent multiple values for %s header", protocolHeader)
+		return "", fmt.Errorf("peer sent multiple values for %s header", protocolVersionHeader)
 	}
 	return strings.TrimSpace(values[0]), nil
 }
 
 func constructMetadata(peerID PeerID) metadata.MD {
 	return metadata.New(map[string]string{
-		peerIDHeader:   string(peerID),
-		protocolHeader: protocolVersionV1,
+		peerIDHeader:          string(peerID),
+		protocolVersionHeader: protocolVersionV1,
 	})
 }

--- a/network/p2p/util_test.go
+++ b/network/p2p/util_test.go
@@ -79,7 +79,7 @@ func Test_constructMetadata(t *testing.T) {
 	t.Run("set default protocol version", func(t *testing.T) {
 		md := constructMetadata("1234")
 
-		v := md.Get(protocolHeader)
+		v := md.Get(protocolVersionHeader)
 
 		assert.Len(t, v, 1)
 		assert.Equal(t, protocolVersionV1, v[0])
@@ -89,7 +89,7 @@ func Test_constructMetadata(t *testing.T) {
 func Test_protocolVersionFromMetadata(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		md := metadata.MD{}
-		md.Append(protocolHeader, "v2")
+		md.Append(protocolVersionHeader, "v2")
 
 		v, err := protocolVersionFromMetadata(md)
 
@@ -112,8 +112,8 @@ func Test_protocolVersionFromMetadata(t *testing.T) {
 
 	t.Run("error - too many values", func(t *testing.T) {
 		md := metadata.MD{}
-		md.Append(protocolHeader, "v1")
-		md.Append(protocolHeader, "v2")
+		md.Append(protocolVersionHeader, "v1")
+		md.Append(protocolVersionHeader, "v2")
 
 		v, err := protocolVersionFromMetadata(md)
 


### PR DESCRIPTION
closes #497

both client/server send their (hardcoded) protocol version.
This will come in handy when switching to v2 