### PR TITLE
Network: fix startup/verify order of DAG state

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/test"
 	"github.com/nuts-foundation/nuts-node/test/io"
-	"go.uber.org/atomic"
+	v1 "github.com/nuts-foundation/nuts-node/vdr/api/v1"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path"
 	"syscall"
 	"testing"
 	"time"
@@ -21,20 +21,94 @@ import (
 // - Waits for the /status endpoint to return HTTP 200, indicating it started properly
 // - Sends SIGINT signal
 // - Waits for the main function to return
+// This test was introduced because the shutdown sequence was never called, due to kill signals not being handled.
 func Test_ServerLifecycle(t *testing.T) {
 	testDirectory := io.TestDirectory(t)
 
-	// Collect options
-	httpAddress := fmt.Sprintf("localhost:%d", test.FreeTCPPort())
-	opts := map[string]string{
-		"configfile":              path.Join(testDirectory, "nuts.yaml"), // does not exist, but that's okay: default config
-		"datadir":                 testDirectory,
-		"network.enabletls":       "false",
-		"network.grpcaddr":        fmt.Sprintf("localhost:%d", test.FreeTCPPort()),
-		"auth.contractvalidators": "dummy", // disables IRMA
-		"http.default.address":    httpAddress,
-		"events.nats.port":        fmt.Sprintf("%d", test.FreeTCPPort()),
+	runningCtx, nodeStoppedCallback := context.WithCancel(context.Background())
+	startCtx := startServer(test.GetIntegrationTestConfig(testDirectory), nodeStoppedCallback)
+
+	// Wait for the Nuts node to start
+	<-startCtx.Done()
+
+	if errors.Is(startCtx.Err(), context.Canceled) {
+		t.Log("Process successfully started, sending KILL signal")
+		stopNode(t, runningCtx)
+	} else {
+		t.Fatalf("Process didn't start before the time-out expired: %v", startCtx.Err())
 	}
+}
+
+// Test_LoadExistingDAG tests the lifecycle and persistence of the DAG:
+// - It starts the Nuts node
+// - It creates and then updates a DID document
+// - It stops and then starts the Nuts node again
+// - It checks whether it can read the DID document from the DAG
+// This test was introduced because we repeatedly encountered a bug where a new DAG could be created and written to,
+// but (DAG) verification failed when starting the node with an existing DAG.
+// It also tests that file resources (that are locked) are properly freed by the shutdown sequence,
+// because it uses the same files when restarting again (without exiting the main process).
+func Test_LoadExistingDAG(t *testing.T) {
+	testDirectory := io.TestDirectory(t)
+
+	opts := test.GetIntegrationTestConfig(testDirectory)
+
+	// Start Nuts node
+	runningCtx, nodeStoppedCallback := context.WithCancel(context.Background())
+	startCtx := startServer(opts, nodeStoppedCallback)
+	<-startCtx.Done()
+	if !errors.Is(startCtx.Err(), context.Canceled) {
+		t.Fatalf("Process didn't start before the time-out expired: %v", startCtx.Err())
+	}
+	defer stopNode(t, runningCtx)
+
+	// Create and update a DID document
+	vdrClient := createVDRClient(opts)
+	didDocument, err := vdrClient.Create(v1.DIDCreateRequest{})
+	if !assert.NoError(t, err) {
+		return
+	}
+	_, err = vdrClient.AddNewVerificationMethod(didDocument.ID.String())
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Now stop node, and start it again
+	stopNode(t, runningCtx)
+	runningCtx, nodeStoppedCallback = context.WithCancel(context.Background())
+	// Make sure we get "fresh" ports since the OS might not immediately free closed sockets
+	opts = test.GetIntegrationTestConfig(testDirectory)
+	startCtx = startServer(opts, nodeStoppedCallback)
+	<-startCtx.Done()
+	if !errors.Is(startCtx.Err(), context.Canceled) {
+		t.Fatalf("Process didn't start before the time-out expired: %v", startCtx.Err())
+	}
+
+	// Assert we can read the DID document
+	vdrClient = createVDRClient(opts)
+	doc, _, err := vdrClient.Get(didDocument.ID.String())
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.NotNil(t, doc)
+}
+
+func createVDRClient(opts map[string]string) v1.HTTPClient {
+	vdrClient := v1.HTTPClient{
+		ServerAddress: "http://" + opts["http.default.address"],
+		Timeout:       5 * time.Second,
+	}
+	return vdrClient
+}
+
+func stopNode(t *testing.T, ctx context.Context) {
+	_ = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+	<-ctx.Done()
+	t.Log("Nuts node shut down successfully.")
+}
+
+func startServer(opts map[string]string, exitCallback func()) context.Context {
+	// Collect options
 	var optsSlice []string
 	for key, value := range opts {
 		optsSlice = append(optsSlice, "--"+key+"="+fmt.Sprintf("%s", value))
@@ -43,18 +117,15 @@ func Test_ServerLifecycle(t *testing.T) {
 	os.Args = append([]string{"nuts", "server"}, optsSlice...)
 	timeout := 10 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	wasRunning := &atomic.Bool{}
 
 	go func() {
 		// Wait for the Nuts node to start, until the given timeout. Check every 100ms
 		interval := 100 * time.Millisecond
 		attempts := int(timeout / interval)
-		address := fmt.Sprintf("http://%s/status", httpAddress)
+		address := fmt.Sprintf("http://%s/status", opts["http.default.address"])
 		for i := 0; i < attempts; i++ {
 			if isRunning(address) {
-				println("Nuts node running, sending SIGINT signal")
-				wasRunning.Store(true)
-				syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+				cancel()
 				break
 			}
 			time.Sleep(interval)
@@ -63,21 +134,10 @@ func Test_ServerLifecycle(t *testing.T) {
 
 	go func() {
 		main()
-		cancel()
+		exitCallback()
 	}()
 
-	// Wait for the main func to exit
-	<-ctx.Done()
-	if errors.Is(ctx.Err(), context.Canceled) {
-		if wasRunning.Load() {
-			// Program exited OK
-			t.Log("Process successfully started and shut down.")
-		} else {
-			t.Fatal("Process didn't start properly")
-		}
-	} else {
-		t.Fatalf("Process didn't start and shut down before the time-out expired: %v", ctx.Err())
-	}
+	return ctx
 }
 
 func isRunning(address string) bool {

--- a/network/dag/state.go
+++ b/network/dag/state.go
@@ -178,11 +178,11 @@ func (s *state) Start() error {
 		return fmt.Errorf("unable to migrate DAG: %w", err)
 	}
 
-	if err := s.Verify(context.Background()); err != nil {
+	if err := s.publisher.Start(); err != nil {
 		return err
 	}
 
-	if err := s.publisher.Start(); err != nil {
+	if err := s.Verify(context.Background()); err != nil {
 		return err
 	}
 

--- a/test/node.go
+++ b/test/node.go
@@ -1,0 +1,19 @@
+package test
+
+import (
+	"fmt"
+	"path"
+)
+
+func GetIntegrationTestConfig(testDirectory string) map[string]string {
+	httpAddress := fmt.Sprintf("localhost:%d", FreeTCPPort())
+	return map[string]string{
+		"configfile":              path.Join(testDirectory, "nuts.yaml"), // does not exist, but that's okay: default config
+		"datadir":                 testDirectory,
+		"network.enabletls":       "false",
+		"network.grpcaddr":        fmt.Sprintf("localhost:%d", FreeTCPPort()),
+		"auth.contractvalidators": "dummy", // disables IRMA
+		"http.default.address":    httpAddress,
+		"events.nats.port":        fmt.Sprintf("%d", FreeTCPPort()),
+	}
+}

--- a/vcr/issuer/interface.go
+++ b/vcr/issuer/interface.go
@@ -62,6 +62,8 @@ type Store interface {
 	// StoreRevocation writes a revocation to storage.
 	StoreRevocation(r credential.Revocation) error
 	CredentialSearcher
+	// Close closes and frees the underlying resources the store uses.
+	Close() error
 }
 
 // CredentialSearcher defines the functions to resolve or search for credentials.

--- a/vcr/issuer/leia_store.go
+++ b/vcr/issuer/leia_store.go
@@ -33,6 +33,7 @@ import (
 // Note: It can not be used in a clustered setup.
 type leiaStore struct {
 	collection leia.Collection
+	store      leia.Store
 }
 
 // NewLeiaStore creates a new instance of leiaStore which implements the Store interface.
@@ -42,7 +43,10 @@ func NewLeiaStore(dbPath string) (Store, error) {
 		return nil, fmt.Errorf("failed to create leiaStore: %w", err)
 	}
 	collection := store.Collection("issuedCredentials")
-	newLeiaStore := &leiaStore{collection: collection}
+	newLeiaStore := &leiaStore{
+		collection: collection,
+		store:      store,
+	}
 	if err := newLeiaStore.createIndices(); err != nil {
 		return nil, err
 	}
@@ -84,6 +88,10 @@ func (s leiaStore) SearchCredential(jsonLDContext ssi.URI, credentialType ssi.UR
 func (s leiaStore) StoreRevocation(r credential.Revocation) error {
 	//TODO implement me
 	panic("implement me")
+}
+
+func (s leiaStore) Close() error {
+	return s.store.Close()
 }
 
 // createIndices creates the needed indices for the issued VC store

--- a/vcr/issuer/leia_store_test.go
+++ b/vcr/issuer/leia_store_test.go
@@ -49,6 +49,14 @@ func TestNewLeiaStore(t *testing.T) {
 	})
 }
 
+func TestLeiaStore_Close(t *testing.T) {
+	testDir := io.TestDirectory(t)
+	issuerStorePath := path.Join(testDir, "vcr", "issued-credentials.db")
+	sut, _ := NewLeiaStore(issuerStorePath)
+	err := sut.Close()
+	assert.NoError(t, err)
+}
+
 func Test_leiaStore_StoreAndSearchCredential(t *testing.T) {
 	vcToStore := vc.VerifiableCredential{}
 	_ = json.Unmarshal([]byte(concept.TestCredential), &vcToStore)

--- a/vcr/issuer/mock.go
+++ b/vcr/issuer/mock.go
@@ -194,6 +194,20 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockStore) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockStoreMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockStore)(nil).Close))
+}
+
 // SearchCredential mocks base method.
 func (m *MockStore) SearchCredential(context, credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error) {
 	m.ctrl.T.Helper()

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -94,14 +94,14 @@ func TestVCR_Start(t *testing.T) {
 }
 
 func TestVCR_Shutdown(t *testing.T) {
-	instance := NewVCRInstance(nil, nil, nil, nil).(*vcr)
+	m := newMockContext(t)
 
-	_ = instance.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
-	err := instance.Start()
+	_ = m.vcr.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
+	err := m.vcr.Start()
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = instance.Shutdown()
+	err = m.vcr.Shutdown()
 	assert.NoError(t, err)
 }
 

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -82,7 +82,7 @@ func TestVCR_Start(t *testing.T) {
 
 		_ = instance.Configure(core.ServerConfig{Datadir: "test"})
 		err := instance.Start()
-		assert.Error(t, err)
+		assert.EqualError(t, err, "mkdir test/vcr: not a directory")
 	})
 
 	t.Run("ok", func(t *testing.T) {
@@ -91,6 +91,18 @@ func TestVCR_Start(t *testing.T) {
 		_, err := os.Stat(instance.credentialsDBPath())
 		assert.NoError(t, err)
 	})
+}
+
+func TestVCR_Shutdown(t *testing.T) {
+	instance := NewVCRInstance(nil, nil, nil, nil).(*vcr)
+
+	_ = instance.Configure(core.ServerConfig{Datadir: io.TestDirectory(t)})
+	err := instance.Start()
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = instance.Shutdown()
+	assert.NoError(t, err)
 }
 
 func TestVCR_SearchInternal(t *testing.T) {


### PR DESCRIPTION
Order of starting publisher/verifying DAG was incorrect. Caused VDR to be empty when the DAG was verified, thus keys were missing for checking signatures.

Fixed and introduced an integration test to assert starting a node with existing DAG works properly. Also found a bug in VCR due to leia store not being closed on shutdown.