### PR TITLE
Network: increase max backoff to declutter log

### DIFF
--- a/network/transport/grpc/backoff.go
+++ b/network/transport/grpc/backoff.go
@@ -70,7 +70,7 @@ func defaultBackoff() Backoff {
 	return &backoff{
 		multiplier: 1.5,
 		value:      0,
-		max:        30 * time.Second,
+		max:        time.Hour,
 		min:        time.Second,
 	}
 }

--- a/network/transport/grpc/backoff_test.go
+++ b/network/transport/grpc/backoff_test.go
@@ -33,7 +33,6 @@ func TestBackoff(t *testing.T) {
 	var current time.Duration = 0
 	for current < b.max {
 		current = b.Backoff()
-		println(current.String())
 	}
 }
 

--- a/network/transport/grpc/backoff_test.go
+++ b/network/transport/grpc/backoff_test.go
@@ -29,12 +29,12 @@ func TestBackoff(t *testing.T) {
 	b := defaultBackoff().(*backoff)
 	// Initially the backoff should be min-backoff
 	assert.Equal(t, b.min, b.Backoff())
-	var i = 0
-	for i = 0; i < 10; i++ {
-		b.Backoff().Milliseconds()
+
+	var current time.Duration = 0
+	for current < b.max {
+		current = b.Backoff()
+		println(current.String())
 	}
-	// In a few passes we should have reached max-backoff
-	assert.Equal(t, b.max, b.Backoff())
 }
 
 func TestBackoffReset(t *testing.T) {
@@ -48,7 +48,7 @@ func TestBackoffReset(t *testing.T) {
 func TestBackoffDefaultValues(t *testing.T) {
 	b := defaultBackoff().(*backoff)
 	assert.Equal(t, time.Second, b.min)
-	assert.Equal(t, 30*time.Second, b.max)
+	assert.Equal(t, time.Hour, b.max)
 }
 
 func TestRandomBackoff(t *testing.T) {


### PR DESCRIPTION
The maximum backoff value (max. time waited before trying to reconnect to a peer) is currently 30 seconds. With configured bootstrap nodes this was fine.

However, now anyone can publish their node's address, to be discovered and connected to. When DID documents with `NutsComm` services are abandoned, this leads to dead endpoints which will be retried every 30 seconds (given there's no node to connect to at the published endpoint), see log below.

If we increase the max. backoff, it won't clutter the log every 30 seconds. I suggest increasing it to 1 hour.

These were the intervals with max = 30s (given some randomness with each step):

```
1.5s
2.25s
3.375s
5.0625s
7.59375s
11.390625s
17.0859375s
25.62890625s
30s
```

And these with max = 1h:

```
1.5s
2.25s
3.375s
5.0625s
7.59375s
11.390625s
17.0859375s
25.62890625s
38.443359375s
57.665039062s
1m26.497558593s
2m9.746337889s
3m14.619506833s
4m51.929260249s
7m17.893890373s
10m56.840835559s
16m25.261253338s
24m37.891880007s
36m56.83782001s
55m25.256730015s
1h0m0s
```


Current reconnect log:
```
time="2022-01-31T12:00:49Z" level=info msg="Connecting to peer: swvjdvpt-grpc.nnaas.reinkrul.nl:5555" module=Network
time="2022-01-31T12:00:54Z" level=info msg="Couldn't connect to peer, reconnecting in 30 seconds (peer=swvjdvpt-grpc.nnaas.reinkrul.nl:5555,err=unable to connect: context deadline exceeded: connection error: desc = \"transport: Error while dialing dial tcp 128.199.61.173:5555: connect: connection refused\")" module=Network
time="2022-01-31T12:01:24Z" level=info msg="Connecting to peer: swvjdvpt-grpc.nnaas.reinkrul.nl:5555" module=Network
time="2022-01-31T12:01:29Z" level=info msg="Couldn't connect to peer, reconnecting in 30 seconds (peer=swvjdvpt-grpc.nnaas.reinkrul.nl:5555,err=unable to connect: context deadline exceeded: connection error: desc = \"transport: Error while dialing dial tcp 128.199.61.173:5555: connect: connection refused\")" module=Network
time="2022-01-31T12:01:59Z" level=info msg="Connecting to peer: swvjdvpt-grpc.nnaas.reinkrul.nl:5555" module=Network
time="2022-01-31T12:02:04Z" level=info msg="Couldn't connect to peer, reconnecting in 30 seconds (peer=swvjdvpt-grpc.nnaas.reinkrul.nl:5555,err=unable to connect: context deadline exceeded: connection error: desc = \"transport: Error while dialing dial tcp 128.199.61.173:5555: connect: connection refused\")" module=Network
time="2022-01-31T12:02:34Z" level=info msg="Connecting to peer: swvjdvpt-grpc.nnaas.reinkrul.nl:5555" module=Network
time="2022-01-31T12:02:39Z" level=info msg="Couldn't connect to peer, reconnecting in 30 seconds (peer=swvjdvpt-grpc.nnaas.reinkrul.nl:5555,err=unable to connect: context deadline exceeded: connection error: desc = \"transport: Error while dialing dial tcp 128.199.61.173:5555: connect: connection refused\")" module=Network
time="2022-01-31T12:03:09Z" level=info msg="Connecting to peer: swvjdvpt-grpc.nnaas.reinkrul.nl:5555" module=Network
time="2022-01-31T12:03:14Z" level=info msg="Couldn't connect to peer, reconnecting in 30 seconds (peer=swvjdvpt-grpc.nnaas.reinkrul.nl:5555,err=unable to connect: context deadline exceeded: connection error: desc = \"transport: Error while dialing dial tcp 128.199.61.173:5555: connect: connection refused\")" module=Network
time="2022-01-31T12:03:44Z" level=info msg="Connecting to peer: swvjdvpt-grpc.nnaas.reinkrul.nl:5555" module=Network
time="2022-01-31T12:03:49Z" level=info msg="Couldn't connect to peer, reconnecting in 30 seconds (peer=swvjdvpt-grpc.nnaas.reinkrul.nl:5555,err=unable to connect: context deadline exceeded: connection error: desc = \"transport: Error while dialing dial tcp 128.199.61.173:5555: connect: connection refused\")" module=Network
time="2022-01-31T12:04:19Z" level=info msg="Connecting to peer: swvjdvpt-grpc.nnaas.reinkrul.nl:5555" module=Network
time="2022-01-31T12:04:24Z" level=info msg="Couldn't connect to peer, reconnecting in 30 seconds (peer=swvjdvpt-grpc.nnaas.reinkrul.nl:5555,err=unable to connect: context deadline exceeded: connection error: desc = \"transport: Error while dialing dial tcp 128.199.61.173:5555: connect: connection refused\")" module=Network
time="2022-01-31T12:04:54Z" level=info msg="Connecting to peer: swvjdvpt-grpc.nnaas.reinkrul.nl:5555" module=Network
time="2022-01-31T12:04:59Z" level=info msg="Couldn't connect to peer, reconnecting in 30 seconds (peer=swvjdvpt-grpc.nnaas.reinkrul.nl:5555,err=unable to connect: context deadline exceeded: connection error: desc = \"transport: Error while dialing dial tcp 128.199.61.173:5555: connect: connection refused\")" module=Network
time="2022-01-31T12:05:29Z" level=info msg="Connecting to peer: swvjdvpt-grpc.nnaas.reinkrul.nl:5555" module=Network
time="2022-01-31T12:05:34Z" level=info msg="Couldn't connect to peer, reconnecting in 30 seconds (peer=swvjdvpt-grpc.nnaas.reinkrul.nl:5555,err=unable to connect: context deadline exceeded: connection error: desc = \"transport: Error while dialing dial tcp 128.199.61.173:5555: connect: connection refused\")" module=Network
time="2022-01-31T12:06:04Z" level=info msg="Connecting to peer: swvjdvpt-grpc.nnaas.reinkrul.nl:5555" module=Network
time="2022-01-31T12:06:09Z" level=info msg="Couldn't connect to peer, reconnecting in 30 seconds (peer=swvjdvpt-grpc.nnaas.reinkrul.nl:5555,err=unable to connect: context deadline exceeded: connection error: desc = \"transport: Error while dialing dial tcp 128.199.61.173:5555: connect: connection refused\")" module=Network
time="2022-01-31T12:06:39Z" level=info msg="Connecting to peer: swvjdvpt-grpc.nnaas.reinkrul.nl:5555" module=Network
time="2022-01-31T12:06:44Z" level=info msg="Couldn't connect to peer, reconnecting in 30 seconds (peer=swvjdvpt-grpc.nnaas.reinkrul.nl:5555,err=unable to connect: context deadline exceeded: connection error: desc = \"transport: Error while dialing dial tcp 128.199.61.173:5555: connect: connection refused\")" module=Network
time="2022-01-31T12:07:14Z" level=info msg="Connecting to peer: swvjdvpt-grpc.nnaas.reinkrul.nl:5555" module=Network
time="2022-01-31T12:07:19Z" level=info msg="Couldn't connect to peer, reconnecting in 30 seconds (peer=swvjdvpt-grpc.nnaas.reinkrul.nl:5555,err=unable to connect: context deadline exceeded: connection error: desc = \"transport: Error while dialing dial tcp 128.199.61.173:5555: connect: connection refused\")" module=Network
time="2022-01-31T12:07:49Z" level=info msg="Connecting to peer: swvjdvpt-grpc.nnaas.reinkrul.nl:5555" module=Network
time="2022-01-31T12:07:54Z" level=info msg="Couldn't connect to peer, reconnecting in 30 seconds (peer=swvjdvpt-grpc.nnaas.reinkrul.nl:5555,err=unable to connect: context deadline exceeded: connection error: desc = \"transport: Error while dialing dial tcp 128.199.61.173:5555: connect: connection refused\")" module=Network
```

