### PR TITLE
Network: connect to bootstrap nodes during start instead of configuration phase

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -141,12 +141,6 @@ func (n *Network) Configure(config core.ServerConfig) error {
 		}
 		n.connectionManager = grpc.NewGRPCConnectionManager(grpc.NewConfig(n.config.GrpcAddr, n.peerID, grpcOpts...), n.protocols...)
 	}
-	for _, bootstrapNode := range n.config.BootstrapNodes {
-		if len(strings.TrimSpace(bootstrapNode)) == 0 {
-			continue
-		}
-		n.connectionManager.Connect(bootstrapNode)
-	}
 	return nil
 }
 
@@ -188,6 +182,13 @@ func (n *Network) Start() error {
 	}
 	for _, prot := range n.protocols {
 		prot.Start()
+	}
+	// Start connecting to bootstrap nodes
+	for _, bootstrapNode := range n.config.BootstrapNodes {
+		if len(strings.TrimSpace(bootstrapNode)) == 0 {
+			continue
+		}
+		n.connectionManager.Connect(bootstrapNode)
 	}
 
 	return nil


### PR DESCRIPTION
Currently, the node starts connecting to bootstrap nodes while still configuring and starting, which causes DAG sync'ing because the node looks out of date, while the DAG is still loading.

It needs to wait to start connecting to nodes until all other services are started.