### PR TITLE
Fix IRMA attr order

### DIFF
--- a/auth/contract/template.go
+++ b/auth/contract/template.go
@@ -80,8 +80,8 @@ var StandardSignerAttributes = []string{
 	".gemeente.personalData.initials",
 	".gemeente.personalData.prefix",
 	".gemeente.personalData.familyname",
-	"pbdf.sidn-pbdf.email.email",
 	".gemeente.personalData.digidlevel",
+	"pbdf.sidn-pbdf.email.email",
 }
 
 func (c Template) timeLocation() *time.Location {


### PR DESCRIPTION
The error is in the IRMA app:

"Within inner conjunctions, attributes from the same credential type must be adjacent"

So I made them adjacent