### PR TITLE
Network: auto-resolve node DID

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -84,6 +84,11 @@ func (client *Crypto) setupVaultBackend(_ core.ServerConfig) error {
 	return err
 }
 
+// List returns the KIDs of the private keys that are present in the key store.
+func (client *Crypto) List() []string {
+	return client.Storage.ListPrivateKeys()
+}
+
 // Configure loads the given configurations in the engine. Any wrong combination will return an error
 func (client *Crypto) Configure(config core.ServerConfig) error {
 	switch client.config.Storage {

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -105,7 +105,6 @@ func (client *Crypto) Configure(config core.ServerConfig) error {
 	default:
 		return errors.New("invalid config for crypto.storage. Available options are: vaultkv, fs")
 	}
-	return nil
 }
 
 // New generates a new key pair.

--- a/crypto/interface.go
+++ b/crypto/interface.go
@@ -43,6 +43,8 @@ type KeyResolver interface {
 	Exists(kid string) bool
 	// Resolve returns a Key for the given KID. ErrKeyNotFound is returned for an unknown KID.
 	Resolve(kid string) (Key, error)
+	// List returns the KIDs of the private keys that are present in the KeyStore.
+	List() []string
 }
 
 // KeyStore defines the functions for working with private keys.

--- a/crypto/mock.go
+++ b/crypto/mock.go
@@ -86,6 +86,20 @@ func (mr *MockKeyResolverMockRecorder) Exists(kid interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockKeyResolver)(nil).Exists), kid)
 }
 
+// List mocks base method.
+func (m *MockKeyResolver) List() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// List indicates an expected call of List.
+func (mr *MockKeyResolverMockRecorder) List() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockKeyResolver)(nil).List))
+}
+
 // Resolve mocks base method.
 func (m *MockKeyResolver) Resolve(kid string) (Key, error) {
 	m.ctrl.T.Helper()
@@ -151,6 +165,20 @@ func (m *MockKeyStore) Exists(kid string) bool {
 func (mr *MockKeyStoreMockRecorder) Exists(kid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockKeyStore)(nil).Exists), kid)
+}
+
+// List mocks base method.
+func (m *MockKeyStore) List() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// List indicates an expected call of List.
+func (mr *MockKeyStoreMockRecorder) List() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockKeyStore)(nil).List))
 }
 
 // New mocks base method.

--- a/crypto/storage/fs.go
+++ b/crypto/storage/fs.go
@@ -118,7 +118,7 @@ func (fsc *fileSystemBackend) ListPrivateKeys() []string {
 	_ = filepath.Walk(fsc.fspath, func(path string, info fs.FileInfo, err error) error {
 		if !info.IsDir() && strings.HasSuffix(info.Name(), string(privateKeyEntry)) {
 			upper := len(info.Name()) - len(privateKeyEntry) - 1
-			if upper < len(info.Name()) {
+			if upper > 0 {
 				result = append(result, info.Name()[:upper])
 			}
 		}

--- a/crypto/storage/fs.go
+++ b/crypto/storage/fs.go
@@ -23,8 +23,10 @@ import (
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/crypto/util"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type entryType string
@@ -109,6 +111,20 @@ func (fsc *fileSystemBackend) SavePrivateKey(kid string, key crypto.PrivateKey) 
 	_, err = outFile.Write([]byte(pem))
 
 	return err
+}
+
+func (fsc *fileSystemBackend) ListPrivateKeys() []string {
+	var result []string
+	_ = filepath.Walk(fsc.fspath, func(path string, info fs.FileInfo, err error) error {
+		if !info.IsDir() && strings.HasSuffix(info.Name(), string(privateKeyEntry)) {
+			upper := len(info.Name()) - len(privateKeyEntry) - 1
+			if upper < len(info.Name()) {
+				result = append(result, info.Name()[:upper])
+			}
+		}
+		return nil
+	})
+	return result
 }
 
 func (fsc fileSystemBackend) readEntry(kid string, entryType entryType) ([]byte, error) {

--- a/crypto/storage/fs_test.go
+++ b/crypto/storage/fs_test.go
@@ -19,9 +19,12 @@
 package storage
 
 import (
+	"fmt"
 	"github.com/nuts-foundation/nuts-node/crypto/test"
 	"github.com/nuts-foundation/nuts-node/test/io"
 	"os"
+	"path"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,4 +94,27 @@ func Test_fs_KeyExistsFor(t *testing.T) {
 		storage.SavePrivateKey(kid, pk)
 		assert.True(t, storage.PrivateKeyExists(kid))
 	})
+}
+
+func Test_fs_ListPrivateKeys(t *testing.T) {
+	storage, _ := NewFileSystemBackend(io.TestDirectory(t))
+	backend := storage.(*fileSystemBackend)
+
+	// Generate a few keys
+	pk := test.GenerateECKey()
+	for i := 0; i < 5; i++ {
+		kid := fmt.Sprintf("key-%d", i)
+		_ = backend.SavePrivateKey(kid, pk)
+	}
+
+	// Store some other cruft that shouldn't return as private key
+	_ = os.WriteFile(path.Join(backend.fspath, "foo.txt"), []byte{1, 2, 3}, os.ModePerm)
+	_ = os.WriteFile(path.Join(backend.fspath, "daslkdjaslkdj_public.json"), []byte{1, 2, 3}, os.ModePerm)
+	_ = os.WriteFile(path.Join(backend.fspath, "daslkdjaslkdj_private.bin"), []byte{1, 2, 3}, os.ModePerm)
+	_ = os.Mkdir(path.Join(backend.fspath, "subdir"), os.ModePerm)
+	_ = os.WriteFile(path.Join(backend.fspath, "subdir", "daslkdjaslkdj_public.json"), []byte{1, 2, 3}, os.ModePerm)
+
+	keys := backend.ListPrivateKeys()
+	sort.Strings(keys)
+	assert.Equal(t, []string{"key-0", "key-1", "key-2", "key-3", "key-4"}, keys)
 }

--- a/crypto/storage/fs_test.go
+++ b/crypto/storage/fs_test.go
@@ -108,6 +108,8 @@ func Test_fs_ListPrivateKeys(t *testing.T) {
 	}
 
 	// Store some other cruft that shouldn't return as private key
+	_ = os.WriteFile(path.Join(backend.fspath, string(privateKeyEntry)), []byte{1, 2, 3}, os.ModePerm)
+	_ = os.WriteFile(path.Join(backend.fspath, "_" + string(privateKeyEntry)), []byte{1, 2, 3}, os.ModePerm)
 	_ = os.WriteFile(path.Join(backend.fspath, "foo.txt"), []byte{1, 2, 3}, os.ModePerm)
 	_ = os.WriteFile(path.Join(backend.fspath, "daslkdjaslkdj_public.json"), []byte{1, 2, 3}, os.ModePerm)
 	_ = os.WriteFile(path.Join(backend.fspath, "daslkdjaslkdj_private.bin"), []byte{1, 2, 3}, os.ModePerm)

--- a/crypto/storage/mock.go
+++ b/crypto/storage/mock.go
@@ -49,6 +49,20 @@ func (mr *MockStorageMockRecorder) GetPrivateKey(kid interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrivateKey", reflect.TypeOf((*MockStorage)(nil).GetPrivateKey), kid)
 }
 
+// ListPrivateKeys mocks base method.
+func (m *MockStorage) ListPrivateKeys() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPrivateKeys")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// ListPrivateKeys indicates an expected call of ListPrivateKeys.
+func (mr *MockStorageMockRecorder) ListPrivateKeys() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPrivateKeys", reflect.TypeOf((*MockStorage)(nil).ListPrivateKeys))
+}
+
 // PrivateKeyExists mocks base method.
 func (m *MockStorage) PrivateKeyExists(kid string) bool {
 	m.ctrl.T.Helper()

--- a/crypto/storage/storage.go
+++ b/crypto/storage/storage.go
@@ -40,6 +40,8 @@ type Storage interface {
 	PrivateKeyExists(kid string) bool
 	// SavePrivateKey stores the key under the kid in the storage backend.
 	SavePrivateKey(kid string, key crypto.PrivateKey) error
+	// ListPrivateKeys returns the KIDs of the private keys that are present.
+	ListPrivateKeys() []string
 }
 
 // PublicKeyEntry is a public key entry also containing the period it's valid for.

--- a/crypto/storage/vault.go
+++ b/crypto/storage/vault.go
@@ -22,6 +22,7 @@ import (
 	"crypto"
 	"fmt"
 	vault "github.com/hashicorp/vault/api"
+	"github.com/nuts-foundation/nuts-node/crypto/log"
 	"github.com/nuts-foundation/nuts-node/crypto/util"
 	"path/filepath"
 )
@@ -149,14 +150,32 @@ func (v vaultKVStorage) PrivateKeyExists(kid string) bool {
 }
 
 func (v vaultKVStorage) ListPrivateKeys() []string {
-	// not supported yet
-	return nil
+	path := privateKeyListPath(v.config.PathPrefix)
+	response, err := v.client.Read(path)
+	if err != nil {
+		log.Logger().Errorf("Could not list private keys in Vault: %v", err)
+		return nil
+	}
+	keys, _ := response.Data["keys"].([]interface{})
+	var result []string
+	for _, key := range keys {
+		keyStr, ok := key.(string)
+		if ok {
+			result = append(result, keyStr)
+		}
+	}
+	return result
 }
 
 // privateKeyPath cleans the kid by removing optional slashes and dots and constructs the key path
 // This prevents “dot-dot-slash” aka “directory traversal” attacks.
 func privateKeyPath(prefix, kid string) string {
 	path := fmt.Sprintf("%s/%s/%s", prefix, privateKeyPathName, filepath.Base(kid))
+	return filepath.Clean(path)
+}
+
+func privateKeyListPath(prefix string) string {
+	path := fmt.Sprintf("%s/%s?list=true", prefix, privateKeyPathName)
 	return filepath.Clean(path)
 }
 

--- a/crypto/storage/vault.go
+++ b/crypto/storage/vault.go
@@ -148,6 +148,11 @@ func (v vaultKVStorage) PrivateKeyExists(kid string) bool {
 	return ok
 }
 
+func (v vaultKVStorage) ListPrivateKeys() []string {
+	// not supported yet
+	return nil
+}
+
 // privateKeyPath cleans the kid by removing optional slashes and dots and constructs the key path
 // This prevents “dot-dot-slash” aka “directory traversal” attacks.
 func privateKeyPath(prefix, kid string) string {

--- a/crypto/storage/vault_test.go
+++ b/crypto/storage/vault_test.go
@@ -115,6 +115,19 @@ func TestVaultKVStorage(t *testing.T) {
 	})
 }
 
+func TestVaultKVStorage_ListPrivateKeys(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Write([]byte("{\"request_id\":\"d728876e-ea1e-8a58-f297-dcd4cd0a41bb\",\"lease_id\":\"\",\"renewable\":false,\"lease_duration\":0,\"data\":{\"keys\":[\"did:nuts:8AB7Jf8KYgNHC52sfyTTK2f2yGnDoSHkgzDgeqvrUBLo#45KSfeG71ZMh9NjGzSWFfcMsmu5587J93prf8Io1wf4\",\"did:nuts:8AB7Jf8KYgNHC52sfyTTK2f2yGnDoSHkgzDgeqvrUBLo#6Cc91cQQze7txdcEor_zkM4YSwX0kH1wsiMyeV9nedA\",\"did:nuts:8AB7Jf8KYgNHC52sfyTTK2f2yGnDoSHkgzDgeqvrUBLo#MaNou-G07aPD7oheretmI2C_VElG1XaHiqh89SlfkWQ\",\"did:nuts:8AB7Jf8KYgNHC52sfyTTK2f2yGnDoSHkgzDgeqvrUBLo#alt3OIpy21VxDlWao0jRumIyXi3qHBPG-ir5q8zdv8w\",\"did:nuts:8AB7Jf8KYgNHC52sfyTTK2f2yGnDoSHkgzDgeqvrUBLo#wumme98rwUOQVle-sT_MP3pRg_oqblvlanv3zYR2scc\",\"did:nuts:8AB7Jf8KYgNHC52sfyTTK2f2yGnDoSHkgzDgeqvrUBLo#yBLHNjVq_WM3qzsRQ_zi2yOcedjY9FfVfByp3HgEbR8\",\"did:nuts:8AB7Jf8KYgNHC52sfyTTK2f2yGnDoSHkgzDgeqvrUBLo#yREqK5id7I6SP1Iq7teThin2o53w17tb9sgEXZBIcDo\"]},\"wrap_info\":null,\"warnings\":null,\"auth\":null}"))
+	}))
+	defer s.Close()
+	storage, _ := NewVaultKVStorage(VaultConfig{Address: s.URL})
+	keys := storage.ListPrivateKeys()
+	assert.Len(t, keys, 7)
+	// Assert first and last entry, rest should be OK then
+	assert.Equal(t, "did:nuts:8AB7Jf8KYgNHC52sfyTTK2f2yGnDoSHkgzDgeqvrUBLo#45KSfeG71ZMh9NjGzSWFfcMsmu5587J93prf8Io1wf4", keys[0])
+	assert.Equal(t, "did:nuts:8AB7Jf8KYgNHC52sfyTTK2f2yGnDoSHkgzDgeqvrUBLo#yREqK5id7I6SP1Iq7teThin2o53w17tb9sgEXZBIcDo", keys[6])
+}
+
 func Test_PrivateKeyPath(t *testing.T) {
 	t.Run("it removes dot-dot-slash paths from the kid", func(t *testing.T) {
 		assert.Equal(t, "kv/nuts-private-keys/did:nuts:123#abc", privateKeyPath("kv", "did:nuts:123#abc"))

--- a/crypto/test.go
+++ b/crypto/test.go
@@ -53,6 +53,14 @@ func NewMemoryStorage() storage.Storage {
 
 type memoryStorage map[string]crypto.PrivateKey
 
+func (m memoryStorage) ListPrivateKeys() []string {
+	var result []string
+	for key := range m {
+		result = append(result, key)
+	}
+	return result
+}
+
 func (m memoryStorage) GetPrivateKey(kid string) (crypto.Signer, error) {
 	pk, ok := m[kid]
 	if !ok {

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -151,6 +151,35 @@ func TestNetwork_Configure(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
+		actual, err := ctx.network.nodeDIDResolver.Resolve()
+		assert.IsType(t, &transport.FixedNodeDIDResolver{}, ctx.network.nodeDIDResolver)
+		assert.NoError(t, err)
+		assert.Equal(t, "did:nuts:test", actual.String())
+	})
+	t.Run("ok - auto-resolve node DID", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		ctx := createNetwork(ctrl)
+
+		err := ctx.network.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.IsType(t, transport.NewAutoNodeDIDResolver(nil, nil), ctx.network.nodeDIDResolver)
+	})
+	t.Run("ok - no DID set in strict mode, should return empty node DID", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		ctx := createNetwork(ctrl)
+
+		err := ctx.network.Configure(core.ServerConfig{Datadir: io.TestDirectory(t), Strictmode: true})
+		if !assert.NoError(t, err) {
+			return
+		}
+		actual, err := ctx.network.nodeDIDResolver.Resolve()
+		assert.IsType(t, &transport.FixedNodeDIDResolver{}, ctx.network.nodeDIDResolver)
+		assert.NoError(t, err)
+		assert.Empty(t, actual)
 	})
 
 	t.Run("error - configured node DID invalid", func(t *testing.T) {

--- a/network/transport/connection_manager.go
+++ b/network/transport/connection_manager.go
@@ -19,7 +19,6 @@
 package transport
 
 import (
-	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/core"
 )
 
@@ -54,17 +53,3 @@ type ConnectionManager interface {
 	Stop()
 }
 
-// NodeDIDResolver defines an interface for types that resolve the local node's DID, which is used to identify the node on the network.
-type NodeDIDResolver interface {
-	// Resolve tries to resolve the node DID. If it's absent, an empty DID is returned. In any other non-successful case an error is returned.
-	Resolve() (did.DID, error)
-}
-
-// FixedNodeDIDResolver is a NodeDIDResolver that returns a preset DID.
-type FixedNodeDIDResolver struct {
-	NodeDID did.DID
-}
-
-func (f FixedNodeDIDResolver) Resolve() (did.DID, error) {
-	return f.NodeDID, nil
-}

--- a/network/transport/connection_manager.go
+++ b/network/transport/connection_manager.go
@@ -52,4 +52,3 @@ type ConnectionManager interface {
 	// Stop shuts down the connections made by the ConnectionManager.
 	Stop()
 }
-

--- a/network/transport/connection_manager_mock.go
+++ b/network/transport/connection_manager_mock.go
@@ -8,7 +8,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	did "github.com/nuts-foundation/go-did/did"
 	core "github.com/nuts-foundation/nuts-node/core"
 )
 
@@ -104,42 +103,4 @@ func (m *MockConnectionManager) Stop() {
 func (mr *MockConnectionManagerMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockConnectionManager)(nil).Stop))
-}
-
-// MockNodeDIDResolver is a mock of NodeDIDResolver interface.
-type MockNodeDIDResolver struct {
-	ctrl     *gomock.Controller
-	recorder *MockNodeDIDResolverMockRecorder
-}
-
-// MockNodeDIDResolverMockRecorder is the mock recorder for MockNodeDIDResolver.
-type MockNodeDIDResolverMockRecorder struct {
-	mock *MockNodeDIDResolver
-}
-
-// NewMockNodeDIDResolver creates a new mock instance.
-func NewMockNodeDIDResolver(ctrl *gomock.Controller) *MockNodeDIDResolver {
-	mock := &MockNodeDIDResolver{ctrl: ctrl}
-	mock.recorder = &MockNodeDIDResolverMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockNodeDIDResolver) EXPECT() *MockNodeDIDResolverMockRecorder {
-	return m.recorder
-}
-
-// Resolve mocks base method.
-func (m *MockNodeDIDResolver) Resolve() (did.DID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Resolve")
-	ret0, _ := ret[0].(did.DID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Resolve indicates an expected call of Resolve.
-func (mr *MockNodeDIDResolverMockRecorder) Resolve() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockNodeDIDResolver)(nil).Resolve))
 }

--- a/network/transport/nodedid.go
+++ b/network/transport/nodedid.go
@@ -27,14 +27,14 @@ func (f FixedNodeDIDResolver) Resolve() (did.DID, error) {
 
 // NewAutoNodeDIDResolver creates a new node DID resolver that tried to look it up by matching DID documents with a NutsComm endpoint set and the private key of the local node.
 func NewAutoNodeDIDResolver(keyResolver crypto.KeyResolver, docFinder types.DocFinder) NodeDIDResolver {
-	return &AutoNodeDIDResolver{
+	return &autoNodeDIDResolver{
 		keyResolver: keyResolver,
 		docFinder:   docFinder,
 		mux:         &sync.Mutex{},
 	}
 }
 
-type AutoNodeDIDResolver struct {
+type autoNodeDIDResolver struct {
 	keyResolver crypto.KeyResolver
 	docFinder   types.DocFinder
 	mux         *sync.Mutex
@@ -42,14 +42,13 @@ type AutoNodeDIDResolver struct {
 }
 
 // Resolve returns the auto-resolved node DID, or an empty DID if none could be found.
-func (a *AutoNodeDIDResolver) Resolve() (did.DID, error) {
+func (a *autoNodeDIDResolver) Resolve() (did.DID, error) {
 	a.mux.Lock()
+	defer a.mux.Unlock()
 	if !a.resolvedDID.Empty() {
 		result := a.resolvedDID
-		a.mux.Unlock()
 		return result, nil
 	}
-	defer a.mux.Unlock()
 
 	documents, err := a.docFinder.Find(doc.IsActive(), doc.ValidAt(time.Now()), doc.ByServiceType(NutsCommServiceType))
 	if err != nil {

--- a/network/transport/nodedid.go
+++ b/network/transport/nodedid.go
@@ -1,0 +1,80 @@
+package transport
+
+import (
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/crypto"
+	"github.com/nuts-foundation/nuts-node/vdr/doc"
+	"github.com/nuts-foundation/nuts-node/vdr/types"
+	"sync"
+	"time"
+)
+
+// NodeDIDResolver defines an interface for types that resolve the local node's DID, which is used to identify the node on the network.
+type NodeDIDResolver interface {
+	// Resolve tries to resolve the node DID. If it's absent, an empty DID is returned. In any other non-successful case an error is returned.
+	Resolve() (did.DID, error)
+}
+
+// FixedNodeDIDResolver is a NodeDIDResolver that returns a preset DID.
+type FixedNodeDIDResolver struct {
+	NodeDID did.DID
+}
+
+func (f FixedNodeDIDResolver) Resolve() (did.DID, error) {
+	return f.NodeDID, nil
+}
+
+func NewAutoNodeDIDResolver(keyResolver crypto.KeyResolver, docFinder types.DocFinder) NodeDIDResolver {
+	return &AutoNodeDIDResolver{
+		keyResolver: keyResolver,
+		docFinder:   docFinder,
+		mux:         &sync.Mutex{},
+	}
+}
+
+type AutoNodeDIDResolver struct {
+	keyResolver crypto.KeyResolver
+	docFinder   types.DocFinder
+	mux         *sync.Mutex
+	resolvedDID did.DID
+}
+
+func (a *AutoNodeDIDResolver) Resolve() (did.DID, error) {
+	a.mux.Lock()
+	if !a.resolvedDID.Empty() {
+		result := a.resolvedDID
+		a.mux.Unlock()
+		return result, nil
+	}
+	defer a.mux.Unlock()
+
+	documents, err := a.docFinder.Find(doc.IsActive(), doc.ValidAt(time.Now()), doc.ByServiceType(NutsCommServiceType))
+	if err != nil {
+		return did.DID{}, err
+	}
+
+	privateKeyIDs := a.keyResolver.List()
+
+	// Intersect DID documents with an absolute NutsComm endpoint (which vendors must have) with the private keys present in the local keystore.
+outer:
+	for _, document := range documents {
+		for _, capabilityInvocation := range document.CapabilityInvocation {
+			// While multiple DID documents may match, always take the first. That way it will always take the same DID document after a restart.
+			if contains(privateKeyIDs, capabilityInvocation.ID.String()) {
+				a.resolvedDID = document.ID
+				break outer
+			}
+		}
+	}
+
+	return a.resolvedDID, nil
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, curr := range haystack {
+		if curr == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/network/transport/nodedid.go
+++ b/network/transport/nodedid.go
@@ -20,10 +20,12 @@ type FixedNodeDIDResolver struct {
 	NodeDID did.DID
 }
 
+// Resolve returns the fixed-set node DID.
 func (f FixedNodeDIDResolver) Resolve() (did.DID, error) {
 	return f.NodeDID, nil
 }
 
+// NewAutoNodeDIDResolver creates a new node DID resolver that tried to look it up by matching DID documents with a NutsComm endpoint set and the private key of the local node.
 func NewAutoNodeDIDResolver(keyResolver crypto.KeyResolver, docFinder types.DocFinder) NodeDIDResolver {
 	return &AutoNodeDIDResolver{
 		keyResolver: keyResolver,
@@ -39,6 +41,7 @@ type AutoNodeDIDResolver struct {
 	resolvedDID did.DID
 }
 
+// Resolve returns the auto-resolved node DID, or an empty DID if none could be found.
 func (a *AutoNodeDIDResolver) Resolve() (did.DID, error) {
 	a.mux.Lock()
 	if !a.resolvedDID.Empty() {

--- a/network/transport/nodedid_test.go
+++ b/network/transport/nodedid_test.go
@@ -1,0 +1,94 @@
+package transport
+
+import (
+	"github.com/golang/mock/gomock"
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/crypto"
+	"github.com/nuts-foundation/nuts-node/vdr/doc"
+	"github.com/nuts-foundation/nuts-node/vdr/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_AutoNodeDIDResolver(t *testing.T) {
+	// Local vendor
+	didLocal, _ := did.ParseDID("did:nuts:local")
+	key0ID := *didLocal
+	key0ID.Fragment = "key-0"
+	key1ID := *didLocal
+	key1ID.Fragment = "key-1"
+
+	// Other vendor
+	didOther, _ := did.ParseDID("did:nuts:other")
+	keyOther := *didOther
+	keyOther.Fragment = "key-1"
+
+	didDocuments := []did.Document{
+		// Other
+		{
+			ID: *didOther,
+			CapabilityInvocation: []did.VerificationRelationship{
+				{VerificationMethod: &did.VerificationMethod{ID: keyOther}},
+			},
+		},
+		// Local
+		{
+			ID: *didLocal,
+			CapabilityInvocation: []did.VerificationRelationship{
+				{VerificationMethod: &did.VerificationMethod{ID: key0ID}},
+				{VerificationMethod: &did.VerificationMethod{ID: key1ID}},
+			},
+		},
+	}
+	t.Run("ok", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		keyResolver := crypto.NewMockKeyResolver(ctrl)
+		docFinder := types.NewMockDocFinder(ctrl)
+
+		keyResolver.EXPECT().List().Return([]string{key0ID.String(), key1ID.String()})
+		docFinder.EXPECT().Find(doc.IsActive(), gomock.Any(), doc.ByServiceType(NutsCommServiceType)).Return(didDocuments, nil)
+		resolver := NewAutoNodeDIDResolver(keyResolver, docFinder)
+
+		actual, err := resolver.Resolve()
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, *didLocal, actual)
+
+		// Call again, mocks should not be triggered again
+		actual, err = resolver.Resolve()
+		assert.NoError(t, err)
+		assert.Equal(t, *didLocal, actual)
+	})
+	t.Run("no private keys in keystore", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		keyResolver := crypto.NewMockKeyResolver(ctrl)
+		docFinder := types.NewMockDocFinder(ctrl)
+
+		keyResolver.EXPECT().List().Return([]string{})
+		docFinder.EXPECT().Find(doc.IsActive(), gomock.Any(), doc.ByServiceType(NutsCommServiceType)).Return(didDocuments, nil)
+		resolver := NewAutoNodeDIDResolver(keyResolver, docFinder)
+
+		actual, err := resolver.Resolve()
+
+		assert.NoError(t, err)
+		assert.Empty(t, actual)
+	})
+	t.Run("no DID documents match", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		keyResolver := crypto.NewMockKeyResolver(ctrl)
+		docFinder := types.NewMockDocFinder(ctrl)
+
+		keyResolver.EXPECT().List().Return([]string{"non-matching-KID"})
+		docFinder.EXPECT().Find(doc.IsActive(), gomock.Any(), doc.ByServiceType(NutsCommServiceType)).Return(didDocuments, nil)
+		resolver := NewAutoNodeDIDResolver(keyResolver, docFinder)
+
+		actual, err := resolver.Resolve()
+		assert.NoError(t, err)
+		assert.Empty(t, actual)
+	})
+}


### PR DESCRIPTION
When not configured and not in strict mode, allow the node DID to be auto-resolved. It's matched by intersecting DID documents with a NutsComm URL endpoint and the private keys in the keystore.

Fixes https://github.com/nuts-foundation/nuts-node/issues/621