### PR TITLE
Set min TLS version to 1.3

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -145,6 +145,7 @@ func (auth *Auth) Configure(config core.ServerConfig) error {
 		tlsConfig := &tls.Config{
 			Certificates: []tls.Certificate{clientCertificate},
 			RootCAs:      trustStore.CertPool,
+			MinVersion:   core.MinTLSVersion,
 		}
 
 		validator := crl.NewValidator(trustStore.Certificates())

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -53,6 +53,19 @@ func TestAuth_Configure(t *testing.T) {
 		assert.NotNil(t, i.tlsConfig)
 	})
 
+	t.Run("ok - TLS is properly configured", func(t *testing.T) {
+		authCfg := TestConfig()
+		authCfg.CertKeyFile = "test/certs/example.com.key"
+		authCfg.CertFile = "test/certs/example.com.pem"
+		authCfg.TrustStoreFile = "test/certs/ca.pem"
+
+		i := testInstance(t, authCfg)
+		err := i.Configure(*core.NewServerConfig())
+		assert.NoError(t, err)
+
+		assert.Equal(t, core.MinTLSVersion, i.TLSConfig().MinVersion)
+	})
+
 	t.Run("error - no publicUrl", func(t *testing.T) {
 		authCfg := TestConfig()
 		authCfg.IrmaSchemeManager = "pbdf"
@@ -105,6 +118,7 @@ func TestAuth_Configure(t *testing.T) {
 		authCfg.CertKeyFile = "test/certs/example.com.key"
 		authCfg.CertFile = "test/certs/example.com.pem"
 		authCfg.TrustStoreFile = "non-existing"
+
 		i := testInstance(t, authCfg)
 		err := i.Configure(*core.NewServerConfig())
 		assert.EqualError(t, err, "unable to read trust store (file=non-existing): open non-existing: no such file or directory")

--- a/core/tls.go
+++ b/core/tls.go
@@ -19,11 +19,15 @@
 package core
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 	"os"
 )
+
+// MinTLSVersion defines the minimal TLS version used by all components that use TLS
+const MinTLSVersion uint16 = tls.VersionTLS13
 
 func parseCertificates(data []byte) (certificates []*x509.Certificate, _ error) {
 	for len(data) > 0 {

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -106,6 +106,7 @@ func (s *grpcConnectionManager) Start() error {
 			Certificates: []tls.Certificate{s.config.serverCert},
 			ClientAuth:   tls.RequireAndVerifyClientCert,
 			ClientCAs:    s.config.trustStore,
+			MinVersion:   core.MinTLSVersion,
 		}
 		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
 
@@ -172,7 +173,8 @@ func (s grpcConnectionManager) Connect(peerAddress string) {
 			Certificates: []tls.Certificate{
 				s.config.clientCert,
 			},
-			RootCAs: s.config.trustStore,
+			RootCAs:    s.config.trustStore,
+			MinVersion: core.MinTLSVersion,
 		}
 	}
 


### PR DESCRIPTION
When using `tls.Config` be sure to set the `MinVersion` because:

>	// If zero, TLS 1.0 is currently taken as the minimum.

Which is obviously not what we want.