### PR TITLE
Auth: fix clockskew test by making the skew larger (slow CirlceCI)

### DIFF
--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -462,7 +462,7 @@ func (s *service) parseAndValidateJwtBearerToken(context *validationContext) err
 	token, err := nutsCrypto.ParseJWT(context.rawJwtBearerToken, func(kid string) (crypto.PublicKey, error) {
 		kidHdr = kid
 		return s.keyResolver.ResolveSigningKey(kid, nil)
-	}, jwt.WithAcceptableSkew(s.clockSkew*time.Millisecond))
+	}, jwt.WithAcceptableSkew(s.clockSkew))
 	if err != nil {
 		return err
 	}
@@ -480,7 +480,7 @@ func (s *service) IntrospectAccessToken(accessToken string) (*services.NutsAcces
 			return nil, fmt.Errorf("JWT signing key not present on this node (kid=%s)", kid)
 		}
 		return s.keyResolver.ResolveSigningKey(kid, nil)
-	}, jwt.WithAcceptableSkew(s.clockSkew*time.Millisecond))
+	}, jwt.WithAcceptableSkew(s.clockSkew))
 	if err != nil {
 		return nil, err
 	}

--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -145,8 +145,8 @@ func NewOAuthService(store types.Store, conceptFinder vcr.ConceptFinder, vcValid
 const BearerTokenMaxValidity = 5
 
 // Configure the service
-func (s *service) Configure(clockSkew int) error {
-	s.clockSkew = time.Duration(clockSkew)
+func (s *service) Configure(clockSkewInMilliseconds int) error {
+	s.clockSkew = time.Duration(clockSkewInMilliseconds) * time.Millisecond
 	return nil
 }
 

--- a/auth/services/oauth/oauth_test.go
+++ b/auth/services/oauth/oauth_test.go
@@ -573,6 +573,7 @@ func TestService_parseAndValidateJwtBearerToken(t *testing.T) {
 	})
 
 	t.Run("valid token with clock diff", func(t *testing.T) {
+		// a token created 10 minutes ago, valid until 4 minutes ago. But due to clock skew of 5 minutes, it should still be valid.
 		ctx := createContext(t)
 		ctx.oauthService.clockSkew = 5 * time.Minute
 		tokenCtx := validContext()

--- a/auth/services/oauth/oauth_test.go
+++ b/auth/services/oauth/oauth_test.go
@@ -574,10 +574,10 @@ func TestService_parseAndValidateJwtBearerToken(t *testing.T) {
 
 	t.Run("valid token with clock diff", func(t *testing.T) {
 		ctx := createContext(t)
-		ctx.oauthService.clockSkew = 5000
+		ctx.oauthService.clockSkew = 5 * time.Minute
 		tokenCtx := validContext()
-		tokenCtx.jwtBearerToken.Set(jwt.IssuedAtKey, time.Now().Add(-6*time.Second))
-		tokenCtx.jwtBearerToken.Set(jwt.ExpirationKey, time.Now().Add(-4000*time.Millisecond))
+		tokenCtx.jwtBearerToken.Set(jwt.IssuedAtKey, time.Now().Add(-10*time.Minute))
+		tokenCtx.jwtBearerToken.Set(jwt.ExpirationKey, time.Now().Add(-4*time.Minute))
 		signToken(tokenCtx)
 
 		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).Return(requesterSigningKey.PublicKey, nil)
@@ -871,7 +871,9 @@ func TestAuth_Configure(t *testing.T) {
 		ctx := createContext(t)
 		defer ctx.ctrl.Finish()
 
-		assert.NoError(t, ctx.oauthService.Configure(0))
+		err := ctx.oauthService.Configure(1000 * 60)
+		assert.NoError(t, err)
+		assert.Equal(t, time.Minute, ctx.oauthService.clockSkew)
 	})
 }
 

--- a/auth/services/services.go
+++ b/auth/services/services.go
@@ -29,7 +29,7 @@ import (
 
 // OAuthClient is the client interface for the OAuth service
 type OAuthClient interface {
-	Configure(clockSkew int) error
+	Configure(clockSkewInMilliseconds int) error
 	CreateAccessToken(request CreateAccessTokenRequest) (*AccessTokenResult, error)
 	CreateJwtGrant(request CreateJwtGrantRequest) (*JwtBearerTokenResult, error)
 	GetOAuthEndpointURL(service string, authorizer did.DID) (url.URL, error)


### PR DESCRIPTION
Randomly fails because the clock skew is too small now and then.

Also made the use of `time.Duration` appropriate.