### PR TITLE
add Finder to VDR

### DIFF
--- a/vdr/doc/finder.go
+++ b/vdr/doc/finder.go
@@ -1,0 +1,86 @@
+/*
+ * Nuts node
+ * Copyright (C) 2021 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package doc
+
+import (
+	"strings"
+	"time"
+
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/vdr/types"
+)
+
+// ByServiceType returns a predicate that matches on service type
+// it only matches on DID Documents with a concrete endpoint (not starting with "did")
+func ByServiceType(serviceType string) types.Predicate {
+	return servicePredicate{serviceType: serviceType}
+}
+
+type servicePredicate struct {
+	serviceType string
+}
+
+func (s servicePredicate) Match(document did.Document, _ types.DocumentMetadata) bool {
+	for _, service := range document.Service {
+		if service.Type == s.serviceType {
+			var nutsCommStr string
+			if err := service.UnmarshalServiceEndpoint(&nutsCommStr); err == nil && !strings.HasPrefix(nutsCommStr, "did") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ValidAt returns a predicate that matches on validity period.
+func ValidAt(at time.Time) types.Predicate {
+	return validAtPredicate{validAt: at}
+}
+
+type validAtPredicate struct {
+	validAt time.Time
+}
+
+func (v validAtPredicate) Match(_ did.Document, metadata types.DocumentMetadata) bool {
+	if v.validAt.Before(metadata.Created) {
+		return false
+	}
+
+	if metadata.Updated != nil {
+		if metadata.Updated.After(v.validAt) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// IsActive returns a predicate that matches DID Documents that are not deactivated.
+func IsActive() types.Predicate {
+	return deactivatedPredicate{deactivated: false}
+}
+
+type deactivatedPredicate struct {
+	deactivated bool
+}
+
+func (d deactivatedPredicate) Match(_ did.Document, metadata types.DocumentMetadata) bool {
+	return d.deactivated == metadata.Deactivated
+}

--- a/vdr/doc/finder.go
+++ b/vdr/doc/finder.go
@@ -84,3 +84,28 @@ type deactivatedPredicate struct {
 func (d deactivatedPredicate) Match(_ did.Document, metadata types.DocumentMetadata) bool {
 	return d.deactivated == metadata.Deactivated
 }
+
+// Finder is a helper that implements the DocFinder interface
+type Finder struct {
+	Store types.Store
+}
+
+func (f Finder) Find(predicate ...types.Predicate) ([]did.Document, error) {
+	matches := make([]did.Document, 0)
+
+	err := f.Store.Iterate(func(doc did.Document, metadata types.DocumentMetadata) error {
+		for _, p := range predicate {
+			if !p.Match(doc, metadata) {
+				return nil
+			}
+		}
+		matches = append(matches, doc)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return matches, err
+}

--- a/vdr/doc/finder_test.go
+++ b/vdr/doc/finder_test.go
@@ -1,0 +1,97 @@
+/*
+ * Nuts node
+ * Copyright (C) 2021 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package doc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/vdr/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsActive(t *testing.T) {
+	p := IsActive()
+
+	t.Run("active", func(t *testing.T) {
+		assert.True(t, p.Match(did.Document{}, types.DocumentMetadata{Deactivated: false}))
+	})
+
+	t.Run("deactivated", func(t *testing.T) {
+		assert.False(t, p.Match(did.Document{}, types.DocumentMetadata{Deactivated: true}))
+	})
+}
+
+func TestValidAt(t *testing.T) {
+	now := time.Now()
+	later := now.AddDate(0, 0, 1)
+	meta := types.DocumentMetadata{
+		Created: now.AddDate(0, 0, -1),
+		Updated: &later,
+	}
+
+	t.Run("ok - latest", func(t *testing.T) {
+		p := ValidAt(now)
+		assert.True(t, p.Match(did.Document{}, types.DocumentMetadata{Created: now.AddDate(0, 0, -1), Updated: nil}))
+	})
+
+	t.Run("ok - updated", func(t *testing.T) {
+		p := ValidAt(now.AddDate(0, 0, 2))
+		assert.True(t, p.Match(did.Document{}, meta))
+	})
+
+	t.Run("not yet", func(t *testing.T) {
+		p := ValidAt(now.AddDate(0, 0, -2))
+		assert.False(t, p.Match(did.Document{}, meta))
+	})
+
+	t.Run("updated", func(t *testing.T) {
+		p := ValidAt(now)
+		assert.False(t, p.Match(did.Document{}, meta))
+	})
+}
+
+func TestByServiceType(t *testing.T) {
+	ID, _ := did.ParseDID("did:nuts:123")
+	p := ByServiceType("NutsComm")
+
+	t.Run("ok", func(t *testing.T) {
+		doc := did.Document{ID: *ID, Controller: []did.DID{*ID}, Service: []did.Service{
+			{
+				Type:            "NutsComm",
+				ServiceEndpoint: "grpc://nuts.nl:5555",
+			},
+		}}
+
+		assert.True(t, p.Match(doc, types.DocumentMetadata{}))
+	})
+
+	t.Run("ignore", func(t *testing.T) {
+		docIgnore := did.Document{ID: *ID, Controller: []did.DID{*ID}, Service: []did.Service{
+			{
+				Type:            "NutsComm",
+				ServiceEndpoint: "did:nuts:321/serviceEndpoint#1",
+			},
+		}}
+
+		assert.False(t, p.Match(docIgnore, types.DocumentMetadata{}))
+	})
+}

--- a/vdr/types/interface.go
+++ b/vdr/types/interface.go
@@ -41,6 +41,17 @@ type DocResolver interface {
 	ResolveControllers(input did.Document, metadata *ResolveMetadata) ([]did.Document, error)
 }
 
+// Predicate is an interface for abstracting search options on DID documents
+type Predicate interface {
+	// Match returns true if the given DID Document passes the predicate condition
+	Match(did.Document, DocumentMetadata) bool
+}
+
+// DocFinder is the interface that groups all methods for finding DID documents based on search conditions
+type DocFinder interface {
+	Find(...Predicate) ([]did.Document, error)
+}
+
 // DocCreator is the interface that wraps the Create method
 type DocCreator interface {
 	// Create creates a new DID document and returns it.

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/vdr/doc"
 	"github.com/nuts-foundation/nuts-node/vdr/store"
@@ -219,4 +220,24 @@ func (r VDR) resolveControllerWithKey(doc did.Document) (did.Document, crypto.Ke
 	}
 
 	return did.Document{}, nil, fmt.Errorf("could not find capabilityInvocation key for updating the DID document: %w", err)
+}
+
+func (r *VDR) Find(predicate ...types.Predicate) ([]did.Document, error) {
+	matches := make([]did.Document, 0)
+
+	err := r.store.Iterate(func(doc did.Document, metadata types.DocumentMetadata) error {
+		for _, p := range predicate {
+			if !p.Match(doc, metadata) {
+				return nil
+			}
+		}
+		matches = append(matches, doc)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return matches, err
 }

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -221,23 +221,3 @@ func (r VDR) resolveControllerWithKey(doc did.Document) (did.Document, crypto.Ke
 
 	return did.Document{}, nil, fmt.Errorf("could not find capabilityInvocation key for updating the DID document: %w", err)
 }
-
-func (r *VDR) Find(predicate ...types.Predicate) ([]did.Document, error) {
-	matches := make([]did.Document, 0)
-
-	err := r.store.Iterate(func(doc did.Document, metadata types.DocumentMetadata) error {
-		for _, p := range predicate {
-			if !p.Match(doc, metadata) {
-				return nil
-			}
-		}
-		matches = append(matches, doc)
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return matches, err
-}

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -359,28 +359,3 @@ func TestVDR_resolveControllerKey(t *testing.T) {
 		assert.Equal(t, types.ErrDIDNotManagedByThisNode, err)
 	})
 }
-
-func TestVDR_Find(t *testing.T) {
-	t.Run("ok", func(t *testing.T) {
-		didStore := store.NewMemoryStore()
-		vdr := VDR{store: didStore}
-		_ = didStore.Write(did.Document{}, types.DocumentMetadata{Deactivated: false})
-		_ = didStore.Write(did.Document{}, types.DocumentMetadata{Deactivated: true})
-
-		docs, err := vdr.Find(doc.IsActive())
-
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.Len(t, docs, 1)
-	})
-
-	t.Run("error", func(t *testing.T) {
-		ctx := newVDRTestCtx(t)
-		ctx.mockStore.EXPECT().Iterate(gomock.Any()).Return(errors.New("b00m!"))
-
-		_, err := ctx.vdr.Find(doc.IsActive())
-
-		assert.Error(t, err)
-	})
-}

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -359,3 +359,28 @@ func TestVDR_resolveControllerKey(t *testing.T) {
 		assert.Equal(t, types.ErrDIDNotManagedByThisNode, err)
 	})
 }
+
+func TestVDR_Find(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		didStore := store.NewMemoryStore()
+		vdr := VDR{store: didStore}
+		_ = didStore.Write(did.Document{}, types.DocumentMetadata{Deactivated: false})
+		_ = didStore.Write(did.Document{}, types.DocumentMetadata{Deactivated: true})
+
+		docs, err := vdr.Find(doc.IsActive())
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Len(t, docs, 1)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		ctx := newVDRTestCtx(t)
+		ctx.mockStore.EXPECT().Iterate(gomock.Any()).Return(errors.New("b00m!"))
+
+		_, err := ctx.vdr.Find(doc.IsActive())
+
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
This adds a DocFinder interface to the VDR.
It supports finding DID Documents with specific predicates.

Stole Predicate setup from @dmeijboom ;)

This feature is required for service discovery. At startup, the network needs to find all did Documents with a concrete NutsComm address.