### PR TITLE
Add versionId param to api/vdr/getDID

### DIFF
--- a/core/echo_test.go
+++ b/core/echo_test.go
@@ -161,9 +161,9 @@ func Test_requestsStatusEndpoint(t *testing.T) {
 func Test_loggerMiddleware(t *testing.T) {
 	t.Run("it logs", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		response  := &echo.Response{}
+		response := &echo.Response{}
 		echoMock := mock.NewMockContext(ctrl)
-		echoMock.EXPECT().NoContent(http.StatusNoContent).Do(func(status int) {response.Status = status})
+		echoMock.EXPECT().NoContent(http.StatusNoContent).Do(func(status int) { response.Status = status })
 		echoMock.EXPECT().Request().Return(&http.Request{RequestURI: "/test"})
 		echoMock.EXPECT().Response().Return(response)
 		echoMock.EXPECT().RealIP().Return("::1")

--- a/docs/_static/vdr/v1.yaml
+++ b/docs/_static/vdr/v1.yaml
@@ -48,6 +48,17 @@ paths:
         schema:
           type: string
     get:
+      parameters:
+        - name: versionId
+          in: query
+          description: |
+            If a versionId DID parameter is provided, the DID resolution algorithm returns a specific version of the DID document.
+            The version is the Sha256 hash of the document.
+            See [the did resolution spec about versioning](https://w3c-ccg.github.io/did-resolution/#versioning)
+          required: false
+          example: "did:nuts:1234?versionId=4960afbdf21280ef248081e6e52317735bbb929a204351291b773c252afeebf4"
+          schema:
+            type: string
       summary: "Resolves a Nuts DID document"
       description: |
         Resolves a Nuts DID document. It also resolves deactivated documents.

--- a/network/transport/v1/protocol_v1_test.go
+++ b/network/transport/v1/protocol_v1_test.go
@@ -4,8 +4,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/nuts-foundation/nuts-node/network/dag"
 	"github.com/nuts-foundation/nuts-node/network/transport"
-	"github.com/nuts-foundation/nuts-node/network/transport/v1/p2p"
 	"github.com/nuts-foundation/nuts-node/network/transport/v1/logic"
+	"github.com/nuts-foundation/nuts-node/network/transport/v1/p2p"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/vdr/api/v1/api_test.go
+++ b/vdr/api/v1/api_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/nuts-foundation/nuts-node/core"
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
 
 	"github.com/golang/mock/gomock"
 	"github.com/nuts-foundation/go-did/did"
@@ -166,8 +167,30 @@ func TestWrapper_GetDID(t *testing.T) {
 		})
 
 		ctx.docResolver.EXPECT().Resolve(*id, &types.ResolveMetadata{AllowDeactivated: true}).Return(didDoc, meta, nil)
-		err := ctx.client.GetDID(ctx.echo, id.String())
+		err := ctx.client.GetDID(ctx.echo, id.String(), GetDIDParams{})
 
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, *id, didResolutionResult.Document.ID)
+	})
+
+	t.Run("ok - with versionId", func(t *testing.T) {
+		ctx := newMockContext(t)
+
+		didResolutionResult := DIDResolutionResult{}
+		ctx.echo.EXPECT().JSON(http.StatusOK, gomock.Any()).DoAndReturn(func(f interface{}, f2 interface{}) error {
+			didResolutionResult = f2.(DIDResolutionResult)
+			return nil
+		})
+
+		versionId := "e6efa34322812bd5ddec7f1aa3389957a2c35d19949913287407cb1068e16eb9"
+		expectedVersionHash, err := hash.ParseHex(versionId)
+		if !assert.NoError(t, err) {
+			return
+		}
+		ctx.docResolver.EXPECT().Resolve(*id, &types.ResolveMetadata{AllowDeactivated: true, Hash: &expectedVersionHash}).Return(didDoc, meta, nil)
+		err = ctx.client.GetDID(ctx.echo, id.String(), GetDIDParams{VersionId: &versionId})
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -177,7 +200,17 @@ func TestWrapper_GetDID(t *testing.T) {
 	t.Run("error - wrong did format", func(t *testing.T) {
 		ctx := newMockContext(t)
 
-		err := ctx.client.GetDID(ctx.echo, "not a did")
+		err := ctx.client.GetDID(ctx.echo, "not a did", GetDIDParams{})
+
+		assert.ErrorIs(t, err, did.ErrInvalidDID)
+		assert.Equal(t, http.StatusBadRequest, ctx.client.ResolveStatusCode(err))
+	})
+
+	t.Run("error - wrong versionId format", func(t *testing.T) {
+		ctx := newMockContext(t)
+
+		invalidVersionId := "123"
+		err := ctx.client.GetDID(ctx.echo, "given hash is not valid: encoding/hex: odd length hex string", GetDIDParams{&invalidVersionId})
 
 		assert.ErrorIs(t, err, did.ErrInvalidDID)
 		assert.Equal(t, http.StatusBadRequest, ctx.client.ResolveStatusCode(err))
@@ -187,7 +220,7 @@ func TestWrapper_GetDID(t *testing.T) {
 		ctx := newMockContext(t)
 
 		ctx.docResolver.EXPECT().Resolve(*id, &types.ResolveMetadata{AllowDeactivated: true}).Return(nil, nil, types.ErrNotFound)
-		err := ctx.client.GetDID(ctx.echo, id.String())
+		err := ctx.client.GetDID(ctx.echo, id.String(), GetDIDParams{})
 
 		assert.ErrorIs(t, err, types.ErrNotFound)
 		assert.Equal(t, http.StatusNotFound, ctx.client.ResolveStatusCode(err))
@@ -197,7 +230,7 @@ func TestWrapper_GetDID(t *testing.T) {
 		ctx := newMockContext(t)
 
 		ctx.docResolver.EXPECT().Resolve(*id, &types.ResolveMetadata{AllowDeactivated: true}).Return(nil, nil, errors.New("b00m!"))
-		err := ctx.client.GetDID(ctx.echo, id.String())
+		err := ctx.client.GetDID(ctx.echo, id.String(), GetDIDParams{})
 
 		assert.Error(t, err)
 	})

--- a/vdr/api/v1/api_test.go
+++ b/vdr/api/v1/api_test.go
@@ -210,10 +210,9 @@ func TestWrapper_GetDID(t *testing.T) {
 		ctx := newMockContext(t)
 
 		invalidVersionId := "123"
-		err := ctx.client.GetDID(ctx.echo, "given hash is not valid: encoding/hex: odd length hex string", GetDIDParams{&invalidVersionId})
+		err := ctx.client.GetDID(ctx.echo, id.String(), GetDIDParams{&invalidVersionId})
 
-		assert.ErrorIs(t, err, did.ErrInvalidDID)
-		assert.Equal(t, http.StatusBadRequest, ctx.client.ResolveStatusCode(err))
+		assert.ErrorIs(t, err, core.Error(http.StatusBadRequest, "foo"))
 	})
 
 	t.Run("error - not found", func(t *testing.T) {

--- a/vdr/api/v1/client.go
+++ b/vdr/api/v1/client.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
 	"io"
 	"net/http"
 	"time"
@@ -67,7 +66,7 @@ func (hb HTTPClient) Get(DID string) (*DIDDocument, *DIDDocumentMetadata, error)
 	ctx, cancel := hb.withTimeout()
 	defer cancel()
 
-	response, err := hb.client().GetDID(ctx, DID)
+	response, err := hb.client().GetDID(ctx, DID, &GetDIDParams{})
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Part of the #572 
Adding a versionId query param to the VDR getDID API call.
Resulting in:

```
GET http://localhost:1323/internal/vdr/v1/did/did:nuts:9uJ8V9aQ1vSoe3fj7ipnMVsnR5Kq6dxmkb7GmdBPntuC?versionId=e6efa34322812bd5ddec7f1aa3389957a2c35d19949913287407cb1068e16eb9
```