### PR TITLE
Match SANs case insensitive in protocol v2 authentication

### DIFF
--- a/network/transport/grpc/authenticator.go
+++ b/network/transport/grpc/authenticator.go
@@ -20,14 +20,14 @@ package grpc
 
 import (
 	"fmt"
-	"net/url"
-
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/network/log"
 	"github.com/nuts-foundation/nuts-node/network/transport"
 	"github.com/nuts-foundation/nuts-node/vdr/doc"
 	"google.golang.org/grpc/credentials"
 	grpcPeer "google.golang.org/grpc/peer"
+	"net/url"
+	"strings"
 )
 
 // Authenticator verifies node identities.
@@ -78,7 +78,7 @@ func (t tlsAuthenticator) Authenticate(nodeDID did.DID, grpcPeer grpcPeer.Peer, 
 	// Check whether one of the DNS names matches one of the NutsComm endpoints
 	hostname := nutsCommURL.Hostname()
 	for _, dnsName := range dnsNames {
-		if dnsName == hostname {
+		if strings.EqualFold(dnsName, hostname) {
 			log.Logger().Debugf("Connection successfully authenticated (nodeDID=%s)", nodeDID)
 			peer.NodeDID = nodeDID
 			return peer, nil


### PR DESCRIPTION
In the authenticator we currently match the NutsComm address with one of the SANs. This is done by a regular comparison which means that it will be case sensitive but RFC5280 states that it should be case-insensitive. 

See: [RFC5280](https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.6)