### PR TITLE
update to go-leia/v2

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -19,13 +19,14 @@
 package auth
 
 import (
+	"os"
+	"testing"
+
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/test/io"
 	"github.com/nuts-foundation/nuts-node/vcr"
 	"github.com/nuts-foundation/nuts-node/vdr/store"
-	"os"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -34,7 +35,7 @@ func TestAuth_Configure(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		os.Setenv("NUTS_NETWORK_ENABLETLS", "false")
 		defer os.Unsetenv("NUTS_NETWORK_ENABLETLS")
-		i := NewTestAuthInstance(io.TestDirectory(t))
+		i := NewTestAuthInstance(t)
 		_ = i.Configure(*core.NewServerConfig())
 	})
 
@@ -113,7 +114,7 @@ func TestAuth_Configure(t *testing.T) {
 func testInstance(t *testing.T, cfg Config) *Auth {
 	testDirectory := io.TestDirectory(t)
 	cryptoInstance := crypto.NewTestCryptoInstance(testDirectory)
-	vcrInstance := vcr.NewTestVCRInstance(testDirectory)
+	vcrInstance := vcr.NewTestVCRInstance(t, testDirectory)
 	return NewAuthInstance(cfg, store.NewMemoryStore(), vcrInstance, cryptoInstance, nil)
 }
 

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -114,7 +114,7 @@ func TestAuth_Configure(t *testing.T) {
 func testInstance(t *testing.T, cfg Config) *Auth {
 	testDirectory := io.TestDirectory(t)
 	cryptoInstance := crypto.NewTestCryptoInstance(testDirectory)
-	vcrInstance := vcr.NewTestVCRInstance(t, testDirectory)
+	vcrInstance := vcr.NewTestVCRInstance(t)
 	return NewAuthInstance(cfg, store.NewMemoryStore(), vcrInstance, cryptoInstance, nil)
 }
 

--- a/auth/services/contract/notary_test.go
+++ b/auth/services/contract/notary_test.go
@@ -225,7 +225,7 @@ func TestNewContractNotary(t *testing.T) {
 			Config{
 				ContractValidity: 60 * time.Minute,
 			},
-			vcr.NewTestVCRInstance(testDir),
+			vcr.NewTestVCRInstance(t, testDir),
 			doc.KeyResolver{Store: store.NewMemoryStore()},
 			crypto.NewTestCryptoInstance(testDir),
 		)

--- a/auth/services/contract/notary_test.go
+++ b/auth/services/contract/notary_test.go
@@ -225,7 +225,7 @@ func TestNewContractNotary(t *testing.T) {
 			Config{
 				ContractValidity: 60 * time.Minute,
 			},
-			vcr.NewTestVCRInstance(t, testDir),
+			vcr.NewTestVCRInstance(t),
 			doc.KeyResolver{Store: store.NewMemoryStore()},
 			crypto.NewTestCryptoInstance(testDir),
 		)

--- a/auth/test.go
+++ b/auth/test.go
@@ -19,16 +19,20 @@
 package auth
 
 import (
+	"testing"
+
 	"github.com/nuts-foundation/nuts-node/crypto"
+	"github.com/nuts-foundation/nuts-node/test/io"
 	"github.com/nuts-foundation/nuts-node/vcr"
 	"github.com/nuts-foundation/nuts-node/vdr/store"
 )
 
-func NewTestAuthInstance(testDirectory string) *Auth {
+func NewTestAuthInstance(t *testing.T) *Auth {
+	testDirectory := io.TestDirectory(t)
 	return NewAuthInstance(
 		TestConfig(),
 		store.NewMemoryStore(),
-		vcr.NewTestVCRInstance(testDirectory),
+		vcr.NewTestVCRInstance(t, testDirectory),
 		crypto.NewTestCryptoInstance(testDirectory),
 		nil,
 	)

--- a/auth/test.go
+++ b/auth/test.go
@@ -32,7 +32,7 @@ func NewTestAuthInstance(t *testing.T) *Auth {
 	return NewAuthInstance(
 		TestConfig(),
 		store.NewMemoryStore(),
-		vcr.NewTestVCRInstance(t, testDirectory),
+		vcr.NewTestVCRInstance(t),
 		crypto.NewTestCryptoInstance(testDirectory),
 		nil,
 	)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -195,9 +195,10 @@ func CreateSystem() *core.System {
 	system.RegisterEngine(statusEngine)
 	system.RegisterEngine(metricsEngine)
 	system.RegisterEngine(cryptoInstance)
+	// the order of the next 3 modules is fixed due to configure and start dependencies
+	system.RegisterEngine(credentialInstance)
 	system.RegisterEngine(networkInstance)
 	system.RegisterEngine(vdrInstance)
-	system.RegisterEngine(credentialInstance)
 	system.RegisterEngine(authInstance)
 	system.RegisterEngine(didmanInstance)
 

--- a/didman/api/v1/api.go
+++ b/didman/api/v1/api.go
@@ -286,7 +286,7 @@ func (w *Wrapper) GetContactInformation(ctx echo.Context, didStr string) error {
 // that map to the "organization" concept and where its subject resolves to an active DID Document.
 // It optionally filters only on organizations which DID documents contain a service with the specified type.
 func (w *Wrapper) SearchOrganizations(ctx echo.Context, params SearchOrganizationsParams) error {
-	results, err := w.Didman.SearchOrganizations(params.Query, params.DidServiceType)
+	results, err := w.Didman.SearchOrganizations(ctx.Request().Context(), params.Query, params.DidServiceType)
 	if err != nil {
 		return err
 	}

--- a/didman/api/v1/api_test.go
+++ b/didman/api/v1/api_test.go
@@ -620,7 +620,8 @@ func TestWrapper_SearchOrganizations(t *testing.T) {
 		ctx := newMockContext(t)
 		serviceType := "service"
 		results := []OrganizationSearchResult{{DIDDocument: did.Document{ID: *id}, Organization: map[string]interface{}{"name": "bar"}}}
-		ctx.didman.EXPECT().SearchOrganizations("query", &serviceType).Return(results, nil)
+		ctx.echo.EXPECT().Request().Return(&http.Request{})
+		ctx.didman.EXPECT().SearchOrganizations(gomock.Any(), "query", &serviceType).Return(results, nil)
 		ctx.echo.EXPECT().JSON(http.StatusOK, results)
 
 		err := ctx.wrapper.SearchOrganizations(ctx.echo, SearchOrganizationsParams{
@@ -633,7 +634,8 @@ func TestWrapper_SearchOrganizations(t *testing.T) {
 	t.Run("no results", func(t *testing.T) {
 		ctx := newMockContext(t)
 		serviceType := "service"
-		ctx.didman.EXPECT().SearchOrganizations("query", &serviceType).Return(nil, nil)
+		ctx.echo.EXPECT().Request().Return(&http.Request{})
+		ctx.didman.EXPECT().SearchOrganizations(gomock.Any(), "query", &serviceType).Return(nil, nil)
 		ctx.echo.EXPECT().JSON(http.StatusOK, []OrganizationSearchResult{})
 
 		err := ctx.wrapper.SearchOrganizations(ctx.echo, SearchOrganizationsParams{
@@ -645,7 +647,8 @@ func TestWrapper_SearchOrganizations(t *testing.T) {
 	})
 	t.Run("error - service fails", func(t *testing.T) {
 		ctx := newMockContext(t)
-		ctx.didman.EXPECT().SearchOrganizations("query", nil).Return(nil, types.ErrNotFound)
+		ctx.echo.EXPECT().Request().Return(&http.Request{})
+		ctx.didman.EXPECT().SearchOrganizations(gomock.Any(), "query", nil).Return(nil, types.ErrNotFound)
 		err := ctx.wrapper.SearchOrganizations(ctx.echo, SearchOrganizationsParams{Query: "query"})
 
 		assert.ErrorIs(t, err, types.ErrNotFound)

--- a/didman/didman.go
+++ b/didman/didman.go
@@ -20,6 +20,7 @@
 package didman
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
@@ -293,8 +294,8 @@ func (d *didman) GetContactInformation(id did.DID) (*ContactInformation, error) 
 	return nil, nil
 }
 
-func (d *didman) SearchOrganizations(query string, didServiceType *string) ([]OrganizationSearchResult, error) {
-	organizations, err := d.vcr.Search(concept.OrganizationConcept, false, map[string]string{concept.OrganizationName: query})
+func (d *didman) SearchOrganizations(ctx context.Context, query string, didServiceType *string) ([]OrganizationSearchResult, error) {
+	organizations, err := d.vcr.Search(ctx, concept.OrganizationConcept, false, map[string]string{concept.OrganizationName: query})
 	if err != nil {
 		return nil, err
 	}

--- a/didman/didman_test.go
+++ b/didman/didman_test.go
@@ -20,6 +20,7 @@
 package didman
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -729,13 +730,13 @@ func TestDidman_SearchOrganizations(t *testing.T) {
 	docWithoutService := did.Document{
 		ID: *id,
 	}
-	//
+	reqCtx := context.Background()
 
 	t.Run("ok - no results", func(t *testing.T) {
 		ctx := newMockContext(t)
-		ctx.vcr.EXPECT().Search("organization", false, map[string]string{"organization.name": "query"}).Return([]concept.Concept{}, nil)
+		ctx.vcr.EXPECT().Search(reqCtx, "organization", false, map[string]string{"organization.name": "query"}).Return([]concept.Concept{}, nil)
 
-		actual, err := ctx.instance.SearchOrganizations("query", nil)
+		actual, err := ctx.instance.SearchOrganizations(reqCtx, "query", nil)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, actual)
@@ -747,32 +748,32 @@ func TestDidman_SearchOrganizations(t *testing.T) {
 	}
 	t.Run("ok - no DID service type", func(t *testing.T) {
 		ctx := newMockContext(t)
-		ctx.vcr.EXPECT().Search("organization", false, map[string]string{"organization.name": "query"}).Return([]concept.Concept{cpt}, nil)
+		ctx.vcr.EXPECT().Search(reqCtx, "organization", false, map[string]string{"organization.name": "query"}).Return([]concept.Concept{cpt}, nil)
 		ctx.docResolver.EXPECT().Resolve(*id, nil).Return(&docWithoutService, nil, nil)
 
-		actual, err := ctx.instance.SearchOrganizations("query", nil)
+		actual, err := ctx.instance.SearchOrganizations(reqCtx, "query", nil)
 
 		assert.NoError(t, err)
 		assert.Len(t, actual, 1)
 	})
 	t.Run("ok - with DID service type (matches)", func(t *testing.T) {
 		ctx := newMockContext(t)
-		ctx.vcr.EXPECT().Search("organization", false, map[string]string{"organization.name": "query"}).Return([]concept.Concept{cpt}, nil)
+		ctx.vcr.EXPECT().Search(reqCtx, "organization", false, map[string]string{"organization.name": "query"}).Return([]concept.Concept{cpt}, nil)
 		ctx.docResolver.EXPECT().Resolve(*id, nil).Return(&docWithService, nil, nil)
 
 		serviceType := "eOverdracht"
-		actual, err := ctx.instance.SearchOrganizations("query", &serviceType)
+		actual, err := ctx.instance.SearchOrganizations(reqCtx, "query", &serviceType)
 
 		assert.NoError(t, err)
 		assert.Len(t, actual, 1)
 	})
 	t.Run("ok - with DID service type (no match)", func(t *testing.T) {
 		ctx := newMockContext(t)
-		ctx.vcr.EXPECT().Search("organization", false, map[string]string{"organization.name": "query"}).Return([]concept.Concept{cpt}, nil)
+		ctx.vcr.EXPECT().Search(reqCtx, "organization", false, map[string]string{"organization.name": "query"}).Return([]concept.Concept{cpt}, nil)
 		ctx.docResolver.EXPECT().Resolve(*id, nil).Return(&docWithoutService, nil, nil)
 
 		serviceType := "eOverdracht"
-		actual, err := ctx.instance.SearchOrganizations("query", &serviceType)
+		actual, err := ctx.instance.SearchOrganizations(reqCtx, "query", &serviceType)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, actual)
@@ -780,10 +781,10 @@ func TestDidman_SearchOrganizations(t *testing.T) {
 	})
 	t.Run("ok - DID document not found (logs, omits result)", func(t *testing.T) {
 		ctx := newMockContext(t)
-		ctx.vcr.EXPECT().Search("organization", false, map[string]string{"organization.name": "query"}).Return([]concept.Concept{cpt}, nil)
+		ctx.vcr.EXPECT().Search(reqCtx, "organization", false, map[string]string{"organization.name": "query"}).Return([]concept.Concept{cpt}, nil)
 		ctx.docResolver.EXPECT().Resolve(*id, nil).Return(nil, nil, types.ErrNotFound)
 
-		actual, err := ctx.instance.SearchOrganizations("query", nil)
+		actual, err := ctx.instance.SearchOrganizations(reqCtx, "query", nil)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, actual)
@@ -791,10 +792,10 @@ func TestDidman_SearchOrganizations(t *testing.T) {
 	})
 	t.Run("ok - DID document deactivated (logs, omits result)", func(t *testing.T) {
 		ctx := newMockContext(t)
-		ctx.vcr.EXPECT().Search("organization", false, map[string]string{"organization.name": "query"}).Return([]concept.Concept{cpt}, nil)
+		ctx.vcr.EXPECT().Search(reqCtx, "organization", false, map[string]string{"organization.name": "query"}).Return([]concept.Concept{cpt}, nil)
 		ctx.docResolver.EXPECT().Resolve(*id, nil).Return(nil, nil, types.ErrDeactivated)
 
-		actual, err := ctx.instance.SearchOrganizations("query", nil)
+		actual, err := ctx.instance.SearchOrganizations(reqCtx, "query", nil)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, actual)
@@ -802,10 +803,10 @@ func TestDidman_SearchOrganizations(t *testing.T) {
 	})
 	t.Run("error - other error while resolving DID document", func(t *testing.T) {
 		ctx := newMockContext(t)
-		ctx.vcr.EXPECT().Search("organization", false, map[string]string{"organization.name": "query"}).Return([]concept.Concept{cpt}, nil)
+		ctx.vcr.EXPECT().Search(reqCtx, "organization", false, map[string]string{"organization.name": "query"}).Return([]concept.Concept{cpt}, nil)
 		ctx.docResolver.EXPECT().Resolve(*id, nil).Return(nil, nil, io.EOF)
 
-		actual, err := ctx.instance.SearchOrganizations("query", nil)
+		actual, err := ctx.instance.SearchOrganizations(reqCtx, "query", nil)
 
 		assert.Error(t, err)
 		assert.Nil(t, actual)

--- a/didman/mock.go
+++ b/didman/mock.go
@@ -5,6 +5,7 @@
 package didman
 
 import (
+	context "context"
 	url "net/url"
 	reflect "reflect"
 
@@ -140,18 +141,18 @@ func (mr *MockDidmanMockRecorder) GetContactInformation(id interface{}) *gomock.
 }
 
 // SearchOrganizations mocks base method.
-func (m *MockDidman) SearchOrganizations(query string, didServiceType *string) ([]OrganizationSearchResult, error) {
+func (m *MockDidman) SearchOrganizations(ctx context.Context, query string, didServiceType *string) ([]OrganizationSearchResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchOrganizations", query, didServiceType)
+	ret := m.ctrl.Call(m, "SearchOrganizations", ctx, query, didServiceType)
 	ret0, _ := ret[0].([]OrganizationSearchResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchOrganizations indicates an expected call of SearchOrganizations.
-func (mr *MockDidmanMockRecorder) SearchOrganizations(query, didServiceType interface{}) *gomock.Call {
+func (mr *MockDidmanMockRecorder) SearchOrganizations(ctx, query, didServiceType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchOrganizations", reflect.TypeOf((*MockDidman)(nil).SearchOrganizations), query, didServiceType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchOrganizations", reflect.TypeOf((*MockDidman)(nil).SearchOrganizations), ctx, query, didServiceType)
 }
 
 // UpdateContactInformation mocks base method.

--- a/didman/types.go
+++ b/didman/types.go
@@ -20,6 +20,7 @@
 package didman
 
 import (
+	"context"
 	"net/url"
 
 	ssi "github.com/nuts-foundation/go-did"
@@ -70,7 +71,7 @@ type Didman interface {
 
 	// SearchOrganizations searches VCR for organizations which's name matches the given query.
 	// It then optionally filters on those which have a service of the specified type on their DID Document.
-	SearchOrganizations(query string, didServiceType *string) ([]OrganizationSearchResult, error)
+	SearchOrganizations(ctx context.Context, query string, didServiceType *string) ([]OrganizationSearchResult, error)
 }
 
 // ServiceResolver defines high-level operations for resolving services of DID documents.

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nats-io/nats-server/v2 v2.6.5
 	github.com/nats-io/nats.go v1.13.1-0.20211018182449-f2416a8b1483
 	github.com/nuts-foundation/go-did v0.1.1
-	github.com/nuts-foundation/go-leia v1.1.0
+	github.com/nuts-foundation/go-leia/v2 v2.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/privacybydesign/irmago v0.8.0
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -484,8 +484,8 @@ github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443/go.mod h1:Jbxf
 github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
 github.com/nuts-foundation/go-did v0.1.1 h1:Yn4Ejjyj4/3urI3HfmOAJnYO2kBrwPFfR+BZKY/uFdc=
 github.com/nuts-foundation/go-did v0.1.1/go.mod h1:tWZ+glowEt1E+SqJQzqyXB3rGuZ+AZHSsXYU9ceuMRM=
-github.com/nuts-foundation/go-leia v1.1.0 h1:gdzrN/8BZ27SYKVO74qW0+n5EXyMvpr7eo22PFnp9s8=
-github.com/nuts-foundation/go-leia v1.1.0/go.mod h1:v14ZhzDLCeWcncRwpoiCmMI3zjWw/ZotXV2bQfP7zm8=
+github.com/nuts-foundation/go-leia/v2 v2.0.0 h1:vbAfkEEXedERTuourPfLkjG3mV0lMafM7+qtTqBn6gk=
+github.com/nuts-foundation/go-leia/v2 v2.0.0/go.mod h1:cr5+rs7z8Q2FIE6wwLxmsjarqgBpMqUkty9VpBaxB/w=
 github.com/ockam-network/did v0.1.4-0.20210103172416-02ae01ce06d8 h1:s5GFggECXv/KwF37ax4B7ACMOKoUnKvmur4i+7I07UE=
 github.com/ockam-network/did v0.1.4-0.20210103172416-02ae01ce06d8 h1:s5GFggECXv/KwF37ax4B7ACMOKoUnKvmur4i+7I07UE=
 github.com/ockam-network/did v0.1.4-0.20210103172416-02ae01ce06d8/go.mod h1:ZsbTIuVGt8OrQEbqWrSztUISN4joeMabdsinbLubbzw=

--- a/network/interface.go
+++ b/network/interface.go
@@ -19,8 +19,9 @@
 package network
 
 import (
-	"github.com/nuts-foundation/nuts-node/network/transport"
 	"time"
+
+	"github.com/nuts-foundation/nuts-node/network/transport"
 
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"

--- a/network/network.go
+++ b/network/network.go
@@ -186,7 +186,6 @@ func (n *Network) Config() interface{} {
 
 // Start initiates the Network subsystem
 func (n *Network) Start() error {
-	log.Logger().Debugf("starting %s", ModuleName)
 	n.startTime.Store(time.Now())
 
 	// Load DAG and start publishing
@@ -229,8 +228,6 @@ func (n *Network) Start() error {
 		}
 		n.connectionManager.Connect(bootstrapNode)
 	}
-
-	log.Logger().Infof("started %s", ModuleName)
 
 	return nil
 }

--- a/network/network.go
+++ b/network/network.go
@@ -22,12 +22,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/nuts-foundation/go-did/did"
-	"github.com/nuts-foundation/nuts-node/network/transport"
-	"github.com/nuts-foundation/nuts-node/network/transport/grpc"
-	"github.com/nuts-foundation/nuts-node/network/transport/v1"
-	v2 "github.com/nuts-foundation/nuts-node/network/transport/v2"
-	"github.com/pkg/errors"
 	"os"
 	"path"
 	"path/filepath"
@@ -35,6 +29,13 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/network/transport"
+	"github.com/nuts-foundation/nuts-node/network/transport/grpc"
+	"github.com/nuts-foundation/nuts-node/network/transport/v1"
+	v2 "github.com/nuts-foundation/nuts-node/network/transport/v2"
+	"github.com/pkg/errors"
 
 	"github.com/google/uuid"
 	"github.com/nuts-foundation/nuts-node/core"
@@ -46,15 +47,13 @@ import (
 	"go.etcd.io/bbolt"
 )
 
-// boltDBFileMode holds the Unix file mode the created BBolt database files will have.
-const boltDBFileMode = 0600
-
-// softwareID contains the name of the vendor/implementation that's published in the node's diagnostic information.
-const softwareID = "https://github.com/nuts-foundation/nuts-node"
-
 const (
+	// boltDBFileMode holds the Unix file mode the created BBolt database files will have.
+	boltDBFileMode = 0600
 	// ModuleName specifies the name of this module.
 	ModuleName = "Network"
+	// softwareID contains the name of the vendor/implementation that's published in the node's diagnostic information.
+	softwareID = "https://github.com/nuts-foundation/nuts-node"
 )
 
 // defaultBBoltOptions are given to bbolt, allows for package local adjustments during test
@@ -187,6 +186,7 @@ func (n *Network) Config() interface{} {
 
 // Start initiates the Network subsystem
 func (n *Network) Start() error {
+	log.Logger().Debugf("starting %s", ModuleName)
 	n.startTime.Store(time.Now())
 
 	// Load DAG and start publishing
@@ -229,6 +229,8 @@ func (n *Network) Start() error {
 		}
 		n.connectionManager.Connect(bootstrapNode)
 	}
+
+	log.Logger().Infof("started %s", ModuleName)
 
 	return nil
 }

--- a/network/transport/connection_manager.go
+++ b/network/transport/connection_manager.go
@@ -54,4 +54,3 @@ type FixedNodeDIDResolver struct {
 func (f FixedNodeDIDResolver) Resolve() (did.DID, error) {
 	return f.NodeDID, nil
 }
-

--- a/network/transport/v1/logic/blocks_test.go
+++ b/network/transport/v1/logic/blocks_test.go
@@ -304,9 +304,9 @@ func TestMultiXOR(t *testing.T) {
 }
 
 type testTX struct {
-	data []byte
-	prev []hash.SHA256Hash
-	sigt time.Time
+	data   []byte
+	prev   []hash.SHA256Hash
+	sigt   time.Time
 	toAddr []byte
 }
 

--- a/vcr/api/v1/api.go
+++ b/vcr/api/v1/api.go
@@ -84,7 +84,7 @@ func (w *Wrapper) Search(ctx echo.Context, conceptName string, requestParams Sea
 		untrusted = *requestParams.Untrusted
 	}
 
-	results, err := w.R.Search(conceptName, untrusted, params)
+	results, err := w.R.Search(ctx.Request().Context(), conceptName, untrusted, params)
 	if err != nil {
 		return err
 	}

--- a/vcr/api/v1/api_test.go
+++ b/vcr/api/v1/api_test.go
@@ -246,13 +246,14 @@ func TestWrapper_Search(t *testing.T) {
 		defer ctx.ctrl.Finish()
 
 		var capturedConcept []concept.Concept
+		ctx.echo.EXPECT().Request().Return(&http.Request{})
 		ctx.echo.EXPECT().Bind(gomock.Any()).DoAndReturn(func(f interface{}) error {
 			sr := f.(*SearchRequest)
 			*sr = searchRequest
 			return nil
 		})
 		cpt := concept.Concept(map[string]interface{}{"foo": "bar"})
-		ctx.vcr.EXPECT().Search(gomock.Any(), false, map[string]string{"name": "Because we care B.V."}).Return([]concept.Concept{cpt}, nil)
+		ctx.vcr.EXPECT().Search(gomock.Any(), gomock.Any(), false, map[string]string{"name": "Because we care B.V."}).Return([]concept.Concept{cpt}, nil)
 		ctx.echo.EXPECT().JSON(http.StatusOK, gomock.Any()).DoAndReturn(func(f interface{}, f2 interface{}) error {
 			capturedConcept = f2.([]concept.Concept)
 			return nil
@@ -285,8 +286,9 @@ func TestWrapper_Search(t *testing.T) {
 		defer ctx.ctrl.Finish()
 		trueVal := true
 
+		ctx.echo.EXPECT().Request().Return(&http.Request{})
 		ctx.echo.EXPECT().Bind(gomock.Any())
-		ctx.vcr.EXPECT().Search(gomock.Any(), true, map[string]string{}).Return(nil, errors.New("b00m!"))
+		ctx.vcr.EXPECT().Search(gomock.Any(), gomock.Any(), true, map[string]string{}).Return(nil, errors.New("b00m!"))
 
 		err := ctx.client.Search(ctx.echo, "human", SearchParams{Untrusted: &trueVal})
 

--- a/vcr/concept/phonetics.go
+++ b/vcr/concept/phonetics.go
@@ -21,7 +21,7 @@ package concept
 
 import (
 	gophonetics "github.com/Regis24GmbH/go-phonetics"
-	"github.com/nuts-foundation/go-leia"
+	"github.com/nuts-foundation/go-leia/v2"
 )
 
 // CologneTransformer is a go-leia compatible function for generating the phonetic representation of a string.

--- a/vcr/concept/phonetics_test.go
+++ b/vcr/concept/phonetics_test.go
@@ -22,7 +22,7 @@ package concept
 import (
 	"testing"
 
-	"github.com/nuts-foundation/go-leia"
+	"github.com/nuts-foundation/go-leia/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/vcr/config.go
+++ b/vcr/config.go
@@ -25,6 +25,8 @@ const moduleName = "VCR"
 type Config struct {
 	// strictMode is a copy from the core server config
 	strictMode bool
+	// datadir holds the location the VCR files are stored
+	datadir string
 }
 
 // DefaultConfig returns a fresh Config filled with default values

--- a/vcr/interface.go
+++ b/vcr/interface.go
@@ -20,6 +20,7 @@
 package vcr
 
 import (
+	"context"
 	"embed"
 	"errors"
 	"time"
@@ -66,7 +67,8 @@ type ConceptFinder interface {
 
 	// Search for matching concepts based upon a query. It returns an empty list if no matches have been found.
 	// It also returns untrusted credentials when allowUntrusted == true
-	Search(conceptName string, allowUntrusted bool, query map[string]string) ([]concept.Concept, error)
+	// a context must be passed to prevent long-running queries
+	Search(ctx context.Context, conceptName string, allowUntrusted bool, query map[string]string) ([]concept.Concept, error)
 }
 
 // Validator is the VCR interface for validation options

--- a/vcr/mock.go
+++ b/vcr/mock.go
@@ -5,6 +5,7 @@
 package vcr
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -54,18 +55,18 @@ func (mr *MockConceptFinderMockRecorder) Get(conceptName, allowUntrusted, subjec
 }
 
 // Search mocks base method.
-func (m *MockConceptFinder) Search(conceptName string, allowUntrusted bool, query map[string]string) ([]concept.Concept, error) {
+func (m *MockConceptFinder) Search(ctx context.Context, conceptName string, allowUntrusted bool, query map[string]string) ([]concept.Concept, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Search", conceptName, allowUntrusted, query)
+	ret := m.ctrl.Call(m, "Search", ctx, conceptName, allowUntrusted, query)
 	ret0, _ := ret[0].([]concept.Concept)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Search indicates an expected call of Search.
-func (mr *MockConceptFinderMockRecorder) Search(conceptName, allowUntrusted, query interface{}) *gomock.Call {
+func (mr *MockConceptFinderMockRecorder) Search(ctx, conceptName, allowUntrusted, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockConceptFinder)(nil).Search), conceptName, allowUntrusted, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockConceptFinder)(nil).Search), ctx, conceptName, allowUntrusted, query)
 }
 
 // MockValidator is a mock of Validator interface.
@@ -387,18 +388,18 @@ func (mr *MockVCRMockRecorder) Revoke(ID interface{}) *gomock.Call {
 }
 
 // Search mocks base method.
-func (m *MockVCR) Search(conceptName string, allowUntrusted bool, query map[string]string) ([]concept.Concept, error) {
+func (m *MockVCR) Search(ctx context.Context, conceptName string, allowUntrusted bool, query map[string]string) ([]concept.Concept, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Search", conceptName, allowUntrusted, query)
+	ret := m.ctrl.Call(m, "Search", ctx, conceptName, allowUntrusted, query)
 	ret0, _ := ret[0].([]concept.Concept)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Search indicates an expected call of Search.
-func (mr *MockVCRMockRecorder) Search(conceptName, allowUntrusted, query interface{}) *gomock.Call {
+func (mr *MockVCRMockRecorder) Search(ctx, conceptName, allowUntrusted, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockVCR)(nil).Search), conceptName, allowUntrusted, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockVCR)(nil).Search), ctx, conceptName, allowUntrusted, query)
 }
 
 // StoreCredential mocks base method.

--- a/vcr/store.go
+++ b/vcr/store.go
@@ -31,6 +31,8 @@ import (
 )
 
 const revocationCollection = "_revocation"
+// maxFindExecutionTime indicates how long a "find by id" type query may take
+const maxFindExecutionTime = 1 * time.Second
 
 func (c *vcr) StoreCredential(credential vc.VerifiableCredential, validAt *time.Time) error {
 	// verify first

--- a/vcr/store.go
+++ b/vcr/store.go
@@ -26,7 +26,7 @@ import (
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/vcr/log"
 
-	"github.com/nuts-foundation/go-leia"
+	"github.com/nuts-foundation/go-leia/v2"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 )
 

--- a/vcr/store.go
+++ b/vcr/store.go
@@ -31,6 +31,7 @@ import (
 )
 
 const revocationCollection = "_revocation"
+
 // maxFindExecutionTime indicates how long a "find by id" type query may take
 const maxFindExecutionTime = 1 * time.Second
 

--- a/vcr/test.go
+++ b/vcr/test.go
@@ -37,9 +37,10 @@ const testKID = "did:nuts:CuE3qeFGGLhEAS3gKzhMCeqd1dGa9at5JCbmCfyMU2Ey#sNGDQ3NlO
 
 // NewTestVCRInstance returns a new vcr instance to be used for integration tests. Any data is stored in the
 // specified test directory.
-func NewTestVCRInstance(t *testing.T, testDirectory string) *vcr {
+func NewTestVCRInstance(t *testing.T) *vcr {
 	// speedup tests
 	noSync = true
+	testDirectory := io.TestDirectory(t)
 	// give network a sub directory to avoid duplicate networks in tests
 	newInstance := NewVCRInstance(
 		nil,

--- a/vcr/test.go
+++ b/vcr/test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/test/io"
 	"github.com/nuts-foundation/nuts-node/vcr/trust"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
-	"github.com/sirupsen/logrus"
 )
 
 // keyID matches the keys in /test
@@ -38,7 +37,7 @@ const testKID = "did:nuts:CuE3qeFGGLhEAS3gKzhMCeqd1dGa9at5JCbmCfyMU2Ey#sNGDQ3NlO
 
 // NewTestVCRInstance returns a new vcr instance to be used for integration tests. Any data is stored in the
 // specified test directory.
-func NewTestVCRInstance(testDirectory string) *vcr {
+func NewTestVCRInstance(t *testing.T, testDirectory string) *vcr {
 	// speedup tests
 	noSync = true
 	// give network a sub directory to avoid duplicate networks in tests
@@ -50,7 +49,10 @@ func NewTestVCRInstance(testDirectory string) *vcr {
 	).(*vcr)
 
 	if err := newInstance.Configure(core.ServerConfig{Datadir: testDirectory}); err != nil {
-		logrus.Fatal(err)
+		t.Fatal(err)
+	}
+	if err := newInstance.Start(); err != nil {
+		t.Fatal(err)
 	}
 
 	return newInstance
@@ -82,6 +84,12 @@ func newMockContext(t *testing.T) mockContext {
 	if err := vcr.Configure(core.ServerConfig{Datadir: testDir}); err != nil {
 		t.Fatal(err)
 	}
+	if err := vcr.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		vcr.Shutdown()
+	})
 	return mockContext{
 		ctrl:        ctrl,
 		crypto:      crypto,

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -430,8 +430,10 @@ func (c *vcr) find(ID ssi.URI) (vc.VerifiableCredential, error) {
 	qp := leia.Eq(concept.IDField, ID.String())
 	q := leia.New(qp)
 
+	ctx, cancel := context.WithTimeout(context.Background(), maxFindExecutionTime)
+	defer cancel()
 	for _, t := range c.registry.Concepts() {
-		docs, err := c.store.Collection(t.CredentialType).Find(context.TODO(), q)
+		docs, err := c.store.Collection(t.CredentialType).Find(ctx, q)
 		if err != nil {
 			return credential, err
 		}
@@ -650,8 +652,10 @@ func (c *vcr) Get(conceptName string, allowUntrusted bool, subject string) (conc
 
 	q.AddClause(concept.Eq(concept.SubjectField, subject))
 
+	ctx, cancel := context.WithTimeout(context.Background(), maxFindExecutionTime)
+	defer cancel()
 	// finding a VC that backs a concept always occurs in the present, so no resolveTime needs to be passed.
-	vcs, err := c.search(context.TODO(), q, allowUntrusted, nil)
+	vcs, err := c.search(ctx, q, allowUntrusted, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -745,7 +749,9 @@ func (c *vcr) isRevoked(ID ssi.URI) (bool, error) {
 	q := leia.New(qp)
 
 	gIndex := c.revocationIndex()
-	docs, err := gIndex.Find(context.TODO(), q)
+	ctx, cancel := context.WithTimeout(context.Background(), maxFindExecutionTime)
+	defer cancel()
+	docs, err := gIndex.Find(ctx, q)
 	if err != nil {
 		return false, err
 	}

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -52,8 +52,6 @@ import (
 
 const (
 	maxSkew = 5 * time.Second
-	// ModuleName specifies the name of this module.
-	ModuleName = "VCR"
 )
 
 var timeFunc = time.Now
@@ -96,7 +94,7 @@ func (c *vcr) Registry() concept.Reader {
 func (c *vcr) Configure(config core.ServerConfig) error {
 	var err error
 
-	// store strictMode
+	// store config parameters for use in Start()
 	c.config = Config{strictMode: config.Strictmode, datadir: config.Datadir}
 
 	tcPath := path.Join(config.Datadir, "vcr", "trusted_issuers.yaml")
@@ -130,7 +128,6 @@ func (c *vcr) Migrate() error {
 
 func (c *vcr) Start() error {
 	var err error
-	log.Logger().Debugf("starting %s", ModuleName)
 
 	// setup DB connection
 	if c.store, err = leia.NewStore(c.credentialsDBPath(), noSync); err != nil {
@@ -144,8 +141,6 @@ func (c *vcr) Start() error {
 
 	// start listening for new credentials
 	c.ambassador.Configure()
-
-	log.Logger().Infof("started %s", ModuleName)
 
 	return nil
 }

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -20,10 +20,12 @@
 package vcr
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -33,7 +35,7 @@ import (
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
-	"github.com/nuts-foundation/go-leia"
+	"github.com/nuts-foundation/go-leia/v2"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
@@ -91,9 +93,8 @@ func (c *vcr) Configure(config core.ServerConfig) error {
 	var err error
 
 	// store strictMode
-	c.config = Config{strictMode: config.Strictmode}
+	c.config = Config{strictMode: config.Strictmode, datadir: config.Datadir}
 
-	fsPath := path.Join(config.Datadir, "vcr", "credentials.db")
 	tcPath := path.Join(config.Datadir, "vcr", "trusted_issuers.yaml")
 
 	// load VC concept templates
@@ -104,12 +105,30 @@ func (c *vcr) Configure(config core.ServerConfig) error {
 	// load trusted issuers
 	c.trustConfig = trust.NewConfig(tcPath)
 
-	if err = c.trustConfig.Load(); err != nil {
-		return err
+	return c.trustConfig.Load()
+}
+
+func (c *vcr) credentialsDBPath() string {
+	return path.Join(c.config.datadir, "vcr", "credentials.db")
+}
+
+func (c *vcr) Migrate() error {
+	// the migration to go-leia V2 needs a fresh DB
+	// The DAG is rewalked so all entries are added
+	// just delete
+	// TODO remove after all parties in development network have migrated.
+	err := os.Remove(c.credentialsDBPath())
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
 	}
+	return err
+}
+
+func (c *vcr) Start() error {
+	var err error
 
 	// setup DB connection
-	if c.store, err = leia.NewStore(fsPath, noSync); err != nil {
+	if c.store, err = leia.NewStore(c.credentialsDBPath(), noSync); err != nil {
 		return err
 	}
 
@@ -122,6 +141,10 @@ func (c *vcr) Configure(config core.ServerConfig) error {
 	c.ambassador.Configure()
 
 	return nil
+}
+
+func (c *vcr) Shutdown() error {
+	return c.store.Close()
 }
 
 func (c *vcr) loadTemplates() error {
@@ -217,13 +240,13 @@ func (c *vcr) Config() interface{} {
 
 // search for matching credentials based upon a query. It returns an empty list if no matches have been found.
 // The optional resolveTime will search for credentials at that point in time.
-func (c *vcr) search(query concept.Query, allowUntrusted bool, resolveTime *time.Time) ([]vc.VerifiableCredential, error) {
+func (c *vcr) search(ctx context.Context, query concept.Query, allowUntrusted bool, resolveTime *time.Time) ([]vc.VerifiableCredential, error) {
 	//transform query to leia query, for each template a query is returned
 	queries := c.convert(query)
 
 	var VCs = make([]vc.VerifiableCredential, 0)
 	for vcType, q := range queries {
-		docs, err := c.store.Collection(vcType).Find(q)
+		docs, err := c.store.Collection(vcType).Find(ctx, q)
 		if err != nil {
 			return nil, err
 		}
@@ -406,7 +429,7 @@ func (c *vcr) find(ID ssi.URI) (vc.VerifiableCredential, error) {
 	q := leia.New(qp)
 
 	for _, t := range c.registry.Concepts() {
-		docs, err := c.store.Collection(t.CredentialType).Find(q)
+		docs, err := c.store.Collection(t.CredentialType).Find(context.TODO(), q)
 		if err != nil {
 			return credential, err
 		}
@@ -626,7 +649,7 @@ func (c *vcr) Get(conceptName string, allowUntrusted bool, subject string) (conc
 	q.AddClause(concept.Eq(concept.SubjectField, subject))
 
 	// finding a VC that backs a concept always occurs in the present, so no resolveTime needs to be passed.
-	vcs, err := c.search(q, allowUntrusted, nil)
+	vcs, err := c.search(context.TODO(), q, allowUntrusted, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -639,7 +662,7 @@ func (c *vcr) Get(conceptName string, allowUntrusted bool, subject string) (conc
 	return c.Registry().Transform(conceptName, vcs[0])
 }
 
-func (c *vcr) Search(conceptName string, allowUntrusted bool, queryParams map[string]string) ([]concept.Concept, error) {
+func (c *vcr) Search(ctx context.Context, conceptName string, allowUntrusted bool, queryParams map[string]string) ([]concept.Concept, error) {
 	query, err := c.registry.QueryFor(conceptName)
 	if err != nil {
 		return nil, err
@@ -649,7 +672,7 @@ func (c *vcr) Search(conceptName string, allowUntrusted bool, queryParams map[st
 		query.AddClause(concept.Prefix(key, value))
 	}
 
-	results, err := c.search(query, allowUntrusted, nil)
+	results, err := c.search(ctx, query, allowUntrusted, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -720,7 +743,7 @@ func (c *vcr) isRevoked(ID ssi.URI) (bool, error) {
 	q := leia.New(qp)
 
 	gIndex := c.revocationIndex()
-	docs, err := gIndex.Find(q)
+	docs, err := gIndex.Find(context.TODO(), q)
 	if err != nil {
 		return false, err
 	}

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -50,7 +50,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const maxSkew = 5 * time.Second
+const (
+	maxSkew = 5 * time.Second
+	// ModuleName specifies the name of this module.
+	ModuleName = "VCR"
+)
 
 var timeFunc = time.Now
 
@@ -126,6 +130,7 @@ func (c *vcr) Migrate() error {
 
 func (c *vcr) Start() error {
 	var err error
+	log.Logger().Debugf("starting %s", ModuleName)
 
 	// setup DB connection
 	if c.store, err = leia.NewStore(c.credentialsDBPath(), noSync); err != nil {
@@ -139,6 +144,8 @@ func (c *vcr) Start() error {
 
 	// start listening for new credentials
 	c.ambassador.Configure()
+
+	log.Logger().Infof("started %s", ModuleName)
 
 	return nil
 }

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -20,6 +20,7 @@
 package vcr
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"encoding/json"
 	"errors"
@@ -35,7 +36,7 @@ import (
 	ssi "github.com/nuts-foundation/go-did"
 	did2 "github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
-	"github.com/nuts-foundation/go-leia"
+	"github.com/nuts-foundation/go-leia/v2"
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/vcr/trust"
@@ -53,35 +54,40 @@ import (
 
 func TestVCR_Configure(t *testing.T) {
 
+	t.Run("loads default configs", func(t *testing.T) {
+		testDir := io.TestDirectory(t)
+		instance := NewTestVCRInstance(t, testDir)
+
+		concepts := instance.registry.Concepts()
+
+		if !assert.Len(t, concepts, 2) {
+			return
+		}
+
+		assert.Equal(t, "NutsAuthorizationCredential", concepts[0].CredentialType)
+		assert.Equal(t, "authorization", concepts[0].Concept)
+		assert.Equal(t, "NutsOrganizationCredential", concepts[1].CredentialType)
+		assert.Equal(t, "organization", concepts[1].Concept)
+	})
+}
+
+func TestVCR_Start(t *testing.T) {
+
 	t.Run("error - creating db", func(t *testing.T) {
 		instance := NewVCRInstance(nil, nil, nil, nil).(*vcr)
 
-		err := instance.Configure(core.ServerConfig{Datadir: "test"})
+		_ = instance.Configure(core.ServerConfig{Datadir: "test"})
+		err := instance.Start()
 		assert.Error(t, err)
 	})
 
 	t.Run("ok", func(t *testing.T) {
 		testDir := io.TestDirectory(t)
-		instance := NewTestVCRInstance(testDir)
+		_ = NewTestVCRInstance(t, testDir)
 
-		t.Run("loads default configs", func(t *testing.T) {
-			concepts := instance.registry.Concepts()
-
-			if !assert.Len(t, concepts, 2) {
-				return
-			}
-
-			assert.Equal(t, "NutsAuthorizationCredential", concepts[0].CredentialType)
-			assert.Equal(t, "authorization", concepts[0].Concept)
-			assert.Equal(t, "NutsOrganizationCredential", concepts[1].CredentialType)
-			assert.Equal(t, "organization", concepts[1].Concept)
-		})
-
-		t.Run("initializes DB", func(t *testing.T) {
-			fsPath := path.Join(testDir, "vcr", "credentials.db")
-			_, err := os.Stat(fsPath)
-			assert.NoError(t, err)
-		})
+		fsPath := path.Join(testDir, "vcr", "credentials.db")
+		_, err := os.Stat(fsPath)
+		assert.NoError(t, err)
 	})
 }
 
@@ -119,6 +125,7 @@ func TestVCR_SearchInternal(t *testing.T) {
 		return ctx, q
 	}
 
+	reqCtx := context.Background()
 	now := time.Now()
 	timeFunc = func() time.Time {
 		return now
@@ -132,7 +139,7 @@ func TestVCR_SearchInternal(t *testing.T) {
 		ctx.vcr.Trust(vc.Type[0], vc.Issuer)
 		ctx.docResolver.EXPECT().Resolve(*issuer, &types.ResolveMetadata{ResolveTime: &now}).Return(nil, nil, nil)
 
-		creds, err := ctx.vcr.search(q, false, &now)
+		creds, err := ctx.vcr.search(reqCtx, q, false, &now)
 
 		if !assert.NoError(t, err) {
 			return
@@ -150,7 +157,7 @@ func TestVCR_SearchInternal(t *testing.T) {
 	t.Run("ok - untrusted", func(t *testing.T) {
 		ctx, q := testInstance(t)
 
-		creds, err := ctx.vcr.search(q, false, nil)
+		creds, err := ctx.vcr.search(reqCtx, q, false, nil)
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -162,7 +169,7 @@ func TestVCR_SearchInternal(t *testing.T) {
 		ctx, q := testInstance(t)
 		ctx.docResolver.EXPECT().Resolve(*issuer, &types.ResolveMetadata{ResolveTime: &now}).Return(nil, nil, nil)
 
-		creds, err := ctx.vcr.search(q, true, nil)
+		creds, err := ctx.vcr.search(reqCtx, q, true, nil)
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -175,7 +182,7 @@ func TestVCR_SearchInternal(t *testing.T) {
 		ctx.vcr.Trust(vc.Type[0], vc.Issuer)
 		rev := leia.DocumentFromString(concept.TestRevocation)
 		ctx.vcr.store.Collection(revocationCollection).Add([]leia.Document{rev})
-		creds, err := ctx.vcr.search(q, false, nil)
+		creds, err := ctx.vcr.search(reqCtx, q, false, nil)
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -188,7 +195,7 @@ func TestVCR_SearchInternal(t *testing.T) {
 		ctx.vcr.Trust(vc.Type[0], vc.Issuer)
 		ctx.docResolver.EXPECT().Resolve(*issuer, &types.ResolveMetadata{ResolveTime: &now}).Return(nil, nil, types.ErrNotFound)
 
-		creds, err := ctx.vcr.search(q, false, nil)
+		creds, err := ctx.vcr.search(reqCtx, q, false, nil)
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -300,7 +307,7 @@ func TestVCR_Resolve(t *testing.T) {
 
 func TestVcr_Instance(t *testing.T) {
 	testDir := io.TestDirectory(t)
-	instance := NewTestVCRInstance(testDir)
+	instance := NewTestVCRInstance(t, testDir)
 
 	t.Run("ok - name", func(t *testing.T) {
 		assert.Equal(t, moduleName, instance.Name())
@@ -309,7 +316,7 @@ func TestVcr_Instance(t *testing.T) {
 	t.Run("ok - config defaults", func(t *testing.T) {
 		cfg := instance.Config().(*Config)
 
-		assert.Equal(t, DefaultConfig(), *cfg)
+		assert.Equal(t, DefaultConfig().strictMode, cfg.strictMode)
 	})
 }
 
@@ -991,14 +998,14 @@ func TestVCR_Search(t *testing.T) {
 		ctx.docResolver.EXPECT().Resolve(gomock.Any(), gomock.Any()).Return(nil, nil, nil)
 		doc := leia.DocumentFromString(concept.TestCredential)
 		ctx.vcr.store.Collection(concept.ExampleType).Add([]leia.Document{doc})
-		results, _ := ctx.vcr.Search("human", false, map[string]string{"human.eyeColour": "blue/grey"})
+		results, _ := ctx.vcr.Search(context.Background(), "human", false, map[string]string{"human.eyeColour": "blue/grey"})
 		assert.Len(t, results, 1)
 	})
 
 	t.Run("error - unknown concept", func(t *testing.T) {
 		ctx := newMockContext(t)
 
-		results, err := ctx.vcr.Search("unknown", false, map[string]string{"human.eyeColour": "blue/grey"})
+		results, err := ctx.vcr.Search(context.Background(), "unknown", false, map[string]string{"human.eyeColour": "blue/grey"})
 		assert.ErrorIs(t, err, concept.ErrUnknownConcept)
 		assert.Nil(t, results)
 	})
@@ -1006,7 +1013,7 @@ func TestVCR_Search(t *testing.T) {
 
 func TestVcr_Untrusted(t *testing.T) {
 	testDir := io.TestDirectory(t)
-	instance := NewTestVCRInstance(testDir)
+	instance := NewTestVCRInstance(t, testDir)
 	vc := concept.TestVC()
 
 	err := instance.registry.Add(concept.ExampleConfig)
@@ -1192,7 +1199,7 @@ func TestVcr_generateProof(t *testing.T) {
 	t.Run("incorrect key", func(t *testing.T) {
 		vc := validNutsOrganizationCredential()
 		testDir := io.TestDirectory(t)
-		instance := NewTestVCRInstance(testDir)
+		instance := NewTestVCRInstance(t, testDir)
 		key := crypto.TestKey{}
 		kid, _ := ssi.ParseURI(testKID)
 
@@ -1213,7 +1220,7 @@ func TestVcr_generateRevocationProof(t *testing.T) {
 
 		// default stuff
 		testDir := io.TestDirectory(t)
-		instance := NewTestVCRInstance(testDir)
+		instance := NewTestVCRInstance(t, testDir)
 		key := crypto.TestKey{}
 		kid, _ := ssi.ParseURI(testKID)
 

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
-	"path"
 	"reflect"
 	"runtime"
 	"strings"
@@ -55,8 +54,7 @@ import (
 func TestVCR_Configure(t *testing.T) {
 
 	t.Run("loads default configs", func(t *testing.T) {
-		testDir := io.TestDirectory(t)
-		instance := NewTestVCRInstance(t, testDir)
+		instance := NewTestVCRInstance(t)
 
 		concepts := instance.registry.Concepts()
 
@@ -82,11 +80,9 @@ func TestVCR_Start(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		testDir := io.TestDirectory(t)
-		_ = NewTestVCRInstance(t, testDir)
+		instance := NewTestVCRInstance(t)
 
-		fsPath := path.Join(testDir, "vcr", "credentials.db")
-		_, err := os.Stat(fsPath)
+		_, err := os.Stat(instance.credentialsDBPath())
 		assert.NoError(t, err)
 	})
 }
@@ -306,8 +302,7 @@ func TestVCR_Resolve(t *testing.T) {
 }
 
 func TestVcr_Instance(t *testing.T) {
-	testDir := io.TestDirectory(t)
-	instance := NewTestVCRInstance(t, testDir)
+	instance := NewTestVCRInstance(t)
 
 	t.Run("ok - name", func(t *testing.T) {
 		assert.Equal(t, moduleName, instance.Name())
@@ -1012,8 +1007,7 @@ func TestVCR_Search(t *testing.T) {
 }
 
 func TestVcr_Untrusted(t *testing.T) {
-	testDir := io.TestDirectory(t)
-	instance := NewTestVCRInstance(t, testDir)
+	instance := NewTestVCRInstance(t)
 	vc := concept.TestVC()
 
 	err := instance.registry.Add(concept.ExampleConfig)
@@ -1198,8 +1192,7 @@ func TestVcr_verifyRevocation(t *testing.T) {
 func TestVcr_generateProof(t *testing.T) {
 	t.Run("incorrect key", func(t *testing.T) {
 		vc := validNutsOrganizationCredential()
-		testDir := io.TestDirectory(t)
-		instance := NewTestVCRInstance(t, testDir)
+		instance := NewTestVCRInstance(t)
 		key := crypto.TestKey{}
 		kid, _ := ssi.ParseURI(testKID)
 
@@ -1219,8 +1212,7 @@ func TestVcr_generateRevocationProof(t *testing.T) {
 		json.Unmarshal(rJSON, &r)
 
 		// default stuff
-		testDir := io.TestDirectory(t)
-		instance := NewTestVCRInstance(t, testDir)
+		instance := NewTestVCRInstance(t)
 		key := crypto.TestKey{}
 		kid, _ := ssi.ParseURI(testKID)
 


### PR DESCRIPTION
fixes #612 

a migration is added that removes the current VCR DB. This is allowed as long as the DAG is walked at startup. When that stops the migration must be removed.

- [ ] create an issue after merge for removing migration