### PR TITLE
Fix duplicate did document creation

### DIFF
--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -469,8 +469,10 @@ func (c *vcr) validate(credential vc.VerifiableCredential, validAt *time.Time) e
 		return ErrInvalidPeriod
 	}
 
-	_, _, err = c.docResolver.Resolve(*issuer, &vdr.ResolveMetadata{ResolveTime: &at})
-	return err
+	if _, _, err = c.docResolver.Resolve(*issuer, &vdr.ResolveMetadata{ResolveTime: &at}); err != nil {
+		return fmt.Errorf("unable to resolve DID Document (ID=%s): %w", issuer.String(), err)
+	}
+	return nil
 }
 
 func (c *vcr) isTrusted(credential vc.VerifiableCredential) bool {
@@ -550,7 +552,7 @@ func (c *vcr) Verify(subject vc.VerifiableCredential, at *time.Time) error {
 	// find key
 	pk, err := c.keyResolver.ResolveSigningKey(proof.VerificationMethod.String(), at)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to resolve signing key: %w", err)
 	}
 
 	// the proof must be correct

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -25,13 +25,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/nuts-node/network/dag"
 	"os"
 	"reflect"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/nuts-foundation/nuts-node/network/dag"
 
 	"github.com/nuts-foundation/nuts-node/network"
 	"github.com/stretchr/testify/mock"
@@ -302,7 +303,7 @@ func TestVCR_Resolve(t *testing.T) {
 		ctx.docResolver.EXPECT().Resolve(*issuer, &types.ResolveMetadata{ResolveTime: &now}).Return(nil, nil, types.ErrNotFound)
 
 		_, err := ctx.vcr.Resolve(*testVC.ID, &now)
-		assert.Equal(t, types.ErrNotFound, err)
+		assert.EqualError(t, err, fmt.Sprintf("unable to resolve DID Document (ID=%s): unable to find the DID document", testVC.Issuer.String()))
 	})
 }
 

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -303,7 +303,7 @@ func TestVCR_Resolve(t *testing.T) {
 		ctx.docResolver.EXPECT().Resolve(*issuer, &types.ResolveMetadata{ResolveTime: &now}).Return(nil, nil, types.ErrNotFound)
 
 		_, err := ctx.vcr.Resolve(*testVC.ID, &now)
-		assert.EqualError(t, err, fmt.Sprintf("unable to resolve DID Document (ID=%s): unable to find the DID document", testVC.Issuer.String()))
+		assert.ErrorIsf(t, err, types.ErrNotFound, fmt.Sprintf("unable to resolve DID Document (ID=%s): unable to find the DID document", testVC.Issuer.String()))
 	})
 }
 

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -110,7 +110,7 @@ func (n *ambassador) callback(tx dag.Transaction, payload []byte) error {
 		return fmt.Errorf("could not process new DID Document: %w", err)
 	}
 	if doc != nil {
-		log.Logger().Infof("Skipping did document, already exists (tx=%s)", tx.Ref().String())
+		log.Logger().Infof("Skipping DID document, already exists (tx=%s)", tx.Ref().String())
 		return nil
 	}
 
@@ -147,9 +147,10 @@ func (n *ambassador) handleCreateDIDDocument(transaction dag.Transaction, propos
 	// check for an existing document, it could have been a parallel create. If existing merge and update.
 	currentDIDDocument, currentDIDMeta, err := n.didStore.Resolve(proposedDIDDocument.ID, nil)
 	if err != nil && !errors.Is(err, types.ErrNotFound) {
-		return fmt.Errorf("unable to create DID document: %w", err)
+		return fmt.Errorf("unable to register DID document: %w", err)
 	}
 	sourceTransactions := []hash.SHA256Hash{transaction.Ref()}
+	// pointer to updated time required for metadata, nil by default
 	var updatedAtP *time.Time
 	if currentDIDDocument != nil {
 		mergedDoc, err := doc.MergeDocuments(*currentDIDDocument, proposedDIDDocument)
@@ -176,8 +177,7 @@ func (n *ambassador) handleCreateDIDDocument(transaction dag.Transaction, propos
 	}
 
 	if err != nil {
-		return fmt.Errorf("unable to create DID document: %w", err)
-
+		return fmt.Errorf("unable to register DID document: %w", err)
 	}
 
 	log.Logger().Infof("DID document registered (tx=%s,did=%s)", transaction.Ref(), proposedDIDDocument.ID)

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"time"
 
 	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
@@ -86,7 +87,7 @@ var thumbprintAlg = crypto.SHA256
 func (n *ambassador) callback(tx dag.Transaction, payload []byte) error {
 	log.Logger().Debugf("Processing DID document received from Nuts Network (ref=%s)", tx.Ref())
 	if err := checkTransactionIntegrity(tx); err != nil {
-		return fmt.Errorf("callback could not process new DID Document: %w", err)
+		return fmt.Errorf("could not process new DID Document: %w", err)
 	}
 
 	// Unmarshal the next/new proposed version of the DID Document
@@ -99,12 +100,7 @@ func (n *ambassador) callback(tx dag.Transaction, payload []byte) error {
 		return fmt.Errorf("callback could not process new DID Document, DID Document integrity check failed: %w", err)
 	}
 
-	isUpdate, err := n.isUpdate(nextDIDDocument)
-	if err != nil {
-		return fmt.Errorf("callback could not process new DID Document, failed to resolve current DID Document: %w", err)
-	}
-
-	if isUpdate {
+	if n.isUpdate(tx) {
 		return n.handleUpdateDIDDocument(tx, nextDIDDocument)
 	}
 	return n.handleCreateDIDDocument(tx, nextDIDDocument)
@@ -134,16 +130,45 @@ func (n *ambassador) handleCreateDIDDocument(transaction dag.Transaction, propos
 		return err
 	}
 
+	// check for an existing document, it could have been a parallel create. If existing merge and update.
+	currentDIDDocument, currentDIDMeta, err := n.didStore.Resolve(proposedDIDDocument.ID, nil)
+	if err != nil && !errors.Is(err, types.ErrNotFound) {
+		return fmt.Errorf("unable to create DID document: %w", err)
+	}
+	sourceTransactions := []hash.SHA256Hash{transaction.Ref()}
+	var updatedAtP *time.Time
+	if currentDIDDocument != nil {
+		mergedDoc, err := doc.MergeDocuments(*currentDIDDocument, proposedDIDDocument)
+		if err != nil {
+			return fmt.Errorf("unable to merge conflicted DID Document: %w", err)
+		}
+		proposedDIDDocument = *mergedDoc
+		sourceTransactions = uniqueTransactions(currentDIDMeta.SourceTransactions, transaction.Ref())
+		updatedAt := transaction.SigningTime()
+		updatedAtP = &updatedAt
+	}
+
 	documentMetadata := types.DocumentMetadata{
 		Created:            transaction.SigningTime(),
+		Updated:            updatedAtP,
 		Hash:               transaction.PayloadHash(),
-		SourceTransactions: []hash.SHA256Hash{transaction.Ref()},
+		SourceTransactions: sourceTransactions,
 	}
-	err = n.didStore.Write(proposedDIDDocument, documentMetadata)
-	if err == nil {
-		log.Logger().Infof("DID document registered (tx=%s,did=%s)", transaction.Ref(), proposedDIDDocument.ID)
+
+	if currentDIDDocument != nil {
+		err = n.didStore.Update(currentDIDDocument.ID, currentDIDMeta.Hash, proposedDIDDocument, &documentMetadata)
+	} else {
+		err = n.didStore.Write(proposedDIDDocument, documentMetadata)
 	}
-	return err
+
+	if err != nil {
+		return fmt.Errorf("unable to create DID document: %w", err)
+
+	}
+
+	log.Logger().Infof("DID document registered (tx=%s,did=%s)", transaction.Ref(), proposedDIDDocument.ID)
+
+	return nil
 }
 
 func (n *ambassador) handleUpdateDIDDocument(transaction dag.Transaction, proposedDIDDocument did.Document) error {
@@ -292,19 +317,8 @@ func checkTransactionIntegrity(transaction dag.Transaction) error {
 	return nil
 }
 
-func (n ambassador) isUpdate(doc did.Document) (bool, error) {
-	_, _, err := n.didStore.Resolve(doc.ID, nil)
-	result := true
-
-	if errors.Is(err, types.ErrNotFound) {
-		return false, nil
-	}
-
-	if err != nil {
-		result = false
-	}
-
-	return result, err
+func (n ambassador) isUpdate(transaction dag.Transaction) bool {
+	return transaction.SigningKey() == nil
 }
 
 // findKeyByThumbprint accepts a SHA256 generated thumbprint and tries to find it in a provided list of did.VerificationRelationship s.

--- a/vdr/ambassador_test.go
+++ b/vdr/ambassador_test.go
@@ -288,7 +288,7 @@ func TestAmbassador_handleCreateDIDDocument(t *testing.T) {
 
 		err = ctx.ambassador.handleCreateDIDDocument(tx, expectedDocument)
 
-		assert.EqualError(t, err, "unable to create DID document: b00m!")
+		assert.EqualError(t, err, "unable to register DID document: b00m!")
 	})
 
 	// This test recreates the situation where the node gets restarted and the ambassador handles all the

--- a/vdr/doc/resolvers.go
+++ b/vdr/doc/resolvers.go
@@ -113,7 +113,7 @@ func (d Resolver) resolveControllers(doc did.Document, metadata *types.ResolveMe
 			return nil, err
 		}
 		if err != nil {
-			return nil, fmt.Errorf("unable to resolve controllers: %w", err)
+			return nil, fmt.Errorf("unable to resolve controller ref: %w", err)
 		}
 		leaves = append(leaves, *node)
 	}

--- a/vdr/doc/resolvers_test.go
+++ b/vdr/doc/resolvers_test.go
@@ -411,7 +411,7 @@ func TestResolver_ResolveControllers(t *testing.T) {
 		docB := did.Document{ID: *id456, Controller: []did.DID{*id123}}
 
 		docs, err := resolver.ResolveControllers(docB, nil)
-		assert.EqualError(t, err, "unable to resolve controllers: unable to find the DID document")
+		assert.EqualError(t, err, "unable to resolve controller ref: unable to find the DID document")
 		assert.Len(t, docs, 0)
 	})
 }


### PR DESCRIPTION
It has a double fix. The callback first searches for docs based on the TX hash, if found it skips the update.
If a creation has been recorded from a different TX it'll merge the two creations.