### PR TITLE
VDR: List DIDs managed by the local node

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -124,6 +124,11 @@ func (client *Crypto) Exists(kid string) bool {
 	return client.Storage.PrivateKeyExists(kid)
 }
 
+// List returns the KIDs of the private keys that are present in the key store.
+func (client *Crypto) List() []string {
+	return client.Storage.ListPrivateKeys()
+}
+
 func (client *Crypto) Resolve(kid string) (Key, error) {
 	keypair, err := client.Storage.GetPrivateKey(kid)
 	if err != nil {
@@ -137,6 +142,7 @@ func (client *Crypto) Resolve(kid string) (Key, error) {
 		kid:        kid,
 	}, nil
 }
+
 
 type keySelector struct {
 	privateKey crypto.Signer

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -143,7 +143,6 @@ func (client *Crypto) Resolve(kid string) (Key, error) {
 	}, nil
 }
 
-
 type keySelector struct {
 	privateKey crypto.Signer
 	kid        string

--- a/crypto/interface.go
+++ b/crypto/interface.go
@@ -43,6 +43,8 @@ type KeyStore interface {
 	Exists(kid string) bool
 	// Resolve returns a Key for the given KID. ErrKeyNotFound is returned for an unknown KID.
 	Resolve(kid string) (Key, error)
+	// List returns the KIDs of the private keys that are present in the KeyStore.
+	List() []string
 
 	KeyCreator
 	JWTSigner

--- a/crypto/mock.go
+++ b/crypto/mock.go
@@ -86,6 +86,20 @@ func (mr *MockKeyStoreMockRecorder) Exists(kid interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockKeyStore)(nil).Exists), kid)
 }
 
+// List mocks base method.
+func (m *MockKeyStore) List() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// List indicates an expected call of List.
+func (mr *MockKeyStoreMockRecorder) List() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockKeyStore)(nil).List))
+}
+
 // New mocks base method.
 func (m *MockKeyStore) New(namingFunc KIDNamingFunc) (Key, error) {
 	m.ctrl.T.Helper()

--- a/crypto/storage/mock.go
+++ b/crypto/storage/mock.go
@@ -64,6 +64,20 @@ func (mr *MockStorageMockRecorder) GetPublicKey(kid interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicKey", reflect.TypeOf((*MockStorage)(nil).GetPublicKey), kid)
 }
 
+// ListPrivateKeys mocks base method.
+func (m *MockStorage) ListPrivateKeys() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPrivateKeys")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// ListPrivateKeys indicates an expected call of ListPrivateKeys.
+func (mr *MockStorageMockRecorder) ListPrivateKeys() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPrivateKeys", reflect.TypeOf((*MockStorage)(nil).ListPrivateKeys))
+}
+
 // PrivateKeyExists mocks base method.
 func (m *MockStorage) PrivateKeyExists(kid string) bool {
 	m.ctrl.T.Helper()

--- a/crypto/storage/storage.go
+++ b/crypto/storage/storage.go
@@ -37,6 +37,8 @@ type Storage interface {
 	GetPrivateKey(kid string) (crypto.Signer, error)
 	PrivateKeyExists(kid string) bool
 	SavePrivateKey(kid string, key crypto.PrivateKey) error
+	// ListPrivateKeys returns the KIDs of the private keys that are present.
+	ListPrivateKeys() []string
 
 	// GetPublicKey returns the public key and the period it is valid in.
 	GetPublicKey(kid string) (PublicKeyEntry, error)

--- a/docs/_static/vdr/v1.yaml
+++ b/docs/_static/vdr/v1.yaml
@@ -37,6 +37,28 @@ paths:
                 $ref: '#/components/schemas/DIDDocument'
         default:
           $ref: '../common/error_response.yaml'
+    get:
+      summary: Returns the DIDs managed by this node.
+      description: |
+        A DID can be managed by a node when at least one of its active private keys is present.
+        This operation will return those DIDs. It will not return deactivated DIDs.
+
+        error returns:
+        * 500 - An error occurred while processing the request
+      operationId: "listManagedDIDs"
+      tags:
+        - DID
+      responses:
+        "200":
+          description: "DIDs that can be managed by this node."
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        default:
+          $ref: '../common/error_response.yaml'
   /internal/vdr/v1/did/{did}:
     parameters:
       - name: did

--- a/vdr/api/v1/api.go
+++ b/vdr/api/v1/api.go
@@ -188,6 +188,14 @@ func (a *Wrapper) GetDID(ctx echo.Context, targetDID string, params GetDIDParams
 	return ctx.JSON(http.StatusOK, resolutionResult)
 }
 
+func (a *Wrapper) ListManagedDIDs(ctx echo.Context) error {
+	dids, err := a.VDR.ManagedDIDs()
+	if err != nil {
+		return err
+	}
+	return ctx.JSON(http.StatusOK, dids)
+}
+
 func (a *Wrapper) ConflictedDIDs(ctx echo.Context) error {
 	docs, metas, err := a.VDR.ConflictedDocuments()
 	if err != nil {

--- a/vdr/api/v1/api.go
+++ b/vdr/api/v1/api.go
@@ -188,6 +188,7 @@ func (a *Wrapper) GetDID(ctx echo.Context, targetDID string, params GetDIDParams
 	return ctx.JSON(http.StatusOK, resolutionResult)
 }
 
+// ListManagedDIDs returns the DIDs that can be managed by the local node.
 func (a *Wrapper) ListManagedDIDs(ctx echo.Context) error {
 	dids, err := a.VDR.ManagedDIDs()
 	if err != nil {

--- a/vdr/types/interface.go
+++ b/vdr/types/interface.go
@@ -118,6 +118,9 @@ type VDR interface {
 
 	// ConflictedDocuments returns the DID Document and metadata of all documents with a conflict.
 	ConflictedDocuments() ([]did.Document, []DocumentMetadata, error)
+
+	// ManagedDIDs returns the DIDs that can be managed by the local node. This does not return the DIDs that
+	ManagedDIDs() ([]did.DID, error)
 }
 
 // DocManipulator groups several higher level methods to alter the state of a DID document.

--- a/vdr/types/interface.go
+++ b/vdr/types/interface.go
@@ -119,7 +119,8 @@ type VDR interface {
 	// ConflictedDocuments returns the DID Document and metadata of all documents with a conflict.
 	ConflictedDocuments() ([]did.Document, []DocumentMetadata, error)
 
-	// ManagedDIDs returns the DIDs that can be managed by the local node. This does not return the DIDs that
+	// ManagedDIDs returns the DIDs that can be managed by the local node.
+	// It does not return the DIDs that are deactivated.
 	ManagedDIDs() ([]did.DID, error)
 }
 

--- a/vdr/types/mock.go
+++ b/vdr/types/mock.go
@@ -417,6 +417,21 @@ func (mr *MockVDRMockRecorder) Create(options interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockVDR)(nil).Create), options)
 }
 
+// ManagedDIDs mocks base method.
+func (m *MockVDR) ManagedDIDs() ([]did.DID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ManagedDIDs")
+	ret0, _ := ret[0].([]did.DID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ManagedDIDs indicates an expected call of ManagedDIDs.
+func (mr *MockVDRMockRecorder) ManagedDIDs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagedDIDs", reflect.TypeOf((*MockVDR)(nil).ManagedDIDs))
+}
+
 // Update mocks base method.
 func (m *MockVDR) Update(id did.DID, current hash.SHA256Hash, next did.Document, metadata *DocumentMetadata) error {
 	m.ctrl.T.Helper()

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -102,6 +102,8 @@ func (r *VDR) ConflictedDocuments() ([]did.Document, []types.DocumentMetadata, e
 	return conflictedDocs, conflictedMeta, err
 }
 
+// ManagedDIDs returns the DIDs that can be managed by the local node.
+// It does not return the DIDs that are deactivated.
 func (r *VDR) ManagedDIDs() ([]did.DID, error) {
 	var result []did.DID
 	kids := r.keyStore.List()


### PR DESCRIPTION
This allows node operators to retrieve the list of DIDs that are managed by the local node (which can be updated). It works by retrieving the list of private keys in the key store and resolving the DID document (based on KID).

It answers the question, "how do I retrieve the DIDs I previously created?"

It does not return the documents controlled by the node via a `controller`. E.g., a vendor's care organizations, where the care organization DID documents don't contain any key material (available to the vendor). That would be a future improvement.