### PR TITLE
Events: removed 'started Events manager' log, since it's already logged by core

### DIFF
--- a/events/event.go
+++ b/events/event.go
@@ -84,8 +84,6 @@ func (m *manager) Start() error {
 
 	server.Start()
 
-	log.Logger().Infof("started %s", moduleName)
-
 	return nil
 }
 


### PR DESCRIPTION
Now logged twice:

```
time="2022-01-06T14:38:07Z" level=warning msg="Revocation-supporting private key installed for irma-demo.MijnOverheid.root, but no revocation server is configured: issuance sessions will always fail"
time="2022-01-06T14:38:07Z" level=info msg="started Event manager" module=events
time="2022-01-06T14:38:07Z" level=info msg="started Event manager" module=core
```