### PR TITLE
Network: improve logging and backoff in case Node DID authentication fails

### DIFF
--- a/network/transport/grpc/connection.go
+++ b/network/transport/grpc/connection.go
@@ -43,7 +43,7 @@ type managedConnection interface {
 	getPeer() transport.Peer
 	connected(protocol string) bool
 	// open instructs the managedConnection to start connecting to the remote peer (attempting an outbound connection).
-	open(config *tls.Config, callback func(grpcConn *grpc.ClientConn))
+	open(config *tls.Config, callback func(grpcConn *grpc.ClientConn) bool)
 	// registerClientStream adds the given grpc.ClientStream to this managedConnection under the given method,
 	// which holds the fully qualified name of the gRPC stream call. It can be formatted using grpc.GetStreamMethod
 	// (the gRPC library does not provide it for grpc.ClientStream, like it does for server grpc.ServerStream).
@@ -210,7 +210,7 @@ func (mc *conn) registerServerStream(serverStream grpc.ServerStream) error {
 	return nil
 }
 
-func (mc *conn) open(tlsConfig *tls.Config, connectedCallback func(grpcConn *grpc.ClientConn)) {
+func (mc *conn) open(tlsConfig *tls.Config, connectedCallback func(grpcConn *grpc.ClientConn) bool) {
 	mc.mux.Lock()
 	defer mc.mux.Unlock()
 
@@ -221,12 +221,12 @@ func (mc *conn) open(tlsConfig *tls.Config, connectedCallback func(grpcConn *grp
 
 	mc.connector = createOutboundConnector(mc.getPeer().Address, mc.dialer, tlsConfig, func() bool {
 		return !mc.connected(AnyProtocol)
-	}, func(conn *grpc.ClientConn) {
+	}, func(conn *grpc.ClientConn) bool {
 		mc.mux.Lock()
 		mc.grpcOutboundConnection = conn
 		mc.mux.Unlock()
 
-		connectedCallback(conn)
+		return connectedCallback(conn)
 	})
 	mc.connector.start()
 }

--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -236,11 +236,12 @@ func Test_grpcConnectionManager_openOutboundStreams(t *testing.T) {
 		waiter.Add(1)
 
 		connection, _ := client.connections.getOrRegister(transport.Peer{Address: "server"}, client.dialer)
-		connection.open(nil, func(grpcConn *grpc.ClientConn) {
+		connection.open(nil, func(grpcConn *grpc.ClientConn) bool {
 			_, err := client.openOutboundStream(connection, grpcConn, &TestProtocol{})
 			capturedError.Store(err)
 			waiter.Done()
 			connection.close()
+			return true
 		})
 
 		waiter.Wait()


### PR DESCRIPTION
Changes:

- When a gRPC stream fails to open (e.g. protocol v1 or v2), log this as a protocol-level error, rather than connection level failure.
- Outbound connections: don't try other protocols when node DID of the peer fails (optimization, declutters log)
- Outbound connections: backoff when node DID authentication fails