### PR TITLE
add migration feature to engine

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,6 +111,11 @@ func startServer(system *core.System) error {
 		return err
 	}
 
+	// migrate DBs if needed
+	if err := system.Migrate(); err != nil {
+		return err
+	}
+
 	// start engines
 	if err := system.Start(); err != nil {
 		return err

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -22,10 +22,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/nuts-node/test"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/nuts-foundation/nuts-node/test"
 
 	http2 "github.com/nuts-foundation/nuts-node/test/http"
 	"github.com/spf13/cobra"
@@ -167,6 +168,17 @@ func Test_serverCmd(t *testing.T) {
 		system.Config.HTTP.AltBinds["internal"] = core.HTTPConfig{Address: "localhost:7642"}
 		err := startServer(system)
 		assert.EqualError(t, err, "unable to start")
+	})
+	t.Run("migration fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		r := core.NewMockMigratable(ctrl)
+		system := core.NewSystem()
+		system.RegisterEngine(r)
+		os.Args = []string{"nuts", "server"}
+
+		r.EXPECT().Migrate().Return(errors.New("b00m!"))
+
+		assert.Error(t, startServer(system))
 	})
 }
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -122,6 +122,18 @@ func (system *System) Configure() error {
 	})
 }
 
+// Migrate migrates data structures in an engine if needed.
+func (system *System) Migrate() error {
+	var err error
+	return system.VisitEnginesE(func(engine Engine) error {
+		// only if Engine is migratable
+		if m, ok := engine.(Migratable); ok {
+			err = m.Migrate()
+		}
+		return err
+	})
+}
+
 // VisitEngines applies the given function on all engines in the system.
 func (system *System) VisitEngines(visitor func(engine Engine)) {
 	_ = system.VisitEnginesE(func(engine Engine) error {
@@ -158,6 +170,13 @@ func (system *System) RegisterRoutes(router Routable) {
 type Runnable interface {
 	Start() error
 	Shutdown() error
+}
+
+// Migratable is the interface that defines if an engine is migratable.
+// If an engine is migratable, Migrate is called between Configure() and Start().
+// Migrations may require their own DB connection, they are closed before Start() is called.
+type Migratable interface {
+	Migrate() error
 }
 
 // Configurable is the interface that contains the Configure method.

--- a/core/engine_mock.go
+++ b/core/engine_mock.go
@@ -96,6 +96,43 @@ func (mr *MockRunnableMockRecorder) Start() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockRunnable)(nil).Start))
 }
 
+// MockMigratable is a mock of Migratable interface.
+type MockMigratable struct {
+	ctrl     *gomock.Controller
+	recorder *MockMigratableMockRecorder
+}
+
+// MockMigratableMockRecorder is the mock recorder for MockMigratable.
+type MockMigratableMockRecorder struct {
+	mock *MockMigratable
+}
+
+// NewMockMigratable creates a new mock instance.
+func NewMockMigratable(ctrl *gomock.Controller) *MockMigratable {
+	mock := &MockMigratable{ctrl: ctrl}
+	mock.recorder = &MockMigratableMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockMigratable) EXPECT() *MockMigratableMockRecorder {
+	return m.recorder
+}
+
+// Migrate mocks base method.
+func (m *MockMigratable) Migrate() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Migrate")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Migrate indicates an expected call of Migrate.
+func (mr *MockMigratableMockRecorder) Migrate() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Migrate", reflect.TypeOf((*MockMigratable)(nil).Migrate))
+}
+
 // MockConfigurable is a mock of Configurable interface.
 type MockConfigurable struct {
 	ctrl     *gomock.Controller

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -70,7 +70,6 @@ func TestSystem_Shutdown(t *testing.T) {
 func TestSystem_Configure(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		r := NewMockConfigurable(ctrl)
 		r.EXPECT().Configure(gomock.Any())
@@ -84,6 +83,29 @@ func TestSystem_Configure(t *testing.T) {
 		system := NewSystem()
 		system.Config = &ServerConfig{Datadir: "engine_test.go"}
 		assert.Error(t, system.Configure())
+	})
+}
+
+func TestSystem_Migrate(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		r := NewMockMigratable(ctrl)
+		system := NewSystem()
+		system.RegisterEngine(r)
+
+		r.EXPECT().Migrate()
+
+		assert.NoError(t, system.Migrate())
+	})
+	t.Run("error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		r := NewMockMigratable(ctrl)
+		system := NewSystem()
+		system.RegisterEngine(r)
+
+		r.EXPECT().Migrate().Return(errors.New("b00m!"))
+
+		assert.Error(t, system.Migrate())
 	})
 }
 

--- a/crypto/mock.go
+++ b/crypto/mock.go
@@ -49,6 +49,58 @@ func (mr *MockKeyCreatorMockRecorder) New(namingFunc interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "New", reflect.TypeOf((*MockKeyCreator)(nil).New), namingFunc)
 }
 
+// MockKeyResolver is a mock of KeyResolver interface.
+type MockKeyResolver struct {
+	ctrl     *gomock.Controller
+	recorder *MockKeyResolverMockRecorder
+}
+
+// MockKeyResolverMockRecorder is the mock recorder for MockKeyResolver.
+type MockKeyResolverMockRecorder struct {
+	mock *MockKeyResolver
+}
+
+// NewMockKeyResolver creates a new mock instance.
+func NewMockKeyResolver(ctrl *gomock.Controller) *MockKeyResolver {
+	mock := &MockKeyResolver{ctrl: ctrl}
+	mock.recorder = &MockKeyResolverMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockKeyResolver) EXPECT() *MockKeyResolverMockRecorder {
+	return m.recorder
+}
+
+// Exists mocks base method.
+func (m *MockKeyResolver) Exists(kid string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Exists", kid)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Exists indicates an expected call of Exists.
+func (mr *MockKeyResolverMockRecorder) Exists(kid interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockKeyResolver)(nil).Exists), kid)
+}
+
+// Resolve mocks base method.
+func (m *MockKeyResolver) Resolve(kid string) (Key, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Resolve", kid)
+	ret0, _ := ret[0].(Key)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Resolve indicates an expected call of Resolve.
+func (mr *MockKeyResolverMockRecorder) Resolve(kid interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockKeyResolver)(nil).Resolve), kid)
+}
+
 // MockKeyStore is a mock of KeyStore interface.
 type MockKeyStore struct {
 	ctrl     *gomock.Controller

--- a/network/transport/connection_manager_mock.go
+++ b/network/transport/connection_manager_mock.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	did "github.com/nuts-foundation/go-did/did"
 	core "github.com/nuts-foundation/nuts-node/core"
 )
 
@@ -98,4 +99,42 @@ func (m *MockConnectionManager) Stop() {
 func (mr *MockConnectionManagerMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockConnectionManager)(nil).Stop))
+}
+
+// MockNodeDIDResolver is a mock of NodeDIDResolver interface.
+type MockNodeDIDResolver struct {
+	ctrl     *gomock.Controller
+	recorder *MockNodeDIDResolverMockRecorder
+}
+
+// MockNodeDIDResolverMockRecorder is the mock recorder for MockNodeDIDResolver.
+type MockNodeDIDResolverMockRecorder struct {
+	mock *MockNodeDIDResolver
+}
+
+// NewMockNodeDIDResolver creates a new mock instance.
+func NewMockNodeDIDResolver(ctrl *gomock.Controller) *MockNodeDIDResolver {
+	mock := &MockNodeDIDResolver{ctrl: ctrl}
+	mock.recorder = &MockNodeDIDResolverMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockNodeDIDResolver) EXPECT() *MockNodeDIDResolverMockRecorder {
+	return m.recorder
+}
+
+// Resolve mocks base method.
+func (m *MockNodeDIDResolver) Resolve() (did.DID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Resolve")
+	ret0, _ := ret[0].(did.DID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Resolve indicates an expected call of Resolve.
+func (mr *MockNodeDIDResolverMockRecorder) Resolve() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockNodeDIDResolver)(nil).Resolve))
 }


### PR DESCRIPTION
This will allow engines to perform migrations before they are started.
How they do this and how they track historic migrations is up to the engine.