### PR TITLE
Add prev document hash to metadata

### DIFF
--- a/docs/_static/vdr/v1.yaml
+++ b/docs/_static/vdr/v1.yaml
@@ -251,25 +251,30 @@ components:
       required:
         - created
         - hash
-        - originJWSHash
-        - version
         - deactivated
+        - txs
       properties:
         created:
           description: Time when DID document was created in rfc3339 form.
           type: string
-        hash:
-          description: Sha256 in hex form of the DID document contents.
-          type: string
-        originJWSHash:
-          description: Sha256 in hex form of the transaction in which the DID document was published.
-          type: string
         updated:
           description: Time when DID document was updated in rfc3339 form.
           type: string
-        version:
-          description: Version of the DID document, starting at 1.
-          type: integer
+        hash:
+          description: Sha256 in hex form of the DID document contents.
+          type: string
+        previousHash:
+          description: Sha256 in hex form of the previous version of this DID document.
+          type: string
+        txs:
+          description: |
+            txs lists the transaction(s) that created the current version of this DID Document.
+            If multiple transactions are listed, the DID Document is conflicted
+          type: array
+          items:
+            type: string
+            description: Sha256 in hex form of the transaction
+            example: "24af55bd08bfe42c603b87565c31ae8f2770e820c4b32e1e928244775ab3ed19"
         deactivated:
           description: Whether the DID document has been deactivated.
           type: boolean

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -212,6 +212,7 @@ func (n *ambassador) handleUpdateDIDDocument(transaction dag.Transaction, propos
 		Created:            currentDIDMeta.Created,
 		Updated:            &updatedAt,
 		Hash:               transaction.PayloadHash(),
+		PreviousHash:       &currentDIDMeta.Hash,
 		Deactivated:        store.IsDeactivated(proposedDIDDocument),
 		SourceTransactions: sourceTransactions,
 	}

--- a/vdr/ambassador_test.go
+++ b/vdr/ambassador_test.go
@@ -293,6 +293,7 @@ func Test_ambassador_callback(t *testing.T) {
 			Updated:            &signingTime,
 			Hash:               payloadHash,
 			Deactivated:        true,
+			PreviousHash:       &currentPayloadHash,
 			SourceTransactions: []hash.SHA256Hash{tx.Ref()},
 		}
 		var pKey crypto2.PublicKey
@@ -339,6 +340,7 @@ func Test_ambassador_callback(t *testing.T) {
 			Created:            createdAt,
 			Updated:            &signingTime,
 			Hash:               payloadHash,
+			PreviousHash:       &currentPayloadHash,
 			SourceTransactions: []hash.SHA256Hash{tx.Ref()},
 		}
 		var pKey crypto2.PublicKey
@@ -386,6 +388,7 @@ func Test_ambassador_callback(t *testing.T) {
 			Created:            createdAt,
 			Updated:            &tx.signingTime,
 			Hash:               payloadHash,
+			PreviousHash:       &currentPayloadHash,
 			SourceTransactions: []hash.SHA256Hash{tx.Ref()},
 		}
 		var pKey crypto2.PublicKey
@@ -428,6 +431,7 @@ func Test_ambassador_callback(t *testing.T) {
 			Created:            createdAt,
 			Updated:            &signingTime,
 			Hash:               payloadHash,
+			PreviousHash:       &currentMetadata.Hash,
 			SourceTransactions: []hash.SHA256Hash{tx.Ref()},
 		}
 		var pKey crypto2.PublicKey
@@ -469,6 +473,7 @@ func Test_ambassador_callback(t *testing.T) {
 			Created:            createdAt,
 			Updated:            &signingTime,
 			Hash:               payloadHash,
+			PreviousHash:       &currentMetadata.Hash,
 			SourceTransactions: []hash.SHA256Hash{tx.Ref()},
 		}
 		var pKey crypto2.PublicKey
@@ -538,6 +543,7 @@ func Test_ambassador_callback(t *testing.T) {
 			Created:            createdAt,
 			Updated:            &signingTime,
 			Hash:               payloadHash,
+			PreviousHash:       &currentMetadata.Hash,
 			SourceTransactions: []hash.SHA256Hash{tx.Ref()},
 		}
 
@@ -655,6 +661,7 @@ func Test_ambassador_callback(t *testing.T) {
 			Created:            signingTime,
 			Updated:            &signingTime,
 			Hash:               payloadHash,
+			PreviousHash:       &didMetadata.Hash,
 			SourceTransactions: []hash.SHA256Hash{hash.EmptyHash(), tx.Ref()},
 		}
 

--- a/vdr/types/common.go
+++ b/vdr/types/common.go
@@ -88,7 +88,13 @@ func (m DocumentMetadata) Copy() DocumentMetadata {
 		updated := *m.Updated
 		m.Updated = &updated
 	}
+
+	if m.PreviousHash != nil {
+		prevHash := *m.PreviousHash
+		m.PreviousHash = &prevHash
+	}
 	m.SourceTransactions = append(m.SourceTransactions[:0:0], m.SourceTransactions...)
+
 	return m
 }
 

--- a/vdr/types/common.go
+++ b/vdr/types/common.go
@@ -73,6 +73,8 @@ type DocumentMetadata struct {
 	Updated *time.Time `json:"updated,omitempty"`
 	// Hash of DID document bytes. Is equal to payloadHash in network layer.
 	Hash hash.SHA256Hash `json:"hash"`
+	// PreviousHash of the previous version of this DID document
+	PreviousHash *hash.SHA256Hash `json:"previousHash,omitempty"`
 	// SourceTransactions points to the transaction(s) that created the current version of this DID Document.
 	// If multiple transactions are listed, the DID Document is conflicted
 	SourceTransactions []hash.SHA256Hash `json:"txs"`

--- a/vdr/types/common_test.go
+++ b/vdr/types/common_test.go
@@ -38,10 +38,11 @@ func TestCopy(t *testing.T) {
 		Created:            timeBefore,
 		Updated:            &timeNow,
 		Hash:               h,
+		PreviousHash:       &h,
 		Deactivated:        false,
 		SourceTransactions: []hash.SHA256Hash{h},
 	}
-	numFields := 5
+	numFields := 6
 
 	t.Run("returns error if metadata can be manipulated", func(t *testing.T) {
 		var metaCopy DocumentMetadata
@@ -58,6 +59,10 @@ func TestCopy(t *testing.T) {
 		// Hash
 		metaCopy.Hash[0] = 0
 		assert.NotEqual(t, metaCopy.Hash, meta.Hash, "Hash is not deep-copied")
+
+		// PreviousHash
+		metaCopy.PreviousHash[0] = 0
+		assert.NotEqual(t, metaCopy.PreviousHash, meta.PreviousHash, "PreviousHash is not deep-copied")
 
 		// SourceTransactions
 		metaCopy.SourceTransactions[0] = hash.SHA256Hash{20}


### PR DESCRIPTION
Part of #572 
Adds a `previousHash` property to resolver metadata:
```json
{
    "document": {
        "@context": "https://www.w3.org/ns/did/v1",
        "id": "did:nuts:9uJ8V9aQ1vSoe3fj7ipnMVsnR5Kq6dxmkb7GmdBPntuC"
    },
    "documentMetadata": {
        "created": "2021-11-02T10:53:25Z",
        "updated": "2021-11-02T15:15:49Z",
        "hash": "223f884b812027c3da02975e117741910491d0491f689e26d2557aec39e07f46",
        "previousHash": "e6efa34322812bd5ddec7f1aa3389957a2c35d19949913287407cb1068e16eb9",
        "txs": [
            "68a2a3d13dc245abdf7ff9330d3710cc4d8e2c564c9d9efb3a6c8012f0654c5c"
        ],
        "deactivated": true
    }
```