### PR TITLE
Enable KeyAgreement by default on DID document creation

### DIFF
--- a/docs/_static/vdr/v1.yaml
+++ b/docs/_static/vdr/v1.yaml
@@ -389,7 +389,7 @@ components:
         capabilityDelegation:
           type: boolean
           description: indicates if the generated key pair can be used for capability delegations.
-          default: false
+          default: true
         keyAgreement:
           type: boolean
           description: indicates if the generated key pair can be used for Key agreements.

--- a/docs/pages/getting-started/4-connecting-crm.rst
+++ b/docs/pages/getting-started/4-connecting-crm.rst
@@ -49,6 +49,7 @@ Consult the :ref:`configuration reference <nuts-node-config>` on how to configur
     POST <internal-node-address>/internal/vdr/v1/did
     {
         "selfControl": true,
+        "keyAgreement": true,
         "assertionMethod": true,
         "capabilityInvocation": true
     }
@@ -79,6 +80,9 @@ If all is well, the node will respond with a DID Document similar to:
         "did:nuts:2mF6KT6eiSx5y2fwTP4Y42yMUh91zGVkbu4KMARvCJz9#_TKzHv2jFIyvdTGF1Dsgwngfdg3SH6TpDv0Ta1aOEkw"
       ],
       "assertion": [
+        "did:nuts:2mF6KT6eiSx5y2fwTP4Y42yMUh91zGVkbu4KMARvCJz9#_TKzHv2jFIyvdTGF1Dsgwngfdg3SH6TpDv0Ta1aOEkw"
+      ],
+      "keyAgreement": [
         "did:nuts:2mF6KT6eiSx5y2fwTP4Y42yMUh91zGVkbu4KMARvCJz9#_TKzHv2jFIyvdTGF1Dsgwngfdg3SH6TpDv0Ta1aOEkw"
       ],
       "service": []

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -295,7 +295,7 @@ func (n ambassador) isUpdate(doc did.Document) (bool, error) {
 	_, _, err := n.didStore.Resolve(doc.ID, nil)
 	result := true
 
-	if err == types.ErrNotFound {
+	if errors.Is(err, types.ErrNotFound) {
 		return false, nil
 	}
 

--- a/vdr/api/v1/api.go
+++ b/vdr/api/v1/api.go
@@ -144,7 +144,7 @@ func (a Wrapper) CreateDID(ctx echo.Context) error {
 		return err
 	}
 
-	// this API returns a DIDDocument according to spec so it may return the business object
+	// this API returns a DIDDocument according to spec, so it may return the business object
 	return ctx.JSON(http.StatusOK, *doc)
 }
 

--- a/vdr/api/v1/api_test.go
+++ b/vdr/api/v1/api_test.go
@@ -21,13 +21,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nuts-foundation/nuts-node/core"
-	"github.com/nuts-foundation/nuts-node/crypto/hash"
-
 	"github.com/golang/mock/gomock"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/nuts-foundation/nuts-node/core"
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/mock"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 )

--- a/vdr/doc/creator.go
+++ b/vdr/doc/creator.go
@@ -46,7 +46,7 @@ type Creator struct {
 	KeyStore nutsCrypto.KeyCreator
 }
 
-// DefaultCreationOptions returns the default DIDCreationOptions: no controllers, CapabilityInvocation = true, AssertionMethod = true and SelfControl = true
+// DefaultCreationOptions returns the default DIDCreationOptions when creating DID Documents.
 func DefaultCreationOptions() vdr.DIDCreationOptions {
 	return vdr.DIDCreationOptions{
 		Controllers:          []did.DID{},
@@ -54,16 +54,14 @@ func DefaultCreationOptions() vdr.DIDCreationOptions {
 		Authentication:       false,
 		CapabilityDelegation: false,
 		CapabilityInvocation: true,
-		KeyAgreement:         false,
+		KeyAgreement:         true,
 		SelfControl:          true,
 	}
 }
 
 // didKIDNamingFunc is a function used to name a key used in newly generated DID Documents.
 func didKIDNamingFunc(pKey crypto.PublicKey) (string, error) {
-	return getKIDName(pKey, func(key jwk.Key) (string, error) {
-		return nutsCrypto.Thumbprint(key)
-	})
+	return getKIDName(pKey, nutsCrypto.Thumbprint)
 }
 
 // didSubKIDNamingFunc returns a KIDNamingFunc that can be used as param in the KeyStore.New function.

--- a/vdr/doc/creator_test.go
+++ b/vdr/doc/creator_test.go
@@ -45,7 +45,7 @@ func TestDefaultCreationOptions(t *testing.T) {
 	assert.False(t, ops.Authentication)
 	assert.False(t, ops.CapabilityDelegation)
 	assert.True(t, ops.CapabilityInvocation)
-	assert.False(t, ops.KeyAgreement)
+	assert.True(t, ops.KeyAgreement)
 	assert.True(t, ops.SelfControl)
 	assert.Empty(t, ops.Controllers)
 }

--- a/vdr/doc/merge.go
+++ b/vdr/doc/merge.go
@@ -49,6 +49,7 @@ func MergeDocuments(docA did.Document, docB did.Document) (*did.Document, error)
 	sort.Slice(result.Context, contextSort(result))
 	sort.Slice(result.Service, serviceSort(result))
 	sort.Slice(result.VerificationMethod, verificationMethodSort(result))
+	sort.Slice(result.KeyAgreement, keyAgreementSort(result))
 	sort.Slice(result.AssertionMethod, assertionSort(result))
 	sort.Slice(result.Authentication, authenticationSort(result))
 	sort.Slice(result.CapabilityInvocation, capabilityInvocationSort(result))
@@ -82,6 +83,7 @@ func mergeKeys(docs []did.Document, result *did.Document) {
 	assertions := map[string]did.VerificationRelationship{}
 	capabilityInvocations := map[string]did.VerificationRelationship{}
 	capabilityDelegations := map[string]did.VerificationRelationship{}
+	keyAgreements := map[string]did.VerificationRelationship{}
 
 	for _, doc := range docs {
 		for _, verificationMethod := range doc.VerificationMethod {
@@ -98,6 +100,9 @@ func mergeKeys(docs []did.Document, result *did.Document) {
 		}
 		for _, capabilityDelegation := range doc.CapabilityDelegation {
 			capabilityDelegations[capabilityDelegation.ID.String()] = capabilityDelegation
+		}
+		for _, keyAgreement := range doc.KeyAgreement {
+			keyAgreements[keyAgreement.ID.String()] = keyAgreement
 		}
 	}
 	// verificationMethods from set
@@ -122,6 +127,9 @@ func mergeKeys(docs []did.Document, result *did.Document) {
 	}
 	for _, relation := range capabilityDelegations {
 		result.CapabilityDelegation = append(result.CapabilityDelegation, relation)
+	}
+	for _, relation := range keyAgreements {
+		result.KeyAgreement = append(result.KeyAgreement, relation)
 	}
 }
 
@@ -156,6 +164,14 @@ func verificationMethodSort(result *did.Document) less {
 	return func(i, j int) bool {
 		is := result.VerificationMethod[i].ID.String()
 		js := result.VerificationMethod[j].ID.String()
+		return strings.Compare(is, js) == -1
+	}
+}
+
+func keyAgreementSort(result *did.Document) less {
+	return func(i, j int) bool {
+		is := result.KeyAgreement[i].ID.String()
+		js := result.KeyAgreement[j].ID.String()
 		return strings.Compare(is, js) == -1
 	}
 }

--- a/vdr/integration_test.go
+++ b/vdr/integration_test.go
@@ -144,6 +144,7 @@ func TestVDRIntegration_Test(t *testing.T) {
 	docA.AssertionMethod = []did.VerificationRelationship{}
 	docA.CapabilityInvocation = []did.VerificationRelationship{}
 	docA.VerificationMethod = []*did.VerificationMethod{}
+	docA.KeyAgreement = []did.VerificationRelationship{}
 	err = vdr.Update(docAID, metadataDocA.Hash, *docA, nil)
 	if !assert.NoError(t, err,
 		"unable to update documentA with a new controller") {

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -181,6 +181,7 @@ func TestVDR_Create(t *testing.T) {
 		}
 		nextDIDDocument.AddCapabilityInvocation(vm)
 		nextDIDDocument.AddAssertionMethod(vm)
+		nextDIDDocument.AddKeyAgreement(vm)
 		expectedPayload, _ := json.Marshal(nextDIDDocument)
 
 		ctx.mockKeyStore.EXPECT().New(gomock.Any()).Return(key, nil)


### PR DESCRIPTION
* Only when the DID document is owned by the node

Fixes https://github.com/nuts-foundation/nuts-node/issues/627