### PR TITLE
Network: reset peer ID when connection closes

### DIFF
--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -155,9 +155,7 @@ func TestNetworkIntegration_OutboundConnectionReconnects(t *testing.T) {
 	}
 
 	// Now start node2 again, node1 should reconnect
-	if err := node2.Start(); err != nil {
-		t.Fatal(err)
-	}
+	node2 = startNode(t, "node2", testDirectory) // important to start a new instance, otherwise PeerID isn't regenerated
 	if !test.WaitFor(t, func() (bool, error) {
 		return len(node1.connectionManager.Peers()) == 1, nil
 	}, defaultTimeout, "time-out while waiting for node 1 to reconnect to node 2") {
@@ -198,8 +196,6 @@ func startNode(t *testing.T, name string, testDirectory string) *Network {
 	log.Logger().Infof("Starting node: %s", name)
 	logrus.SetLevel(logrus.DebugLevel)
 	core.NewServerConfig().Load(&cobra.Command{})
-	mutex.Lock()
-	mutex.Unlock()
 	// Create Network instance
 	config := Config{
 		GrpcAddr:       fmt.Sprintf("localhost:%d", nameToPort(t, name)),

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -124,8 +124,6 @@ func TestNetworkIntegration_NodesConnectToEachOther(t *testing.T) {
 }
 
 func TestNetworkIntegration_OutboundConnectionReconnects(t *testing.T) {
-	t.SkipNow()
-
 	testDirectory := io.TestDirectory(t)
 	resetIntegrationTest()
 

--- a/network/transport/grpc/connection.go
+++ b/network/transport/grpc/connection.go
@@ -136,6 +136,9 @@ func (mc *conn) doDisconnect() {
 		_ = mc.grpcOutboundConnection.Close()
 		mc.grpcOutboundConnection = nil
 	}
+
+	// Reset peer ID, since when it reconnects it might have changed (due to a reboot)
+	mc.peer.Store(transport.Peer{})
 }
 
 func (mc *conn) verifyOrSetPeerID(id transport.PeerID) bool {

--- a/network/transport/grpc/connection_test.go
+++ b/network/transport/grpc/connection_test.go
@@ -42,6 +42,12 @@ func Test_conn_close(t *testing.T) {
 		conn.close()
 		assert.True(t, called)
 	})
+	t.Run("resets peer ID", func(t *testing.T) {
+		conn := conn{}
+		conn.verifyOrSetPeerID("foo")
+		conn.close()
+		assert.Empty(t, conn.getPeer())
+	})
 }
 
 func Test_conn_registerServerStream(t *testing.T) {


### PR DESCRIPTION
Based on https://github.com/nuts-foundation/nuts-node/pull/635 (rebase first).

Currently, the peer ID is never reset, while it is randomly generated when a node starts. That way, when a bootstrap node restarts, its peers aren't able to reconnect (because it sends a new peer ID after the restart). Peer ID should be reset/emptied when a peer disconnects, then it can be set again when it reconnects.

