### PR TITLE
add LC to new transactions and verify them when they are parsed

### DIFF
--- a/network/cmd/cmd_test.go
+++ b/network/cmd/cmd_test.go
@@ -95,7 +95,7 @@ func TestCmd_List(t *testing.T) {
 func TestCmd_Get(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		cmd := Cmd()
-		response := dag.CreateTestTransactionWithJWK(1, hash.SHA256Sum([]byte{1, 2, 3}))
+		response := dag.CreateTestTransactionWithJWK(1)
 		handler := http2.Handler{StatusCode: http.StatusOK, ResponseData: string(response.Data())}
 		s := httptest.NewServer(handler)
 		os.Setenv("NUTS_ADDRESS", s.URL)

--- a/network/dag/bbolt_dag.go
+++ b/network/dag/bbolt_dag.go
@@ -417,7 +417,7 @@ func indexClockValue(tx *bbolt.Tx, transaction Transaction) error {
 		return nil
 	}
 
-	if clock != 0 {
+	if clock == 0 {
 		for _, prev := range transaction.Previous() {
 			lClockBytes := lcIndex.Get(prev.Slice())
 			if lClockBytes == nil {

--- a/network/dag/dotviz_test.go
+++ b/network/dag/dotviz_test.go
@@ -20,8 +20,9 @@ package dag
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDotGraphVisitor(t *testing.T) {
@@ -29,8 +30,8 @@ func TestDotGraphVisitor(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", style), func(t *testing.T) {
 			visitor := NewDotGraphVisitor(style)
 			txA, _, _ := CreateTestTransaction(1)
-			txB, _, _ := CreateTestTransaction(2, txA.Ref())
-			txC, _, _ := CreateTestTransaction(3, txA.Ref())
+			txB, _, _ := CreateTestTransaction(2, txA)
+			txC, _, _ := CreateTestTransaction(3, txA)
 			visitor.Accept(nil, txA)
 			visitor.Accept(nil, txB)
 			visitor.Accept(nil, txC)

--- a/network/dag/parser.go
+++ b/network/dag/parser.go
@@ -54,6 +54,7 @@ func ParseTransaction(input []byte) (Transaction, error) {
 		parseVersion,
 		parsePrevious,
 		parsePAL,
+		parseLamportClock,
 	}
 
 	result := &transaction{}
@@ -186,6 +187,19 @@ func parsePAL(transaction *transaction, headers jws.Headers, _ *jws.Message) err
 	}
 	transaction.pal = pal
 	return nil
+}
+
+func parseLamportClock(transaction *transaction, headers jws.Headers, _ *jws.Message) error {
+	if lcAsInterf, ok := headers.Get(lamportClockHeader); !ok {
+		// not required as of this point
+		// deprecated
+		return nil
+	} else if lcAsFloat64, ok := lcAsInterf.(float64); !ok {
+		return transactionValidationError(invalidHeaderErrFmt, lamportClockHeader)
+	} else {
+		transaction.lamportClock = uint32(lcAsFloat64)
+		return nil
+	}
 }
 
 func isAlgoAllowed(algo jwa.SignatureAlgorithm) bool {

--- a/network/dag/parser_test.go
+++ b/network/dag/parser_test.go
@@ -219,6 +219,16 @@ func TestParseTransaction(t *testing.T) {
 		assert.Nil(t, transaction)
 		assert.EqualError(t, err, "transaction validation failed: signing algorithm not allowed: RS256")
 	})
+	t.Run("error - invalid lamport clock", func(t *testing.T) {
+		headers := makeJWSHeaders(key, "123", true)
+		headers.Set(lamportClockHeader, "a")
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		transaction, err := ParseTransaction(signature)
+
+		assert.Nil(t, transaction)
+		assert.EqualError(t, err, "transaction validation failed: invalid lc header")
+	})
 	t.Run("error - invalid payload", func(t *testing.T) {
 		headers := makeJWSHeaders(key, "123", true)
 		signature, _ := jws.Sign([]byte("not a valid hash"), headers.Algorithm(), key, jws.WithHeaders(headers))

--- a/network/dag/publisher_test.go
+++ b/network/dag/publisher_test.go
@@ -97,7 +97,7 @@ func TestReplayingDAGPublisher_replay(t *testing.T) {
 	})
 
 	t.Run("txs without payload - first is blocking", func(t *testing.T) {
-		tx1 := CreateTestTransactionWithJWK(2, tx0.Ref())
+		tx1 := CreateTestTransactionWithJWK(2, tx0)
 		ctx := context.Background()
 		publisher, dag, _ := newPublisher(t)
 		dag.Add(ctx, tx0)
@@ -120,7 +120,7 @@ func TestReplayingDAGPublisher_replay(t *testing.T) {
 	})
 
 	t.Run("txs with payload - first is blocking", func(t *testing.T) {
-		tx1 := CreateTestTransactionWithJWK(2, tx0.Ref())
+		tx1 := CreateTestTransactionWithJWK(2, tx0)
 		ctx := context.Background()
 		publisher, dag, payloadStore := newPublisher(t)
 		dag.Add(ctx, tx0)
@@ -144,8 +144,8 @@ func TestReplayingDAGPublisher_replay(t *testing.T) {
 		assert.Equal(t, 2, txPayloadAddedCalls)
 	})
 	t.Run("txs not processed again when payload has been processed", func(t *testing.T) {
-		tx1 := CreateTestTransactionWithJWK(2, tx0.Ref())
-		tx2 := CreateTestTransactionWithJWK(3, tx1.Ref())
+		tx1 := CreateTestTransactionWithJWK(2, tx0)
+		tx2 := CreateTestTransactionWithJWK(3, tx1)
 		ctx := context.Background()
 		publisher, dag, payloadStore := newPublisher(t)
 		dag.Add(ctx, tx0, tx1)
@@ -188,8 +188,8 @@ func TestReplayingDAGPublisher_replay(t *testing.T) {
 
 		txA := CreateTestTransactionWithJWK(1)
 		txAPayload := []byte{0, 0, 0, 1}
-		one := CreateTestTransactionWithJWK(2, txA.Ref())
-		two := CreateTestTransactionWithJWK(3, txA.Ref())
+		one := CreateTestTransactionWithJWK(2, txA)
+		two := CreateTestTransactionWithJWK(3, txA)
 		var txB, txC Transaction
 		var txBPayload, txCPayload []byte
 		if one.Ref().Compare(two.Ref()) <= 0 {
@@ -203,7 +203,7 @@ func TestReplayingDAGPublisher_replay(t *testing.T) {
 			txBPayload = []byte{0, 0, 0, 3}
 			txCPayload = []byte{0, 0, 0, 2}
 		}
-		txD := CreateTestTransactionWithJWK(4, txB.Ref(), txC.Ref())
+		txD := CreateTestTransactionWithJWK(4, txB, txC)
 		txDPayload := []byte{0, 0, 0, 4}
 
 		txB.(*transaction).payloadType = "foo/bar"

--- a/network/dag/signing.go
+++ b/network/dag/signing.go
@@ -82,6 +82,7 @@ func (d transactionSigner) Sign(input UnsignedTransaction, signingTime time.Time
 		signingTimeHeader:  normalizedMoment.Unix(),
 		previousHeader:     prevsAsString,
 		versionHeader:      input.Version(),
+		lamportClockHeader: input.Clock(),
 	}
 
 	if input.PAL() != nil {

--- a/network/dag/signing_test.go
+++ b/network/dag/signing_test.go
@@ -41,7 +41,7 @@ func TestTransactionSigner(t *testing.T) {
 	contentType := "foo/bar"
 	moment := time.Date(2020, 10, 23, 13, 0, 0, 0, time.FixedZone("test", 1))
 	t.Run("ok - attach key", func(t *testing.T) {
-		tx, err := NewTransaction(payloadHash, contentType, expectedPrevs, nil)
+		tx, err := NewTransaction(payloadHash, contentType, expectedPrevs, nil, 0)
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -67,7 +67,7 @@ func TestTransactionSigner(t *testing.T) {
 		assert.Equal(t, time.UTC, signedTx.SigningTime().Location())
 	})
 	t.Run("ok - with kid", func(t *testing.T) {
-		tx, err := NewTransaction(payloadHash, contentType, expectedPrevs, nil)
+		tx, err := NewTransaction(payloadHash, contentType, expectedPrevs, nil, 0)
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -82,13 +82,13 @@ func TestTransactionSigner(t *testing.T) {
 		assert.NotEmpty(t, signedTx.Data())
 	})
 	t.Run("signing time is zero", func(t *testing.T) {
-		tx, _ := NewTransaction(payloadHash, contentType, expectedPrevs, nil)
+		tx, _ := NewTransaction(payloadHash, contentType, expectedPrevs, nil, 0)
 		signedTransaction, err := NewTransactionSigner(crypto.NewTestKey(kid), false).Sign(tx, time.Time{})
 		assert.Empty(t, signedTransaction)
 		assert.EqualError(t, err, "signing time is zero")
 	})
 	t.Run("already signed", func(t *testing.T) {
-		tx, _ := NewTransaction(payloadHash, contentType, expectedPrevs, nil)
+		tx, _ := NewTransaction(payloadHash, contentType, expectedPrevs, nil, 0)
 		signer := NewTransactionSigner(crypto.NewTestKey(kid), false)
 		signedTransaction, _ := signer.Sign(tx, time.Now())
 		signedTransaction2, err := signer.Sign(signedTransaction, time.Now())

--- a/network/dag/test.go
+++ b/network/dag/test.go
@@ -56,6 +56,30 @@ func CreateSignedTestTransaction(payloadNum uint32, signingTime time.Time, pal [
 
 }
 
+// CreateLegacyTransactionWithJWK creates a transaction with the given num as payload hash and signs it with a random EC key.
+// The JWK is attached, rather than referred to using the kid.
+// Deprecated: remove when V1 transactions are no longer possible
+func CreateLegacyTransactionWithJWK(num uint32, prevs ...Transaction) Transaction {
+	return CreateSignedLegacyTransaction(num, time.Now(), nil, "application/did+json", true, prevs...)
+}
+
+// CreateSignedLegacyTransaction creates a signed transaction with more control
+// Deprecated: remove when V1 transactions are no longer possible
+func CreateSignedLegacyTransaction(payloadNum uint32, signingTime time.Time, pal [][]byte, payloadType string, attach bool, prevs ...Transaction) Transaction {
+	payload := make([]byte, 4)
+	binary.BigEndian.PutUint32(payload, payloadNum)
+	payloadHash := hash.SHA256Sum(payload)
+	unsignedTransaction, _ := NewTransaction(payloadHash, payloadType, prevHashes(prevs), pal, 0)
+
+	signer := crypto2.NewTestKey(fmt.Sprintf("%d", payloadNum))
+	signedTransaction, err := NewTransactionSigner(signer, attach).Sign(unsignedTransaction, signingTime)
+	if err != nil {
+		panic(err)
+	}
+	return signedTransaction
+
+}
+
 // CreateTestTransactionEx creates a transaction with the given payload hash and signs it with a random EC key.
 func CreateTestTransactionEx(num uint32, payloadHash hash.SHA256Hash, participants EncryptedPAL, prevs ...Transaction) (Transaction, string, crypto.PublicKey) {
 	lamportClock := calculateLamportClock(prevs)

--- a/network/dag/transaction_test.go
+++ b/network/dag/transaction_test.go
@@ -36,7 +36,7 @@ func TestNewTransaction(t *testing.T) {
 	hash, _ := hash2.ParseHex("452d9e89d5bd5d9225fb6daecd579e7388a166c7661ca04e47fd3cd8446e4620")
 
 	t.Run("ok", func(t *testing.T) {
-		transaction, err := NewTransaction(payloadHash, "some/type", []hash2.SHA256Hash{hash}, nil, 0)
+		transaction, err := NewTransaction(payloadHash, "some/type", []hash2.SHA256Hash{hash}, nil, 1)
 
 		if !assert.NoError(t, err) {
 			return
@@ -45,6 +45,7 @@ func TestNewTransaction(t *testing.T) {
 		assert.Equal(t, transaction.PayloadHash(), payloadHash)
 		assert.Equal(t, []hash2.SHA256Hash{hash}, transaction.Previous())
 		assert.Equal(t, Version(1), transaction.Version())
+		assert.Equal(t, uint32(1), transaction.Clock())
 	})
 	t.Run("ok - with pal", func(t *testing.T) {
 		transaction, err := NewTransaction(payloadHash, "some/type", []hash2.SHA256Hash{hash}, [][]byte{{1}, {2}}, 0)

--- a/network/dag/transaction_test.go
+++ b/network/dag/transaction_test.go
@@ -36,7 +36,7 @@ func TestNewTransaction(t *testing.T) {
 	hash, _ := hash2.ParseHex("452d9e89d5bd5d9225fb6daecd579e7388a166c7661ca04e47fd3cd8446e4620")
 
 	t.Run("ok", func(t *testing.T) {
-		transaction, err := NewTransaction(payloadHash, "some/type", []hash2.SHA256Hash{hash}, nil)
+		transaction, err := NewTransaction(payloadHash, "some/type", []hash2.SHA256Hash{hash}, nil, 0)
 
 		if !assert.NoError(t, err) {
 			return
@@ -47,7 +47,7 @@ func TestNewTransaction(t *testing.T) {
 		assert.Equal(t, Version(1), transaction.Version())
 	})
 	t.Run("ok - with pal", func(t *testing.T) {
-		transaction, err := NewTransaction(payloadHash, "some/type", []hash2.SHA256Hash{hash}, [][]byte{{1}, {2}})
+		transaction, err := NewTransaction(payloadHash, "some/type", []hash2.SHA256Hash{hash}, [][]byte{{1}, {2}}, 0)
 
 		if !assert.NoError(t, err) {
 			return
@@ -55,7 +55,7 @@ func TestNewTransaction(t *testing.T) {
 		assert.Len(t, transaction.PAL(), 2)
 	})
 	t.Run("ok - with duplicates", func(t *testing.T) {
-		transaction, err := NewTransaction(payloadHash, "some/type", []hash2.SHA256Hash{hash, hash}, nil)
+		transaction, err := NewTransaction(payloadHash, "some/type", []hash2.SHA256Hash{hash, hash}, nil, 0)
 
 		if !assert.NoError(t, err) {
 			return
@@ -63,17 +63,17 @@ func TestNewTransaction(t *testing.T) {
 		assert.Equal(t, []hash2.SHA256Hash{hash}, transaction.Previous())
 	})
 	t.Run("error - type empty", func(t *testing.T) {
-		transaction, err := NewTransaction(payloadHash, "", nil, nil)
+		transaction, err := NewTransaction(payloadHash, "", nil, nil, 0)
 		assert.EqualError(t, err, errInvalidPayloadType.Error())
 		assert.Nil(t, transaction)
 	})
 	t.Run("error - type not a MIME type", func(t *testing.T) {
-		transaction, err := NewTransaction(payloadHash, "foo", nil, nil)
+		transaction, err := NewTransaction(payloadHash, "foo", nil, nil, 0)
 		assert.EqualError(t, err, errInvalidPayloadType.Error())
 		assert.Nil(t, transaction)
 	})
 	t.Run("error - invalid prev", func(t *testing.T) {
-		transaction, err := NewTransaction(payloadHash, "foo/bar", []hash2.SHA256Hash{hash2.EmptyHash()}, nil)
+		transaction, err := NewTransaction(payloadHash, "foo/bar", []hash2.SHA256Hash{hash2.EmptyHash()}, nil, 0)
 		assert.EqualError(t, err, errInvalidPrevs.Error())
 		assert.Nil(t, transaction)
 	})

--- a/network/dag/verifier.go
+++ b/network/dag/verifier.go
@@ -86,7 +86,7 @@ func NewPrevTransactionsVerifier() Verifier {
 			if previousTransaction == nil {
 				return ErrPreviousTransactionMissing
 			}
-			if previousTransaction.Clock() > highestLamportClock {
+			if previousTransaction.Clock() >= highestLamportClock {
 				highestLamportClock = previousTransaction.Clock()
 			}
 		}

--- a/network/dag/verifier_test.go
+++ b/network/dag/verifier_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/lestrrat-go/jwx/jwk"
+	crypto2 "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/vdr/doc"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
@@ -44,7 +45,9 @@ func Test_PrevTransactionVerifier(t *testing.T) {
 		txState := NewMockState(ctrl)
 		txState.EXPECT().GetTransaction(ctx, root.Ref()).Return(root, nil)
 		tx, _, _ := CreateTestTransaction(1, root)
+
 		err := NewPrevTransactionsVerifier()(ctx, tx, txState)
+
 		assert.NoError(t, err)
 	})
 	t.Run("failed - prev not present", func(t *testing.T) {
@@ -53,8 +56,24 @@ func Test_PrevTransactionVerifier(t *testing.T) {
 		txState := NewMockState(ctrl)
 		txState.EXPECT().GetTransaction(ctx, root.Ref()).Return(nil, nil)
 		tx, _, _ := CreateTestTransaction(1, root)
+
 		err := NewPrevTransactionsVerifier()(ctx, tx, txState)
+
 		assert.Contains(t, err.Error(), "transaction is referring to non-existing previous transaction")
+	})
+	t.Run("error - incorrect lamport clock", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		ctx := context.Background()
+		txState := NewMockState(ctrl)
+		txState.EXPECT().GetTransaction(ctx, root.Ref()).Return(root, nil)
+		// malformed TX with LC = 2
+		unsignedTransaction, _ := NewTransaction(hash.EmptyHash(), "application/did+json", []hash.SHA256Hash{root.Ref()}, nil, 2)
+		signer := crypto2.NewTestKey("1")
+		signedTransaction, _ := NewTransactionSigner(signer, true).Sign(unsignedTransaction, time.Now())
+
+		err := NewPrevTransactionsVerifier()(ctx, signedTransaction, txState)
+
+		assert.EqualError(t, err, "transaction has an invalid lamport clock value")
 	})
 }
 

--- a/network/transport/v1/logic/payload_collector_test.go
+++ b/network/transport/v1/logic/payload_collector_test.go
@@ -34,7 +34,7 @@ func Test_missingPayloadCollector(t *testing.T) {
 
 	// 2 transactions: TX0 is OK, TX1 is missing payload
 	tx0, _, _ := dag.CreateTestTransaction(0)
-	tx1, _, _ := dag.CreateTestTransaction(1, tx0.Ref())
+	tx1, _, _ := dag.CreateTestTransaction(1, tx0)
 
 	state := dag.NewMockState(ctrl)
 	// looks a bit odd because of mocking callbacks

--- a/network/transport/v1/protocol_integration_test.go
+++ b/network/transport/v1/protocol_integration_test.go
@@ -60,7 +60,7 @@ func TestProtocolV1_MissingPayloads(t *testing.T) {
 		return
 	}
 	// TX 1
-	tx1, _, _ := dag.CreateTestTransaction(2, tx0Root.Ref())
+	tx1, _, _ := dag.CreateTestTransaction(2, tx0Root)
 	err = node1.state.Add(context.Background(), tx1, nil)
 	if !assert.NoError(t, err) {
 		return
@@ -106,7 +106,7 @@ func TestProtocolV1_Pagination(t *testing.T) {
 	}
 	prev := rootTX
 	for i := 0; i < numberOfTransactions-1; i++ { // minus 1 to subtract root TX
-		tx, _, _ := dag.CreateTestTransaction(uint32(i+2), prev.Ref())
+		tx, _, _ := dag.CreateTestTransaction(uint32(i+2), prev)
 		err := node1.state.Add(context.Background(), tx, []byte{0, 0, 0, byte(i + 2)})
 		if !assert.NoError(t, err) {
 			return

--- a/network/tx.go
+++ b/network/tx.go
@@ -19,11 +19,12 @@
 package network
 
 import (
+	"time"
+
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network/dag"
-	"time"
 )
 
 // TransactionTemplate creates a new Template with the given required properties.

--- a/vcr/ambassador_test.go
+++ b/vcr/ambassador_test.go
@@ -23,16 +23,14 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/nuts-foundation/nuts-node/vcr/types"
-
-	"github.com/nuts-foundation/go-did/vc"
-
 	"github.com/golang/mock/gomock"
+	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network"
 	"github.com/nuts-foundation/nuts-node/network/dag"
 	"github.com/nuts-foundation/nuts-node/vcr/concept"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
+	"github.com/nuts-foundation/nuts-node/vcr/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/vcr/ambassador_test.go
+++ b/vcr/ambassador_test.go
@@ -21,8 +21,9 @@ package vcr
 
 import (
 	"errors"
-	"github.com/nuts-foundation/nuts-node/vcr/types"
 	"testing"
+
+	"github.com/nuts-foundation/nuts-node/vcr/types"
 
 	"github.com/nuts-foundation/go-did/vc"
 
@@ -56,7 +57,7 @@ func TestAmbassador_Configure(t *testing.T) {
 
 func TestAmbassador_vcCallback(t *testing.T) {
 	payload := []byte(concept.TestCredential)
-	tx, _ := dag.NewTransaction(hash.EmptyHash(), types.VcDocumentType, nil, nil)
+	tx, _ := dag.NewTransaction(hash.EmptyHash(), types.VcDocumentType, nil, nil, 0)
 	stx := tx.(dag.Transaction)
 	validAt := stx.SigningTime()
 
@@ -109,7 +110,7 @@ func TestAmbassador_vcCallback(t *testing.T) {
 
 func TestAmbassador_rCallback(t *testing.T) {
 	payload := []byte("{\"subject\":\"did:nuts:1#123\"}")
-	tx, _ := dag.NewTransaction(hash.EmptyHash(), types.RevocationDocumentType, nil, nil)
+	tx, _ := dag.NewTransaction(hash.EmptyHash(), types.RevocationDocumentType, nil, nil, 0)
 	stx := tx.(dag.Transaction)
 
 	t.Run("ok", func(t *testing.T) {


### PR DESCRIPTION
closes #779 

some parts are marked with `deprecated` to make sure when LC is mandatory to reduce code complexity.