### PR TITLE
Network: enable TLS by default, do not derive from other properties

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/test/io"
 	"github.com/nuts-foundation/nuts-node/vcr"
 	"github.com/nuts-foundation/nuts-node/vdr/store"
-
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +14,8 @@ import (
 
 func TestAuth_Configure(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
+		os.Setenv("NUTS_NETWORK_ENABLETLS", "false")
+		defer os.Unsetenv("NUTS_NETWORK_ENABLETLS")
 		i := NewTestAuthInstance(io.TestDirectory(t))
 		_ = i.Configure(*core.NewServerConfig())
 	})

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 const grpcListenAddressEnvKey = "NUTS_NETWORK_GRPCADDR"
+const enableTLSEnvKey = "NUTS_NETWORK_ENABLETLS"
 
 func Test_rootCmd(t *testing.T) {
 	t.Run("no args prints help", func(t *testing.T) {
@@ -102,6 +103,8 @@ func Test_serverCmd(t *testing.T) {
 	t.Run("defaults and alt binds are used", func(t *testing.T) {
 		os.Setenv(grpcListenAddressEnvKey, fmt.Sprintf("localhost:%d", test.FreeTCPPort()))
 		defer os.Unsetenv(grpcListenAddressEnvKey)
+		os.Setenv(enableTLSEnvKey, "false")
+		defer os.Unsetenv(enableTLSEnvKey)
 
 		var echoServers []*http2.StubEchoServer
 		system := CreateSystem()

--- a/network/cmd/cmd.go
+++ b/network/cmd/cmd.go
@@ -41,7 +41,7 @@ func FlagSet() *pflag.FlagSet {
 		"If empty the gRPC server won't be started and other nodes will not be able to connect to this node "+
 		"(outbound connections can still be made).")
 	flagSet.StringSlice("network.bootstrapnodes", defs.BootstrapNodes, "List of bootstrap nodes (`<host>:<port>`) which the node initially connect to.")
-	flagSet.Bool("network.enabletls", defs.TLSEnabled(), "Whether to enable TLS for incoming and outgoing gRPC connections. "+
+	flagSet.Bool("network.enabletls", defs.EnableTLS, "Whether to enable TLS for incoming and outgoing gRPC connections. "+
 		"When `certfile` or `certkeyfile` is specified it defaults to `true`, otherwise `false`.")
 	flagSet.String("network.certfile", defs.CertFile, "PEM file containing the server certificate for the gRPC server. "+
 		"Required when `enableTLS` is `true`.")

--- a/network/config.go
+++ b/network/config.go
@@ -9,7 +9,7 @@ type Config struct {
 	// Socket address for gRPC to listen on
 	GrpcAddr string `koanf:"network.grpcaddr"`
 	// EnableTLS specifies whether to enable TLS for incoming connections.
-	EnableTLS *bool `koanf:"network.enabletls"`
+	EnableTLS bool `koanf:"network.enabletls"`
 	// Public address of this nodes other nodes can use to connect to this node.
 	BootstrapNodes []string `koanf:"network.bootstrapnodes"`
 	CertFile       string   `koanf:"network.certfile"`
@@ -23,18 +23,11 @@ type Config struct {
 	ProtocolV1 v1.Config `koanf:"network.v1"`
 }
 
-// TLSEnabled indicates whether TLS should be enabled or not for incoming traffic.
-func (c Config) TLSEnabled() bool {
-	if c.EnableTLS != nil {
-		return *c.EnableTLS
-	}
-	return c.CertFile != "" || c.CertKeyFile != ""
-}
-
 // DefaultConfig returns the default NetworkEngine configuration.
 func DefaultConfig() Config {
 	return Config{
 		GrpcAddr:   ":5555",
 		ProtocolV1: v1.DefaultConfig(),
+		EnableTLS:  true,
 	}
 }

--- a/network/config_test.go
+++ b/network/config_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestDefaultConfig(t *testing.T) {
 	defs := DefaultConfig()
-	assert.False(t, defs.TLSEnabled())
+	assert.True(t, defs.EnableTLS)
 	assert.Equal(t, ":5555", defs.GrpcAddr)
 }
 

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -150,13 +150,12 @@ func startNode(name string, directory string) (*Network, error) {
 	mutex.Lock()
 	mutex.Unlock()
 	// Create Network instance
-	enableTLS := true
 	config := Config{
 		GrpcAddr:       fmt.Sprintf("localhost:%d", nameToPort(name)),
 		CertFile:       "test/certificate-and-key.pem",
 		CertKeyFile:    "test/certificate-and-key.pem",
 		TrustStoreFile: "test/truststore.pem",
-		EnableTLS:      &enableTLS,
+		EnableTLS:      true,
 		ProtocolV1: v1.Config{
 			AdvertHashesInterval:      500,
 			AdvertDiagnosticsInterval: 5000,

--- a/network/test.go
+++ b/network/test.go
@@ -41,8 +41,6 @@ func NewTestNetworkInstance(testDirectory string) *Network {
 // TestNetworkConfig creates new network config with a test directory as data path.
 func TestNetworkConfig() Config {
 	config := DefaultConfig()
-	config.GrpcAddr = ":5555"
-	enableTLS := false
-	config.EnableTLS = &enableTLS
+	config.EnableTLS = false
 	return config
 }

--- a/vdr/integration_test.go
+++ b/vdr/integration_test.go
@@ -50,7 +50,9 @@ func TestVDRIntegration_Test(t *testing.T) {
 	didStore := store.NewMemoryStore()
 
 	// Startup the network layer
-	nutsNetwork := network.NewNetworkInstance(network.DefaultConfig(), doc.KeyResolver{Store: didStore})
+	networkCfg := network.DefaultConfig()
+	networkCfg.EnableTLS = false
+	nutsNetwork := network.NewNetworkInstance(networkCfg, doc.KeyResolver{Store: didStore})
 	nutsNetwork.Configure(nutsConfig)
 	nutsNetwork.Start()
 
@@ -222,7 +224,9 @@ func TestVDRIntegration_ConcurrencyTest(t *testing.T) {
 	didStore := store.NewMemoryStore()
 
 	// Startup the network layer
-	nutsNetwork := network.NewNetworkInstance(network.DefaultConfig(), doc.KeyResolver{Store: didStore})
+	networkCfg := network.DefaultConfig()
+	networkCfg.EnableTLS = false
+	nutsNetwork := network.NewNetworkInstance(networkCfg, doc.KeyResolver{Store: didStore})
 	nutsNetwork.Configure(nutsConfig)
 	nutsNetwork.Start()
 	defer nutsNetwork.Shutdown()


### PR DESCRIPTION
Was previously derived from `CertFile` and `CertKeyFile` being set, but this didn't actually work. Changed it to be set explicitly, with default = `true`. Also logs a warning when one of the cert/key properties is set, but TLS is disabled.