### PR TITLE
Network: fix call on nil context due to racy connection close

### DIFF
--- a/network/transport/grpc/connection.go
+++ b/network/transport/grpc/connection.go
@@ -40,8 +40,8 @@ type managedConnection interface {
 	// close shuts down active inbound or outbound streams and stops active outbound connectors.
 	// After calling close() the managedConnection cannot be reused.
 	close()
-	// waitTilClosed blocks until the connection is closed. If it already is closed or was never open, it returns immediately.
-	waitTilClosed()
+	// waitUntilClosed blocks until the connection is closed. If it already is closed or was never open, it returns immediately.
+	waitUntilClosed()
 	getPeer() transport.Peer
 	connected(protocol string) bool
 	// open instructs the managedConnection to start connecting to the remote peer (attempting an outbound connection).
@@ -126,7 +126,7 @@ func (mc *conn) context() context.Context {
 	return mc.ctx
 }
 
-func (mc *conn) waitTilClosed() {
+func (mc *conn) waitUntilClosed() {
 	mc.mux.RLock()
 	var done <-chan struct{}
 	if mc.ctx != nil {

--- a/network/transport/grpc/connection.go
+++ b/network/transport/grpc/connection.go
@@ -40,6 +40,8 @@ type managedConnection interface {
 	// close shuts down active inbound or outbound streams and stops active outbound connectors.
 	// After calling close() the managedConnection cannot be reused.
 	close()
+	// waitTilClosed blocks until the connection is closed. If it already is closed or was never open, it returns immediately.
+	waitTilClosed()
 	getPeer() transport.Peer
 	connected(protocol string) bool
 	// open instructs the managedConnection to start connecting to the remote peer (attempting an outbound connection).
@@ -122,6 +124,18 @@ func (mc *conn) context() context.Context {
 	mc.mux.RLock()
 	defer mc.mux.RUnlock()
 	return mc.ctx
+}
+
+func (mc *conn) waitTilClosed() {
+	mc.mux.RLock()
+	var done <-chan struct{}
+	if mc.ctx != nil {
+		done = mc.ctx.Done()
+	}
+	mc.mux.RUnlock()
+	if done != nil {
+		<-done
+	}
 }
 
 func (mc *conn) doDisconnect() {

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -238,7 +238,7 @@ func (s *grpcConnectionManager) openOutboundStreams(connection managedConnection
 	if protocolNum == 0 {
 		return fmt.Errorf("could not use any of the supported protocols to communicate with peer (id=%s)", connection.getPeer())
 	}
-	<-connection.context().Done() // block until connection is closed
+	connection.waitTilClosed()
 	return nil
 }
 

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -238,7 +238,7 @@ func (s *grpcConnectionManager) openOutboundStreams(connection managedConnection
 	if protocolNum == 0 {
 		return fmt.Errorf("could not use any of the supported protocols to communicate with peer (id=%s)", connection.getPeer())
 	}
-	connection.waitTilClosed()
+	connection.waitUntilClosed()
 	return nil
 }
 

--- a/network/transport/grpc/connection_test.go
+++ b/network/transport/grpc/connection_test.go
@@ -52,10 +52,10 @@ func Test_conn_close(t *testing.T) {
 	})
 }
 
-func Test_conn_waitTilClosed(t *testing.T) {
+func Test_conn_waitUntilClosed(t *testing.T) {
 	t.Run("never open, should return immediately", func(t *testing.T) {
 		conn := conn{}
-		conn.waitTilClosed()
+		conn.waitUntilClosed()
 	})
 	t.Run("closed while waiting, should return almost immediately", func(t *testing.T) {
 		conn := conn{}
@@ -67,13 +67,13 @@ func Test_conn_waitTilClosed(t *testing.T) {
 			conn.close()
 		}()
 		wg.Done()
-		conn.waitTilClosed()
+		conn.waitUntilClosed()
 	})
 	t.Run("waiting after close, should return immediately", func(t *testing.T) {
 		conn := conn{}
 		conn.ctx, conn.cancelCtx = context.WithCancel(context.Background())
 		conn.close()
-		conn.waitTilClosed()
+		conn.waitUntilClosed()
 	})
 }
 

--- a/network/transport/grpc/connection_test.go
+++ b/network/transport/grpc/connection_test.go
@@ -19,9 +19,11 @@
 package grpc
 
 import (
+	"context"
 	"github.com/nuts-foundation/nuts-node/network/transport"
 	"github.com/nuts-foundation/nuts-node/test"
 	"github.com/stretchr/testify/assert"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -47,6 +49,31 @@ func Test_conn_close(t *testing.T) {
 		conn.verifyOrSetPeerID("foo")
 		conn.close()
 		assert.Empty(t, conn.getPeer())
+	})
+}
+
+func Test_conn_waitTilClosed(t *testing.T) {
+	t.Run("never open, should return immediately", func(t *testing.T) {
+		conn := conn{}
+		conn.waitTilClosed()
+	})
+	t.Run("closed while waiting, should return almost immediately", func(t *testing.T) {
+		conn := conn{}
+		conn.ctx, conn.cancelCtx = context.WithCancel(context.Background())
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			wg.Wait()
+			conn.close()
+		}()
+		wg.Done()
+		conn.waitTilClosed()
+	})
+	t.Run("waiting after close, should return immediately", func(t *testing.T) {
+		conn := conn{}
+		conn.ctx, conn.cancelCtx = context.WithCancel(context.Background())
+		conn.close()
+		conn.waitTilClosed()
 	})
 }
 


### PR DESCRIPTION
Happens now and then on CircleCI, can theoretically happen runtime as well.

`close()` causes `context()` to return `nil` (which is valid), callers should handle it. Introduced `waitTilClosed()` to reduce chance of errornous use.