### PR TITLE
Make inject config work recursively

### DIFF
--- a/core/server_config.go
+++ b/core/server_config.go
@@ -23,15 +23,15 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/providers/posflag"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -184,7 +184,50 @@ func (ngc *ServerConfig) PrintConfig() string {
 
 // InjectIntoEngine takes the loaded config and sets the engine's config struct
 func (ngc *ServerConfig) InjectIntoEngine(e Injectable) error {
-	return ngc.configMap.UnmarshalWithConf("", e.Config(), koanf.UnmarshalConf{
+	return unmarshalRecursive(e.Config(), ngc.configMap)
+}
+
+func elemType(ty reflect.Type) (reflect.Type, bool) {
+	isPtr := ty.Kind() == reflect.Ptr
+
+	if isPtr {
+		return ty.Elem(), true
+	}
+
+	return ty, false
+}
+
+func unmarshalRecursive(config interface{}, configMap *koanf.Koanf) error {
+	if err := configMap.UnmarshalWithConf("", config, koanf.UnmarshalConf{
 		FlatPaths: true,
-	})
+	}); err != nil {
+		return err
+	}
+
+	configType, isPtr := elemType(reflect.TypeOf(config))
+
+	// If `config` is a struct or a pointer to a struct we're iterating its fields to find structs
+	if configType.Kind() == reflect.Struct {
+		valueOfConfig := reflect.ValueOf(config)
+
+		if isPtr {
+			valueOfConfig = valueOfConfig.Elem()
+		}
+
+		for i := 0; i < configType.NumField(); i++ {
+			field := configType.Field(i)
+			fieldType, _ := elemType(field.Type)
+
+			// Unmarshal this field if it's a struct, and it has a `koanf` tag
+			if fieldType.Kind() == reflect.Struct && field.Tag.Get("koanf") != "" {
+				fieldAddr := valueOfConfig.Field(i).Addr()
+
+				if err := unmarshalRecursive(fieldAddr.Interface(), configMap); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/core/server_config_test.go
+++ b/core/server_config_test.go
@@ -208,8 +208,12 @@ func TestNewNutsConfig_InjectIntoEngine(t *testing.T) {
 	flagSet.String("key", "", "")
 	flagSet.String("sub.test", "", "")
 	flagSet.String("subptr.test", "", "")
-	flagSet.Parse([]string{"--key", "value", "--sub.test", "testvalue", "--subptr.test", "test2value"})
+
+	err := flagSet.Parse([]string{"--key", "value", "--sub.test", "testvalue", "--subptr.test", "test2value"})
+	assert.NoError(t, err)
+
 	cmd.PersistentFlags().AddFlagSet(flagSet)
+
 	in := &TestEngine{
 		TestConfig: TestEngineConfig{},
 	}

--- a/core/server_config_test.go
+++ b/core/server_config_test.go
@@ -206,20 +206,37 @@ func TestNewNutsConfig_InjectIntoEngine(t *testing.T) {
 	cmd := testCommand()
 	flagSet := pflag.NewFlagSet("dummy", pflag.ContinueOnError)
 	flagSet.String("key", "", "")
-	flagSet.Parse([]string{"--key", "value"})
+	flagSet.String("sub.test", "", "")
+	flagSet.String("subptr.test", "", "")
+	flagSet.Parse([]string{"--key", "value", "--sub.test", "testvalue", "--subptr.test", "test2value"})
 	cmd.PersistentFlags().AddFlagSet(flagSet)
 	in := &TestEngine{
 		TestConfig: TestEngineConfig{},
 	}
 
 	t.Run("param is injected", func(t *testing.T) {
-		cfg.Load(cmd)
-		err := cfg.InjectIntoEngine(in)
+		err := cfg.Load(cmd)
+		assert.NoError(t, err)
+
+		err = cfg.InjectIntoEngine(in)
 		if !assert.NoError(t, err) {
 			return
 		}
 
 		assert.Equal(t, "value", in.TestConfig.Key)
+	})
+
+	t.Run("param is injected recursively", func(t *testing.T) {
+		err := cfg.Load(cmd)
+		assert.NoError(t, err)
+
+		err = cfg.InjectIntoEngine(in)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Equal(t, "testvalue", in.TestConfig.Sub.Test)
+		assert.Equal(t, "test2value", in.TestConfig.SubPtr.Test)
 	})
 }
 

--- a/core/test.go
+++ b/core/test.go
@@ -24,20 +24,15 @@ import (
 
 // TestEngineConfig defines the configuration for the test engine
 type TestEngineConfig struct {
-	Key     string                  `koanf:"key"`
-	Datadir string                  `koanf:"datadir"`
-	Sub     TestEngineSubConfig     `koanf:"sub"`
-	SubPtr  *TestEngineSubPtrConfig `koanf:"subptr"`
+	Key     string               `koanf:"key"`
+	Datadir string               `koanf:"datadir"`
+	Sub     TestEngineSubConfig  `koanf:"sub"`
+	SubPtr  *TestEngineSubConfig `koanf:"subptr"`
 }
 
 // TestEngineSubConfig defines the `sub` configuration for the test engine
 type TestEngineSubConfig struct {
-	Test string `koanf:"sub.test"`
-}
-
-// TestEngineSubPtrConfig defines the `subptr` configuration for the test engine
-type TestEngineSubPtrConfig struct {
-	Test string `koanf:"subptr.test"`
+	Test string `koanf:"test"`
 }
 
 type TestEngine struct {

--- a/core/test.go
+++ b/core/test.go
@@ -22,9 +22,22 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// TestEngineConfig defines the configuration for the test engine
 type TestEngineConfig struct {
-	Key     string `koanf:"key"`
-	Datadir string `koanf:"datadir"`
+	Key     string                  `koanf:"key"`
+	Datadir string                  `koanf:"datadir"`
+	Sub     TestEngineSubConfig     `koanf:"sub"`
+	SubPtr  *TestEngineSubPtrConfig `koanf:"subptr"`
+}
+
+// TestEngineSubConfig defines the `sub` configuration for the test engine
+type TestEngineSubConfig struct {
+	Test string `koanf:"sub.test"`
+}
+
+// TestEngineSubPtrConfig defines the `subptr` configuration for the test engine
+type TestEngineSubPtrConfig struct {
+	Test string `koanf:"subptr.test"`
 }
 
 type TestEngine struct {

--- a/network/config.go
+++ b/network/config.go
@@ -50,9 +50,9 @@ type Config struct {
 
 // NatsConfig holds all NATS related configuration
 type NatsConfig struct {
-	Port     int    `koanf:"network.nats.port"`
-	Hostname string `koanf:"network.nats.hostname"`
-	Timeout  int    `koanf:"network.nats.timeout"`
+	Port     int    `koanf:"port"`
+	Hostname string `koanf:"hostname"`
+	Timeout  int    `koanf:"timeout"`
 }
 
 // DefaultConfig returns the default NetworkEngine configuration.

--- a/network/transport/v1/protocol_v1.go
+++ b/network/transport/v1/protocol_v1.go
@@ -37,11 +37,11 @@ var _ grpc.OutboundStreamer = &protocolV1{}
 type Config struct {
 	// AdvertHashesInterval specifies how often (in milliseconds) the node should broadcasts its last hashes,
 	// so other nodes can compare and synchronize.
-	AdvertHashesInterval int `koanf:"network.v1.adverthashesinterval"`
+	AdvertHashesInterval int `koanf:"adverthashesinterval"`
 	// AdvertDiagnosticsInterval specifies how often (in milliseconds) the node should query its peers for diagnostic information.
-	AdvertDiagnosticsInterval int `koanf:"network.v1.advertdiagnosticsinterval"`
+	AdvertDiagnosticsInterval int `koanf:"advertdiagnosticsinterval"`
 	// CollectMissingPayloadsInterval specifies how often (in milliseconds) the node should query peers for missing payloads.
-	CollectMissingPayloadsInterval int `koanf:"network.v1.collectmissingpayloadsinterval"`
+	CollectMissingPayloadsInterval int `koanf:"collectmissingpayloadsinterval"`
 }
 
 // DefaultConfig returns the default configuration for protocol v1.


### PR DESCRIPTION
It seems like with `FlatPaths` set to `true` in koanf we can't parse configuration when using child structs. With this PR you can use a struct or pointer to a struct and it will unmarshal the configuration recursively. However, at some point we might want to think about building a library ourselves that handles flags, environment variables and configuration files.

Note that it uses the `koanf` tag to determine the path. So, this will work:

```go
type TestConfig struct {
    Example string `koanf:"test.example"`
    Inner InnerConfig `koanf:"test.inner"`
}

type InnerConfig struct {
    Example string `koanf:"example"`
}
```

With the following YAML configuration:
```yaml
test:
  example: value
  inner:
    example: value2
```