### PR TITLE
find NutsComm service owners for private credentials

### DIFF
--- a/vcr/test.go
+++ b/vcr/test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/network"
 	"github.com/nuts-foundation/nuts-node/test/io"
 	"github.com/nuts-foundation/nuts-node/vcr/trust"
+	"github.com/nuts-foundation/nuts-node/vdr/doc"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 )
 
@@ -60,12 +61,13 @@ func NewTestVCRInstance(t *testing.T) *vcr {
 }
 
 type mockContext struct {
-	ctrl        *gomock.Controller
-	crypto      *crypto.MockKeyStore
-	tx          *network.MockTransactions
-	vcr         *vcr
-	keyResolver *types.MockKeyResolver
-	docResolver *types.MockDocResolver
+	ctrl            *gomock.Controller
+	crypto          *crypto.MockKeyStore
+	tx              *network.MockTransactions
+	vcr             *vcr
+	keyResolver     *types.MockKeyResolver
+	docResolver     *types.MockDocResolver
+	serviceResolver *doc.MockServiceResolver
 }
 
 func newMockContext(t *testing.T) mockContext {
@@ -79,7 +81,9 @@ func newMockContext(t *testing.T) mockContext {
 	tx.EXPECT().Subscribe(gomock.Any(), gomock.Any()).AnyTimes()
 	keyResolver := types.NewMockKeyResolver(ctrl)
 	docResolver := types.NewMockDocResolver(ctrl)
+	serviceResolver := doc.NewMockServiceResolver(ctrl)
 	vcr := NewVCRInstance(crypto, docResolver, keyResolver, tx).(*vcr)
+	vcr.serviceResolver = serviceResolver
 	vcr.trustConfig = trust.NewConfig(path.Join(testDir, "trust.yaml"))
 
 	if err := vcr.Configure(core.ServerConfig{Datadir: testDir}); err != nil {
@@ -92,11 +96,12 @@ func newMockContext(t *testing.T) mockContext {
 		vcr.Shutdown()
 	})
 	return mockContext{
-		ctrl:        ctrl,
-		crypto:      crypto,
-		tx:          tx,
-		vcr:         vcr,
-		keyResolver: keyResolver,
-		docResolver: docResolver,
+		ctrl:            ctrl,
+		crypto:          crypto,
+		tx:              tx,
+		vcr:             vcr,
+		keyResolver:     keyResolver,
+		docResolver:     docResolver,
+		serviceResolver: serviceResolver,
 	}
 }

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -40,11 +40,12 @@ import (
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network"
+	"github.com/nuts-foundation/nuts-node/network/transport"
 	"github.com/nuts-foundation/nuts-node/vcr/concept"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/log"
 	"github.com/nuts-foundation/nuts-node/vcr/trust"
-	doc2 "github.com/nuts-foundation/nuts-node/vdr/doc"
+	"github.com/nuts-foundation/nuts-node/vdr/doc"
 	vdr "github.com/nuts-foundation/nuts-node/vdr/types"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
@@ -62,12 +63,13 @@ var noSync bool
 // NewVCRInstance creates a new vcr instance with default config and empty concept registry
 func NewVCRInstance(keyStore crypto.KeyStore, docResolver vdr.DocResolver, keyResolver vdr.KeyResolver, network network.Transactions) VCR {
 	r := &vcr{
-		config:      DefaultConfig(),
-		docResolver: docResolver,
-		keyStore:    keyStore,
-		keyResolver: keyResolver,
-		network:     network,
-		registry:    concept.NewRegistry(),
+		config:          DefaultConfig(),
+		docResolver:     docResolver,
+		keyStore:        keyStore,
+		keyResolver:     keyResolver,
+		serviceResolver: doc.NewServiceResolver(docResolver),
+		network:         network,
+		registry:        concept.NewRegistry(),
 	}
 
 	r.ambassador = NewAmbassador(network, r)
@@ -76,15 +78,16 @@ func NewVCRInstance(keyStore crypto.KeyStore, docResolver vdr.DocResolver, keyRe
 }
 
 type vcr struct {
-	registry    concept.Registry
-	config      Config
-	store       leia.Store
-	keyStore    crypto.KeyStore
-	docResolver vdr.DocResolver
-	keyResolver vdr.KeyResolver
-	ambassador  Ambassador
-	network     network.Transactions
-	trustConfig *trust.Config
+	registry        concept.Registry
+	config          Config
+	store           leia.Store
+	keyStore        crypto.KeyStore
+	docResolver     vdr.DocResolver
+	keyResolver     vdr.KeyResolver
+	serviceResolver doc.ServiceResolver
+	ambassador      Ambassador
+	network         network.Transactions
+	trustConfig     *trust.Config
 }
 
 func (c *vcr) Registry() concept.Reader {
@@ -302,13 +305,13 @@ func (c *vcr) Issue(template vc.VerifiableCredential) (*vc.VerifiableCredential,
 		return nil, fmt.Errorf("failed to parse issuer: %w", err)
 	}
 	// find did document/metadata for originating TXs
-	doc, meta, err := c.docResolver.Resolve(*issuer, nil)
+	document, meta, err := c.docResolver.Resolve(*issuer, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	// resolve an assertionMethod key for issuer
-	kid, err := doc2.ExtractAssertionKeyID(*doc)
+	kid, err := doc.ExtractAssertionKeyID(*document)
 	if err != nil {
 		return nil, fmt.Errorf("invalid issuer: %w", err)
 	}
@@ -346,9 +349,15 @@ func (c *vcr) Issue(template vc.VerifiableCredential) (*vc.VerifiableCredential,
 			return nil, fmt.Errorf("failed to determine credentialSubject.ID: %w", err)
 		}
 
-		// participants are the issuer and the credentialSubject.id
-		participants = append(participants, *issuer)
-		participants = append(participants, *credentialSubjectID)
+		// participants are not the issuer and the credentialSubject.id but the DID that holds the concrete endpoint for the NutsComm service
+		for _, vcp := range []did.DID{*issuer, *credentialSubjectID} {
+			serviceOwner, err := c.resolveNutsCommServiceOwner(vcp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve participating node (did=%s): %w", vcp.String(), err)
+			}
+
+			participants = append(participants, *serviceOwner)
+		}
 	}
 
 	payload, _ := json.Marshal(verifiableCredential)
@@ -372,6 +381,21 @@ func (c *vcr) Issue(template vc.VerifiableCredential) (*vc.VerifiableCredential,
 	}
 
 	return &verifiableCredential, nil
+}
+
+func (c *vcr) resolveNutsCommServiceOwner(DID did.DID) (*did.DID, error) {
+	serviceUser, _ := ssi.ParseURI(fmt.Sprintf("%s/serviceEndpoint?type=%s", DID.String(), transport.NutsCommServiceType))
+
+	service, err := c.serviceResolver.Resolve(*serviceUser, 5)
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve NutsComm service owner: %w", err)
+	}
+	serviceID := service.ID
+	serviceID.Fragment = ""
+	serviceID.Path = ""
+
+	// impossible that this will return an error, so we won't wrap it within a different message
+	return did.ParseDID(serviceID.String())
 }
 
 func (c *vcr) Resolve(ID ssi.URI, resolveTime *time.Time) (*vc.VerifiableCredential, error) {
@@ -559,13 +583,13 @@ func (c *vcr) Revoke(ID ssi.URI) (*credential.Revocation, error) {
 		return nil, fmt.Errorf("failed to extract issuer: %w", err)
 	}
 	// find did document/metadata for originating TXs
-	doc, meta, err := c.docResolver.Resolve(*issuer, nil)
+	document, meta, err := c.docResolver.Resolve(*issuer, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	// resolve an assertionMethod key for issuer
-	kid, err := doc2.ExtractAssertionKeyID(*doc)
+	kid, err := doc.ExtractAssertionKeyID(*document)
 	if err != nil {
 		return nil, fmt.Errorf("invalid issuer: %w", err)
 	}


### PR DESCRIPTION
fixes #698 

the vcr translates the DIDs in the VC to their `NutsComm` service owners.

After merge, notify Slack channel on changes since issuing a private VC will no longer work without a node identity.