### PR TITLE
validate replayed VCs at signing time

### DIFF
--- a/vcr/ambassador.go
+++ b/vcr/ambassador.go
@@ -67,7 +67,8 @@ func (n ambassador) vcCallback(tx dag.Transaction, payload []byte) error {
 	}
 
 	// Verify and store
-	return n.writer.StoreCredential(target)
+	validAt := tx.SigningTime()
+	return n.writer.StoreCredential(target, &validAt)
 }
 
 // rCallback gets called when new credential revocations are received by the network. All checks on the signature are already performed.

--- a/vcr/ambassador_test.go
+++ b/vcr/ambassador_test.go
@@ -57,6 +57,7 @@ func TestAmbassador_vcCallback(t *testing.T) {
 	payload := []byte(concept.TestCredential)
 	tx, _ := dag.NewTransaction(hash.EmptyHash(), vcDocumentType, nil)
 	stx := tx.(dag.Transaction)
+	validAt := stx.SigningTime()
 
 	t.Run("ok", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -65,7 +66,7 @@ func TestAmbassador_vcCallback(t *testing.T) {
 
 		target := vc.VerifiableCredential{}
 		a := NewAmbassador(nil, wMock).(ambassador)
-		wMock.EXPECT().StoreCredential(gomock.Any()).DoAndReturn(func(f interface{}) error {
+		wMock.EXPECT().StoreCredential(gomock.Any(), &validAt).DoAndReturn(func(f interface{}, g interface{}) error {
 			target = f.(vc.VerifiableCredential)
 			return nil
 		})
@@ -85,7 +86,7 @@ func TestAmbassador_vcCallback(t *testing.T) {
 		defer ctrl.Finish()
 
 		a := NewAmbassador(nil, wMock).(ambassador)
-		wMock.EXPECT().StoreCredential(gomock.Any()).Return(errors.New("b00m!"))
+		wMock.EXPECT().StoreCredential(gomock.Any(), &validAt).Return(errors.New("b00m!"))
 
 		err := a.vcCallback(stx, payload)
 

--- a/vcr/interface.go
+++ b/vcr/interface.go
@@ -84,7 +84,7 @@ type Validator interface {
 // Writer is the interface that groups al the VC write methods
 type Writer interface {
 	// StoreCredential writes a VC to storage. Before writing, it calls Verify!
-	StoreCredential(vc vc.VerifiableCredential) error
+	StoreCredential(vc vc.VerifiableCredential, validAt *time.Time) error
 	// StoreRevocation writes a revocation to storage.
 	StoreRevocation(r credential.Revocation) error
 }

--- a/vcr/mock.go
+++ b/vcr/mock.go
@@ -129,17 +129,17 @@ func (m *MockWriter) EXPECT() *MockWriterMockRecorder {
 }
 
 // StoreCredential mocks base method.
-func (m *MockWriter) StoreCredential(vc vc.VerifiableCredential) error {
+func (m *MockWriter) StoreCredential(vc vc.VerifiableCredential, validAt *time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreCredential", vc)
+	ret := m.ctrl.Call(m, "StoreCredential", vc, validAt)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StoreCredential indicates an expected call of StoreCredential.
-func (mr *MockWriterMockRecorder) StoreCredential(vc interface{}) *gomock.Call {
+func (mr *MockWriterMockRecorder) StoreCredential(vc, validAt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreCredential", reflect.TypeOf((*MockWriter)(nil).StoreCredential), vc)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreCredential", reflect.TypeOf((*MockWriter)(nil).StoreCredential), vc, validAt)
 }
 
 // StoreRevocation mocks base method.
@@ -402,17 +402,17 @@ func (mr *MockVCRMockRecorder) Search(conceptName, allowUntrusted, query interfa
 }
 
 // StoreCredential mocks base method.
-func (m *MockVCR) StoreCredential(vc vc.VerifiableCredential) error {
+func (m *MockVCR) StoreCredential(vc vc.VerifiableCredential, validAt *time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreCredential", vc)
+	ret := m.ctrl.Call(m, "StoreCredential", vc, validAt)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StoreCredential indicates an expected call of StoreCredential.
-func (mr *MockVCRMockRecorder) StoreCredential(vc interface{}) *gomock.Call {
+func (mr *MockVCRMockRecorder) StoreCredential(vc, validAt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreCredential", reflect.TypeOf((*MockVCR)(nil).StoreCredential), vc)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreCredential", reflect.TypeOf((*MockVCR)(nil).StoreCredential), vc, validAt)
 }
 
 // StoreRevocation mocks base method.

--- a/vcr/store.go
+++ b/vcr/store.go
@@ -21,6 +21,7 @@ package vcr
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/vcr/log"
@@ -31,9 +32,9 @@ import (
 
 const revocationCollection = "_revocation"
 
-func (c *vcr) StoreCredential(credential vc.VerifiableCredential) error {
+func (c *vcr) StoreCredential(credential vc.VerifiableCredential, validAt *time.Time) error {
 	// verify first
-	if err := c.Verify(credential, nil); err != nil {
+	if err := c.Verify(credential, validAt); err != nil {
 		return err
 	}
 

--- a/vcr/store_test.go
+++ b/vcr/store_test.go
@@ -64,7 +64,19 @@ func TestVcr_StoreCredential(t *testing.T) {
 		ctx.keyResolver.EXPECT().ResolveSigningKey(gomock.Any(), nil).Return(pk, nil)
 		ctx.docResolver.EXPECT().Resolve(*did, &types.ResolveMetadata{ResolveTime: &now}).Return(nil, nil, nil)
 
-		err := ctx.vcr.StoreCredential(target)
+		err := ctx.vcr.StoreCredential(target, nil)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("ok - with validAt", func(t *testing.T) {
+		ctx := newMockContext(t)
+		now := time.Now()
+
+		ctx.keyResolver.EXPECT().ResolveSigningKey(gomock.Any(), &now).Return(pk, nil)
+		ctx.docResolver.EXPECT().Resolve(*did, &types.ResolveMetadata{ResolveTime: &now}).Return(nil, nil, nil)
+
+		err := ctx.vcr.StoreCredential(target, &now)
 
 		assert.NoError(t, err)
 	})
@@ -72,7 +84,7 @@ func TestVcr_StoreCredential(t *testing.T) {
 	t.Run("error - validation", func(t *testing.T) {
 		ctx := newMockContext(t)
 
-		err := ctx.vcr.StoreCredential(vc.VerifiableCredential{})
+		err := ctx.vcr.StoreCredential(vc.VerifiableCredential{}, nil)
 
 		assert.Error(t, err)
 	})


### PR DESCRIPTION
fixes #633 

At startup all TXs are replayed from the DAG. Any VC is then written to the VCR. Before it's written a validation takes place, this validation is always done against the current time, not the signing time.