### PR TITLE
Network: fix ConnectionManager shutdown deadlock due to GRPCServer.GracefulStop()

### DIFF
--- a/network/transport/grpc/connection.go
+++ b/network/transport/grpc/connection.go
@@ -70,7 +70,7 @@ type Connection interface {
 	Connected() bool
 }
 
-func createConnection(dialer dialer, peer transport.Peer, parentCtx context.Context) Connection {
+func createConnection(parentCtx context.Context, dialer dialer, peer transport.Peer) Connection {
 	result := &conn{
 		dialer:    dialer,
 		streams:   make(map[string]Stream),

--- a/network/transport/grpc/connection_list.go
+++ b/network/transport/grpc/connection_list.go
@@ -76,7 +76,7 @@ func (c *connectionList) forEach(consumer func(connection Connection)) {
 // It returns false if the peer matched an existing connection.
 // It returns true if a new connection was created.
 // The given context is used as parent context for new connections: if it's cancelled, callers blocked by waitUntilDisconnected will be unblocked.
-func (c *connectionList) getOrRegister(peer transport.Peer, dialer dialer, ctx context.Context) (Connection, bool) {
+func (c *connectionList) getOrRegister(ctx context.Context, peer transport.Peer, dialer dialer) (Connection, bool) {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
@@ -93,7 +93,7 @@ func (c *connectionList) getOrRegister(peer transport.Peer, dialer dialer, ctx c
 		}
 	}
 
-	result := createConnection(dialer, peer, ctx)
+	result := createConnection(ctx, dialer, peer)
 	c.list = append(c.list, result)
 	return result, true
 }

--- a/network/transport/grpc/connection_list.go
+++ b/network/transport/grpc/connection_list.go
@@ -19,6 +19,7 @@
 package grpc
 
 import (
+	"context"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/network/transport"
 	"sync"
@@ -74,7 +75,8 @@ func (c *connectionList) forEach(consumer func(connection Connection)) {
 // If no connections match the given peer it creates a new one.
 // It returns false if the peer matched an existing connection.
 // It returns true if a new connection was created.
-func (c *connectionList) getOrRegister(peer transport.Peer, dialer dialer) (Connection, bool) {
+// The given context is used as parent context for new connections: if it's cancelled, callers blocked by waitUntilDisconnected will be unblocked.
+func (c *connectionList) getOrRegister(peer transport.Peer, dialer dialer, ctx context.Context) (Connection, bool) {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
@@ -91,7 +93,7 @@ func (c *connectionList) getOrRegister(peer transport.Peer, dialer dialer) (Conn
 		}
 	}
 
-	result := createConnection(dialer, peer)
+	result := createConnection(dialer, peer, ctx)
 	c.list = append(c.list, result)
 	return result, true
 }

--- a/network/transport/grpc/connection_list_test.go
+++ b/network/transport/grpc/connection_list_test.go
@@ -51,8 +51,8 @@ func TestConnectionList_Get(t *testing.T) {
 func TestConnectionList_All(t *testing.T) {
 	cn := connectionList{}
 
-	cn.getOrRegister(transport.Peer{ID: "a"}, nil, context.Background())
-	cn.getOrRegister(transport.Peer{ID: "b"}, nil, context.Background())
+	cn.getOrRegister(context.Background(), transport.Peer{ID: "a"}, nil)
+	cn.getOrRegister(context.Background(), transport.Peer{ID: "b"}, nil)
 
 	assert.Len(t, cn.All(), 2)
 }
@@ -60,18 +60,18 @@ func TestConnectionList_All(t *testing.T) {
 func TestConnectionList_getOrRegister(t *testing.T) {
 	t.Run("second call with same peer ID should return same connection", func(t *testing.T) {
 		cn := connectionList{}
-		connA, created1 := cn.getOrRegister(transport.Peer{ID: "a"}, nil, context.Background())
+		connA, created1 := cn.getOrRegister(context.Background(), transport.Peer{ID: "a"}, nil)
 		assert.True(t, created1)
-		connASecondCall, created2 := cn.getOrRegister(transport.Peer{ID: "a"}, nil, context.Background())
+		connASecondCall, created2 := cn.getOrRegister(context.Background(), transport.Peer{ID: "a"}, nil)
 		assert.False(t, created2)
 		assert.Equal(t, connA, connASecondCall)
 	})
 
 	t.Run("call with other peer ID should return same connection", func(t *testing.T) {
 		cn := connectionList{}
-		connA, created1 := cn.getOrRegister(transport.Peer{ID: "a"}, nil, context.Background())
+		connA, created1 := cn.getOrRegister(context.Background(), transport.Peer{ID: "a"}, nil)
 		assert.True(t, created1)
-		connB, created2 := cn.getOrRegister(transport.Peer{ID: "b"}, nil, context.Background())
+		connB, created2 := cn.getOrRegister(context.Background(), transport.Peer{ID: "b"}, nil)
 		assert.True(t, created2)
 		assert.NotEqual(t, connA, connB)
 	})
@@ -79,9 +79,9 @@ func TestConnectionList_getOrRegister(t *testing.T) {
 
 func TestConnectionList_remove(t *testing.T) {
 	cn := connectionList{}
-	connA, _ := cn.getOrRegister(transport.Peer{ID: "a"}, nil, context.Background())
-	connB, _ := cn.getOrRegister(transport.Peer{ID: "b"}, nil, context.Background())
-	connC, _ := cn.getOrRegister(transport.Peer{ID: "c"}, nil, context.Background())
+	connA, _ := cn.getOrRegister(context.Background(), transport.Peer{ID: "a"}, nil)
+	connB, _ := cn.getOrRegister(context.Background(), transport.Peer{ID: "b"}, nil)
+	connC, _ := cn.getOrRegister(context.Background(), transport.Peer{ID: "c"}, nil)
 
 	assert.Len(t, cn.list, 3)
 	cn.remove(connB)

--- a/network/transport/grpc/connection_list_test.go
+++ b/network/transport/grpc/connection_list_test.go
@@ -19,6 +19,7 @@
 package grpc
 
 import (
+	"context"
 	"github.com/nuts-foundation/nuts-node/network/transport"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -50,8 +51,8 @@ func TestConnectionList_Get(t *testing.T) {
 func TestConnectionList_All(t *testing.T) {
 	cn := connectionList{}
 
-	cn.getOrRegister(transport.Peer{ID: "a"}, nil)
-	cn.getOrRegister(transport.Peer{ID: "b"}, nil)
+	cn.getOrRegister(transport.Peer{ID: "a"}, nil, context.Background())
+	cn.getOrRegister(transport.Peer{ID: "b"}, nil, context.Background())
 
 	assert.Len(t, cn.All(), 2)
 }
@@ -59,18 +60,18 @@ func TestConnectionList_All(t *testing.T) {
 func TestConnectionList_getOrRegister(t *testing.T) {
 	t.Run("second call with same peer ID should return same connection", func(t *testing.T) {
 		cn := connectionList{}
-		connA, created1 := cn.getOrRegister(transport.Peer{ID: "a"}, nil)
+		connA, created1 := cn.getOrRegister(transport.Peer{ID: "a"}, nil, context.Background())
 		assert.True(t, created1)
-		connASecondCall, created2 := cn.getOrRegister(transport.Peer{ID: "a"}, nil)
+		connASecondCall, created2 := cn.getOrRegister(transport.Peer{ID: "a"}, nil, context.Background())
 		assert.False(t, created2)
 		assert.Equal(t, connA, connASecondCall)
 	})
 
 	t.Run("call with other peer ID should return same connection", func(t *testing.T) {
 		cn := connectionList{}
-		connA, created1 := cn.getOrRegister(transport.Peer{ID: "a"}, nil)
+		connA, created1 := cn.getOrRegister(transport.Peer{ID: "a"}, nil, context.Background())
 		assert.True(t, created1)
-		connB, created2 := cn.getOrRegister(transport.Peer{ID: "b"}, nil)
+		connB, created2 := cn.getOrRegister(transport.Peer{ID: "b"}, nil, context.Background())
 		assert.True(t, created2)
 		assert.NotEqual(t, connA, connB)
 	})
@@ -78,9 +79,9 @@ func TestConnectionList_getOrRegister(t *testing.T) {
 
 func TestConnectionList_remove(t *testing.T) {
 	cn := connectionList{}
-	connA, _ := cn.getOrRegister(transport.Peer{ID: "a"}, nil)
-	connB, _ := cn.getOrRegister(transport.Peer{ID: "b"}, nil)
-	connC, _ := cn.getOrRegister(transport.Peer{ID: "c"}, nil)
+	connA, _ := cn.getOrRegister(transport.Peer{ID: "a"}, nil, context.Background())
+	connB, _ := cn.getOrRegister(transport.Peer{ID: "b"}, nil, context.Background())
+	connC, _ := cn.getOrRegister(transport.Peer{ID: "c"}, nil, context.Background())
 
 	assert.Len(t, cn.list, 3)
 	cn.remove(connB)

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -74,7 +74,7 @@ func NewGRPCConnectionManager(config Config, nodeDIDResolver transport.NodeDIDRe
 		protocol := curr.(Protocol)
 		grpcProtocols = append(grpcProtocols, protocol)
 	}
-	return &grpcConnectionManager{
+	cm := &grpcConnectionManager{
 		protocols:       grpcProtocols,
 		nodeDIDResolver: nodeDIDResolver,
 		authenticator:   authenticator,
@@ -84,6 +84,8 @@ func NewGRPCConnectionManager(config Config, nodeDIDResolver transport.NodeDIDRe
 		listenerCreator: config.listener,
 		dialer:          config.dialer,
 	}
+	cm.ctx, cm.ctxCancel = context.WithCancel(context.Background())
+	return cm
 }
 
 // grpcConnectionManager is a ConnectionManager that does not discover peers on its own, but just connects to the peers for which Connect() is called.
@@ -93,6 +95,8 @@ type grpcConnectionManager struct {
 	connections      *connectionList
 	grpcServer       *grpc.Server
 	grpcServerMutex  *sync.Mutex
+	ctx              context.Context
+	ctxCancel        func()
 	listener         net.Listener
 	listenerCreator  func(string) (net.Listener, error)
 	dialer           dialer
@@ -169,6 +173,10 @@ func (s *grpcConnectionManager) Stop() {
 		connection.disconnect()
 	})
 
+	if s.ctxCancel != nil {
+		s.ctxCancel()
+	}
+
 	s.grpcServerMutex.Lock()
 	defer s.grpcServerMutex.Unlock()
 
@@ -189,7 +197,7 @@ func (s grpcConnectionManager) Connect(peerAddress string, options ...transport.
 	for _, o := range options {
 		o(&peer)
 	}
-	connection, isNew := s.connections.getOrRegister(peer, s.dialer)
+	connection, isNew := s.connections.getOrRegister(peer, s.dialer, s.ctx)
 	if !isNew {
 		log.Logger().Infof("A connection for %s already exists.", peerAddress)
 		return
@@ -373,7 +381,7 @@ func (s *grpcConnectionManager) handleInboundStream(protocol Protocol, inboundSt
 
 	// TODO: Need to authenticate PeerID, to make sure a second stream with a known PeerID is from the same node (maybe even connection).
 	//       Use address from peer context?
-	connection, _ := s.connections.getOrRegister(peer, s.dialer)
+	connection, _ := s.connections.getOrRegister(peer, s.dialer, s.ctx)
 	if !connection.registerStream(protocol, inboundStream) {
 		return ErrAlreadyConnected
 	}

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -197,7 +197,7 @@ func (s grpcConnectionManager) Connect(peerAddress string, options ...transport.
 	for _, o := range options {
 		o(&peer)
 	}
-	connection, isNew := s.connections.getOrRegister(peer, s.dialer, s.ctx)
+	connection, isNew := s.connections.getOrRegister(s.ctx, peer, s.dialer)
 	if !isNew {
 		log.Logger().Infof("A connection for %s already exists.", peerAddress)
 		return
@@ -381,7 +381,7 @@ func (s *grpcConnectionManager) handleInboundStream(protocol Protocol, inboundSt
 
 	// TODO: Need to authenticate PeerID, to make sure a second stream with a known PeerID is from the same node (maybe even connection).
 	//       Use address from peer context?
-	connection, _ := s.connections.getOrRegister(peer, s.dialer, s.ctx)
+	connection, _ := s.connections.getOrRegister(s.ctx, peer, s.dialer)
 	if !connection.registerStream(protocol, inboundStream) {
 		return ErrAlreadyConnected
 	}

--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -288,7 +288,7 @@ func Test_grpcConnectionManager_openOutboundStreams(t *testing.T) {
 		var waiter sync.WaitGroup
 		waiter.Add(1)
 
-		connection, _ := client.connections.getOrRegister(transport.Peer{Address: "server"}, client.dialer, context.Background())
+		connection, _ := client.connections.getOrRegister(context.Background(), transport.Peer{Address: "server"}, client.dialer)
 		connection.startConnecting(nil, func(grpcConn *grpc.ClientConn) bool {
 			err := client.openOutboundStreams(connection, grpcConn)
 			capturedError.Store(err)

--- a/network/transport/grpc/connection_test.go
+++ b/network/transport/grpc/connection_test.go
@@ -75,7 +75,7 @@ func Test_conn_waitUntilDisconnected(t *testing.T) {
 
 func Test_conn_registerStream(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
-		connection := createConnection(nil, transport.Peer{}, context.Background()).(*conn)
+		connection := createConnection(context.Background(), nil, transport.Peer{}).(*conn)
 		stream := newServerStream("foo", "")
 		defer stream.cancelFunc()
 
@@ -85,7 +85,7 @@ func Test_conn_registerStream(t *testing.T) {
 		assert.True(t, connection.Connected())
 	})
 	t.Run("already connected (same protocol)", func(t *testing.T) {
-		connection := createConnection(nil, transport.Peer{}, context.Background()).(*conn)
+		connection := createConnection(context.Background(), nil, transport.Peer{}).(*conn)
 		stream := newServerStream("foo", "")
 		defer stream.cancelFunc()
 

--- a/network/transport/grpc/connection_test.go
+++ b/network/transport/grpc/connection_test.go
@@ -75,7 +75,7 @@ func Test_conn_waitUntilDisconnected(t *testing.T) {
 
 func Test_conn_registerStream(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
-		connection := createConnection(nil, transport.Peer{}).(*conn)
+		connection := createConnection(nil, transport.Peer{}, context.Background()).(*conn)
 		stream := newServerStream("foo", "")
 		defer stream.cancelFunc()
 
@@ -85,7 +85,7 @@ func Test_conn_registerStream(t *testing.T) {
 		assert.True(t, connection.Connected())
 	})
 	t.Run("already connected (same protocol)", func(t *testing.T) {
-		connection := createConnection(nil, transport.Peer{}).(*conn)
+		connection := createConnection(nil, transport.Peer{}, context.Background()).(*conn)
 		stream := newServerStream("foo", "")
 		defer stream.cancelFunc()
 


### PR DESCRIPTION
Previously caused calling `Stop()` while a new inbound connection is received caused the Connection Manager to deadlock, being blocked by `conn.waitUntilDisconnected()` which blocks `GRPCServer.GracefulStop()`.

Solved by having the context `conn.waitUntilDisconnected()` waits for, derive from a parent context supplied by ConnectionManager, which is cancelled when `Stop()` is called.