### PR TITLE
added conversation manager to v2 protocol

### DIFF
--- a/network/transport/v2/conversation.go
+++ b/network/transport/v2/conversation.go
@@ -1,0 +1,201 @@
+/*
+ * Nuts node
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package v2
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
+)
+
+var maxValidity = 30 * time.Second
+
+type conversationID uuid.UUID
+
+func newConversationID() conversationID {
+	return conversationID(uuid.New())
+}
+
+func parseConversationID(bytes []byte) (cid conversationID, err error) {
+	var u uuid.UUID
+	u, err = uuid.FromBytes(bytes)
+	if err != nil {
+		return
+	}
+	cid = conversationID(u)
+	return
+}
+
+func (cid conversationID) slice() []byte {
+	// error not possible when marshalling
+	bytes, _ := uuid.UUID(cid).MarshalBinary()
+	return bytes
+}
+
+func (cid conversationID) String() string {
+	return hex.EncodeToString(cid.slice())
+}
+
+type conversation interface {
+	checkResponse(envelop isEnvelope_Message) error
+	conversationID() conversationID
+	createdAt() time.Time
+}
+
+type conversationManager struct {
+	mutex         sync.RWMutex
+	conversations map[string]conversation
+	validity      time.Duration
+}
+
+func newConversationManager(validity time.Duration) *conversationManager {
+	return &conversationManager{
+		conversations: map[string]conversation{},
+		validity:      validity,
+	}
+}
+
+func (cMan *conversationManager) start(ctx context.Context) {
+	done := ctx.Done()
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-time.Tick(cMan.validity):
+				cMan.evict()
+			}
+		}
+	}()
+}
+
+func (cMan *conversationManager) evict() {
+	cMan.mutex.Lock()
+	defer cMan.mutex.Unlock()
+
+	for k, v := range cMan.conversations {
+		createdAt := v.createdAt()
+		if createdAt.Add(cMan.validity).Before(time.Now()) {
+			delete(cMan.conversations, k)
+		}
+	}
+}
+
+func (cMan *conversationManager) done(cid conversationID) {
+	cMan.mutex.Lock()
+	defer cMan.mutex.Unlock()
+
+	delete(cMan.conversations, cid.String())
+}
+
+// conversationFromEnvelop sets a conversationID on the envelop and stores the conversation
+func (cMan *conversationManager) conversationFromEnvelop(envelop isEnvelope_Message) (newConversation conversation) {
+	cid := newConversationID()
+
+	switch t := envelop.(type) {
+	case *Envelope_TransactionListQuery:
+		t.TransactionListQuery.ConversationID = cid.slice()
+		newConversation = transactionListConversation{
+			id:  cid,
+			at:  time.Now(),
+			msg: t,
+		}
+	default:
+		return
+	}
+
+	cMan.mutex.Lock()
+	defer cMan.mutex.Unlock()
+
+	cMan.conversations[cid.String()] = newConversation
+
+	return
+}
+
+func (cMan *conversationManager) check(envelop isEnvelope_Message) error {
+	var cidBytes []byte
+
+	switch t := envelop.(type) {
+	case *Envelope_TransactionList:
+		cidBytes = t.TransactionList.ConversationID
+	default:
+		return errors.New("invalid response msg type")
+	}
+
+	cid, err := parseConversationID(cidBytes)
+	if err != nil {
+		return fmt.Errorf("failed to parse conversationID: %w", err)
+	}
+
+	cMan.mutex.RLock()
+	defer cMan.mutex.RUnlock()
+
+	if req, ok := cMan.conversations[cid.String()]; !ok {
+		return fmt.Errorf("unknown conversation (id=%s)", cid)
+	} else {
+		return req.checkResponse(envelop)
+	}
+}
+
+type transactionListConversation struct {
+	id  conversationID
+	at  time.Time
+	msg *Envelope_TransactionListQuery
+}
+
+func (c transactionListConversation) checkResponse(envelop isEnvelope_Message) error {
+	// envelop type already checked in cMan.check()
+	otherEnvelop := envelop.(*Envelope_TransactionList)
+
+	payloadRequest := c.msg.TransactionListQuery
+	payloadResponse := otherEnvelop.TransactionList
+
+	// as map for easy finding
+	refs := map[string]bool{}
+	for _, bytes := range payloadRequest.Refs {
+		ref := hash.FromSlice(bytes)
+		refs[ref.String()] = true
+	}
+
+	for _, transaction := range payloadResponse.Transactions {
+		// ref is the sha256 of the transaction payload
+		ref := hash.FromSlice(transaction.Hash)
+		if _, ok := refs[ref.String()]; !ok {
+			return fmt.Errorf("response contains non-requested transaction (ref=%s)", ref.String())
+		}
+	}
+
+	return nil
+}
+
+func (c transactionListConversation) conversationID() conversationID {
+	return c.id
+}
+
+func (c transactionListConversation) createdAt() time.Time {
+	return c.at
+}

--- a/network/transport/v2/conversation_test.go
+++ b/network/transport/v2/conversation_test.go
@@ -93,9 +93,13 @@ func TestConversationManager_start(t *testing.T) {
 
 	_ = cMan.conversationFromEnvelop(envelop)
 
+	cMan.mutex.Lock()
 	assert.Len(t, cMan.conversations, 1)
+	cMan.mutex.Unlock()
 	time.Sleep(5 * time.Millisecond)
+	cMan.mutex.Lock()
 	assert.Len(t, cMan.conversations, 0)
+	cMan.mutex.Unlock()
 }
 
 func TestConversationManager_done(t *testing.T) {

--- a/network/transport/v2/conversation_test.go
+++ b/network/transport/v2/conversation_test.go
@@ -1,0 +1,198 @@
+/*
+ * Nuts node
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package v2
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConversationID(t *testing.T) {
+	hexUUID := "bd7baaa8f3244d229dc6512d02a88336"
+
+	t.Run("new creates a v4 uuid", func(t *testing.T) {
+		cid := newConversationID()
+
+		u := uuid.UUID(cid)
+
+		assert.Equal(t, uuid.Version(4), u.Version())
+	})
+
+	t.Run("String returns hex encoding", func(t *testing.T) {
+		cid := newConversationID()
+
+		s := cid.String()
+
+		assert.Len(t, s, 32)
+	})
+
+	t.Run("slice() returns bytes", func(t *testing.T) {
+		cid := newConversationID()
+
+		bytes := cid.slice()
+
+		assert.Len(t, bytes, 16)
+	})
+
+	t.Run("ok - parseConversationID", func(t *testing.T) {
+		bytes, _ := hex.DecodeString(hexUUID)
+
+		cid, err := parseConversationID(bytes)
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, hexUUID, cid.String())
+	})
+
+	t.Run("error - parseConversationID", func(t *testing.T) {
+		_, err := parseConversationID([]byte{})
+
+		assert.Error(t, err)
+	})
+}
+
+func TestNewConversationManager(t *testing.T) {
+	cMan := newConversationManager(maxValidity)
+
+	assert.Equal(t, maxValidity, cMan.validity)
+	assert.NotNil(t, cMan.conversations)
+}
+
+func TestConversationManager_start(t *testing.T) {
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+	cMan := newConversationManager(time.Millisecond)
+	cMan.start(ctx)
+	envelop := &Envelope_TransactionListQuery{
+		TransactionListQuery: &TransactionListQuery{},
+	}
+
+	_ = cMan.conversationFromEnvelop(envelop)
+
+	assert.Len(t, cMan.conversations, 1)
+	time.Sleep(5 * time.Millisecond)
+	assert.Len(t, cMan.conversations, 0)
+}
+
+func TestConversationManager_done(t *testing.T) {
+	cMan := newConversationManager(time.Millisecond)
+	envelop := &Envelope_TransactionListQuery{
+		TransactionListQuery: &TransactionListQuery{},
+	}
+	c := cMan.conversationFromEnvelop(envelop)
+
+	cMan.done(c.conversationID())
+
+	assert.Len(t, cMan.conversations, 0)
+}
+
+func TestConversationManager_checkTransactionList(t *testing.T) {
+	ref := hash.EmptyHash().Slice()
+	cMan := newConversationManager(time.Millisecond)
+	request := &Envelope_TransactionListQuery{
+		TransactionListQuery: &TransactionListQuery{
+			Refs: [][]byte{ref},
+		},
+	}
+
+	t.Run("ok", func(t *testing.T) {
+		c := cMan.conversationFromEnvelop(request)
+		response := &Envelope_TransactionList{
+			TransactionList: &TransactionList{
+				ConversationID: c.conversationID().slice(),
+				Transactions: []*Transaction{
+					{
+						Hash: ref,
+					},
+				},
+			},
+		}
+
+		err := cMan.check(response)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("error - invalid conversation ID", func(t *testing.T) {
+		_ = cMan.conversationFromEnvelop(request)
+		response := &Envelope_TransactionList{
+			TransactionList: &TransactionList{
+				Transactions: []*Transaction{
+					{
+						Hash: ref,
+					},
+				},
+			},
+		}
+
+		err := cMan.check(response)
+
+		assert.EqualError(t, err, "failed to parse conversationID: invalid UUID (got 0 bytes)")
+	})
+
+	t.Run("error - unknown conversation ID", func(t *testing.T) {
+		u, _ := uuid.Parse("9dbacbabf0c6413591f7553ff4348753")
+		cid := conversationID(u)
+		_ = cMan.conversationFromEnvelop(request)
+		response := &Envelope_TransactionList{
+			TransactionList: &TransactionList{
+				ConversationID: cid.slice(),
+				Transactions: []*Transaction{
+					{
+						Hash: ref,
+					},
+				},
+			},
+		}
+
+		err := cMan.check(response)
+
+		assert.EqualError(t, err, "unknown conversation (id=9dbacbabf0c6413591f7553ff4348753)")
+	})
+
+	t.Run("error - invalid response", func(t *testing.T) {
+		ref2 := hash.SHA256Sum([]byte{0}).Slice()
+		c := cMan.conversationFromEnvelop(request)
+		response := &Envelope_TransactionList{
+			TransactionList: &TransactionList{
+				ConversationID: c.conversationID().slice(),
+				Transactions: []*Transaction{
+					{
+						Hash: ref,
+					},
+					{
+						Hash: ref2,
+					},
+				},
+			},
+		}
+
+		err := cMan.check(response)
+
+		assert.EqualError(t, err, "response contains non-requested transaction (ref=6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d)")
+	})
+}

--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -102,7 +102,7 @@ func (p protocol) handleTransactionPayload(msg *TransactionPayload) error {
 	ctx := context.Background()
 	ref := hash.FromSlice(msg.TransactionRef)
 	if ref.Empty() {
-		return errors.New("message is missing transaction reference")
+		return errors.New("msg is missing transaction reference")
 	}
 	if len(msg.Data) == 0 {
 		return fmt.Errorf("peer does not have transaction payload (tx=%s)", ref)

--- a/network/transport/v2/handlers_test.go
+++ b/network/transport/v2/handlers_test.go
@@ -84,7 +84,7 @@ func TestProtocol_handleTransactionPayload(t *testing.T) {
 		envelope := &Envelope{Message: &Envelope_TransactionPayload{&TransactionPayload{}}}
 		err := p.Handle(peer, envelope)
 
-		assert.EqualError(t, err, "message is missing transaction reference")
+		assert.EqualError(t, err, "msg is missing transaction reference")
 	})
 
 	t.Run("error - no data", func(t *testing.T) {

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -88,6 +88,7 @@ type protocol struct {
 	connectionList    grpc.ConnectionList
 	nodeDIDResolver   transport.NodeDIDResolver
 	connectionManager transport.ConnectionManager
+	cMan              *conversationManager
 }
 
 func (p protocol) CreateClientStream(outgoingContext context.Context, grpcConn grpcLib.ClientConnInterface) (grpcLib.ClientStream, error) {
@@ -142,6 +143,10 @@ func (p *protocol) Configure(_ transport.PeerID) error {
 
 func (p *protocol) Start() (err error) {
 	p.ctx, p.cancel = context.WithCancel(context.Background())
+
+	// conversation manager is stopped through the context
+	p.cMan = newConversationManager(maxValidity)
+	p.cMan.start(p.ctx)
 
 	// load old payload query jobs
 	if err = p.payloadScheduler.Run(); err != nil {
@@ -228,7 +233,7 @@ func (p *protocol) handlePrivateTxRetryErr(hash hash.SHA256Hash) error {
 			}})
 
 			if err != nil {
-				log.Logger().Warnf("Failed to send TransactionPayloadQuery message to private TX participant (tx=%s, PAL=%v): %v", hash.String(), pal, err)
+				log.Logger().Warnf("Failed to send TransactionPayloadQuery msg to private TX participant (tx=%s, PAL=%v): %v", hash.String(), pal, err)
 			} else {
 				sent = true
 			}
@@ -272,7 +277,7 @@ func (p protocol) PeerDiagnostics() map[transport.PeerID]transport.Diagnostics {
 func (p *protocol) send(peer transport.Peer, message isEnvelope_Message) error {
 	connection := p.connectionList.Get(grpc.ByPeerID(peer.ID))
 	if connection == nil {
-		return fmt.Errorf("unable to send message, connection not found (peer=%s)", peer)
+		return fmt.Errorf("unable to send msg, connection not found (peer=%s)", peer)
 	}
 	return connection.Send(p, &Envelope{Message: message})
 }

--- a/network/transport/v2/protocol.pb.go
+++ b/network/transport/v2/protocol.pb.go
@@ -337,8 +337,8 @@ func (x *Transaction) GetPayload() []byte {
 	return nil
 }
 
-// Gossip is a message broadcast to inform peers of the node's DAG state and recent additions to it (if any).
-// The message has no response, but the peer may decide to follow up with State or TransactionListQuery.
+// Gossip is a msg broadcast to inform peers of the node's DAG state and recent additions to it (if any).
+// The msg has no response, but the peer may decide to follow up with State or TransactionListQuery.
 type Gossip struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -472,7 +472,7 @@ func (x *State) GetLC() uint32 {
 	return 0
 }
 
-// TransactionSet sends an IBLT in response to a State message
+// TransactionSet sends an IBLT in response to a State msg
 type TransactionSet struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -480,9 +480,9 @@ type TransactionSet struct {
 
 	// conversationID contains the token used to identify the response
 	ConversationID []byte `protobuf:"bytes,1,opt,name=conversationID,proto3" json:"conversationID,omitempty"`
-	// LCReq contains the LC value that was sent in the State message
+	// LCReq contains the LC value that was sent in the State msg
 	LCReq uint32 `protobuf:"varint,2,opt,name=LCReq,proto3" json:"LCReq,omitempty"`
-	// LC contains the highest transaction Lamport Clock value from the sender of this message.
+	// LC contains the highest transaction Lamport Clock value from the sender of this msg.
 	LC uint32 `protobuf:"varint,3,opt,name=LC,proto3" json:"LC,omitempty"`
 	// IBLT contains the serialized IBLT. The first byte indicates the serialization format of the IBLT.
 	IBLT []byte `protobuf:"bytes,4,opt,name=IBLT,proto3" json:"IBLT,omitempty"`
@@ -731,7 +731,7 @@ func (x *TransactionList) GetTransactions() []*Transaction {
 	return nil
 }
 
-// TransactionPayloadQuery is a message used to query the payload of a transaction.
+// TransactionPayloadQuery is a msg used to query the payload of a transaction.
 type TransactionPayloadQuery struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -789,7 +789,7 @@ func (x *TransactionPayloadQuery) GetTransactionRef() []byte {
 	return nil
 }
 
-// TransactionPayload is the response message for TransactionPayloadQuery
+// TransactionPayload is the response msg for TransactionPayloadQuery
 type TransactionPayload struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -856,7 +856,7 @@ func (x *TransactionPayload) GetData() []byte {
 	return nil
 }
 
-// Diagnostics is a message to inform peers of the local node's state. All fields are optional.
+// Diagnostics is a msg to inform peers of the local node's state. All fields are optional.
 type Diagnostics struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/network/transport/v2/protocol_test.go
+++ b/network/transport/v2/protocol_test.go
@@ -144,7 +144,7 @@ func TestProtocol_send(t *testing.T) {
 
 		err := p.send(transport.Peer{ID: "123"}, &Envelope_TransactionPayloadQuery{})
 
-		assert.EqualError(t, err, "unable to send message, connection not found (peer=123@)")
+		assert.EqualError(t, err, "unable to send msg, connection not found (peer=123@)")
 	})
 }
 


### PR DESCRIPTION
closes #819

This is just the managing of conversations.
The `TransactionListQuery` and `TransactionList` messages are supported. This does not mean those messages are implemented in the protocol. It's just to show how the response checking works.