### PR TITLE
Network: fix node DID not being passed to v2

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -107,6 +107,7 @@ func NewNetworkInstance(
 		didDocumentResolver:    didDocumentResolver,
 		eventManager:           eventManager,
 		lastTransactionTracker: lastTransactionTracker{headRefs: make(map[hash.SHA256Hash]bool)},
+		nodeDIDResolver:        &transport.FixedNodeDIDResolver{},
 	}
 }
 
@@ -154,8 +155,6 @@ func (n *Network) Configure(config core.ServerConfig) error {
 			return fmt.Errorf("configured NodeDID is invalid: %w", err)
 		}
 		n.nodeDIDResolver = &transport.FixedNodeDIDResolver{NodeDID: *configuredNodeDID}
-	} else {
-		n.nodeDIDResolver = &transport.FixedNodeDIDResolver{}
 	}
 
 	// Configure protocols

--- a/network/network.go
+++ b/network/network.go
@@ -105,7 +105,6 @@ func NewNetworkInstance(
 		keyResolver:            keyResolver,
 		privateKeyResolver:     privateKeyResolver,
 		didDocumentResolver:    didDocumentResolver,
-		nodeDIDResolver:        &transport.FixedNodeDIDResolver{},
 		eventManager:           eventManager,
 		lastTransactionTracker: lastTransactionTracker{headRefs: make(map[hash.SHA256Hash]bool)},
 	}
@@ -148,6 +147,17 @@ func (n *Network) Configure(config core.ServerConfig) error {
 		log.Logger().Warn("TLS is disabled but CertFile and/or CertKeyFile is set. Did you really mean to disable TLS?")
 	}
 
+	// Resolve node DID
+	if n.config.NodeDID != "" {
+		configuredNodeDID, err := did.ParseDID(n.config.NodeDID)
+		if err != nil {
+			return fmt.Errorf("configured NodeDID is invalid: %w", err)
+		}
+		n.nodeDIDResolver = &transport.FixedNodeDIDResolver{NodeDID: *configuredNodeDID}
+	} else {
+		n.nodeDIDResolver = &transport.FixedNodeDIDResolver{}
+	}
+
 	// Configure protocols
 	n.protocols = []transport.Protocol{
 		v1.New(n.config.ProtocolV1, n.graph, n.publisher, n.payloadStore, n.collectDiagnostics),
@@ -164,14 +174,6 @@ func (n *Network) Configure(config core.ServerConfig) error {
 		// Configure TLS
 		if n.config.EnableTLS {
 			grpcOpts = append(grpcOpts, grpc.WithTLS(clientCert, trustStore, n.config.MaxCRLValidityDays))
-		}
-		// Resolve node DID
-		if n.config.NodeDID != "" {
-			configuredNodeDID, err := did.ParseDID(n.config.NodeDID)
-			if err != nil {
-				return fmt.Errorf("configured NodeDID is invalid: %w", err)
-			}
-			n.nodeDIDResolver = &transport.FixedNodeDIDResolver{NodeDID: *configuredNodeDID}
 		}
 		// Instantiate
 		var authenticator grpc.Authenticator

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -626,6 +626,10 @@ func createNetwork(ctrl *gomock.Controller, cfgFn ...func(config *Config)) *netw
 	network.protocols = []transport.Protocol{prot}
 	network.publisher = publisher
 	network.didDocumentResolver = docResolver
+	if len(networkConfig.NodeDID) > 0 {
+		nodeDID, _ := did.ParseDID(networkConfig.NodeDID)
+		network.nodeDIDResolver = &transport.FixedNodeDIDResolver{NodeDID: *nodeDID}
+	}
 	network.startTime.Store(time.Now())
 	return &networkTestContext{
 		network:           network,

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -152,6 +152,16 @@ func TestNetwork_Configure(t *testing.T) {
 		}
 	})
 
+	t.Run("error - configured node DID invalid", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		ctx := createNetwork(ctrl)
+		ctx.network.config.NodeDID = "invalid"
+
+		err := ctx.network.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
+		assert.EqualError(t, err, "configured NodeDID is invalid: invalid DID: input does not begin with 'did:' prefix")
+	})
+
 	t.Run("ok - TLS enabled", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()


### PR DESCRIPTION
Taken from https://github.com/nuts-foundation/nuts-node/pull/708/commits/b1fc658016b22bd13cc8b5b94dea465e82c79c33

The `nodeDIDResolver` passed to `v2.New()` (create v2 protocol instance) got passed the default, emtpy node DID resolver. After that, it's overwritten with a resolver that contains the actual node DID. But since it's overwritten, v2 doesn't get the new, populated node DID resolver. Leading to node DID not being populated when encountering a private TX. Simply moving the initialization be before the protocol init fixes this.

Not really unit testable, since it calls package functions (`v2.New`), which can't be mocked. It's also a private member of v2 protocol, so not accessible for assertion. Integration-testable by https://github.com/nuts-foundation/nuts-node/pull/708