### PR TITLE
Network: don't notify observers when TX isn't added to DAG

### DIFF
--- a/network/dag/bbolt_dag_test.go
+++ b/network/dag/bbolt_dag_test.go
@@ -155,13 +155,21 @@ func TestBBoltDAG_Add(t *testing.T) {
 	t.Run("duplicate", func(t *testing.T) {
 		ctx := context.Background()
 		graph := CreateDAG(t)
+		observerCalls := 0
+		graph.RegisterObserver(func(_ context.Context, _ interface{}) {
+			observerCalls++
+		})
 		tx := CreateTestTransactionWithJWK(0)
 
 		_ = graph.Add(ctx, tx)
 		err := graph.Add(ctx, tx)
+
 		assert.NoError(t, err)
+		// Assert we can find the TX, but make sure it's only there once
 		actual, _ := graph.FindBetween(ctx, MinTime(), MaxTime())
 		assert.Len(t, actual, 1)
+		// Assert observers are only called once
+		assert.Equal(t, 1, observerCalls)
 	})
 	t.Run("second root", func(t *testing.T) {
 		ctx := context.Background()


### PR DESCRIPTION
DAG observers are currently notified when a TX was passed to `Add()` which already existed on the DAG. This never caused issues, but https://github.com/nuts-foundation/nuts-node/pull/741 assumes its `transactionAdded()` function is called only once per TX, because otherwise it emits duplicate `TransactionAddedEvent`s.

It would not be a big issue since all subscribers should be idempotent, but it might cause unneeded logging/confusion/load. Thus we should avoid if we can do so with relative ease.