### PR TITLE
split dag.State observers in transactional and non-transactional

### DIFF
--- a/network/dag/interface.go
+++ b/network/dag/interface.go
@@ -55,7 +55,8 @@ type State interface {
 	// PayloadHashes applies the visitor function to the payload hashes of all transactions, in random order.
 	PayloadHashes(ctx context.Context, visitor func(payloadHash hash.SHA256Hash) error) error
 	// RegisterObserver allows observers to be notified when a transaction is added to the DAG.
-	RegisterObserver(observer Observer)
+	// If the observer needs to be called within the transaction, transactional must be true.
+	RegisterObserver(observer Observer, transactional bool)
 	// Subscribe lets an application subscribe to a specific type of transaction. When a new transaction is received
 	// the `receiver` function is called. If an asterisk (`*`) is specified as `payloadType` the receiver is subscribed
 	// to all payload types.

--- a/network/dag/mock.go
+++ b/network/dag/mock.go
@@ -184,15 +184,15 @@ func (mr *MockStateMockRecorder) ReadPayload(ctx, payloadHash interface{}) *gomo
 }
 
 // RegisterObserver mocks base method.
-func (m *MockState) RegisterObserver(observer Observer) {
+func (m *MockState) RegisterObserver(observer Observer, transactional bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterObserver", observer)
+	m.ctrl.Call(m, "RegisterObserver", observer, transactional)
 }
 
 // RegisterObserver indicates an expected call of RegisterObserver.
-func (mr *MockStateMockRecorder) RegisterObserver(observer interface{}) *gomock.Call {
+func (mr *MockStateMockRecorder) RegisterObserver(observer, transactional interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterObserver", reflect.TypeOf((*MockState)(nil).RegisterObserver), observer)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterObserver", reflect.TypeOf((*MockState)(nil).RegisterObserver), observer, transactional)
 }
 
 // Shutdown mocks base method.

--- a/network/dag/publisher.go
+++ b/network/dag/publisher.go
@@ -51,6 +51,7 @@ type replayingDAGPublisher struct {
 }
 
 func (s *replayingDAGPublisher) ConfigureCallbacks(state State) {
+	// the publisher only signals the VDR, VCR and transaction state. These need to be called after the bbolt transaction is completed.
 	state.RegisterObserver(func(ctx context.Context, transaction Transaction, payload []byte) {
 		s.publishMux.Lock()
 		defer s.publishMux.Unlock()
@@ -61,7 +62,7 @@ func (s *replayingDAGPublisher) ConfigureCallbacks(state State) {
 		if payload != nil {
 			s.payloadWritten(ctx, transaction, payload)
 		}
-	})
+	}, false)
 }
 
 func (s *replayingDAGPublisher) payloadWritten(ctx context.Context, _ Transaction, payload []byte) {

--- a/network/storage/bbolt_context.go
+++ b/network/storage/bbolt_context.go
@@ -61,8 +61,14 @@ func BBoltTXUpdate(ctx context.Context, db *bbolt.DB, cb bboltTXCallback) error 
 	return callBBoltCallbackWithTX(ctx, db, cb, true)
 }
 
-func callBBoltCallbackWithTX(ctx context.Context, db *bbolt.DB, cb bboltTXCallback, writable bool) error {
+// BBoltTX returns the active TX from the context and true. If no TX is active it returns nil, false.
+func BBoltTX(ctx context.Context) (*bbolt.Tx, bool) {
 	tx, txIsActive := ctx.Value(bboltTXContextKey).(*bbolt.Tx)
+	return tx, txIsActive
+}
+
+func callBBoltCallbackWithTX(ctx context.Context, db *bbolt.DB, cb bboltTXCallback, writable bool) error {
+	tx, txIsActive := BBoltTX(ctx)
 	if !txIsActive {
 		// No active TX, we can simply start one here as long as we put it in the context we pass down, allowing nested BBolt database callers to re-use the transaction.
 		if writable {

--- a/network/storage/bbolt_context.go
+++ b/network/storage/bbolt_context.go
@@ -51,14 +51,16 @@ type bboltTXCallback func(contextWithTX context.Context, tx *bbolt.Tx) error
 // BBoltTXView executes the given callback in a read-only BBolt transaction. It attempts to re-use the active transaction from the given context, if there is one.
 // If there's no active transaction a new one will be started.
 func BBoltTXView(ctx context.Context, db *bbolt.DB, cb bboltTXCallback) error {
-	return callBBoltCallbackWithTX(ctx, db, cb, false)
+	err := callBBoltCallbackWithTX(ctx, db, cb, false)
+	return err
 }
 
 // BBoltTXUpdate executes the given callback in a writable BBolt transaction. It attempts to re-use the active transaction from the given context, if there is one.
 // If there's no active transaction a new one will be started.
 // If there's an active transaction which is readonly an error will be returned.
 func BBoltTXUpdate(ctx context.Context, db *bbolt.DB, cb bboltTXCallback) error {
-	return callBBoltCallbackWithTX(ctx, db, cb, true)
+	err := callBBoltCallbackWithTX(ctx, db, cb, true)
+	return err
 }
 
 // BBoltTX returns the active TX from the context and true. If no TX is active it returns nil, false.

--- a/network/transport/v1/protocol_integration_test.go
+++ b/network/transport/v1/protocol_integration_test.go
@@ -126,7 +126,7 @@ func TestProtocolV1_Pagination(t *testing.T) {
 		txs := node2.countTXs()
 		t.Logf("received %d transactions", txs)
 		return txs == numberOfTransactions, nil
-	}, 10*time.Second, "node2 didn't receive all transactions")
+	}, integrationTestTimeout, "node2 didn't receive all transactions")
 }
 
 type integrationTestContext struct {

--- a/test/predicates.go
+++ b/test/predicates.go
@@ -42,7 +42,7 @@ func WaitFor(t *testing.T, p Predicate, timeout time.Duration, message string, m
 			assert.Fail(t, fmt.Sprintf(message, msgArgs...))
 			return false
 		}
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(20 * time.Millisecond)
 	}
 }
 

--- a/test/predicates.go
+++ b/test/predicates.go
@@ -42,7 +42,7 @@ func WaitFor(t *testing.T, p Predicate, timeout time.Duration, message string, m
 			assert.Fail(t, fmt.Sprintf(message, msgArgs...))
 			return false
 		}
-		time.Sleep(20 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
fixes #799

a dag.State observer can now be called with or without a transactional context. 