### PR TITLE
Diagnostics: change text view to YAML for improved readability

### DIFF
--- a/core/status/engine_test.go
+++ b/core/status/engine_test.go
@@ -79,10 +79,7 @@ func TestNewStatusEngine_Diagnostics(t *testing.T) {
     engines:
         - Status
         - Metrics
-    git_commit: "0"
-    os_arch: darwin/amd64
-    software_version: development
-    uptime: 0s`
+    git_commit: "0"`
 		echo.EXPECT().String(http.StatusOK, test.Contains(expected))
 
 		(&status{system: system}).diagnosticsOverview(echo)

--- a/core/status/engine_test.go
+++ b/core/status/engine_test.go
@@ -68,13 +68,22 @@ func TestNewStatusEngine_Diagnostics(t *testing.T) {
 		assert.Equal(t, core.OSArch(), ds[4].String())
 	})
 
-	t.Run("diagnosticsOverview() text output", func(t *testing.T) {
+	t.Run("diagnosticsOverview() YAML output", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		echo := mock.NewMockContext(ctrl)
 		echo.EXPECT().Request().Return(&http.Request{Header: map[string][]string{}})
 
-		echo.EXPECT().String(http.StatusOK, test.Contains("engines: [Status Metrics]"))
+		expected :=
+`status:
+    engines:
+        - Status
+        - Metrics
+    git_commit: "0"
+    os_arch: darwin/amd64
+    software_version: development
+    uptime: 0s`
+		echo.EXPECT().String(http.StatusOK, test.Contains(expected))
 
 		(&status{system: system}).diagnosticsOverview(echo)
 	})

--- a/crypto/hash/sha256.go
+++ b/crypto/hash/sha256.go
@@ -30,6 +30,7 @@ const SHA256HashSize = 32
 // SHA256Hash is a SHA256 Hash over some bytes
 type SHA256Hash [SHA256HashSize]byte
 
+// MarshalText implements encoding.TextMarshaler
 func (h SHA256Hash) MarshalText() ([]byte, error) {
 	return []byte(h.String()), nil
 }

--- a/crypto/hash/sha256.go
+++ b/crypto/hash/sha256.go
@@ -30,6 +30,10 @@ const SHA256HashSize = 32
 // SHA256Hash is a SHA256 Hash over some bytes
 type SHA256Hash [SHA256HashSize]byte
 
+func (h SHA256Hash) MarshalText() ([]byte, error) {
+	return []byte(h.String()), nil
+}
+
 // SHA256Sum creates a sha256 hash from the given bytes
 func SHA256Sum(data []byte) SHA256Hash {
 	return sha256.Sum256(data)

--- a/crypto/hash/sha256_test.go
+++ b/crypto/hash/sha256_test.go
@@ -19,12 +19,16 @@
 package hash
 
 import (
+	"encoding"
 	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+var _ fmt.Stringer = SHA256Hash{}
+var _ encoding.TextMarshaler = SHA256Hash{}
 
 func TestHash_Empty(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {


### PR DESCRIPTION
We already supported JSON for easier consumption by systems, but the text view became less and less readable. Returning the text view in YAML format makes reading much easier (because of its indentation), less work (use Go's default YAML marshaler) and lets other systems parse the node's diagnostics as YAML too (aside from JSON).

Fixes https://github.com/nuts-foundation/nuts-node/issues/467