### PR TITLE
Network: emit TransactionAddedEvent in unblocking fashion

### DIFF
--- a/network/dag/publisher.go
+++ b/network/dag/publisher.go
@@ -59,17 +59,14 @@ type replayingDAGPublisher struct {
 }
 
 func (s *replayingDAGPublisher) payloadWritten(ctx context.Context, _ interface{}) {
-	s.publishMux.Lock()
-	defer s.publishMux.Unlock()
-
 	s.publish(ctx)
 }
 
 func (s *replayingDAGPublisher) transactionAdded(ctx context.Context, transaction interface{}) {
-	s.publishMux.Lock()
-	defer s.publishMux.Unlock()
-
 	tx := transaction.(Transaction)
+
+	s.emitEvent(TransactionAddedEvent, tx, nil)
+
 	// Received new transaction, add it to the subscription walker resume list, so it resumes from this transaction
 	// when the payload is received.
 	s.resumeAt.PushBack(tx.Ref())
@@ -110,19 +107,18 @@ func (s *replayingDAGPublisher) Start() error {
 		return fmt.Errorf("failed to setup NATS stream: %w", err)
 	}
 
-	s.dag.RegisterObserver(s.transactionAdded)
-	s.payloadStore.RegisterObserver(s.payloadWritten)
+	s.dag.RegisterObserver(func(ctx context.Context, subject interface{}) {
+		s.publishMux.Lock()
+		defer s.publishMux.Unlock()
+		s.transactionAdded(ctx, subject)
+	})
+	s.payloadStore.RegisterObserver(func(ctx context.Context, subject interface{}) {
+		s.publishMux.Lock()
+		defer s.publishMux.Unlock()
+		s.payloadWritten(ctx, subject)
+	})
 
-	ctx = context.Background()
-	s.publishMux.Lock()
-	defer s.publishMux.Unlock()
-
-	// since the walker starts at root for an empty hash, no need to find the root first
-	s.resumeAt.PushBack(hash.EmptyHash())
-	s.publish(ctx)
-
-	log.Logger().Debug("Finished replaying DAG")
-	return nil
+	return s.replay()
 }
 
 // publish is called both from payloadWritten and transactionAdded. Only when both are satified (transaction is present and payload as well), the transaction is published.
@@ -137,6 +133,7 @@ func (s *replayingDAGPublisher) publish(ctx context.Context) {
 	err := s.dag.Walk(ctx, func(ctx context.Context, transaction Transaction) bool {
 		outcome := true
 		txRef := transaction.Ref()
+
 		// visit once
 		if !s.visitedTransactions[txRef] {
 			if outcome = s.publishTransaction(ctx, transaction); outcome {
@@ -179,24 +176,54 @@ func (s *replayingDAGPublisher) publishTransaction(ctx context.Context, transact
 		return false
 	}
 
-	// TODO: Now calls TransactionAddedEvent and TransactionPayloadAddedEvent after checken whether the payload is present.
+	// TODO: Now calls TransactionAddedEvent and TransactionPayloadAddedEvent after checking whether the payload is present.
 	//       This will need to be changed: TransactionAddedEvent must be called regardless whether the payload is present or not (e.g. top of this function).
 	//       However, when doing that at this moment, TransactionAddedEvent might be published multiple times for transactions which payload is not present the first time.
 	//       This is generally the case during operation when new transactions are received over the network.
 	//       Since not all subscribers are guaranteed to be idempotent at this time, they might break if we introduce it at this moment in time.
 	//       So after all subscribers are made idempotent, TransactionAddedEvent must be published regardless of the payload is present or not.
 	//       This is to accommodate syncing DAGs even when receiving a TX with a detached payload, or a private TX not meant for the local node.
-	for eventType := range s.subscribers {
-		for _, payloadType := range []string{transaction.PayloadType(), AnyPayloadType} {
-			receiver := s.subscribers[eventType][payloadType]
-			if receiver == nil {
-				continue
-			}
-			if err := receiver(transaction, payload); err != nil {
-				log.Logger().Errorf("Transaction subscriber returned an error (ref=%s,type=%s): %v", transaction.Ref(), transaction.PayloadType(), err)
-			}
-		}
-	}
+	s.emitEvent(TransactionPayloadAddedEvent, transaction, payload)
 
 	return true
+}
+
+func (s *replayingDAGPublisher) emitEvent(eventType EventType, transaction Transaction, payload []byte) {
+	for _, payloadType := range []string{transaction.PayloadType(), AnyPayloadType} {
+		subs := s.subscribers[eventType]
+		if subs == nil {
+			continue
+		}
+		receiver := subs[payloadType]
+		if receiver == nil {
+			continue
+		}
+		if err := receiver(transaction, payload); err != nil {
+			log.Logger().Errorf("Transaction subscriber returned an error (ref=%s,type=%s): %v", transaction.Ref(), transaction.PayloadType(), err)
+		}
+	}
+}
+
+func (s *replayingDAGPublisher) replay() error {
+	log.Logger().Debug("Replaying DAG...")
+	s.publishMux.Lock()
+	defer s.publishMux.Unlock()
+
+	err := s.dag.Walk(context.Background(), func(ctx context.Context, tx Transaction) bool {
+		s.transactionAdded(ctx, tx)
+		payload, err := s.payloadStore.ReadPayload(ctx, tx.PayloadHash())
+		if err != nil {
+			log.Logger().Errorf("Error reading payload (tx=%s): %v", tx.Ref(), err)
+		}
+		if payload == nil {
+			return false
+		}
+		s.payloadWritten(ctx, tx)
+		return true
+	}, hash.EmptyHash())
+	if err != nil {
+		return err
+	}
+	log.Logger().Debug("Finished replaying DAG")
+	return nil
 }

--- a/network/dag/publisher_test.go
+++ b/network/dag/publisher_test.go
@@ -21,6 +21,9 @@ package dag
 import (
 	"context"
 	"errors"
+	"go.etcd.io/bbolt"
+	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -101,102 +104,116 @@ func TestReplayingPublisher(t *testing.T) {
 	})
 }
 
-func TestReplayingPublisher_publishTransaction(t *testing.T) {
+func TestReplayingPublisher_Publish(t *testing.T) {
 	ctx := context.Background()
+	rootTX := CreateTestTransactionWithJWK(1)
+	rootTXPayload := []byte{1, 2, 3}
 	t.Run("no subscribers", func(t *testing.T) {
 		ctrl := createPublisher(t)
 
-		ctrl.payloadStore.EXPECT().ReadPayload(ctx, gomock.Any()).Return([]byte{1, 2, 3}, nil)
+		ctrl.payloadStore.EXPECT().ReadPayload(gomock.Any(), rootTX.PayloadHash()).Return(rootTXPayload, nil)
+		ctrl.graph.Add(ctx, rootTX)
 
-		ctrl.publisher.publishTransaction(ctx, CreateTestTransactionWithJWK(1))
+		ctrl.publisher.transactionAdded(ctx, rootTX)
 	})
 	t.Run("single subscriber", func(t *testing.T) {
 		ctrl := createPublisher(t)
 
-		transaction := CreateTestTransactionWithJWK(1)
-		ctrl.payloadStore.EXPECT().ReadPayload(ctx, transaction.PayloadHash()).Return([]byte{1, 2, 3}, nil)
+		ctrl.payloadStore.EXPECT().ReadPayload(gomock.Any(), rootTX.PayloadHash()).Return(rootTXPayload, nil)
+		ctrl.graph.Add(ctx, rootTX)
 
 		calls := 0
-		ctrl.publisher.Subscribe(TransactionPayloadAddedEvent, transaction.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
-			assert.Equal(t, transaction, actualTransaction)
+		ctrl.publisher.Subscribe(TransactionPayloadAddedEvent, rootTX.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
+			assert.Equal(t, rootTX, actualTransaction)
 			calls++
 			return nil
 		})
-		ctrl.publisher.publishTransaction(ctx, transaction)
+
+		ctrl.publisher.transactionAdded(ctx, rootTX)
+		ctrl.publisher.payloadWritten(ctx, nil)
+
 		assert.Equal(t, 1, calls)
 	})
 	t.Run("subscribers on multiple event types", func(t *testing.T) {
 		ctrl := createPublisher(t)
 
-		transaction := CreateTestTransactionWithJWK(1)
-		ctrl.payloadStore.EXPECT().ReadPayload(ctx, transaction.PayloadHash()).Return([]byte{1, 2, 3}, nil)
+		ctrl.payloadStore.EXPECT().ReadPayload(gomock.Any(), rootTX.PayloadHash()).Return(rootTXPayload, nil)
+		ctrl.graph.Add(ctx, rootTX)
 
 		txAddedCalls := 0
 		txPayloadAddedCalls := 0
-		ctrl.publisher.Subscribe(TransactionAddedEvent, transaction.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
-			assert.Equal(t, transaction, actualTransaction)
+		ctrl.publisher.Subscribe(TransactionAddedEvent, rootTX.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
+			assert.Equal(t, rootTX, actualTransaction)
 			txAddedCalls++
 			return nil
 		})
-		ctrl.publisher.Subscribe(TransactionPayloadAddedEvent, transaction.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
-			assert.Equal(t, transaction, actualTransaction)
+		ctrl.publisher.Subscribe(TransactionPayloadAddedEvent, rootTX.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
+			assert.Equal(t, rootTX, actualTransaction)
 			txPayloadAddedCalls++
 			return nil
 		})
-		ctrl.publisher.publishTransaction(ctx, transaction)
 
-		assert.Equal(t, 0, txAddedCalls)
+		ctrl.publisher.transactionAdded(ctx, rootTX)
+		ctrl.publisher.payloadWritten(ctx, nil)
+
+		assert.Equal(t, 1, txAddedCalls)
 		assert.Equal(t, 1, txPayloadAddedCalls)
 	})
 	t.Run("not received when transaction with pal header is skipped", func(t *testing.T) {
 		ctrl := createPublisher(t)
 
-		transaction := CreateSignedTestTransaction(1, time.Now(), [][]byte{{9, 8, 7}}, "foo/bar", true)
+		tx := CreateSignedTestTransaction(1, time.Now(), [][]byte{{9, 8, 7}}, "foo/bar", true)
 
-		ctrl.payloadStore.EXPECT().ReadPayload(ctx, transaction.PayloadHash()).Return(nil, nil)
-		ctrl.privateTxCtx.EXPECT().PublishAsync(events.PrivateTransactionsSubject, gomock.Any()).Return(nil, nil)
+		ctrl.payloadStore.EXPECT().ReadPayload(gomock.Any(), tx.PayloadHash()).AnyTimes().Return(nil, nil)
+		ctrl.privateTxCtx.EXPECT().PublishAsync(events.PrivateTransactionsSubject, gomock.Any()).
+			MinTimes(1). // TODO: This is currently broken: should only be published once
+			Return(nil, nil)
+		ctrl.graph.Add(ctx, tx)
 
 		txAddedCalled := 0
-		ctrl.publisher.Subscribe(TransactionAddedEvent, transaction.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
+		ctrl.publisher.Subscribe(TransactionAddedEvent, tx.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
 			txAddedCalled++
 			return nil
 		})
 		txPayloadAddedCalled := 0
-		ctrl.publisher.Subscribe(TransactionPayloadAddedEvent, transaction.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
+		ctrl.publisher.Subscribe(TransactionPayloadAddedEvent, tx.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
 			txPayloadAddedCalled++
 			return nil
 		})
 
-		ctrl.publisher.publishTransaction(ctx, transaction)
-		assert.Equal(t, 0, txAddedCalled)
+		ctrl.publisher.transactionAdded(ctx, tx)
+
+		assert.Equal(t, 1, txAddedCalled)
 		assert.Equal(t, 0, txPayloadAddedCalled)
 	})
 	t.Run("payload not present (but present later)", func(t *testing.T) {
 		ctrl := createPublisher(t)
 
-		transaction := CreateTestTransactionWithJWK(1)
-		ctrl.payloadStore.EXPECT().ReadPayload(ctx, transaction.PayloadHash()).Return(nil, nil)
+		ctrl.payloadStore.EXPECT().ReadPayload(gomock.Any(), rootTX.PayloadHash()).Return(nil, nil)
+		ctrl.graph.Add(ctx, rootTX)
 
 		txAddedCalled := 0
-		ctrl.publisher.Subscribe(TransactionAddedEvent, transaction.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
-			assert.Equal(t, transaction, actualTransaction)
+		ctrl.publisher.Subscribe(TransactionAddedEvent, rootTX.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
+			assert.Equal(t, rootTX, actualTransaction)
 			txAddedCalled++
 			return nil
 		})
 		txPayloadAddedCalled := 0
-		ctrl.publisher.Subscribe(TransactionPayloadAddedEvent, transaction.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
-			assert.Equal(t, transaction, actualTransaction)
+		ctrl.publisher.Subscribe(TransactionPayloadAddedEvent, rootTX.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
+			assert.Equal(t, rootTX, actualTransaction)
 			txPayloadAddedCalled++
 			return nil
 		})
 
-		ctrl.publisher.publishTransaction(ctx, transaction)
-		assert.Equal(t, 0, txAddedCalled)
+		ctrl.publisher.transactionAdded(ctx, rootTX)
+
+		assert.Equal(t, 1, txAddedCalled)
 		assert.Equal(t, 0, txPayloadAddedCalled)
 
 		// Now add the payload and trigger subscribers
-		ctrl.payloadStore.EXPECT().ReadPayload(ctx, transaction.PayloadHash()).Return([]byte{1, 2, 3}, nil)
-		ctrl.publisher.publishTransaction(ctx, transaction)
+		ctrl.payloadStore.EXPECT().ReadPayload(gomock.Any(), rootTX.PayloadHash()).Return(rootTXPayload, nil)
+
+		ctrl.publisher.payloadWritten(ctx, nil)
 
 		assert.Equal(t, 1, txAddedCalled)
 		assert.Equal(t, 1, txPayloadAddedCalled)
@@ -204,54 +221,60 @@ func TestReplayingPublisher_publishTransaction(t *testing.T) {
 	t.Run("error reading payload", func(t *testing.T) {
 		ctrl := createPublisher(t)
 
-		transaction := CreateTestTransactionWithJWK(1)
-		ctrl.payloadStore.EXPECT().ReadPayload(ctx, transaction.PayloadHash()).Return(nil, errors.New("failed"))
+		ctrl.payloadStore.EXPECT().ReadPayload(gomock.Any(), rootTX.PayloadHash()).MinTimes(1).Return(nil, errors.New("failed"))
+		ctrl.graph.Add(ctx, rootTX)
 
 		txAddedCalled := false
-		ctrl.publisher.Subscribe(TransactionAddedEvent, transaction.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
+		ctrl.publisher.Subscribe(TransactionAddedEvent, rootTX.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
 			txAddedCalled = true
 			return nil
 		})
 		txPayloadAddedCalled := false
-		ctrl.publisher.Subscribe(TransactionAddedEvent, transaction.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
+		ctrl.publisher.Subscribe(TransactionPayloadAddedEvent, rootTX.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
 			txPayloadAddedCalled = true
 			return nil
 		})
-		ctrl.publisher.publishTransaction(ctx, transaction)
-		assert.False(t, txAddedCalled)
+
+		ctrl.publisher.transactionAdded(ctx, rootTX)
+		ctrl.publisher.payloadWritten(ctx, nil)
+
+		assert.True(t, txAddedCalled)
 		assert.False(t, txPayloadAddedCalled)
 	})
 	t.Run("multiple subscribers on single event type", func(t *testing.T) {
 		ctrl := createPublisher(t)
 
-		transaction := CreateTestTransactionWithJWK(1)
-		ctrl.payloadStore.EXPECT().ReadPayload(ctx, transaction.PayloadHash()).Return([]byte{1, 2, 3}, nil)
+		ctrl.payloadStore.EXPECT().ReadPayload(gomock.Any(), rootTX.PayloadHash()).Return(rootTXPayload, nil)
+		ctrl.graph.Add(ctx, rootTX)
 
 		calls := 0
 		receiver := func(actualTransaction Transaction, actualPayload []byte) error {
 			calls++
 			return nil
 		}
-		ctrl.publisher.Subscribe(TransactionAddedEvent, transaction.PayloadType(), receiver)
-		ctrl.publisher.Subscribe(TransactionAddedEvent, transaction.PayloadType(), receiver)
+		ctrl.publisher.Subscribe(TransactionAddedEvent, rootTX.PayloadType(), receiver)
+		ctrl.publisher.Subscribe(TransactionAddedEvent, rootTX.PayloadType(), receiver)
 
-		ctrl.publisher.publishTransaction(ctx, transaction)
+		ctrl.publisher.transactionAdded(ctx, rootTX)
 
 		assert.Equal(t, 2, calls)
 	})
 	t.Run("multiple subscribers on single event type, first fails", func(t *testing.T) {
 		ctrl := createPublisher(t)
 
-		transaction := CreateTestTransactionWithJWK(1)
-		ctrl.payloadStore.EXPECT().ReadPayload(ctx, transaction.PayloadHash()).Return([]byte{1, 2, 3}, nil)
+		ctrl.payloadStore.EXPECT().ReadPayload(gomock.Any(), rootTX.PayloadHash()).Return(rootTXPayload, nil)
+		ctrl.graph.Add(ctx, rootTX)
+
 		calls := 0
 		receiver := func(actualTransaction Transaction, actualPayload []byte) error {
 			calls++
 			return errors.New("failed")
 		}
-		ctrl.publisher.Subscribe(TransactionAddedEvent, transaction.PayloadType(), receiver)
-		ctrl.publisher.Subscribe(TransactionAddedEvent, transaction.PayloadType(), receiver)
-		ctrl.publisher.transactionAdded(ctx, transaction)
+		ctrl.publisher.Subscribe(TransactionAddedEvent, rootTX.PayloadType(), receiver)
+		ctrl.publisher.Subscribe(TransactionAddedEvent, rootTX.PayloadType(), receiver)
+
+		ctrl.publisher.transactionAdded(ctx, rootTX)
+
 		assert.Equal(t, 1, calls)
 	})
 }
@@ -259,10 +282,14 @@ func TestReplayingPublisher_publishTransaction(t *testing.T) {
 func createPublisher(t *testing.T) testPublisher {
 	ctrl := gomock.NewController(t)
 	payloadStore := NewMockPayloadStore(ctrl)
-	dag := NewMockDAG(ctrl)
+	db, _ := bbolt.Open(path.Join(io.TestDirectory(t), "dag.bbolt"), os.ModePerm, nil)
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	graph := NewBBoltDAG(db)
 	privateTxCtx := events.NewMockJetStreamContext(ctrl)
 	eventManager := events.NewMockEvent(ctrl)
-	publisher := NewReplayingDAGPublisher(eventManager, payloadStore, dag).(*replayingDAGPublisher)
+	publisher := NewReplayingDAGPublisher(eventManager, payloadStore, graph).(*replayingDAGPublisher)
 	publisher.privateTxCtx = privateTxCtx
 	return testPublisher{
 		ctrl:         ctrl,
@@ -270,6 +297,7 @@ func createPublisher(t *testing.T) testPublisher {
 		eventManager: eventManager,
 		privateTxCtx: privateTxCtx,
 		publisher:    publisher,
+		graph:        graph,
 	}
 }
 
@@ -279,4 +307,5 @@ type testPublisher struct {
 	eventManager *events.MockEvent
 	privateTxCtx *events.MockJetStreamContext
 	publisher    *replayingDAGPublisher
+	graph        DAG
 }

--- a/network/dag/publisher_test.go
+++ b/network/dag/publisher_test.go
@@ -117,13 +117,13 @@ func TestReplayingPublisher_publishTransaction(t *testing.T) {
 		ctrl.payloadStore.EXPECT().ReadPayload(ctx, transaction.PayloadHash()).Return([]byte{1, 2, 3}, nil)
 
 		calls := 0
-		ctrl.publisher.Subscribe(TransactionAddedEvent, transaction.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
+		ctrl.publisher.Subscribe(TransactionPayloadAddedEvent, transaction.PayloadType(), func(actualTransaction Transaction, actualPayload []byte) error {
 			assert.Equal(t, transaction, actualTransaction)
 			calls++
 			return nil
 		})
 		ctrl.publisher.publishTransaction(ctx, transaction)
-		assert.Equal(t, calls, 1)
+		assert.Equal(t, 1, calls)
 	})
 	t.Run("subscribers on multiple event types", func(t *testing.T) {
 		ctrl := createPublisher(t)
@@ -145,7 +145,7 @@ func TestReplayingPublisher_publishTransaction(t *testing.T) {
 		})
 		ctrl.publisher.publishTransaction(ctx, transaction)
 
-		assert.Equal(t, 1, txAddedCalls)
+		assert.Equal(t, 0, txAddedCalls)
 		assert.Equal(t, 1, txPayloadAddedCalls)
 	})
 	t.Run("not received when transaction with pal header is skipped", func(t *testing.T) {
@@ -251,7 +251,7 @@ func TestReplayingPublisher_publishTransaction(t *testing.T) {
 		}
 		ctrl.publisher.Subscribe(TransactionAddedEvent, transaction.PayloadType(), receiver)
 		ctrl.publisher.Subscribe(TransactionAddedEvent, transaction.PayloadType(), receiver)
-		ctrl.publisher.publishTransaction(ctx, transaction)
+		ctrl.publisher.transactionAdded(ctx, transaction)
 		assert.Equal(t, 1, calls)
 	})
 }

--- a/network/dag/replayer.go
+++ b/network/dag/replayer.go
@@ -1,7 +1,0 @@
-package dag
-
-type Replayer struct {
-	payloadStore PayloadStore
-	graph        DAG
-
-}

--- a/network/dag/replayer.go
+++ b/network/dag/replayer.go
@@ -1,0 +1,7 @@
+package dag
+
+type Replayer struct {
+	payloadStore PayloadStore
+	graph        DAG
+
+}


### PR DESCRIPTION
Now publishes `TransactionAddedEvent` directly when a new TX is added to the DAG. Had to rework DAG replay, because otherwise it wouldn't be emitted.

Consequence is that `Publisher` now relies heavily on the calling of `transactionAdded` and `payloadWritten`, especially the first one. It must be called in correct order for the emitted events to be in correct order. But luckily, that is the DAG's job, which does it well.