### PR TITLE
DIDMan: return empty array instead of null in REST API calls

### DIFF
--- a/didman/api/v1/api.go
+++ b/didman/api/v1/api.go
@@ -133,6 +133,10 @@ func (w *Wrapper) GetCompoundServices(ctx echo.Context, didStr string) error {
 	if err != nil {
 		return err
 	}
+	// Service may return nil for empty arrays, map to empty array to avoid returning null from the REST API
+	if services == nil {
+		services = make([]did.Service, 0)
+	}
 	return ctx.JSON(http.StatusOK, services)
 }
 
@@ -285,6 +289,10 @@ func (w *Wrapper) SearchOrganizations(ctx echo.Context, params SearchOrganizatio
 	results, err := w.Didman.SearchOrganizations(params.Query, params.DidServiceType)
 	if err != nil {
 		return err
+	}
+	// Service may return nil for empty arrays, map to empty array to avoid returning null from the REST API
+	if results == nil {
+		results = make([]OrganizationSearchResult, 0)
 	}
 	return ctx.JSON(http.StatusOK, results)
 }

--- a/didman/api/v1/api_test.go
+++ b/didman/api/v1/api_test.go
@@ -389,6 +389,13 @@ func TestWrapper_GetCompoundServices(t *testing.T) {
 		err := ctx.wrapper.GetCompoundServices(ctx.echo, idStr)
 		assert.NoError(t, err)
 	})
+	t.Run("no results (nil maps to empty array)", func(t *testing.T) {
+		ctx := newMockContext(t)
+		ctx.didman.EXPECT().GetCompoundServices(*id).Return(nil, nil)
+		ctx.echo.EXPECT().JSON(http.StatusOK, []did.Service{})
+		err := ctx.wrapper.GetCompoundServices(ctx.echo, idStr)
+		assert.NoError(t, err)
+	})
 	t.Run("error - invalid DID", func(t *testing.T) {
 		invalidDIDStr := "nuts:123"
 		ctx := newMockContext(t)
@@ -615,6 +622,19 @@ func TestWrapper_SearchOrganizations(t *testing.T) {
 		results := []OrganizationSearchResult{{DIDDocument: did.Document{ID: *id}, Organization: map[string]interface{}{"name": "bar"}}}
 		ctx.didman.EXPECT().SearchOrganizations("query", &serviceType).Return(results, nil)
 		ctx.echo.EXPECT().JSON(http.StatusOK, results)
+
+		err := ctx.wrapper.SearchOrganizations(ctx.echo, SearchOrganizationsParams{
+			Query:          "query",
+			DidServiceType: &serviceType,
+		})
+
+		assert.NoError(t, err)
+	})
+	t.Run("no results", func(t *testing.T) {
+		ctx := newMockContext(t)
+		serviceType := "service"
+		ctx.didman.EXPECT().SearchOrganizations("query", &serviceType).Return(nil, nil)
+		ctx.echo.EXPECT().JSON(http.StatusOK, []OrganizationSearchResult{})
 
 		err := ctx.wrapper.SearchOrganizations(ctx.echo, SearchOrganizationsParams{
 			Query:          "query",


### PR DESCRIPTION
Fixes #556