### PR TITLE
Return session not found in IRMA signer if a session was not found

### DIFF
--- a/auth/services/irma/signer.go
+++ b/auth/services/irma/signer.go
@@ -22,6 +22,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/privacybydesign/irmago/server/irmaserver"
 	"os"
 	"strings"
 
@@ -112,6 +113,10 @@ func (v Service) StartSigningSession(rawContractText string) (contract.SessionPo
 func (v Service) SigningSessionStatus(sessionID string) (contract.SigningSessionResult, error) {
 	result, err := v.IrmaSessionHandler.GetSessionResult(sessionID)
 	if err != nil {
+		if _, ok := err.(*irmaserver.UnknownSessionError); ok {
+			return nil, services.ErrSessionNotFound
+		}
+
 		return nil, err
 	}
 	if result == nil {

--- a/auth/services/irma/signer_test.go
+++ b/auth/services/irma/signer_test.go
@@ -20,6 +20,7 @@ package irma
 
 import (
 	"errors"
+	"github.com/privacybydesign/irmago/server/irmaserver"
 	"testing"
 
 	"github.com/nuts-foundation/nuts-node/crypto"
@@ -126,6 +127,7 @@ func TestService_SigningSessionStatus(t *testing.T) {
 
 		irmaMock := ctx.service.IrmaSessionHandler.(*mockIrmaClient)
 		irmaMock.sessionResult = nil
+		irmaMock.err = &irmaserver.UnknownSessionError{}
 
 		_, err := ctx.service.SigningSessionStatus("session")
 

--- a/auth/services/irma/validator_test.go
+++ b/auth/services/irma/validator_test.go
@@ -42,7 +42,7 @@ type mockIrmaClient struct {
 
 func (m *mockIrmaClient) GetSessionResult(token string) (*irmaservercore.SessionResult, error) {
 	if m.err != nil {
-		return nil, nil
+		return nil, m.err
 	}
 	return m.sessionResult, nil
 }


### PR DESCRIPTION
Hotfix for now. This should be 'redesigned' as currently we are checking every signer for a specific error (whether a session was found or not) until one either returns no error or another error. This will break when third-party libraries (such as IRMA) decide to raise other errors but with the same meaning.