### PR TITLE
use bbolt as vdr store

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,12 +23,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"go.uber.org/atomic"
 	"io"
 	"net/http"
 	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"go.uber.org/atomic"
 
 	"github.com/nuts-foundation/nuts-node/auth"
 	authIrmaAPI "github.com/nuts-foundation/nuts-node/auth/api/irma"
@@ -177,20 +178,20 @@ func CreateCommand(system *core.System) *cobra.Command {
 func CreateSystem() *core.System {
 	system := core.NewSystem()
 
+	// supporting components
+	didStore := store.NewBBoltStore()
+	keyResolver := doc.KeyResolver{Store: didStore}
+	docResolver := doc.Resolver{Store: didStore}
+	docFinder := doc.Finder{Store: didStore}
+
 	// Create instances
 	cryptoInstance := crypto.NewCryptoInstance()
-	memoryStore := store.NewMemoryStore()
-	keyResolver := doc.KeyResolver{Store: memoryStore}
-	docResolver := doc.Resolver{Store: memoryStore}
-	docFinder := doc.Finder{Store: memoryStore}
-
 	eventManager := events.NewManager()
-
 	networkInstance := network.NewNetworkInstance(network.DefaultConfig(), keyResolver, cryptoInstance, cryptoInstance, docResolver, docFinder)
-	vdrInstance := vdr.NewVDR(vdr.DefaultConfig(), cryptoInstance, networkInstance, memoryStore)
+	vdrInstance := vdr.NewVDR(vdr.DefaultConfig(), cryptoInstance, networkInstance, didStore)
 	credentialInstance := vcr.NewVCRInstance(cryptoInstance, docResolver, keyResolver, networkInstance)
-	didmanInstance := didman.NewDidmanInstance(docResolver, memoryStore, vdrInstance, credentialInstance)
-	authInstance := auth.NewAuthInstance(auth.DefaultConfig(), memoryStore, credentialInstance, cryptoInstance, didmanInstance)
+	didmanInstance := didman.NewDidmanInstance(docResolver, didStore, vdrInstance, credentialInstance)
+	authInstance := auth.NewAuthInstance(auth.DefaultConfig(), didStore, credentialInstance, cryptoInstance, didmanInstance)
 
 	statusEngine := status.NewStatusEngine(system)
 	metricsEngine := core.NewMetricsEngine()
@@ -214,6 +215,7 @@ func CreateSystem() *core.System {
 
 	// Register engines
 	system.RegisterEngine(eventManager)
+	system.RegisterEngine(didStore)
 	system.RegisterEngine(statusEngine)
 	system.RegisterEngine(metricsEngine)
 	system.RegisterEngine(cryptoInstance)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -202,7 +202,7 @@ func Test_CreateSystem(t *testing.T) {
 	system.VisitEngines(func(engine core.Engine) {
 		numEngines++
 	})
-	assert.Equal(t, 9, numEngines)
+	assert.Equal(t, 10, numEngines)
 }
 
 func testCommand() *cobra.Command {

--- a/vdr/store/bbolt.go
+++ b/vdr/store/bbolt.go
@@ -18,8 +18,11 @@ package store
 import (
 	"encoding/json"
 	"errors"
+	"os"
+	"path"
 
 	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/core"
 	"go.etcd.io/bbolt"
 
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
@@ -86,8 +89,31 @@ type bboltStore struct {
 }
 
 // NewBBoltStore returns an instance of a BBolt based VDR store
-func NewBBoltStore(db *bbolt.DB) vdr.Store {
-	return &bboltStore{db: db}
+func NewBBoltStore() vdr.Store {
+	return &bboltStore{}
+}
+
+func (store *bboltStore) Configure(config core.ServerConfig) error {
+	var err error
+	filePath := path.Join(config.Datadir, "vdr", "didstore.db")
+	if err = os.MkdirAll(path.Join(config.Datadir, "vdr"), os.ModePerm); err != nil {
+		return err
+	}
+	store.db, err = bbolt.Open(filePath, 0600, bbolt.DefaultOptions)
+
+	return err
+}
+
+func (store *bboltStore) Start() error {
+	// already done in Configure
+	return nil
+}
+
+func (store *bboltStore) Shutdown() error {
+	if store.db != nil {
+		return store.db.Close()
+	}
+	return nil
 }
 
 func (store *bboltStore) storeDocument(tx *bbolt.Tx, document did.Document, metadata vdr.DocumentMetadata) error {
@@ -160,19 +186,19 @@ func (store *bboltStore) Iterate(fn vdr.DocIterator) error {
 	})
 }
 
-func (store *bboltStore) filterDocument(doc *documentVersion, metadata *vdr.ResolveMetadata) error {
+func (store *bboltStore) filterDocument(doc *documentVersion, metadata *vdr.ResolveMetadata) bool {
 	// Verify deactivated
 	if IsDeactivated(doc.Document) && (metadata == nil || !metadata.AllowDeactivated) {
-		return vdr.ErrDeactivated
+		return false
 	}
 
 	if metadata == nil {
-		return nil
+		return true
 	}
 
 	// Filter on hash
 	if metadata.Hash != nil && !doc.Metadata.Hash.Equals(*metadata.Hash) {
-		return vdr.ErrNotFound
+		return false
 	}
 
 	// Filter on creation and update time
@@ -180,30 +206,28 @@ func (store *bboltStore) filterDocument(doc *documentVersion, metadata *vdr.Reso
 		resolveTime := *metadata.ResolveTime
 
 		if doc.Metadata.Created.After(resolveTime) {
-			return vdr.ErrNotFound
+			return false
 		}
 
 		if doc.Metadata.Updated != nil {
 			if doc.Metadata.Updated.After(resolveTime) {
-				return vdr.ErrNotFound
+				return false
 			}
 		}
 	}
 
 	// Filter on SourceTransaction
 	if metadata.SourceTransaction != nil {
-		for i, keyTx := range doc.Metadata.SourceTransactions {
+		for _, keyTx := range doc.Metadata.SourceTransactions {
 			if keyTx.Equals(*metadata.SourceTransaction) {
 				break
 			}
 
-			if i == len(doc.Metadata.SourceTransactions)-1 {
-				return vdr.ErrNotFound
-			}
+			return false
 		}
 	}
 
-	return nil
+	return true
 }
 
 // Resolve returns the DID Document for the provided DID.
@@ -228,31 +252,28 @@ func (store *bboltStore) Resolve(id did.DID, metadata *vdr.ResolveMetadata) (doc
 		}
 
 		versionList := parseDocumentVersionList(data)
-		versionHash := versionList.Latest()
 
-		if metadata != nil && metadata.Hash != nil {
-			versionHash = *metadata.Hash
+		for i := len(versionList.Versions) - 1; i >= 0; i-- {
+			versionHash := versionList.Versions[i]
+			data = documents.Get(versionHash.Slice())
+			if data == nil {
+				return vdr.ErrNotFound
+			}
+
+			doc := &documentVersion{}
+
+			if err := json.Unmarshal(data, doc); err != nil {
+				return err
+			}
+
+			if store.filterDocument(doc, metadata) {
+				document = &doc.Document
+				documentMeta = &doc.Metadata
+				return nil
+			}
 		}
 
-		data = documents.Get(versionHash.Slice())
-		if data == nil {
-			return vdr.ErrNotFound
-		}
-
-		doc := &documentVersion{}
-
-		if err := json.Unmarshal(data, doc); err != nil {
-			return err
-		}
-
-		if err := store.filterDocument(doc, metadata); err != nil {
-			return err
-		}
-
-		document = &doc.Document
-		documentMeta = &doc.Metadata
-
-		return nil
+		return vdr.ErrNotFound
 	})
 
 	return

--- a/vdr/store/bbolt_test.go
+++ b/vdr/store/bbolt_test.go
@@ -17,13 +17,13 @@ package store
 
 import (
 	"errors"
-	"io/ioutil"
-	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/core"
+	"github.com/nuts-foundation/nuts-node/test/io"
 	"github.com/stretchr/testify/assert"
 	"go.etcd.io/bbolt"
 
@@ -35,13 +35,11 @@ func newBBoltTestStore(t *testing.T) *bboltStore {
 	opts := *bbolt.DefaultOptions
 	opts.NoSync = true
 
-	dir, err := ioutil.TempDir("/tmp", "go_test_vdr_bboltstore")
-	assert.NoError(t, err)
+	testDir := io.TestDirectory(t)
 
-	db, err := bbolt.Open(filepath.Join(dir, "bbolt.db"), 0644, &opts)
-	assert.NoError(t, err)
-
-	return NewBBoltStore(db).(*bboltStore)
+	store := NewBBoltStore().(*bboltStore)
+	store.Configure(core.ServerConfig{Datadir: testDir})
+	return store
 }
 
 func TestBBoltStore_Write(t *testing.T) {
@@ -121,8 +119,8 @@ func TestBBoltStore_Resolve(t *testing.T) {
 		assert.NotNil(t, m)
 	})
 
-	t.Run("returns no document with resolve metadata - selection on date", func(t *testing.T) {
-		before := time.Now().Add(time.Hour * -48)
+	t.Run("returns error when not found - selection on date", func(t *testing.T) {
+		before := time.Now().Add(time.Hour * -72)
 		_, _, err := store.Resolve(*did1, &types.ResolveMetadata{
 			ResolveTime: &before,
 		})
@@ -407,7 +405,7 @@ func TestBBoltStore_DeactivatedFilter(t *testing.T) {
 
 	t.Run("returns error when document is deactivated", func(t *testing.T) {
 		_, _, err := store.Resolve(*did1, nil)
-		assert.ErrorIs(t, types.ErrDeactivated, err)
+		assert.ErrorIs(t, err, types.ErrNotFound)
 	})
 
 	t.Run("returns deactivated document when allow deactivated is enabled in metadata", func(t *testing.T) {

--- a/vdr/types/common.go
+++ b/vdr/types/common.go
@@ -55,7 +55,7 @@ var ErrServiceNotFound = errors.New("service not found in DID Document")
 
 // DIDDocumentResolveEpoch represents the epoch on which DID Document resolving switched from time based to hash based
 // GMT: Saturday, 27 November 2021 08:00:00
-var DIDDocumentResolveEpoch = time.Unix(1638000000, 0)
+var DIDDocumentResolveEpoch = time.Unix(1643810219, 0)
 
 // ErrServiceReferenceToDeep is returned when a service reference is chain is nested too deeply.
 var ErrServiceReferenceToDeep = errors.New("service references are nested to deeply before resolving to a non-reference")


### PR DESCRIPTION
Also updated the transition timestamp for TX that find signing key by ref to Now(). There are still nodes that use a really really old version.