### PR TITLE
correct VDR bbolt filtering on source TX

### DIFF
--- a/vdr/store/bbolt.go
+++ b/vdr/store/bbolt.go
@@ -220,11 +220,10 @@ func (store *bboltStore) filterDocument(doc *documentVersion, metadata *vdr.Reso
 	if metadata.SourceTransaction != nil {
 		for _, keyTx := range doc.Metadata.SourceTransactions {
 			if keyTx.Equals(*metadata.SourceTransaction) {
-				break
+				return true
 			}
-
-			return false
 		}
+		return false
 	}
 
 	return true

--- a/vdr/store/bbolt_test.go
+++ b/vdr/store/bbolt_test.go
@@ -101,7 +101,7 @@ func TestBBoltStore_Resolve(t *testing.T) {
 	firstMeta := types.DocumentMetadata{
 		Created:            time.Now().Add(time.Hour * -48),
 		Hash:               firstHash,
-		SourceTransactions: []hash.SHA256Hash{txHash},
+		SourceTransactions: []hash.SHA256Hash{hash.EmptyHash(), txHash},
 	}
 
 	err := store.Write(doc, firstMeta)
@@ -111,7 +111,7 @@ func TestBBoltStore_Resolve(t *testing.T) {
 	meta := types.DocumentMetadata{
 		Created:            time.Now().Add(time.Hour * -24),
 		Hash:               latestHash,
-		SourceTransactions: []hash.SHA256Hash{txHash},
+		SourceTransactions: []hash.SHA256Hash{hash.EmptyHash(), txHash},
 	}
 
 	err = store.Update(*did1, firstHash, doc, &meta)


### PR DESCRIPTION
fixes #834

The scope of the return false was wrong, so it only succeeded if the first item in the list was a match. 