### PR TITLE
Core: properly shutdown node on OS interrupt

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -143,12 +143,12 @@ func startServer(ctx context.Context, system *core.System) error {
 	// Start Echo server, cancels the server context when it exits/errors, so the shutdown sequence will run.
 	var serverError atomic.Error
 	go func() {
-		defer cancel()
 		if err := echoServer.Start(); err != nil {
 			if !errors.Is(err, http.ErrServerClosed) {
 				serverError.Store(err)
 			}
 		}
+		cancel()
 	}()
 
 	// Wait until instructed to shut down when instructed through context cancellation (e.g. SIGINT signal or Echo server error/exit)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -226,12 +226,12 @@ func CreateSystem() *core.System {
 }
 
 // Execute registers all engines into the system and executes the root command.
-func Execute(ctx context.Context, system *core.System) {
+func Execute(ctx context.Context, system *core.System) error {
 	command := CreateCommand(system)
 	command.SetOut(stdOutWriter)
 
 	// blocking main call
-	command.ExecuteContext(ctx)
+	return command.ExecuteContext(ctx)
 }
 
 func addSubCommands(system *core.System, root *cobra.Command) {

--- a/core/echo_mock.go
+++ b/core/echo_mock.go
@@ -5,6 +5,7 @@
 package core
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -51,6 +52,20 @@ func (mr *MockEchoServerMockRecorder) Add(method, path, handler interface{}, mid
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{method, path, handler}, middleware...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockEchoServer)(nil).Add), varargs...)
+}
+
+// Shutdown mocks base method.
+func (m *MockEchoServer) Shutdown(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Shutdown", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Shutdown indicates an expected call of Shutdown.
+func (mr *MockEchoServerMockRecorder) Shutdown(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockEchoServer)(nil).Shutdown), ctx)
 }
 
 // Start mocks base method.

--- a/core/engine.go
+++ b/core/engine.go
@@ -105,9 +105,9 @@ func (system *System) Start() error {
 	var err error
 	return system.VisitEnginesE(func(engine Engine) error {
 		if m, ok := engine.(Runnable); ok {
-			conditionalDebugf(engine, "starting %s")
+			conditionalDebugf(engine, "Starting %s")
 			err = m.Start()
-			conditionalInfof(engine, "started %s")
+			conditionalInfof(engine, "Started %s")
 		}
 		return err
 	})
@@ -118,9 +118,9 @@ func (system *System) Shutdown() error {
 	var err error
 	return system.VisitEnginesE(func(engine Engine) error {
 		if m, ok := engine.(Runnable); ok {
-			conditionalDebugf(engine, "stopping %s")
+			conditionalDebugf(engine, "Stopping %s")
 			err = m.Shutdown()
-			conditionalInfof(engine, "stopped %s")
+			conditionalInfof(engine, "Stopped %s")
 		}
 		return err
 	})

--- a/core/test.go
+++ b/core/test.go
@@ -19,6 +19,7 @@
 package core
 
 import (
+	"errors"
 	"github.com/spf13/pflag"
 )
 
@@ -36,8 +37,20 @@ type TestEngineSubConfig struct {
 }
 
 type TestEngine struct {
-	TestConfig TestEngineConfig
-	flagSet    *pflag.FlagSet
+	TestConfig    TestEngineConfig
+	flagSet       *pflag.FlagSet
+	ShutdownError bool
+}
+
+func (i *TestEngine) Start() error {
+	return nil
+}
+
+func (i *TestEngine) Shutdown() error {
+	if i.ShutdownError {
+		return errors.New("failure")
+	}
+	return nil
 }
 
 func (i *TestEngine) ConfigKey() string {

--- a/core/test.go
+++ b/core/test.go
@@ -42,10 +42,12 @@ type TestEngine struct {
 	ShutdownError bool
 }
 
+// Start does test stuff
 func (i *TestEngine) Start() error {
 	return nil
 }
 
+// Shutdown does test stuff
 func (i *TestEngine) Shutdown() error {
 	if i.ShutdownError {
 		return errors.New("failure")

--- a/events/event.go
+++ b/events/event.go
@@ -22,10 +22,8 @@ package events
 import (
 	"path"
 
-	"github.com/nuts-foundation/nuts-node/core"
-	"github.com/nuts-foundation/nuts-node/events/log"
-
 	natsServer "github.com/nats-io/nats-server/v2/server"
+	"github.com/nuts-foundation/nuts-node/core"
 )
 
 const moduleName = "Event manager"
@@ -68,13 +66,12 @@ func (m *manager) Configure(config core.ServerConfig) error {
 }
 
 func (m *manager) Start() error {
-	log.Logger().Debugf("starting %s", moduleName)
-
 	server, err := natsServer.NewServer(&natsServer.Options{
 		JetStream: true,
 		Port:      m.config.Port,
 		Host:      m.config.Hostname,
 		StoreDir:  m.config.StorageDir,
+		NoSigs:    true, // Signals are handled by Nuts node, Nats Server is shut down when Event Engine is shut down.
 	})
 	if err != nil {
 		return err
@@ -92,13 +89,9 @@ func (m *manager) Shutdown() error {
 		return nil
 	}
 
-	log.Logger().Debugf("shutting down %s", moduleName)
-
 	m.server.Shutdown()
 	m.pool.Shutdown()
 	m.server.WaitForShutdown()
-
-	log.Logger().Infof("%s shutdown complete", moduleName)
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ package main
 import (
 	"context"
 	"github.com/nuts-foundation/nuts-node/cmd"
+	"github.com/sirupsen/logrus"
 	"os"
 	"os/signal"
 	"syscall"
@@ -32,5 +33,8 @@ func main() {
 	ctx := context.Background()
 	ctx, _ = signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 
-	cmd.Execute(ctx, cmd.CreateSystem())
+	err := cmd.Execute(ctx, cmd.CreateSystem())
+	if err != nil {
+		logrus.Errorf("Server error: %v", err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -20,9 +20,17 @@
 package main
 
 import (
+	"context"
 	"github.com/nuts-foundation/nuts-node/cmd"
+	"os"
+	"os/signal"
+	"syscall"
 )
 
 func main() {
-	cmd.Execute(cmd.CreateSystem())
+	// Listen for interrupt signals (CTRL/CMD+C, OS instructing the process to stop) to cancel context.
+	ctx := context.Background()
+	ctx, _ = signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+
+	cmd.Execute(ctx, cmd.CreateSystem())
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/nuts-foundation/nuts-node/test"
+	"github.com/nuts-foundation/nuts-node/test/io"
+	"go.uber.org/atomic"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Test_ServerLifecycle tests the lifecycle of the Nuts node:
+// - It starts the Nuts node
+// - Waits for the /status endpoint to return HTTP 200, indicating it started properly
+// - Sends SIGINT signal
+// - Waits for the main function to return
+func Test_ServerLifecycle(t *testing.T) {
+	testDirectory := io.TestDirectory(t)
+
+	// Collect options
+	httpAddress := fmt.Sprintf("localhost:%d", test.FreeTCPPort())
+	opts := map[string]string{
+		"datadir":                 testDirectory,
+		"network.enabletls":       "false",
+		"network.grpcaddr":        fmt.Sprintf("localhost:%d", test.FreeTCPPort()),
+		"auth.contractvalidators": "dummy", // disables IRMA
+		"http.default.address":    httpAddress,
+		"events.nats.port":        fmt.Sprintf("%d", test.FreeTCPPort()),
+	}
+	var optsSlice []string
+	for key, value := range opts {
+		optsSlice = append(optsSlice, "--"+key+"="+fmt.Sprintf("%s", value))
+	}
+
+	os.Args = append([]string{"nuts", "server"}, optsSlice...)
+	timeout := 10 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	wasRunning := &atomic.Bool{}
+
+	go func() {
+		// Wait for the Nuts node to start, until the given timeout. Check every 100ms
+		interval := 100 * time.Millisecond
+		attempts := int(timeout / interval)
+		address := fmt.Sprintf("http://%s/status", httpAddress)
+		for i := 0; i < attempts; i++ {
+			if isRunning(address) {
+				println("Nuts node running, sending SIGINT signal")
+				wasRunning.Store(true)
+				syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+				break
+			}
+			time.Sleep(interval)
+		}
+	}()
+
+	go func() {
+		main()
+		cancel()
+	}()
+
+	// Wait for the main func to exit
+	<-ctx.Done()
+	if errors.Is(ctx.Err(), context.Canceled) {
+		if wasRunning.Load() {
+			// Program exited OK
+			t.Log("Process successfully started and shut down.")
+		} else {
+			t.Fatal("Process didn't start properly")
+		}
+	} else {
+		t.Fatalf("Process didn't start and shut down before the time-out expired: %v", ctx.Err())
+	}
+}
+
+func isRunning(address string) bool {
+	response, err := http.Get(address)
+	if err != nil {
+		println(err.Error())
+		return false
+	}
+	_, _ = ioutil.ReadAll(response.Body)
+	return response.StatusCode == http.StatusOK
+}

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -172,7 +172,7 @@ func (s *grpcConnectionManager) Start() error {
 }
 
 func (s *grpcConnectionManager) Stop() {
-	log.Logger().Info("Stopping gRPC connection manager")
+	log.Logger().Debug("Stopping gRPC connection manager")
 	s.connections.forEach(func(connection Connection) {
 		connection.stopConnecting()
 		connection.disconnect()

--- a/test/http/server.go
+++ b/test/http/server.go
@@ -18,10 +18,17 @@
 
 package http
 
-import "github.com/labstack/echo/v4"
+import (
+	"context"
+	"github.com/labstack/echo/v4"
+)
 
 type StubEchoServer struct {
 	BoundAddress string
+}
+
+func (s StubEchoServer) Shutdown(ctx context.Context) error {
+	return nil
 }
 
 func (s StubEchoServer) Add(method, path string, handler echo.HandlerFunc, middleware ...echo.MiddlewareFunc) *echo.Route {


### PR DESCRIPTION
Currently, the Nuts node isn't shut down at all. This risks data corruption and sending avoidable errors to network peers.

This PR introduces signal trapping to instruct the engines to shut down. It also has some fixes for existing problems with the shutdown.