### PR TITLE
DIDMan: provide CLI commands for registering/deleting endpoints

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,7 @@ import (
 	cryptoCmd "github.com/nuts-foundation/nuts-node/crypto/cmd"
 	"github.com/nuts-foundation/nuts-node/didman"
 	didmanAPI "github.com/nuts-foundation/nuts-node/didman/api/v1"
+	didmanCmd "github.com/nuts-foundation/nuts-node/didman/cmd"
 	"github.com/nuts-foundation/nuts-node/events"
 	eventsCmd "github.com/nuts-foundation/nuts-node/events/cmd"
 	"github.com/nuts-foundation/nuts-node/network"
@@ -243,6 +244,7 @@ func addSubCommands(system *core.System, root *cobra.Command) {
 		networkCmd.Cmd(),
 		vcrCmd.Cmd(),
 		vdrCmd.Cmd(),
+		didmanCmd.Cmd(),
 	}
 	clientFlags := core.ClientConfigFlags()
 	for _, clientCommand := range clientCommands {

--- a/didman/cmd/cmd.go
+++ b/didman/cmd/cmd.go
@@ -1,0 +1,104 @@
+/*
+ * Nuts node
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/nuts-foundation/nuts-node/core"
+	"github.com/nuts-foundation/nuts-node/didman/api/v1"
+	"github.com/spf13/cobra"
+)
+
+// Cmd contains sub-commands for the remote client
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "didman",
+		Short: "didman commands",
+	}
+	serviceCmds := &cobra.Command{
+		Use: "svc",
+		Short: "service commands",
+	}
+	serviceCmds.AddCommand(addService())
+	serviceCmds.AddCommand(deleteService())
+	cmd.AddCommand(serviceCmds)
+	return cmd
+}
+
+func addService() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add [DID] [type] [endpoint]",
+		Short: "Adds a service to a DID document.",
+		Long:  "Adds a service of the specified type to DID document identified by the given DID. " +
+			"The given service endpoint can either be a string a compound service map in JSON format.",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := httpClient(core.NewClientConfig(cmd.Flags()))
+
+			targetDID := args[0]
+			serviceType := args[1]
+			serviceEndpoint := args[2]
+			compoundService := make(map[string]string, 0)
+			var result interface{}
+
+			err := json.Unmarshal([]byte(serviceEndpoint), &compoundService)
+			if err == nil {
+				// Compound service
+				result, err = client.AddCompoundService(targetDID, serviceType, compoundService)
+			} else {
+				// string endpoint
+				result, err = client.AddEndpoint(targetDID, serviceType, serviceEndpoint)
+			}
+			if err != nil {
+				return fmt.Errorf("unable to register service: %w", err)
+			}
+
+			resultJSON, _ := json.MarshalIndent(result, "", "  ")
+			cmd.Println(string(resultJSON))
+
+			return nil
+		},
+	}
+}
+
+func deleteService() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete [DID] [type]",
+		Short: "Deletes a service from a DID document.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := httpClient(core.NewClientConfig(cmd.Flags()))
+			err := client.DeleteEndpointsByType(args[0], args[1])
+			if err != nil {
+				return err
+			}
+			cmd.Println("Service deleted")
+			return nil
+		},
+	}
+}
+
+// httpClient creates a remote client
+func httpClient(config core.ClientConfig) v1.HTTPClient {
+	return v1.HTTPClient{
+		ServerAddress: config.GetAddress(),
+		Timeout:       config.Timeout,
+	}
+}

--- a/didman/cmd/cmd.go
+++ b/didman/cmd/cmd.go
@@ -33,7 +33,7 @@ func Cmd() *cobra.Command {
 		Short: "didman commands",
 	}
 	serviceCmds := &cobra.Command{
-		Use: "svc",
+		Use:   "svc",
 		Short: "service commands",
 	}
 	serviceCmds.AddCommand(addService())
@@ -46,9 +46,9 @@ func addService() *cobra.Command {
 	return &cobra.Command{
 		Use:   "add [DID] [type] [endpoint]",
 		Short: "Adds a service to a DID document.",
-		Long:  "Adds a service of the specified type to DID document identified by the given DID. " +
+		Long: "Adds a service of the specified type to DID document identified by the given DID. " +
 			"The given service endpoint can either be a string a compound service map in JSON format.",
-		Args:  cobra.ExactArgs(3),
+		Args: cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client := httpClient(core.NewClientConfig(cmd.Flags()))
 

--- a/didman/cmd/cmd_test.go
+++ b/didman/cmd/cmd_test.go
@@ -1,6 +1,6 @@
 /*
  * Nuts node
- * Copyright (C) 2021 Nuts community
+ * Copyright (C) 2022 Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/didman/cmd/cmd_test.go
+++ b/didman/cmd/cmd_test.go
@@ -1,0 +1,96 @@
+/*
+ * Nuts node
+ * Copyright (C) 2021 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/core"
+	v1 "github.com/nuts-foundation/nuts-node/didman/api/v1"
+	http2 "github.com/nuts-foundation/nuts-node/test/http"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestCmd_AddService(t *testing.T) {
+	t.Run("add compound service", func(t *testing.T) {
+		serviceEndpoint := map[string]string{
+			"foo": "bar",
+		}
+
+		cmd := Cmd()
+		response := did.Service{
+			Type:            "type",
+			ServiceEndpoint: serviceEndpoint,
+		}
+		handler := http2.Handler{StatusCode: http.StatusOK, ResponseData: response}
+		s := httptest.NewServer(handler)
+		os.Setenv("NUTS_ADDRESS", s.URL)
+		defer os.Unsetenv("NUTS_ADDRESS")
+		core.NewServerConfig().Load(cmd)
+		defer s.Close()
+
+		endpointAsJSON, _ := json.Marshal(serviceEndpoint)
+		cmd.SetArgs([]string{"svc", "add", "did:nuts:1234", "type", string(endpointAsJSON)})
+		err := cmd.Execute()
+
+		assert.NoError(t, err)
+	})
+	t.Run("add service with string endpoint", func(t *testing.T) {
+		serviceEndpoint := "https://nuts.nl"
+
+		cmd := Cmd()
+		response := v1.Endpoint{
+			Type:     "type",
+			Endpoint: serviceEndpoint,
+		}
+		handler := http2.Handler{StatusCode: http.StatusOK, ResponseData: response}
+		s := httptest.NewServer(handler)
+		os.Setenv("NUTS_ADDRESS", s.URL)
+		defer os.Unsetenv("NUTS_ADDRESS")
+		core.NewServerConfig().Load(cmd)
+		defer s.Close()
+
+		cmd.SetArgs([]string{"svc", "add", "did:nuts:1234", "type", serviceEndpoint})
+		err := cmd.Execute()
+
+		assert.NoError(t, err)
+	})
+}
+
+
+func TestCmd_DeleteService(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		cmd := Cmd()
+		handler := http2.Handler{StatusCode: http.StatusNoContent, ResponseData: ""}
+		s := httptest.NewServer(handler)
+		os.Setenv("NUTS_ADDRESS", s.URL)
+		defer os.Unsetenv("NUTS_ADDRESS")
+		core.NewServerConfig().Load(cmd)
+		defer s.Close()
+
+		cmd.SetArgs([]string{"svc", "delete", "did:nuts:1234", "type"})
+		err := cmd.Execute()
+
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Useful for registering NutsComm endpoint, e.g.:

```
nuts didman svc add did:nuts:Ey1KsopGGroX5pqTbNntWLALXuJv4ze9jZqdaSSKU5WX NutsComm grpc://swvjdvpt-grpc.nnaas.reinkrul.nl:5555
```

or registering a compound endpoint:

```
nuts didman svc add did:nuts:Ey1KsopGGroX5pqTbNntWLALXuJv4ze9jZqdaSSKU5WX some-service '{"foo": "bar"}'
```
