### PR TITLE
Network: fix nil deref when existing connection fails to open v1 stream

### DIFF
--- a/network/transport/v1/p2p/impl.go
+++ b/network/transport/v1/p2p/impl.go
@@ -57,6 +57,9 @@ type adapter struct {
 func (n adapter) OpenStream(outgoingContext context.Context, grpcConn *grpcLib.ClientConn, callback func(stream grpcLib.ClientStream, method string) (transport.Peer, error)) (context.Context, error) {
 	client := protobuf.NewNetworkClient(grpcConn)
 	messenger, err := client.Connect(outgoingContext)
+	if err != nil {
+		return nil, err
+	}
 	peer, err := callback(messenger, grpc.GetStreamMethod(protobuf.Network_ServiceDesc.ServiceName, protobuf.Network_ServiceDesc.Streams[0]))
 	if err != nil {
 		_ = messenger.CloseSend()

--- a/network/transport/v1/p2p/impl_test.go
+++ b/network/transport/v1/p2p/impl_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/network/transport/v1/protobuf"
 	"github.com/nuts-foundation/nuts-node/test"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
 	"sync"
 	"testing"
 	"time"
@@ -130,6 +131,16 @@ func Test_adapter_Send(t *testing.T) {
 		assert.Len(t, adapter.peerOutMessages[peerID], outMessagesBacklog)
 
 		testDone.Done()
+	})
+}
+
+func Test_adapter_OpenStream(t *testing.T) {
+	t.Run("unable to open", func(t *testing.T) {
+		ctx := context.Background()
+		conn, _ := grpc.DialContext(ctx, "invalid-address", grpc.WithInsecure())
+		stream, err := adapter{}.OpenStream(ctx, conn, nil)
+		assert.Nil(t, stream)
+		assert.Error(t, err, "")
 	})
 }
 


### PR DESCRIPTION
Now and then fails during test.

Caused by missing `err` check.