### PR TITLE
make evidence optional for explicit auth

### DIFF
--- a/vcr/credential/validator.go
+++ b/vcr/credential/validator.go
@@ -170,15 +170,6 @@ func (d nutsAuthorizationCredentialValidator) Validate(credential vc.VerifiableC
 		if cs.Subject == nil || len(strings.TrimSpace(*cs.Subject)) == 0 {
 			return failure("'credentialSubject.Subject' is required when consentType is 'explicit'")
 		}
-		if cs.LegalBase.Evidence == nil {
-			return failure("'credentialSubject.LegalBase.Evidence' is required when consentType is 'explicit'")
-		}
-		if len(strings.TrimSpace(cs.LegalBase.Evidence.Path)) == 0 {
-			return failure("'credentialSubject.LegalBase.Evidence.Path' is required when consentType is 'explicit'")
-		}
-		if len(strings.TrimSpace(cs.LegalBase.Evidence.Type)) == 0 {
-			return failure("'credentialSubject.LegalBase.Evidence.Type' is required when consentType is 'explicit'")
-		}
 	default:
 		return failure("'credentialSubject.LegalBase.ConsentType' must be 'implied' or 'explicit'")
 	}

--- a/vcr/credential/validator_test.go
+++ b/vcr/credential/validator_test.go
@@ -328,54 +328,6 @@ func TestNutsAuthorizationCredentialValidator_Validate(t *testing.T) {
 		assert.Error(t, err)
 		assert.EqualError(t, err, "validation failed: 'credentialSubject.Subject' is required when consentType is 'explicit'")
 	})
-
-	t.Run("failed - missing evidence", func(t *testing.T) {
-		v := ValidExplicitNutsAuthorizationCredential()
-		cs := v.CredentialSubject[0].(NutsAuthorizationCredentialSubject)
-		cs.LegalBase = LegalBase{
-			ConsentType: "explicit",
-		}
-		v.CredentialSubject[0] = cs
-
-		err := validator.Validate(*v)
-
-		assert.Error(t, err)
-		assert.EqualError(t, err, "validation failed: 'credentialSubject.LegalBase.Evidence' is required when consentType is 'explicit'")
-	})
-
-	t.Run("failed - missing evidence.Path", func(t *testing.T) {
-		v := ValidExplicitNutsAuthorizationCredential()
-		cs := v.CredentialSubject[0].(NutsAuthorizationCredentialSubject)
-		cs.LegalBase = LegalBase{
-			ConsentType: "explicit",
-			Evidence: &Evidence{
-				Type: "application/pdf",
-			},
-		}
-		v.CredentialSubject[0] = cs
-
-		err := validator.Validate(*v)
-
-		assert.Error(t, err)
-		assert.EqualError(t, err, "validation failed: 'credentialSubject.LegalBase.Evidence.Path' is required when consentType is 'explicit'")
-	})
-
-	t.Run("failed - missing evidence.Type", func(t *testing.T) {
-		v := ValidExplicitNutsAuthorizationCredential()
-		cs := v.CredentialSubject[0].(NutsAuthorizationCredentialSubject)
-		cs.LegalBase = LegalBase{
-			ConsentType: "explicit",
-			Evidence: &Evidence{
-				Path: "pdf/1.pdf",
-			},
-		}
-		v.CredentialSubject[0] = cs
-
-		err := validator.Validate(*v)
-
-		assert.Error(t, err)
-		assert.EqualError(t, err, "validation failed: 'credentialSubject.LegalBase.Evidence.Type' is required when consentType is 'explicit'")
-	})
 }
 
 func validNutsOrganizationCredential() *vc.VerifiableCredential {


### PR DESCRIPTION
closes #682

spec changed so evidence is optional for a NutsAuthorizationCredential