### PR TITLE
allow connection to bootstrapnode

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -242,7 +242,7 @@ func (n *Network) Start() error {
 		if len(strings.TrimSpace(bootstrapNode)) == 0 {
 			continue
 		}
-		n.connectionManager.Connect(bootstrapNode, true)
+		n.connectionManager.Connect(bootstrapNode, transport.WithUnauthenticated())
 	}
 
 	return nil

--- a/network/network.go
+++ b/network/network.go
@@ -242,7 +242,7 @@ func (n *Network) Start() error {
 		if len(strings.TrimSpace(bootstrapNode)) == 0 {
 			continue
 		}
-		n.connectionManager.Connect(bootstrapNode)
+		n.connectionManager.Connect(bootstrapNode, true)
 	}
 
 	return nil

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -22,6 +22,12 @@ import (
 	"context"
 	"crypto"
 	"fmt"
+	"hash/crc32"
+	"path"
+	"sync"
+	"testing"
+	"time"
+
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/network/transport"
@@ -31,11 +37,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/vdr/doc"
 	"github.com/nuts-foundation/nuts-node/vdr/store"
 	vdr "github.com/nuts-foundation/nuts-node/vdr/types"
-	"hash/crc32"
-	"path"
-	"sync"
-	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -67,9 +68,9 @@ func TestNetworkIntegration_HappyFlow(t *testing.T) {
 	// each other that way.
 	bootstrap := startNode(t, "integration_bootstrap", testDirectory)
 	node1 := startNode(t, "integration_node1", testDirectory)
-	node1.connectionManager.Connect(nameToAddress(t, "integration_bootstrap"))
+	node1.connectionManager.Connect(nameToAddress(t, "integration_bootstrap"), false)
 	node2 := startNode(t, "integration_node2", testDirectory)
-	node2.connectionManager.Connect(nameToAddress(t, "integration_bootstrap"))
+	node2.connectionManager.Connect(nameToAddress(t, "integration_bootstrap"), false)
 
 	// Wait until nodes are connected
 	if !test.WaitFor(t, func() (bool, error) {
@@ -119,7 +120,7 @@ func TestNetworkIntegration_NodesConnectToEachOther(t *testing.T) {
 	node2 := startNode(t, "node2", testDirectory)
 
 	// Now connect node1 to node2 and wait for them to set up
-	node1.connectionManager.Connect(nameToAddress(t, "node2"))
+	node1.connectionManager.Connect(nameToAddress(t, "node2"), false)
 	if !test.WaitFor(t, func() (bool, error) {
 		return len(node1.connectionManager.Peers()) == 1 && len(node2.connectionManager.Peers()) == 1, nil
 	}, defaultTimeout, "time-out while waiting for node 1 and 2 to be connected") {
@@ -127,7 +128,7 @@ func TestNetworkIntegration_NodesConnectToEachOther(t *testing.T) {
 	}
 
 	// Now instruct node2 to connect to node1
-	node2.connectionManager.Connect(nameToAddress(t, "node1"))
+	node2.connectionManager.Connect(nameToAddress(t, "node1"), false)
 	time.Sleep(time.Second)
 	assert.Len(t, node1.connectionManager.Peers(), 1)
 	assert.Len(t, node2.connectionManager.Peers(), 1)
@@ -146,7 +147,7 @@ func TestNetworkIntegration_NodeDIDAuthentication(t *testing.T) {
 			cfg.NodeDID = "did:nuts:node2"
 		})
 		// Now connect node1 to node2 and wait for them to set up
-		node1.connectionManager.Connect(nameToAddress(t, "node2"))
+		node1.connectionManager.Connect(nameToAddress(t, "node2"), false)
 
 		test.WaitFor(t, func() (bool, error) {
 			return len(node1.connectionManager.Peers()) == 1 && len(node2.connectionManager.Peers()) == 1, nil
@@ -167,7 +168,7 @@ func TestNetworkIntegration_NodeDIDAuthentication(t *testing.T) {
 		node1.nodeDIDResolver.(*transport.FixedNodeDIDResolver).NodeDID = *malloryDID
 
 		// Now connect node1 to node2 and wait for them to set up
-		node1.connectionManager.Connect(nameToAddress(t, "node2"))
+		node1.connectionManager.Connect(nameToAddress(t, "node2"), false)
 		if !test.WaitFor(t, func() (bool, error) {
 			diagnostics := node1.connectionManager.Diagnostics()
 			connectorsStats := diagnostics[3].(grpc.ConnectorsStats)
@@ -196,7 +197,7 @@ func TestNetworkIntegration_NodeDIDAuthentication(t *testing.T) {
 		node2.nodeDIDResolver.(*transport.FixedNodeDIDResolver).NodeDID = *malloryDID
 
 		// Now connect node1 to node2 and wait for them to set up
-		node1.connectionManager.Connect(nameToAddress(t, "node2"))
+		node1.connectionManager.Connect(nameToAddress(t, "node2"), false)
 		if !test.WaitFor(t, func() (bool, error) {
 			diagnostics := node1.connectionManager.Diagnostics()
 			connectorsStats := diagnostics[3].(grpc.ConnectorsStats)
@@ -226,7 +227,7 @@ func TestNetworkIntegration_OutboundConnectionReconnects(t *testing.T) {
 	node2 := startNode(t, "node2", testDirectory)
 
 	// Now connect node1 to node2 and wait for them to set up
-	node1.connectionManager.Connect(nameToAddress(t, "node2"))
+	node1.connectionManager.Connect(nameToAddress(t, "node2"), false)
 	if !test.WaitFor(t, func() (bool, error) {
 		return len(node1.connectionManager.Peers()) == 1 && len(node2.connectionManager.Peers()) == 1, nil
 	}, defaultTimeout, "time-out while waiting for node 1 and 2 to be connected") {

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -68,9 +68,9 @@ func TestNetworkIntegration_HappyFlow(t *testing.T) {
 	// each other that way.
 	bootstrap := startNode(t, "integration_bootstrap", testDirectory)
 	node1 := startNode(t, "integration_node1", testDirectory)
-	node1.connectionManager.Connect(nameToAddress(t, "integration_bootstrap"), false)
+	node1.connectionManager.Connect(nameToAddress(t, "integration_bootstrap"))
 	node2 := startNode(t, "integration_node2", testDirectory)
-	node2.connectionManager.Connect(nameToAddress(t, "integration_bootstrap"), false)
+	node2.connectionManager.Connect(nameToAddress(t, "integration_bootstrap"))
 
 	// Wait until nodes are connected
 	if !test.WaitFor(t, func() (bool, error) {
@@ -120,7 +120,7 @@ func TestNetworkIntegration_NodesConnectToEachOther(t *testing.T) {
 	node2 := startNode(t, "node2", testDirectory)
 
 	// Now connect node1 to node2 and wait for them to set up
-	node1.connectionManager.Connect(nameToAddress(t, "node2"), false)
+	node1.connectionManager.Connect(nameToAddress(t, "node2"))
 	if !test.WaitFor(t, func() (bool, error) {
 		return len(node1.connectionManager.Peers()) == 1 && len(node2.connectionManager.Peers()) == 1, nil
 	}, defaultTimeout, "time-out while waiting for node 1 and 2 to be connected") {
@@ -128,7 +128,7 @@ func TestNetworkIntegration_NodesConnectToEachOther(t *testing.T) {
 	}
 
 	// Now instruct node2 to connect to node1
-	node2.connectionManager.Connect(nameToAddress(t, "node1"), false)
+	node2.connectionManager.Connect(nameToAddress(t, "node1"))
 	time.Sleep(time.Second)
 	assert.Len(t, node1.connectionManager.Peers(), 1)
 	assert.Len(t, node2.connectionManager.Peers(), 1)
@@ -147,7 +147,7 @@ func TestNetworkIntegration_NodeDIDAuthentication(t *testing.T) {
 			cfg.NodeDID = "did:nuts:node2"
 		})
 		// Now connect node1 to node2 and wait for them to set up
-		node1.connectionManager.Connect(nameToAddress(t, "node2"), false)
+		node1.connectionManager.Connect(nameToAddress(t, "node2"))
 
 		test.WaitFor(t, func() (bool, error) {
 			return len(node1.connectionManager.Peers()) == 1 && len(node2.connectionManager.Peers()) == 1, nil
@@ -168,7 +168,7 @@ func TestNetworkIntegration_NodeDIDAuthentication(t *testing.T) {
 		node1.nodeDIDResolver.(*transport.FixedNodeDIDResolver).NodeDID = *malloryDID
 
 		// Now connect node1 to node2 and wait for them to set up
-		node1.connectionManager.Connect(nameToAddress(t, "node2"), false)
+		node1.connectionManager.Connect(nameToAddress(t, "node2"))
 		if !test.WaitFor(t, func() (bool, error) {
 			diagnostics := node1.connectionManager.Diagnostics()
 			connectorsStats := diagnostics[3].(grpc.ConnectorsStats)
@@ -197,7 +197,7 @@ func TestNetworkIntegration_NodeDIDAuthentication(t *testing.T) {
 		node2.nodeDIDResolver.(*transport.FixedNodeDIDResolver).NodeDID = *malloryDID
 
 		// Now connect node1 to node2 and wait for them to set up
-		node1.connectionManager.Connect(nameToAddress(t, "node2"), false)
+		node1.connectionManager.Connect(nameToAddress(t, "node2"))
 		if !test.WaitFor(t, func() (bool, error) {
 			diagnostics := node1.connectionManager.Diagnostics()
 			connectorsStats := diagnostics[3].(grpc.ConnectorsStats)
@@ -227,7 +227,7 @@ func TestNetworkIntegration_OutboundConnectionReconnects(t *testing.T) {
 	node2 := startNode(t, "node2", testDirectory)
 
 	// Now connect node1 to node2 and wait for them to set up
-	node1.connectionManager.Connect(nameToAddress(t, "node2"), false)
+	node1.connectionManager.Connect(nameToAddress(t, "node2"))
 	if !test.WaitFor(t, func() (bool, error) {
 		return len(node1.connectionManager.Peers()) == 1 && len(node2.connectionManager.Peers()) == 1, nil
 	}, defaultTimeout, "time-out while waiting for node 1 and 2 to be connected") {

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -23,10 +23,11 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
-	"github.com/nuts-foundation/go-did/did"
-	"github.com/nuts-foundation/nuts-node/network/transport"
 	"testing"
 	"time"
+
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/network/transport"
 
 	"github.com/golang/mock/gomock"
 	"github.com/nuts-foundation/nuts-node/core"
@@ -356,8 +357,8 @@ func TestNetwork_Start(t *testing.T) {
 		cxt := createNetwork(ctrl, func(config *Config) {
 			config.BootstrapNodes = []string{"bootstrap-node-1", "", "bootstrap-node-2"}
 		})
-		cxt.connectionManager.EXPECT().Connect("bootstrap-node-1")
-		cxt.connectionManager.EXPECT().Connect("bootstrap-node-2")
+		cxt.connectionManager.EXPECT().Connect("bootstrap-node-1", true)
+		cxt.connectionManager.EXPECT().Connect("bootstrap-node-2", true)
 		err := cxt.start()
 		if !assert.NoError(t, err) {
 			return

--- a/network/transport/connection_manager.go
+++ b/network/transport/connection_manager.go
@@ -28,7 +28,9 @@ type ConnectionManager interface {
 	core.Diagnosable
 
 	// Connect attempts to make an outbound connection to the given peer if it's not already connected.
-	Connect(peerAddress string)
+	// acceptNonAuthenticated indicates if the connection must be kept even if the other end can't be authenticated.
+	// The connection can then still be used for non-authenticated purposes.
+	Connect(peerAddress string, acceptNonAuthenticated bool)
 
 	// Peers returns a slice containing the peers that are currently connected.
 	Peers() []Peer

--- a/network/transport/connection_manager.go
+++ b/network/transport/connection_manager.go
@@ -23,6 +23,18 @@ import (
 	"github.com/nuts-foundation/nuts-node/core"
 )
 
+// ConnectionOption is the option function for adding options when establishing a connection through the connection manager.
+// The options are set on the Peer
+type ConnectionOption func(peer *Peer)
+
+// WithUnauthenticated is the option for allowing the connection to be unauthenticated.
+// The node.DID authentication on a connection will always succeed. Actions that require the node.DID will fail.
+func WithUnauthenticated() ConnectionOption {
+	return func(peer *Peer) {
+		peer.AcceptUnauthenticated = true
+	}
+}
+
 // ConnectionManager manages the connections to peers, making outbound connections if required. It also determines the network layout.
 type ConnectionManager interface {
 	core.Diagnosable
@@ -30,7 +42,7 @@ type ConnectionManager interface {
 	// Connect attempts to make an outbound connection to the given peer if it's not already connected.
 	// acceptNonAuthenticated indicates if the connection must be kept even if the other end can't be authenticated.
 	// The connection can then still be used for non-authenticated purposes.
-	Connect(peerAddress string, acceptNonAuthenticated bool)
+	Connect(peerAddress string, option ...ConnectionOption)
 
 	// Peers returns a slice containing the peers that are currently connected.
 	Peers() []Peer

--- a/network/transport/connection_manager_mock.go
+++ b/network/transport/connection_manager_mock.go
@@ -36,15 +36,15 @@ func (m *MockConnectionManager) EXPECT() *MockConnectionManagerMockRecorder {
 }
 
 // Connect mocks base method.
-func (m *MockConnectionManager) Connect(peerAddress string) {
+func (m *MockConnectionManager) Connect(peerAddress string, acceptNonAuthenticated bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Connect", peerAddress)
+	m.ctrl.Call(m, "Connect", peerAddress, acceptNonAuthenticated)
 }
 
 // Connect indicates an expected call of Connect.
-func (mr *MockConnectionManagerMockRecorder) Connect(peerAddress interface{}) *gomock.Call {
+func (mr *MockConnectionManagerMockRecorder) Connect(peerAddress, acceptNonAuthenticated interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connect", reflect.TypeOf((*MockConnectionManager)(nil).Connect), peerAddress)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connect", reflect.TypeOf((*MockConnectionManager)(nil).Connect), peerAddress, acceptNonAuthenticated)
 }
 
 // Diagnostics mocks base method.

--- a/network/transport/connection_manager_mock.go
+++ b/network/transport/connection_manager_mock.go
@@ -36,15 +36,20 @@ func (m *MockConnectionManager) EXPECT() *MockConnectionManagerMockRecorder {
 }
 
 // Connect mocks base method.
-func (m *MockConnectionManager) Connect(peerAddress string, acceptNonAuthenticated bool) {
+func (m *MockConnectionManager) Connect(peerAddress string, option ...ConnectionOption) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Connect", peerAddress, acceptNonAuthenticated)
+	varargs := []interface{}{peerAddress}
+	for _, a := range option {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Connect", varargs...)
 }
 
 // Connect indicates an expected call of Connect.
-func (mr *MockConnectionManagerMockRecorder) Connect(peerAddress, acceptNonAuthenticated interface{}) *gomock.Call {
+func (mr *MockConnectionManagerMockRecorder) Connect(peerAddress interface{}, option ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connect", reflect.TypeOf((*MockConnectionManager)(nil).Connect), peerAddress, acceptNonAuthenticated)
+	varargs := append([]interface{}{peerAddress}, option...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connect", reflect.TypeOf((*MockConnectionManager)(nil).Connect), varargs...)
 }
 
 // Diagnostics mocks base method.

--- a/network/transport/connection_manager_test.go
+++ b/network/transport/connection_manager_test.go
@@ -19,13 +19,22 @@
 package transport
 
 import (
-	"github.com/magiconair/properties/assert"
-	"github.com/nuts-foundation/go-did/did"
 	"testing"
+
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFixedNodeDIDResolver_Resolve(t *testing.T) {
 	expected, _ := did.ParseDID("did:nuts:test")
 	actual, _ := FixedNodeDIDResolver{NodeDID: *expected}.Resolve()
 	assert.Equal(t, actual.String(), expected.String())
+}
+
+func TestWithUnauthenticated(t *testing.T) {
+	peer := Peer{}
+
+	WithUnauthenticated()(&peer)
+
+	assert.True(t, peer.AcceptUnauthenticated)
 }

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -22,6 +22,9 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
+	"sync"
+
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/network/log"
@@ -31,8 +34,6 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	grpcPeer "google.golang.org/grpc/peer"
-	"net"
-	"sync"
 )
 
 const defaultMaxMessageSizeInBytes = 1024 * 512
@@ -183,8 +184,8 @@ func (s *grpcConnectionManager) Stop() {
 	}
 }
 
-func (s grpcConnectionManager) Connect(peerAddress string) {
-	connection, isNew := s.connections.getOrRegister(transport.Peer{Address: peerAddress}, s.dialer)
+func (s grpcConnectionManager) Connect(peerAddress string, acceptUnauthenticated bool) {
+	connection, isNew := s.connections.getOrRegister(transport.Peer{Address: peerAddress, AcceptUnauthenticated: acceptUnauthenticated}, s.dialer)
 	if !isNew {
 		log.Logger().Infof("A connection for %s already exists.", peerAddress)
 		return
@@ -303,10 +304,8 @@ func (s *grpcConnectionManager) openOutboundStream(connection Connection, protoc
 		return nil, fatalError{error: fmt.Errorf("peer sent invalid ID (id=%s)", peerID)}
 	}
 
-	peer := transport.Peer{
-		ID:      peerID,
-		Address: grpcConn.Target(),
-	}
+	//when bootstrap node, this instance has the AcceptUnauthenticated param
+	peer := connection.Peer()
 	peerFromCtx, _ := grpcPeer.FromContext(clientStream.Context())
 	peer, err = s.authenticate(nodeDID, peer, peerFromCtx)
 	if err != nil {

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -184,8 +184,12 @@ func (s *grpcConnectionManager) Stop() {
 	}
 }
 
-func (s grpcConnectionManager) Connect(peerAddress string, acceptUnauthenticated bool) {
-	connection, isNew := s.connections.getOrRegister(transport.Peer{Address: peerAddress, AcceptUnauthenticated: acceptUnauthenticated}, s.dialer)
+func (s grpcConnectionManager) Connect(peerAddress string, options ...transport.ConnectionOption) {
+	peer := transport.Peer{Address: peerAddress}
+	for _, o := range options {
+		o(&peer)
+	}
+	connection, isNew := s.connections.getOrRegister(peer, s.dialer)
 	if !isNew {
 		log.Logger().Infof("A connection for %s already exists.", peerAddress)
 		return

--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -72,7 +72,7 @@ func Test_grpcConnectionManager_Connect(t *testing.T) {
 		cm := NewGRPCConnectionManager(NewConfig("", "test"), &stubNodeDIDReader{}, nil, p).(*grpcConnectionManager)
 
 		peerAddress := fmt.Sprintf("127.0.0.1:%d", test.FreeTCPPort())
-		cm.Connect(peerAddress, false)
+		cm.Connect(peerAddress)
 		assert.Len(t, cm.connections.list, 1)
 	})
 
@@ -81,8 +81,8 @@ func Test_grpcConnectionManager_Connect(t *testing.T) {
 		cm := NewGRPCConnectionManager(NewConfig("", "test"), &stubNodeDIDReader{}, nil, p).(*grpcConnectionManager)
 
 		peerAddress := fmt.Sprintf("127.0.0.1:%d", test.FreeTCPPort())
-		cm.Connect(peerAddress, false)
-		cm.Connect(peerAddress, false)
+		cm.Connect(peerAddress)
+		cm.Connect(peerAddress)
 		assert.Len(t, cm.connections.list, 1)
 	})
 
@@ -100,7 +100,7 @@ func Test_grpcConnectionManager_Connect(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer server.Stop()
-		client.Connect("server", false)
+		client.Connect("server")
 	})
 }
 
@@ -129,14 +129,14 @@ func Test_grpcConnectionManager_Peers(t *testing.T) {
 		authenticator1.EXPECT().Authenticate(*nodeDID, gomock.Any(), gomock.Any()).Return(transport.Peer{}, nil)
 		cm2, authenticator2, _, _ := create(t, withBufconnDialer(listener))
 		authenticator2.EXPECT().Authenticate(*nodeDID, gomock.Any(), gomock.Any()).Return(transport.Peer{}, nil)
-		cm2.Connect("bufnet", false)
+		cm2.Connect("bufnet")
 		test.WaitFor(t, func() (bool, error) {
 			return len(cm2.Peers()) > 0, nil
 		}, time.Second*2, "waiting for peer 1 to connect")
 	})
 	t.Run("0 peers (1 connection which failed)", func(t *testing.T) {
 		cm, _, _, _ := create(t)
-		cm.Connect("non-existing", false)
+		cm.Connect("non-existing")
 		assert.Empty(t, cm.Peers())
 	})
 }

--- a/network/transport/types.go
+++ b/network/transport/types.go
@@ -20,8 +20,9 @@ package transport
 
 import (
 	"fmt"
-	"github.com/nuts-foundation/go-did/did"
 	"time"
+
+	"github.com/nuts-foundation/go-did/did"
 )
 
 // PeerID defines a peer's unique identifier.
@@ -41,6 +42,8 @@ type Peer struct {
 	// NodeDID holds the DID that the peer uses to identify its node on the network.
 	// It is only set when properly authenticated.
 	NodeDID did.DID
+	// AcceptUnauthenticated indicates if a connection may be made with this Peer even if the NodeDID is not set.
+	AcceptUnauthenticated bool
 }
 
 // String returns the peer as string.

--- a/network/transport/v1/protocol_v1_integration_test.go
+++ b/network/transport/v1/protocol_v1_integration_test.go
@@ -76,7 +76,7 @@ func TestProtocolV1_MissingPayloads(t *testing.T) {
 		return
 	}
 
-	node2.connectionManager.Connect(nameToAddress("node1"), false)
+	node2.connectionManager.Connect(nameToAddress("node1"))
 	// Wait until nodes are connected
 	if !test.WaitFor(t, func() (bool, error) {
 		return len(node1.connectionManager.Peers()) == 1 && len(node2.connectionManager.Peers()) == 1, nil
@@ -126,7 +126,7 @@ func TestProtocolV1_Pagination(t *testing.T) {
 		prev = tx
 	}
 
-	node2.connectionManager.Connect(nameToAddress("pagination_node1"), false)
+	node2.connectionManager.Connect(nameToAddress("pagination_node1"))
 	// Wait until nodes are connected
 	if !test.WaitFor(t, func() (bool, error) {
 		return len(node1.connectionManager.Peers()) == 1 && len(node2.connectionManager.Peers()) == 1, nil

--- a/network/transport/v1/protocol_v1_integration_test.go
+++ b/network/transport/v1/protocol_v1_integration_test.go
@@ -76,8 +76,7 @@ func TestProtocolV1_MissingPayloads(t *testing.T) {
 		return
 	}
 
-	node2.connectionManager.Connect(
-		nameToAddress("node1"))
+	node2.connectionManager.Connect(nameToAddress("node1"), false)
 	// Wait until nodes are connected
 	if !test.WaitFor(t, func() (bool, error) {
 		return len(node1.connectionManager.Peers()) == 1 && len(node2.connectionManager.Peers()) == 1, nil
@@ -127,7 +126,7 @@ func TestProtocolV1_Pagination(t *testing.T) {
 		prev = tx
 	}
 
-	node2.connectionManager.Connect(nameToAddress("pagination_node1"))
+	node2.connectionManager.Connect(nameToAddress("pagination_node1"), false)
 	// Wait until nodes are connected
 	if !test.WaitFor(t, func() (bool, error) {
 		return len(node1.connectionManager.Peers()) == 1 && len(node2.connectionManager.Peers()) == 1, nil

--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network/log"
 	"github.com/nuts-foundation/nuts-node/network/transport"

--- a/network/transport/v2/handlers_test.go
+++ b/network/transport/v2/handlers_test.go
@@ -1,6 +1,8 @@
 package v2
 
 import (
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
@@ -8,7 +10,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/network/transport"
 	"github.com/nuts-foundation/nuts-node/network/transport/grpc"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 var peer = transport.Peer{


### PR DESCRIPTION
fixes #699 

Adds a bool to `Connect` allowing unauthenticated connections to bootstrap nodes.
