### PR TITLE
Network: log historic block queries on debug instead, since it will be replaced by v2

### DIFF
--- a/network/transport/v1/logic/handlers.go
+++ b/network/transport/v1/logic/handlers.go
@@ -87,7 +87,7 @@ func (p *protocol) handleAdvertHashes(peer transport.PeerID, advertHash *protobu
 	peerHistoryHash := hash.FromSlice(advertHash.HistoricHash)
 	if !localHistoryHash.Equals(peerHistoryHash) {
 		// TODO: Disallowed when https://github.com/nuts-foundation/nuts-specification/issues/57 is implemented
-		log.Logger().Infof("Peer's historic block differs which will be sync-ed for now, but will be disallowed in the future (peer=%s,local hash=%s,peer hash=%s)", peer, localHistoryHash, peerHistoryHash)
+		log.Logger().Debugf("Peer's historic block differs which will be sync-ed for now, but will be disallowed in the future (peer=%s,local hash=%s,peer hash=%s)", peer, localHistoryHash, peerHistoryHash)
 		p.sender.sendTransactionListQuery(peer, time.Time{})
 	} else {
 		// Finally, check the rest of the blocks
@@ -277,7 +277,7 @@ func (p *protocol) handleTransactionListQuery(peer transport.PeerID, blockDateIn
 	var endDate time.Time
 	if blockDateInt == 0 {
 		// TODO: Disallowed when https://github.com/nuts-foundation/nuts-specification/issues/57 is implemented
-		logrus.Infof("Peer queries historic block which is supported for now, but will be disallowed in the future (peer=%s)", peer)
+		logrus.Debugf("Peer queries historic block which is supported for now, but will be disallowed in the future (peer=%s)", peer)
 		// Historic block is queried, query from start up to the first block
 		endDate = p.blocks.get()[1].start
 	} else {


### PR DESCRIPTION
When starting a new node or a new node connects to the local node, sync'ing the complete DAG, the log (on both sides) is be littered with the following messages:

```
time="2022-01-27T10:53:42Z" level=info msg="Peer's historic block differs which will be sync-ed for now, but will be disallowed in the future (peer=b3f308de-630d-4c63-a77a-16c6b7cf1d4f,local hash=2ba4abfb214b2379a35668e559c43590854c4aa5f5779f3bf498b560a3dfc8c9,peer hash=45978d76a009ceef5e8bff24d2c94b38af6f0b931ae9ea47c864934299da4b03)" module=Network
time="2022-01-27T10:53:42Z" level=info msg="Peer queries historic block which is supported for now, but will be disallowed in the future (peer=53b37e3d-cab4-48cb-a40f-87e2e49250cc)"
```

These are part of the v1 protocol DAG sync, which will be replaced by v2 before disallowing historic block querying. So we can skip logging these warning in normal circumstances altogether.