### PR TITLE
VDR: Fix resolving disabled DID docs

### DIFF
--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -32,6 +32,9 @@ import (
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jws"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
@@ -47,8 +50,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/vcr/trust"
 	"github.com/nuts-foundation/nuts-node/vdr/doc"
 	vdr "github.com/nuts-foundation/nuts-node/vdr/types"
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -305,9 +306,7 @@ func (c *vcr) Issue(template vc.VerifiableCredential) (*vc.VerifiableCredential,
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse issuer: %w", err)
 	}
-	// find did document/metadata for originating TXs. ResolveMetadata is required to also check the validity of the issuer's controller.
-	now := timeFunc()
-	document, meta, err := c.docResolver.Resolve(*issuer, &vdr.ResolveMetadata{ResolveTime: &now})
+	document, meta, err := c.docResolver.Resolve(*issuer, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -341,7 +341,7 @@ func TestVcr_Issue(t *testing.T) {
 		cred.CredentialStatus = &vc.CredentialStatus{
 			Type: "test",
 		}
-		ctx.docResolver.EXPECT().Resolve(*vdr.TestDIDA, &types.ResolveMetadata{ResolveTime: &now}).Return(&document, &documentMetadata, nil)
+		ctx.docResolver.EXPECT().Resolve(*vdr.TestDIDA, nil).Return(&document, &documentMetadata, nil)
 		testKey := crypto.NewTestKey("kid")
 		ctx.crypto.EXPECT().Resolve(vdr.TestMethodDIDA.String()).Return(testKey, nil)
 		ctx.tx.EXPECT().CreateTransaction(

--- a/vdr/doc/resolvers.go
+++ b/vdr/doc/resolvers.go
@@ -61,6 +61,7 @@ func (d Resolver) resolve(id did.DID, metadata *types.ResolveMetadata, depth int
 		return nil, nil, err
 	}
 
+	// has the doc controllers, should we check for controller deactivation?
 	if len(doc.Controller) > 0 && (metadata == nil || !metadata.AllowDeactivated) {
 		// also check if the controller is not deactivated
 		// since ResolveControllers calls Resolve and propagates the metadata
@@ -68,6 +69,7 @@ func (d Resolver) resolve(id did.DID, metadata *types.ResolveMetadata, depth int
 		if err != nil {
 			return nil, nil, err
 		}
+		// doc should have controllers, but no results, so they are not active, return error:
 		if len(controllers) == 0 {
 			return nil, nil, types.ErrNoActiveController
 		}

--- a/vdr/doc/resolvers.go
+++ b/vdr/doc/resolvers.go
@@ -61,7 +61,7 @@ func (d Resolver) resolve(id did.DID, metadata *types.ResolveMetadata, depth int
 		return nil, nil, err
 	}
 
-	if metadata != nil && !metadata.AllowDeactivated {
+	if len(doc.Controller) > 0 && (metadata == nil || !metadata.AllowDeactivated) {
 		// also check if the controller is not deactivated
 		// since ResolveControllers calls Resolve and propagates the metadata
 		controllers, err := d.resolveControllers(*doc, metadata, depth+1)

--- a/vdr/doc/resolvers_test.go
+++ b/vdr/doc/resolvers_test.go
@@ -190,30 +190,46 @@ func TestResolver_Resolve(t *testing.T) {
 	})
 
 	t.Run("docA is controller of docB and docA is deactivated", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		store := types.NewMockStore(ctrl)
-		resolver := Resolver{Store: store}
-		store.EXPECT().Resolve(*id456, resolveMD).Return(&docB, &types.DocumentMetadata{}, nil)
-		store.EXPECT().Resolve(*id123, resolveMD).Return(&docA, &types.DocumentMetadata{}, nil)
+		t.Run("err - with resolver metadata", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := types.NewMockStore(ctrl)
+			resolver := Resolver{Store: store}
+			store.EXPECT().Resolve(*id456, resolveMD).Return(&docB, &types.DocumentMetadata{}, nil)
+			store.EXPECT().Resolve(*id123, resolveMD).Return(&docA, &types.DocumentMetadata{}, nil)
 
-		doc, _, err := resolver.Resolve(*id456, resolveMD)
+			doc, _, err := resolver.Resolve(*id456, resolveMD)
 
-		assert.Error(t, err)
-		assert.Equal(t, types.ErrNoActiveController, err)
-		assert.Nil(t, doc)
-	})
+			assert.Error(t, err)
+			assert.Equal(t, types.ErrNoActiveController, err)
+			assert.Nil(t, doc)
+		})
 
-	t.Run("docA is controller of docB and docA is deactivated but is allowed", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		store := types.NewMockStore(ctrl)
-		resolver := Resolver{Store: store}
-		resolveMD := &types.ResolveMetadata{ResolveTime: &resolveTime, AllowDeactivated: true}
+		t.Run("err - without resolve metadata", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := types.NewMockStore(ctrl)
+			resolver := Resolver{Store: store}
+			store.EXPECT().Resolve(*id456, nil).Return(&docB, &types.DocumentMetadata{}, nil)
+			store.EXPECT().Resolve(*id123, nil).Return(&docA, &types.DocumentMetadata{}, nil)
 
-		store.EXPECT().Resolve(*id456, resolveMD).Return(&docB, &types.DocumentMetadata{}, nil)
+			doc, _, err := resolver.Resolve(*id456, nil)
 
-		doc, _, err := resolver.Resolve(*id456, resolveMD)
-		assert.NoError(t, err)
-		assert.Equal(t, docB, *doc)
+			assert.Error(t, err)
+			assert.Equal(t, types.ErrNoActiveController, err)
+			assert.Nil(t, doc)
+		})
+
+		t.Run("ok - allowed deactivated", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := types.NewMockStore(ctrl)
+			resolver := Resolver{Store: store}
+			resolveMD := &types.ResolveMetadata{ResolveTime: &resolveTime, AllowDeactivated: true}
+
+			store.EXPECT().Resolve(*id456, resolveMD).Return(&docB, &types.DocumentMetadata{}, nil)
+
+			doc, _, err := resolver.Resolve(*id456, resolveMD)
+			assert.NoError(t, err)
+			assert.Equal(t, docB, *doc)
+		})
 	})
 
 	t.Run("Controller hierarchy nested too deeply", func(t *testing.T) {

--- a/vdr/types/interface.go
+++ b/vdr/types/interface.go
@@ -34,8 +34,8 @@ type DocResolver interface {
 	// If metadata is not provided the latest version is returned.
 	// If metadata is provided then the result is filtered or scoped on that metadata.
 	// It returns ErrNotFound if there are no corresponding DID documents or when the DID Documents are disjoint with the provided ResolveMetadata
-	// It returns ErrDeactivated if the DID Document has been deactivated
-	// It returns ErrNoActiveController if all of the DID Documents controllers have been deactivated, this only occurs if ResolveMetadata is passed.
+	// It returns ErrDeactivated if the DID Document has been deactivated and metadata is unset or metadata.AllowDeactivated is false.
+	// It returns ErrNoActiveController if all of the DID Documents controllers have been deactivated and metadata is unset or metadata.AllowDeactivated is false.
 	Resolve(id did.DID, metadata *ResolveMetadata) (*did.Document, *DocumentMetadata, error)
 	// ResolveControllers finds the DID Document controllers
 	ResolveControllers(input did.Document, metadata *ResolveMetadata) ([]did.Document, error)


### PR DESCRIPTION
Better fix for #743.
Instead of providing an empty resolverMetadata (or a time), make checking for disabled controllers default.