### PR TITLE
Use logrus as http request logger

### DIFF
--- a/core/echo.go
+++ b/core/echo.go
@@ -132,7 +132,7 @@ type loggerConfig struct {
 func loggerMiddleware(config loggerConfig) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) (err error) {
-			if config.Skipper != nil  && config.Skipper(c) {
+			if config.Skipper != nil && config.Skipper(c) {
 				return next(c)
 			}
 			err = next(c)

--- a/core/echo.go
+++ b/core/echo.go
@@ -110,6 +110,7 @@ func getGroup(path string) string {
 }
 
 var _logger = logrus.StandardLogger().WithField("module", "http-server")
+
 // Logger returns a logger which should be used for logging in this engine. It adds fields so
 // log entries from this engine can be recognized as such.
 func Logger() *logrus.Entry {
@@ -151,9 +152,9 @@ func loggerMiddleware(config loggerConfig) echo.MiddlewareFunc {
 
 			Logger().WithFields(logrus.Fields{
 				"remote_ip": c.RealIP(),
-				"method": req.Method,
-				"uri": req.RequestURI,
-				"status": status,
+				"method":    req.Method,
+				"uri":       req.RequestURI,
+				"status":    status,
 			}).Info("request")
 			return
 		}

--- a/core/echo_errors.go
+++ b/core/echo_errors.go
@@ -3,9 +3,10 @@ package core
 import (
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
-	"net/http"
 	"schneider.vip/problem"
 )
 
@@ -20,6 +21,8 @@ const OperationIDContextKey = "!!OperationId"
 // for logging/error returning.
 const ModuleNameContextKey = "!!ModuleName"
 const unmappedStatusCode = 0
+
+
 
 func createHTTPErrorHandler() echo.HTTPErrorHandler {
 	return func(err error, ctx echo.Context) {
@@ -58,6 +61,7 @@ func createHTTPErrorHandler() echo.HTTPErrorHandler {
 // Error returns an error that maps to a HTTP status
 func Error(statusCode int, errStr string, args ...interface{}) error {
 	return httpStatusCodeError{msg: fmt.Errorf(errStr, args...).Error(), err: getErrArg(args), statusCode: statusCode}
+	return echo.NewHTTPError(statusCode, )
 }
 
 // NotFoundError returns an error that maps to a HTTP 404 Status Not Found.

--- a/core/echo_errors.go
+++ b/core/echo_errors.go
@@ -59,7 +59,6 @@ func createHTTPErrorHandler() echo.HTTPErrorHandler {
 // Error returns an error that maps to a HTTP status
 func Error(statusCode int, errStr string, args ...interface{}) error {
 	return httpStatusCodeError{msg: fmt.Errorf(errStr, args...).Error(), err: getErrArg(args), statusCode: statusCode}
-	return echo.NewHTTPError(statusCode)
 }
 
 // NotFoundError returns an error that maps to a HTTP 404 Status Not Found.

--- a/core/echo_errors.go
+++ b/core/echo_errors.go
@@ -22,8 +22,6 @@ const OperationIDContextKey = "!!OperationId"
 const ModuleNameContextKey = "!!ModuleName"
 const unmappedStatusCode = 0
 
-
-
 func createHTTPErrorHandler() echo.HTTPErrorHandler {
 	return func(err error, ctx echo.Context) {
 		// HTTPErrors occur e.g. when a parameter bind fails. We map this to a httpStatusCodeError so its status code
@@ -61,7 +59,7 @@ func createHTTPErrorHandler() echo.HTTPErrorHandler {
 // Error returns an error that maps to a HTTP status
 func Error(statusCode int, errStr string, args ...interface{}) error {
 	return httpStatusCodeError{msg: fmt.Errorf(errStr, args...).Error(), err: getErrArg(args), statusCode: statusCode}
-	return echo.NewHTTPError(statusCode, )
+	return echo.NewHTTPError(statusCode)
 }
 
 // NotFoundError returns an error that maps to a HTTP 404 Status Not Found.

--- a/core/echo_test.go
+++ b/core/echo_test.go
@@ -1,12 +1,17 @@
 package core
 
 import (
+	"errors"
 	"fmt"
-	"github.com/golang/mock/gomock"
-	"github.com/labstack/echo/v4"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/labstack/echo/v4"
+	"github.com/nuts-foundation/nuts-node/mock"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_MultiEcho_Bind(t *testing.T) {
@@ -150,5 +155,85 @@ func Test_requestsStatusEndpoint(t *testing.T) {
 		assert.False(t, requestsStatusEndpoint(ctx))
 		req.RequestURI = "/foobar"
 		assert.False(t, requestsStatusEndpoint(ctx))
+	})
+}
+
+func Test_loggerMiddleware(t *testing.T) {
+	t.Run("it logs", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		response  := &echo.Response{}
+		echoMock := mock.NewMockContext(ctrl)
+		echoMock.EXPECT().NoContent(http.StatusNoContent).Do(func(status int) {response.Status = status})
+		echoMock.EXPECT().Request().Return(&http.Request{RequestURI: "/test"})
+		echoMock.EXPECT().Response().Return(response)
+		echoMock.EXPECT().RealIP().Return("::1")
+
+		logger, hook := test.NewNullLogger()
+		logFunc := loggerMiddleware(loggerConfig{logger: logger.WithFields(logrus.Fields{})})
+		err := logFunc(func(context echo.Context) error {
+			return context.NoContent(http.StatusNoContent)
+		})(echoMock)
+
+		assert.NoError(t, err)
+		assert.Len(t, hook.Entries, 1)
+		assert.Equal(t, "::1", hook.LastEntry().Data["remote_ip"])
+		assert.Equal(t, http.StatusNoContent, hook.LastEntry().Data["status"])
+		assert.Equal(t, "/test", hook.LastEntry().Data["uri"])
+		ctrl.Finish()
+	})
+
+	t.Run("it handles echo.HTTPErrors", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		echoMock := mock.NewMockContext(ctrl)
+		echoMock.EXPECT().Request().Return(&http.Request{})
+		echoMock.EXPECT().Response().Return(&echo.Response{Status: http.StatusOK})
+		echoMock.EXPECT().RealIP().Return("::1")
+
+		logger, hook := test.NewNullLogger()
+		logFunc := loggerMiddleware(loggerConfig{logger: logger.WithFields(logrus.Fields{})})
+		_ = logFunc(func(context echo.Context) error {
+			return echo.NewHTTPError(http.StatusForbidden)
+		})(echoMock)
+
+		assert.Len(t, hook.Entries, 1)
+		assert.Equal(t, http.StatusForbidden, hook.LastEntry().Data["status"])
+		ctrl.Finish()
+
+	})
+
+	t.Run("it handles httpStatusCodeError", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		echoMock := mock.NewMockContext(ctrl)
+		echoMock.EXPECT().Request().Return(&http.Request{})
+		echoMock.EXPECT().Response().Return(&echo.Response{Status: http.StatusOK})
+		echoMock.EXPECT().RealIP().Return("::1")
+
+		logger, hook := test.NewNullLogger()
+		logFunc := loggerMiddleware(loggerConfig{logger: logger.WithFields(logrus.Fields{})})
+		_ = logFunc(func(context echo.Context) error {
+			return NotFoundError("not found")
+		})(echoMock)
+
+		assert.Len(t, hook.Entries, 1)
+		assert.Equal(t, http.StatusNotFound, hook.LastEntry().Data["status"])
+		ctrl.Finish()
+	})
+
+	t.Run("it handles go errors", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		echoMock := mock.NewMockContext(ctrl)
+		echoMock.EXPECT().Request().Return(&http.Request{})
+		echoMock.EXPECT().Response().Return(&echo.Response{Status: http.StatusOK})
+		echoMock.EXPECT().RealIP().Return("::1")
+
+		logger, hook := test.NewNullLogger()
+		logFunc := loggerMiddleware(loggerConfig{logger: logger.WithFields(logrus.Fields{})})
+		_ = logFunc(func(context echo.Context) error {
+			return errors.New("failed")
+		})(echoMock)
+
+		assert.Len(t, hook.Entries, 1)
+		assert.Equal(t, http.StatusInternalServerError, hook.LastEntry().Data["status"])
+		ctrl.Finish()
 	})
 }


### PR DESCRIPTION
Adds custom logger middleware instead of using echo.RequestLogger because of this issue: https://github.com/labstack/echo/issues/2015