### PR TITLE
Network: allow bi-directional connections to be deduplicated

### DIFF
--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -136,6 +136,12 @@ func TestNetworkIntegration_NodesConnectToEachOther(t *testing.T) {
 	time.Sleep(time.Second)
 	assert.Len(t, node1.connectionManager.Peers(), 1)
 	assert.Len(t, node2.connectionManager.Peers(), 1)
+
+	// Assert that the connectors of node1 and node2 are deduplicated: outbound connection is "merged" with existing inbound connection
+	node1Diagnostics := node1.connectionManager.Diagnostics()
+	assert.Len(t, node1Diagnostics[3].(grpc.ConnectorsStats), 1)
+	node2Diagnostics := node2.connectionManager.Diagnostics()
+	assert.Len(t, node2Diagnostics[3].(grpc.ConnectorsStats), 1)
 }
 
 func TestNetworkIntegration_NodeDIDAuthentication(t *testing.T) {

--- a/network/transport/grpc/connection.go
+++ b/network/transport/grpc/connection.go
@@ -41,7 +41,7 @@ type Connection interface {
 	// waitUntilDisconnected blocks until the connection is closed. If it already is closed or was never open, it returns immediately.
 	waitUntilDisconnected()
 	// startConnecting instructs the Connection to start connecting to the remote peer (attempting an outbound connection).
-	startConnecting(config *tls.Config, callback func(grpcConn *grpc.ClientConn) bool)
+	startConnecting(address string, config *tls.Config, callback func(grpcConn *grpc.ClientConn) bool)
 	// stopConnecting instructs the Connection to stop connecting to the remote peer.
 	stopConnecting()
 
@@ -258,7 +258,7 @@ func (mc *conn) startSending(protocol Protocol, stream Stream) {
 	}()
 }
 
-func (mc *conn) startConnecting(tlsConfig *tls.Config, connectedCallback func(grpcConn *grpc.ClientConn) bool) {
+func (mc *conn) startConnecting(address string, tlsConfig *tls.Config, connectedCallback func(grpcConn *grpc.ClientConn) bool) {
 	mc.mux.Lock()
 	defer mc.mux.Unlock()
 
@@ -267,7 +267,7 @@ func (mc *conn) startConnecting(tlsConfig *tls.Config, connectedCallback func(gr
 		return
 	}
 
-	mc.connector = createOutboundConnector(mc.Peer().Address, mc.dialer, tlsConfig, func() bool {
+	mc.connector = createOutboundConnector(address, mc.dialer, tlsConfig, func() bool {
 		return !mc.IsConnected()
 	}, connectedCallback)
 	mc.connector.start()

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -207,28 +207,7 @@ func (s grpcConnectionManager) Connect(peerAddress string, options ...transport.
 		log.Logger().Infof("A connection for %s already exists.", peer.Address)
 		return
 	}
-
-	var tlsConfig *tls.Config
-	if s.config.tlsEnabled() {
-		tlsConfig = &tls.Config{
-			Certificates: []tls.Certificate{
-				s.config.clientCert,
-			},
-			RootCAs:    s.config.trustStore,
-			MinVersion: core.MinTLSVersion,
-		}
-	}
-
-	connection.startConnecting(tlsConfig, func(grpcConn *grpc.ClientConn) bool {
-		err := s.openOutboundStreams(connection, grpcConn)
-		if err != nil {
-			log.Logger().Errorf("Error while setting up outbound gRPC streams, disconnecting (peer=%s): %v", connection.Peer(), err)
-			connection.disconnect()
-			_ = grpcConn.Close()
-			return false
-		}
-		return true
-	})
+	s.startConnecting(peer.Address, connection)
 }
 
 func (s grpcConnectionManager) Peers() []transport.Peer {
@@ -315,6 +294,21 @@ func (s *grpcConnectionManager) openOutboundStream(connection Connection, protoc
 	peerID, nodeDID, err := readMetadata(peerHeaders)
 	if err != nil {
 		return nil, fatalError{error: fmt.Errorf("failed to read peer ID header: %w", err)}
+	}
+
+	// When 2 nodes connect to each other, the connections will have to be deduplicated.
+	// When a node receives an inbound connection from a peer which it is already connected to, it must disconnect that new connection.
+	// This means the connecting side (outbound) should stop connecting to that address, because it's already connected.
+	// But it can't just clean up the outbound connection,
+	// since it's a discovered Nuts Node address which is not known by the existing inbound connection.
+	// To avoid "losing" that address it should start the outbound connector on the inbound connection,
+	// so that it can make an outbound connection when the inbound connection is closed.
+	existingConnection := s.connections.Get(ByPeerID(peerID))
+	if existingConnection != nil && existingConnection != connection {
+		connection.stopConnecting()
+		s.connections.remove(connection)
+		s.startConnecting(connection.Peer().Address, existingConnection)
+		return nil, fatalError{error: ErrAlreadyConnected}
 	}
 
 	if !connection.verifyOrSetPeerID(peerID) {
@@ -413,4 +407,28 @@ func (s *grpcConnectionManager) constructMetadata() (metadata.MD, error) {
 		md.Set(nodeDIDHeader, nodeDID.String())
 	}
 	return md, nil
+}
+
+func (s *grpcConnectionManager) startConnecting(address string, connection Connection) {
+	var tlsConfig *tls.Config
+	if s.config.tlsEnabled() {
+		tlsConfig = &tls.Config{
+			Certificates: []tls.Certificate{
+				s.config.clientCert,
+			},
+			RootCAs:    s.config.trustStore,
+			MinVersion: core.MinTLSVersion,
+		}
+	}
+
+	connection.startConnecting(address, tlsConfig, func(grpcConn *grpc.ClientConn) bool {
+		err := s.openOutboundStreams(connection, grpcConn)
+		if err != nil {
+			log.Logger().Errorf("Error while setting up outbound gRPC streams, disconnecting (peer=%s): %v", connection.Peer(), err)
+			connection.disconnect()
+			_ = grpcConn.Close()
+			return false
+		}
+		return true
+	})
 }

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -207,7 +207,7 @@ func (s grpcConnectionManager) Connect(peerAddress string, options ...transport.
 		log.Logger().Infof("A connection for %s already exists.", peer.Address)
 		return
 	}
-	s.startConnecting(peer.Address, connection)
+	s.startOutboundConnector(peer.Address, connection)
 }
 
 func (s grpcConnectionManager) Peers() []transport.Peer {
@@ -307,7 +307,7 @@ func (s *grpcConnectionManager) openOutboundStream(connection Connection, protoc
 	if existingConnection != nil && existingConnection != connection {
 		connection.stopConnecting()
 		s.connections.remove(connection)
-		s.startConnecting(connection.Peer().Address, existingConnection)
+		s.startOutboundConnector(connection.Peer().Address, existingConnection)
 		return nil, fatalError{error: ErrAlreadyConnected}
 	}
 
@@ -409,7 +409,7 @@ func (s *grpcConnectionManager) constructMetadata() (metadata.MD, error) {
 	return md, nil
 }
 
-func (s *grpcConnectionManager) startConnecting(address string, connection Connection) {
+func (s *grpcConnectionManager) startOutboundConnector(address string, connection Connection) {
 	var tlsConfig *tls.Config
 	if s.config.tlsEnabled() {
 		tlsConfig = &tls.Config{

--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -266,7 +266,7 @@ func Test_grpcConnectionManager_Diagnostics(t *testing.T) {
 			return len(cm.Peers()) == 2, nil
 		}, 5*time.Second, "time-out while waiting for peers to connect")
 
-		assert.Equal(t, "2", cm.Diagnostics()[1].String())                                                // assert number_of_peers
+		assert.Equal(t, "2", cm.Diagnostics()[1].String())                                         // assert number_of_peers
 		assert.Equal(t, "peer2@127.0.0.1:1028 peer1@127.0.0.1:6718", cm.Diagnostics()[2].String()) // assert peers
 	})
 }
@@ -337,7 +337,7 @@ func Test_grpcConnectionManager_openOutboundStreams(t *testing.T) {
 		waiter.Add(1)
 
 		connection, _ := client.connections.getOrRegister(context.Background(), transport.Peer{Address: "server"}, client.dialer)
-		connection.startConnecting(nil, func(grpcConn *grpc.ClientConn) bool {
+		connection.startConnecting("", nil, func(grpcConn *grpc.ClientConn) bool {
 			err := client.openOutboundStreams(connection, grpcConn)
 			capturedError.Store(err)
 			waiter.Done()
@@ -446,6 +446,42 @@ func Test_grpcConnectionManager_openOutboundStream(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, stream)
 	})
+
+	t.Run("already connected", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		existingConn := NewMockConnection(ctrl)
+		// due to connectionList.Get(ByPeerID(newConn.peerID)):
+		existingConn.EXPECT().Peer().MinTimes(1).Return(transport.Peer{ID: "remote"})
+		// due to ConnectionManager.Stop():
+		existingConn.EXPECT().disconnect()
+		existingConn.EXPECT().stopConnecting() // due to ConnectionManager.Stop()
+
+		cm := NewGRPCConnectionManager(Config{peerID: "local"}, &stubNodeDIDReader{}, nil).(*grpcConnectionManager)
+		cm.connections.list = append(cm.connections.list, existingConn)
+
+		defer cm.Stop()
+
+		meta, _ := cm.constructMetadata()
+		meta.Set(peerIDHeader, "remote")
+
+		grpcStream := NewMockClientStream(ctrl)
+		grpcStream.EXPECT().Header().Return(meta, nil)
+
+		grpcConn := NewMockConn(ctrl)
+		grpcConn.EXPECT().NewStream(gomock.Any(), gomock.Any(), "/grpc.Test/DoStuff", gomock.Any()).Return(grpcStream, nil)
+
+		newConn := NewMockConnection(ctrl)
+		// New outbound connection's connector should be stopped, peer address copied to existing connection's connector
+		newConn.EXPECT().stopConnecting()
+		newConn.EXPECT().Peer().Return(transport.Peer{ID: "remote", Address: "remote-address"})
+		existingConn.EXPECT().startConnecting("remote-address", gomock.Any(), gomock.Any())
+
+		stream, err := cm.openOutboundStream(newConn, protocol, grpcConn, metadata.MD{})
+
+		assert.ErrorIs(t, err, ErrAlreadyConnected)
+		assert.Nil(t, stream)
+	})
 }
 
 func Test_grpcConnectionManager_handleInboundStream(t *testing.T) {
@@ -472,7 +508,7 @@ func Test_grpcConnectionManager_handleInboundStream(t *testing.T) {
 
 		peerInfo := cm.Peers()[0]
 		assert.Equal(t, transport.PeerID("client-peer-id"), peerInfo.ID)
-		assert.Equal(t,  "127.0.0.1:9522", peerInfo.Address)
+		assert.Equal(t, "127.0.0.1:9522", peerInfo.Address)
 		assert.Equal(t, "did:nuts:client", peerInfo.NodeDID.String())
 
 		// Assert headers sent to client

--- a/network/transport/grpc/connection_mock.go
+++ b/network/transport/grpc/connection_mock.go
@@ -117,15 +117,15 @@ func (mr *MockConnectionMockRecorder) setPeer(peer interface{}) *gomock.Call {
 }
 
 // startConnecting mocks base method.
-func (m *MockConnection) startConnecting(config *tls.Config, callback func(*grpc.ClientConn) bool) {
+func (m *MockConnection) startConnecting(address string, config *tls.Config, callback func(*grpc.ClientConn) bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "startConnecting", config, callback)
+	m.ctrl.Call(m, "startConnecting", address, config, callback)
 }
 
 // startConnecting indicates an expected call of startConnecting.
-func (mr *MockConnectionMockRecorder) startConnecting(config, callback interface{}) *gomock.Call {
+func (mr *MockConnectionMockRecorder) startConnecting(address, config, callback interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "startConnecting", reflect.TypeOf((*MockConnection)(nil).startConnecting), config, callback)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "startConnecting", reflect.TypeOf((*MockConnection)(nil).startConnecting), address, config, callback)
 }
 
 // stats mocks base method.

--- a/network/transport/grpc/test.go
+++ b/network/transport/grpc/test.go
@@ -147,7 +147,7 @@ func (s StubConnection) waitUntilDisconnected() {
 	panic("implement me")
 }
 
-func (s StubConnection) startConnecting(_ *tls.Config, _ func(_ *grpc.ClientConn) bool) {
+func (s StubConnection) startConnecting(address string, _ *tls.Config, _ func(_ *grpc.ClientConn) bool) {
 	panic("implement me")
 }
 


### PR DESCRIPTION
Since introducing service discovery, nodes will connect to each other if they both published their `NutsComm` endpoint. We have an integration test which tests this bi-directional connection (node A and B both connect to each other), but the assertions in that test was wrong. And it appears to be broken, leading to a reconnect loop:

```
time="2022-01-24T08:13:23Z" level=info msg="Connected to peer (outbound): nuts.woutslakhorst.nl:5555" module=Network
time="2022-01-24T08:13:23Z" level=warning msg="/transport.Network/Connect: Peer connection error (peer=8fe5a452-2bc0-436d-8e22-2e97d0b53b8b(did:nuts:3wEb8GJEuenjMexQXKfrdAr8CvA69SdbVh8qhUpDMcX2)@): rpc error: code = Unknown desc = already connected" module=Network
time="2022-01-24T08:13:23Z" level=warning msg="/v2.Protocol/Stream: Peer connection error (peer=8fe5a452-2bc0-436d-8e22-2e97d0b53b8b(did:nuts:3wEb8GJEuenjMexQXKfrdAr8CvA69SdbVh8qhUpDMcX2)@): rpc error: code = Unknown desc = already connected" module=Network
time="2022-01-24T08:13:27Z" level=info msg="Connecting to peer: nuts.woutslakhorst.nl:5555" module=Network
time="2022-01-24T08:13:27Z" level=info msg="Connected to peer (outbound): nuts.woutslakhorst.nl:5555" module=Network
time="2022-01-24T08:13:27Z" level=warning msg="/transport.Network/Connect: Peer connection error (peer=8fe5a452-2bc0-436d-8e22-2e97d0b53b8b(did:nuts:3wEb8GJEuenjMexQXKfrdAr8CvA69SdbVh8qhUpDMcX2)@): rpc error: code = Unknown desc = already connected" module=Network
time="2022-01-24T08:13:27Z" level=warning msg="/v2.Protocol/Stream: Peer connection error (peer=8fe5a452-2bc0-436d-8e22-2e97d0b53b8b(did:nuts:3wEb8GJEuenjMexQXKfrdAr8CvA69SdbVh8qhUpDMcX2)@): rpc error: code = Unknown desc = already connected" module=Network
time="2022-01-24T08:13:30Z" level=info msg="Connecting to peer: nuts.woutslakhorst.nl:5555" module=Network
time="2022-01-24T08:13:30Z" level=info msg="Connected to peer (outbound): nuts.woutslakhorst.nl:5555" module=Network
time="2022-01-24T08:13:30Z" level=warning msg="/transport.Network/Connect: Peer connection error (peer=8fe5a452-2bc0-436d-8e22-2e97d0b53b8b(did:nuts:3wEb8GJEuenjMexQXKfrdAr8CvA69SdbVh8qhUpDMcX2)@): rpc error: code = Unknown desc = already connected" module=Network
time="2022-01-24T08:13:30Z" level=warning msg="/v2.Protocol/Stream: Peer connection error (peer=8fe5a452-2bc0-436d-8e22-2e97d0b53b8b(did:nuts:3wEb8GJEuenjMexQXKfrdAr8CvA69SdbVh8qhUpDMcX2)@): rpc error: code = Unknown desc = already connected" module=Network
```

This PR fixes that: when an outbound connection is made and the connecting node receives the remote's peer ID, it checks whether it's already connected to that peer. If so, it instructs the existing connection to start connecting (if not already connecting) to the discovered node address, and then disconnects and removes the new (outbound) connection from the connection list. In other words, in merges the new outbound connection into the existing (inbound) connection.

Note that the receiving node will still disconnect the connecting node on the "inbound" side, so if the connecting node fails to "merge" the connections, it will still be disconnected by the other party (this is existing behavior).