### PR TITLE
Implemented a persisent version of the vdr store

### DIFF
--- a/vdr/store/bbolt.go
+++ b/vdr/store/bbolt.go
@@ -34,6 +34,10 @@ type documentVersionList struct {
 }
 
 func (entry documentVersionList) Latest() hash.SHA256Hash {
+	if len(entry.Versions) == 0 {
+		return hash.EmptyHash()
+	}
+
 	return entry.Versions[len(entry.Versions)-1]
 }
 

--- a/vdr/store/bbolt.go
+++ b/vdr/store/bbolt.go
@@ -125,7 +125,7 @@ func (store *bboltStore) filterDocument(doc *documentVersion, metadata *vdr.Reso
 		return vdr.ErrNotFound
 	}
 
-	// Verify creation and update time
+	// Filter on creation and update time
 	if metadata.ResolveTime != nil {
 		resolveTime := *metadata.ResolveTime
 
@@ -140,7 +140,7 @@ func (store *bboltStore) filterDocument(doc *documentVersion, metadata *vdr.Reso
 		}
 	}
 
-	// Verify KeyTransaction
+	// Filter on SourceTransaction
 	if metadata.SourceTransaction != nil {
 		for i, keyTx := range doc.Metadata.SourceTransactions {
 			if keyTx.Equals(*metadata.SourceTransaction) {

--- a/vdr/store/bbolt.go
+++ b/vdr/store/bbolt.go
@@ -1,0 +1,305 @@
+package store
+
+import (
+	"encoding/json"
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	vdr "github.com/nuts-foundation/nuts-node/vdr/types"
+	"go.etcd.io/bbolt"
+)
+
+type documentVersion struct {
+	Document did.Document
+	Metadata vdr.DocumentMetadata
+}
+
+type documentVersionList struct {
+	Deactivated bool
+	Versions    []hash.SHA256Hash
+}
+
+func (entry documentVersionList) Latest() hash.SHA256Hash {
+	return entry.Versions[len(entry.Versions)-1]
+}
+
+var (
+	documentsBucket = []byte("vdrDocuments")
+	versionsBucket  = []byte("vdrDocumentVersions")
+)
+
+type bboltStore struct {
+	db *bbolt.DB
+}
+
+// NewBBoltStore returns an instance of a BBolt based VDR store
+func NewBBoltStore(db *bbolt.DB) vdr.Store {
+	return &bboltStore{db: db}
+}
+
+func (store *bboltStore) getDocumentKey(id did.DID, hash hash.SHA256Hash) []byte {
+	return append([]byte(id.String()), hash.Slice()...)
+}
+
+func (store *bboltStore) storeDocument(tx *bbolt.Tx, document did.Document, metadata vdr.DocumentMetadata) error {
+	documents, err := tx.CreateBucketIfNotExists(documentsBucket)
+	if err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(documentVersion{
+		Document: document,
+		Metadata: metadata,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := documents.Put(store.getDocumentKey(document.ID, metadata.Hash), data); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (store *bboltStore) getDocumentVersion(bucket *bbolt.Bucket, id did.DID, hash hash.SHA256Hash) (*documentVersion, error) {
+	data := bucket.Get(store.getDocumentKey(id, hash))
+	if data == nil {
+		return nil, nil
+	}
+
+	result := &documentVersion{}
+
+	if err := json.Unmarshal(data, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// Iterate loops over all the latest versions of the stored DID Documents and applies fn
+func (store *bboltStore) Iterate(fn vdr.DocIterator) error {
+	return store.db.View(func(tx *bbolt.Tx) error {
+		versions := tx.Bucket(versionsBucket)
+		if versions == nil {
+			return nil
+		}
+
+		documents := tx.Bucket(documentsBucket)
+		if documents == nil {
+			return nil
+		}
+
+		if err := versions.ForEach(func(key, data []byte) error {
+			versionList := &documentVersionList{}
+
+			if err := json.Unmarshal(data, versionList); err != nil {
+				return err
+			}
+
+			id, _ := did.ParseDID(string(key))
+			doc, err := store.getDocumentVersion(documents, *id, versionList.Latest())
+			if err != nil {
+				return err
+			}
+
+			if err := fn(doc.Document, doc.Metadata); err != nil {
+				return err
+			}
+
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func (store *bboltStore) filterDocument(doc *documentVersion, metadata *vdr.ResolveMetadata) error {
+	// Verify deactivated
+	if IsDeactivated(doc.Document) {
+		return vdr.ErrDeactivated
+	}
+
+	if metadata == nil {
+		return nil
+	}
+
+	// Verify creation and update time
+	if metadata.ResolveTime != nil {
+		resolveTime := *metadata.ResolveTime
+
+		if doc.Metadata.Created.After(resolveTime) {
+			return vdr.ErrNotFound
+		}
+
+		if doc.Metadata.Updated != nil {
+			if doc.Metadata.Updated.After(resolveTime) {
+				return vdr.ErrNotFound
+			}
+		}
+	}
+
+	// Verify KeyTransaction
+	if metadata.SourceTransaction != nil {
+		for i, keyTx := range doc.Metadata.SourceTransactions {
+			if keyTx.Equals(*metadata.SourceTransaction) {
+				break
+			}
+
+			if i == len(doc.Metadata.SourceTransactions)-1 {
+				return vdr.ErrNotFound
+			}
+		}
+	}
+
+	return nil
+}
+
+// Resolve returns the DID Document for the provided DID
+func (store *bboltStore) Resolve(id did.DID, metadata *vdr.ResolveMetadata) (document *did.Document, documentMeta *vdr.DocumentMetadata, txErr error) {
+	txErr = store.db.View(func(tx *bbolt.Tx) error {
+		documents := tx.Bucket(documentsBucket)
+		if documents == nil {
+			return vdr.ErrNotFound
+		}
+
+		// If `metadata.Hash` is set we can fetch the document without iterating
+		if metadata != nil && metadata.Hash != nil {
+			doc, err := store.getDocumentVersion(documents, id, *metadata.Hash)
+			if err != nil {
+				return nil
+			}
+
+			if err := store.filterDocument(doc, metadata); err != nil {
+				return err
+			}
+
+			document = &doc.Document
+			documentMeta = &doc.Metadata
+
+			return nil
+		}
+
+		versions := tx.Bucket(versionsBucket)
+		if versions == nil {
+			return vdr.ErrNotFound
+		}
+
+		versionList := &documentVersionList{}
+
+		data := versions.Get([]byte(id.String()))
+		if data == nil {
+			return vdr.ErrNotFound
+		}
+
+		if err := json.Unmarshal(data, versionList); err != nil {
+			return err
+		}
+
+		for _, versionHash := range versionList.Versions {
+			data = documents.Get(store.getDocumentKey(id, versionHash))
+			if data == nil {
+				continue
+			}
+
+			doc := &documentVersion{}
+
+			if err := json.Unmarshal(data, doc); err != nil {
+				return err
+			}
+
+			if err := store.filterDocument(doc, metadata); err == nil {
+				document = &doc.Document
+				documentMeta = &doc.Metadata
+
+				return nil
+			}
+		}
+
+		return vdr.ErrNotFound
+	})
+
+	return
+}
+
+// Write writes a DID Document
+func (store *bboltStore) Write(document did.Document, metadata vdr.DocumentMetadata) error {
+	return store.db.Update(func(tx *bbolt.Tx) error {
+		versions, err := tx.CreateBucketIfNotExists(versionsBucket)
+		if err != nil {
+			return err
+		}
+
+		key := []byte(document.ID.String())
+
+		if versions.Get(key) != nil {
+			return vdr.ErrDIDAlreadyExists
+		}
+
+		// Store versions entry
+		data, err := json.Marshal(documentVersionList{
+			Deactivated: IsDeactivated(document),
+			Versions:    []hash.SHA256Hash{metadata.Hash},
+		})
+		if err != nil {
+			return err
+		}
+
+		if err := versions.Put([]byte(document.ID.String()), data); err != nil {
+			return err
+		}
+
+		// Store the actual document
+		return store.storeDocument(tx, document, metadata)
+	})
+}
+
+// Update replaces the DID document identified by DID with the nextVersion
+func (store *bboltStore) Update(id did.DID, current hash.SHA256Hash, next did.Document, metadata *vdr.DocumentMetadata) error {
+	return store.db.Update(func(tx *bbolt.Tx) error {
+		versions, err := tx.CreateBucketIfNotExists(versionsBucket)
+		if err != nil {
+			return err
+		}
+
+		versionKey := []byte(id.String())
+
+		// Lookup the version information
+		data := versions.Get(versionKey)
+		if data == nil {
+			return vdr.ErrNotFound
+		}
+
+		versionList := &documentVersionList{}
+
+		if err := json.Unmarshal(data, versionList); err != nil {
+			return err
+		}
+
+		if versionList.Deactivated {
+			return vdr.ErrDeactivated
+		}
+
+		// Verify if the current version hash exists, if so append it
+		if versionList.Versions[len(versionList.Versions)-1] != current {
+			return vdr.ErrUpdateOnOutdatedData
+		}
+
+		// Update version information
+		versionList.Versions = append(versionList.Versions, metadata.Hash)
+		versionList.Deactivated = versionList.Deactivated || IsDeactivated(next)
+
+		data, err = json.Marshal(versionList)
+		if err != nil {
+			return err
+		}
+
+		if err := versions.Put(versionKey, data); err != nil {
+			return err
+		}
+
+		// Store the document
+		return store.storeDocument(tx, next, *metadata)
+	})
+}

--- a/vdr/store/bbolt.go
+++ b/vdr/store/bbolt.go
@@ -127,7 +127,7 @@ func (store *bboltStore) Iterate(fn vdr.DocIterator) error {
 
 func (store *bboltStore) filterDocument(doc *documentVersion, metadata *vdr.ResolveMetadata) error {
 	// Verify deactivated
-	if IsDeactivated(doc.Document) {
+	if IsDeactivated(doc.Document) && (metadata == nil || !metadata.AllowDeactivated) {
 		return vdr.ErrDeactivated
 	}
 
@@ -206,14 +206,14 @@ func (store *bboltStore) Resolve(id did.DID, metadata *vdr.ResolveMetadata) (doc
 			return err
 		}
 
-		if err := store.filterDocument(doc, metadata); err == nil {
-			document = &doc.Document
-			documentMeta = &doc.Metadata
-
-			return nil
+		if err := store.filterDocument(doc, metadata); err != nil {
+			return err
 		}
 
-		return vdr.ErrNotFound
+		document = &doc.Document
+		documentMeta = &doc.Metadata
+
+		return nil
 	})
 
 	return

--- a/vdr/store/bbolt.go
+++ b/vdr/store/bbolt.go
@@ -1,3 +1,18 @@
+/*
+ * Nuts node
+ * Copyright (C) 2021 Nuts community
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package store
 
 import (

--- a/vdr/store/bbolt.go
+++ b/vdr/store/bbolt.go
@@ -234,7 +234,7 @@ func (store *bboltStore) Write(document did.Document, metadata vdr.DocumentMetad
 		key := []byte(document.ID.String())
 
 		if versions.Get(key) != nil {
-			return vdr.ErrDIDAlreadyExists
+			return nil
 		}
 
 		// Store versions entry

--- a/vdr/store/bbolt_test.go
+++ b/vdr/store/bbolt_test.go
@@ -58,12 +58,9 @@ func TestBBoltStore_Write(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("returns error when already exist", func(t *testing.T) {
+	t.Run("doesn't return an error when already exist", func(t *testing.T) {
 		err := store.Write(doc, meta)
-		if !assert.Error(t, err) {
-			return
-		}
-		assert.Equal(t, types.ErrDIDAlreadyExists, err)
+		assert.NoError(t, err)
 	})
 }
 

--- a/vdr/store/bbolt_test.go
+++ b/vdr/store/bbolt_test.go
@@ -1,0 +1,351 @@
+package store
+
+import (
+	"errors"
+	"io/ioutil"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/stretchr/testify/assert"
+	"go.etcd.io/bbolt"
+
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	"github.com/nuts-foundation/nuts-node/vdr/types"
+)
+
+func newBBoltTestStore(t *testing.T) *bboltStore {
+	opts := *bbolt.DefaultOptions
+	opts.NoSync = true
+
+	dir, err := ioutil.TempDir("/tmp", "go_test_vdr_bboltstore")
+	assert.NoError(t, err)
+
+	db, err := bbolt.Open(filepath.Join(dir, "bbolt.db"), 0644, &opts)
+	assert.NoError(t, err)
+
+	return NewBBoltStore(db).(*bboltStore)
+}
+
+func TestBBoltStore_Write(t *testing.T) {
+	store := newBBoltTestStore(t)
+	did1, _ := did.ParseDID("did:nuts:1")
+	doc := did.Document{
+		ID: *did1,
+	}
+	meta := types.DocumentMetadata{}
+
+	err := store.Write(doc, meta)
+
+	t.Run("returns no error on successful write", func(t *testing.T) {
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns error when already exist", func(t *testing.T) {
+		err := store.Write(doc, meta)
+		if !assert.Error(t, err) {
+			return
+		}
+		assert.Equal(t, types.ErrDIDAlreadyExists, err)
+	})
+}
+
+func TestBBoltStore_Resolve(t *testing.T) {
+	store := newBBoltTestStore(t)
+	did1, _ := did.ParseDID("did:nuts:1")
+	doc := did.Document{
+		ID:         *did1,
+		Controller: []did.DID{*did1},
+	}
+
+	//upd := time.Now().Add(time.Hour * 24)
+	h, _ := hash.ParseHex("452d9e89d5bd5d9225fb6daecd579e7388a166c7661ca04e47fd3cd8446e4620")
+	txHash := hash.FromSlice([]byte("keyTransactionHash"))
+	meta := types.DocumentMetadata{
+		Created:            time.Now().Add(time.Hour * -24),
+		Hash:               h,
+		SourceTransactions: []hash.SHA256Hash{txHash},
+	}
+
+	_ = store.Write(doc, meta)
+
+	t.Run("returns ErrNotFound on unknown did", func(t *testing.T) {
+		did2, _ := did.ParseDID("did:nuts:2")
+		_, _, err := store.Resolve(*did2, nil)
+		assert.Equal(t, types.ErrNotFound, err)
+	})
+
+	t.Run("returns document without resolve metadata", func(t *testing.T) {
+		d, m, err := store.Resolve(*did1, nil)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotNil(t, d)
+		assert.NotNil(t, m)
+	})
+
+	t.Run("returns document with resolve metadata - selection on date", func(t *testing.T) {
+		now := time.Now()
+		d, m, err := store.Resolve(*did1, &types.ResolveMetadata{
+			ResolveTime: &now,
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotNil(t, d)
+		assert.NotNil(t, m)
+	})
+
+	t.Run("returns no document with resolve metadata - selection on date", func(t *testing.T) {
+		before := time.Now().Add(time.Hour * -48)
+		_, _, err := store.Resolve(*did1, &types.ResolveMetadata{
+			ResolveTime: &before,
+		})
+		assert.Equal(t, types.ErrNotFound, err)
+	})
+
+	t.Run("returns document with resolve metadata - selection on hash", func(t *testing.T) {
+		d, m, err := store.Resolve(*did1, &types.ResolveMetadata{
+			Hash: &h,
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotNil(t, d)
+		assert.NotNil(t, m)
+	})
+
+	t.Run("returns document with resolve metadata - selection on KeyTransaction", func(t *testing.T) {
+		d, m, err := store.Resolve(*did1, &types.ResolveMetadata{
+			SourceTransaction: &txHash,
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotNil(t, d)
+		assert.NotNil(t, m)
+	})
+
+	t.Run("returns no document with resolve metadata - selection on KeyTransaction", func(t *testing.T) {
+		_, _, err := store.Resolve(*did1, &types.ResolveMetadata{
+			SourceTransaction: &h,
+		})
+		if !assert.Error(t, err) {
+			return
+		}
+		assert.Equal(t, types.ErrNotFound, err)
+	})
+}
+
+func TestBBoltStore_TimeSelectionFilter(t *testing.T) {
+	earlier := time.Now().Add(time.Hour * -24)
+	now := time.Now()
+	later := time.Now().Add(time.Hour * 24)
+
+	metadata := types.ResolveMetadata{
+		ResolveTime: &now,
+	}
+	f := timeSelectionFilter(metadata)
+
+	t.Run("returns false when created later", func(t *testing.T) {
+		entry := memoryEntry{
+			metadata: types.DocumentMetadata{
+				Created: later,
+			},
+		}
+		assert.False(t, f(entry))
+	})
+
+	t.Run("returns true when created earlier", func(t *testing.T) {
+		entry := memoryEntry{
+			metadata: types.DocumentMetadata{
+				Created: earlier,
+			},
+		}
+		assert.True(t, f(entry))
+	})
+
+	t.Run("returns false when next document was updated earlier", func(t *testing.T) {
+		entry := memoryEntry{
+			metadata: types.DocumentMetadata{
+				Created: earlier,
+				Updated: &earlier,
+			},
+			next: &memoryEntry{
+				metadata: types.DocumentMetadata{
+					Created: earlier,
+					Updated: &earlier,
+				},
+			},
+		}
+		assert.False(t, f(entry))
+	})
+
+	t.Run("returns false when document was updated later", func(t *testing.T) {
+		entry := memoryEntry{
+			metadata: types.DocumentMetadata{
+				Created: earlier,
+				Updated: &later,
+			},
+		}
+		assert.False(t, f(entry))
+	})
+}
+
+func TestBBoltStore_Update(t *testing.T) {
+	store := newBBoltTestStore(t)
+	did1, _ := did.ParseDID("did:nuts:1")
+	doc := did.Document{
+		ID:         *did1,
+		Controller: []did.DID{*did1},
+	}
+	h, _ := hash.ParseHex("452d9e89d5bd5d9225fb6daecd579e7388a166c7661ca04e47fd3cd8446e4620")
+	meta := types.DocumentMetadata{
+		Hash: h,
+	}
+
+	_ = store.Write(doc, meta)
+
+	t.Run("returns no error on success", func(t *testing.T) {
+		err := store.Update(*did1, h, doc, &meta)
+		assert.NoError(t, err)
+	})
+
+	t.Run("updates the previous record", func(t *testing.T) {
+		later := time.Now().Add(time.Hour * 24)
+		meta = types.DocumentMetadata{
+			Hash:    h,
+			Created: time.Now(),
+			Updated: &later,
+		}
+		err := store.Update(*did1, h, doc, &meta)
+		assert.NoError(t, err)
+
+		//s := store.(*memory)
+		//assert.NotNil(t, s.store[did1.String()][0].next)
+	})
+
+	t.Run("returns error when DID document doesn't exist", func(t *testing.T) {
+		did1, _ := did.ParseDID("did:nuts:2")
+		err := store.Update(*did1, h, doc, &meta)
+		assert.Equal(t, types.ErrNotFound, err)
+	})
+
+	t.Run("returns error when hashes don't match", func(t *testing.T) {
+		h, _ := hash.ParseHex("452d9e89d5bd5d9225fb6daecd579e7388a166c7661ca04e47fd3cd8446e4621")
+		err := store.Update(*did1, h, doc, &meta)
+		assert.Equal(t, types.ErrUpdateOnOutdatedData, err)
+	})
+
+	t.Run("returns error when DID Document is deactivated", func(t *testing.T) {
+		did1, _ := did.ParseDID("did:nuts:2")
+		doc := did.Document{
+			ID: *did1,
+		}
+		err := store.Write(doc, meta)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		err = store.Update(*did1, h, doc, &meta)
+		assert.Equal(t, types.ErrDeactivated, err)
+	})
+}
+
+func TestBBoltStore_Parallelism(t *testing.T) {
+	// This test, when run with -race, assures access to internals is synchronized
+	store := newBBoltTestStore(t)
+	did1, _ := did.ParseDID("did:nuts:1")
+	did2, _ := did.ParseDID("did:nuts:2")
+	doc := did.Document{
+		ID: *did1,
+	}
+	doc2 := did.Document{
+		ID: *did2,
+	}
+	meta := types.DocumentMetadata{}
+
+	// Make sure update, resolve and iterate have something to work on
+	_ = store.Write(doc, meta)
+
+	// Prepare functions to be called
+	wg := sync.WaitGroup{}
+	funcs := []func(){
+		func() {
+			_ = store.Write(doc2, meta)
+		},
+		func() {
+			_ = store.Iterate(func(_ did.Document, _ types.DocumentMetadata) error {
+				return nil
+			})
+		},
+		func() {
+			_ = store.Update(*did1, hash.EmptyHash(), doc, &meta)
+		},
+		func() {
+			_, _, _ = store.Resolve(*did1, nil)
+		},
+	}
+	wg.Add(len(funcs))
+
+	// Execute functions and wait for them to finish
+	for _, fn := range funcs {
+		go func(actual func()) {
+			actual()
+			wg.Done()
+		}(fn)
+	}
+	wg.Wait()
+}
+
+func TestBBoltStore_Iterate(t *testing.T) {
+	store := newBBoltTestStore(t)
+	did1, _ := did.ParseDID("did:nuts:1")
+	doc := did.Document{
+		ID: *did1,
+	}
+	meta := types.DocumentMetadata{}
+	counter := func(count *int) types.DocIterator {
+		return func(doc did.Document, metadata types.DocumentMetadata) error {
+			*count++
+			return nil
+		}
+	}
+
+	t.Run("no hits", func(t *testing.T) {
+		count := 0
+		fn := counter(&count)
+
+		err := store.Iterate(fn)
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("hit", func(t *testing.T) {
+		_ = store.Write(doc, meta)
+		count := 0
+		fn := counter(&count)
+
+		err := store.Iterate(fn)
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		fn := func(doc did.Document, metadata types.DocumentMetadata) error {
+			return errors.New("b00m!")
+		}
+
+		err := store.Iterate(fn)
+
+		assert.Error(t, err)
+	})
+}

--- a/vdr/store/bbolt_test.go
+++ b/vdr/store/bbolt_test.go
@@ -1,3 +1,18 @@
+/*
+ * Nuts node
+ * Copyright (C) 2021 Nuts community
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package store
 
 import (

--- a/vdr/store/bbolt_test.go
+++ b/vdr/store/bbolt_test.go
@@ -99,19 +99,14 @@ func TestBBoltStore_Resolve(t *testing.T) {
 		assert.Equal(t, types.ErrNotFound, err)
 	})
 
-	t.Run("returns document without resolve metadata", func(t *testing.T) {
+	t.Run("returns the last document without resolve metadata", func(t *testing.T) {
 		d, m, err := store.Resolve(*did1, nil)
 		if !assert.NoError(t, err) {
 			return
 		}
 		assert.NotNil(t, d)
 		assert.NotNil(t, m)
-	})
-
-	t.Run("only returns the last document", func(t *testing.T) {
-		_, m, err := store.Resolve(*did1, &types.ResolveMetadata{Hash: &firstHash})
-		assert.Error(t, err)
-		assert.Nil(t, m)
+		assert.Equal(t, m.Hash, latestHash)
 	})
 
 	t.Run("returns document with resolve metadata - selection on date", func(t *testing.T) {
@@ -136,7 +131,7 @@ func TestBBoltStore_Resolve(t *testing.T) {
 
 	t.Run("returns document with resolve metadata - selection on hash", func(t *testing.T) {
 		d, m, err := store.Resolve(*did1, &types.ResolveMetadata{
-			Hash: &latestHash,
+			Hash: &firstHash,
 		})
 		if !assert.NoError(t, err) {
 			return
@@ -382,7 +377,7 @@ func TestBBoltStore_DeactivatedFilter(t *testing.T) {
 	store := newBBoltTestStore(t)
 	did1, _ := did.ParseDID("did:nuts:1")
 	doc := did.Document{
-		ID:         *did1,
+		ID: *did1,
 	}
 	h, _ := hash.ParseHex("452d9e89d5bd5d9225fb6daecd579e7388a166c7661ca04e47fd3cd8446e4620")
 	meta := types.DocumentMetadata{


### PR DESCRIPTION
This is only the 'bare' implementation + tests. Need to configure it by default and test it using my local nuts node (but maybe that could be in a different PR?).

The tests are copied from the `MemoryStore` tests so we can verify it works more or less the same.

Fixes #109 