### PR TITLE
issuing unknown credentials adds them to the concept registry

### DIFF
--- a/vcr/concept/mock.go
+++ b/vcr/concept/mock.go
@@ -48,6 +48,20 @@ func (mr *MockReaderMockRecorder) Concepts() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Concepts", reflect.TypeOf((*MockReader)(nil).Concepts))
 }
 
+// HasCredentialType mocks base method.
+func (m *MockReader) HasCredentialType(credentialType string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasCredentialType", credentialType)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasCredentialType indicates an expected call of HasCredentialType.
+func (mr *MockReaderMockRecorder) HasCredentialType(credentialType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasCredentialType", reflect.TypeOf((*MockReader)(nil).HasCredentialType), credentialType)
+}
+
 // QueryFor mocks base method.
 func (m *MockReader) QueryFor(concept string) (Query, error) {
 	m.ctrl.T.Helper()
@@ -164,6 +178,20 @@ func (m *MockRegistry) Concepts() []Config {
 func (mr *MockRegistryMockRecorder) Concepts() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Concepts", reflect.TypeOf((*MockRegistry)(nil).Concepts))
+}
+
+// HasCredentialType mocks base method.
+func (m *MockRegistry) HasCredentialType(credentialType string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasCredentialType", credentialType)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasCredentialType indicates an expected call of HasCredentialType.
+func (mr *MockRegistryMockRecorder) HasCredentialType(credentialType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasCredentialType", reflect.TypeOf((*MockRegistry)(nil).HasCredentialType), credentialType)
 }
 
 // QueryFor mocks base method.

--- a/vcr/concept/registry.go
+++ b/vcr/concept/registry.go
@@ -27,6 +27,8 @@ import (
 type Reader interface {
 	// Concepts returns a list of concept configs
 	Concepts() []Config
+	// HasCredentialType returns true if the given credentialType is registered
+	HasCredentialType(credentialType string) bool
 	// QueryFor creates a query for the given concept.
 	// The query is preloaded with required fixed values like the type.
 	// It returns ErrUnknownConcept if the concept is not found
@@ -126,6 +128,15 @@ func (r *registry) QueryFor(concept string) (Query, error) {
 	}
 
 	return &q, nil
+}
+
+func (r *registry) HasCredentialType(credentialType string) bool {
+	for _, c := range r.configs {
+		if c.CredentialType == credentialType {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *registry) hasConcept(concept string) bool {

--- a/vcr/concept/registry_test.go
+++ b/vcr/concept/registry_test.go
@@ -134,6 +134,23 @@ func TestRegistry_Concepts(t *testing.T) {
 	assert.Equal(t, "human", cs[0].Concept)
 }
 
+func TestRegistry_HasCredentialType(t *testing.T) {
+	r := NewRegistry().(*registry)
+
+	err := r.Add(ExampleConfig)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	t.Run("true", func(t *testing.T) {
+		assert.True(t, r.HasCredentialType(ExampleType))
+	})
+
+	t.Run("false", func(t *testing.T) {
+		assert.False(t, r.HasCredentialType("other"))
+	})
+}
+
 func TestRegistry_QueryFor(t *testing.T) {
 	r := NewRegistry().(*registry)
 

--- a/vcr/config.go
+++ b/vcr/config.go
@@ -22,7 +22,10 @@ package vcr
 const moduleName = "Verifiable Credential Store"
 
 // Config holds the config for the vcr engine
-type Config struct{}
+type Config struct {
+	// strictMode is a copy from the core server config
+	strictMode bool
+}
 
 // DefaultConfig returns a fresh Config filled with default values
 func DefaultConfig() Config {

--- a/vdr/store/memory_test.go
+++ b/vdr/store/memory_test.go
@@ -270,7 +270,7 @@ func TestMemory_Parallelism(t *testing.T) {
 
 	// Prepare functions to be called
 	wg := sync.WaitGroup{}
-	funcs := []func() {
+	funcs := []func(){
 		func() {
 			_ = store.Write(doc2, meta)
 		},


### PR DESCRIPTION
closes #544 

unknown credential types can now be used when not in strict mode.
this will allow for testing new credentials without code changes or configuration.

The downside is that those credentials will not be indexed in go-leia (full table scan)