### PR TITLE
Adds TransactionListQuery and response to v2 protocol

### DIFF
--- a/network/dag/state.go
+++ b/network/dag/state.go
@@ -90,6 +90,7 @@ func (s *state) RegisterObserver(observer Observer, transactional bool) {
 
 }
 
+// TODO add payloadHash verifier!
 func (s *state) Add(ctx context.Context, transaction Transaction, payload []byte) error {
 	return storage.BBoltTXUpdate(ctx, s.db, func(contextWithTX context.Context, tx *bbolt.Tx) error {
 		if err := s.verifyTX(contextWithTX, transaction); err != nil {
@@ -111,6 +112,7 @@ func (s *state) Add(ctx context.Context, transaction Transaction, payload []byte
 
 }
 
+// TODO add payloadHash verifier!
 func (s *state) verifyTX(ctx context.Context, tx Transaction) error {
 	for _, verifier := range s.txVerifiers {
 		if err := verifier(ctx, tx, s); err != nil {

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -196,11 +196,20 @@ func TestState_Observe(t *testing.T) {
 		}, false)
 		expected := CreateTestTransactionWithJWK(1)
 
-		err := txState.Add(ctx, expected, []byte{1})
+		err := txState.Add(ctx, expected, []byte{0, 0, 0, 1})
 
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actualTX)
-		assert.Equal(t, []byte{1}, actualPayload)
+		assert.Equal(t, []byte{0, 0, 0, 1}, actualPayload)
+	})
+	t.Run("transaction added with incorrect payload", func(t *testing.T) {
+		ctx := context.Background()
+		txState := createState(t)
+		expected := CreateTestTransactionWithJWK(1)
+
+		err := txState.Add(ctx, expected, []byte{1})
+
+		assert.EqualError(t, err, "tx.PayloadHash does not match hash of payload")
 	})
 	t.Run("payload added", func(t *testing.T) {
 		ctx := context.Background()

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -131,6 +131,13 @@ func TestNetworkIntegration_V2Gossip(t *testing.T) {
 	})
 	node1.connectionManager.Connect(nameToAddress(t, "integration_bootstrap"))
 
+	// Wait until nodes are connected
+	if !test.WaitFor(t, func() (bool, error) {
+		return len(bootstrap.connectionManager.Peers()) == 1, nil
+	}, defaultTimeout, "time-out while waiting for node 1 and 2 to be connected") {
+		return
+	}
+
 	// create some transactions on the bootstrap node
 	for i := 0; i < 10; i++ {
 		if !addTransactionAndWaitForItToArrive(t, fmt.Sprintf("doc%d", i), key, bootstrap) {

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -505,7 +505,7 @@ func startNode(t *testing.T, name string, testDirectory string, opts ...func(cfg
 			AdvertDiagnosticsInterval: 5000,
 		},
 		ProtocolV2: v2.Config{
-			GossipInterval: 1000,
+			GossipInterval: 100,
 		},
 	}
 	for _, f := range opts {

--- a/network/transport/grpc/connection_list.go
+++ b/network/transport/grpc/connection_list.go
@@ -20,10 +20,15 @@ package grpc
 
 import (
 	"context"
+	"errors"
+	"sync"
+
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/network/transport"
-	"sync"
 )
+
+// ErrNoConnection can be used when no connectin is available but one is required.
+var ErrNoConnection = errors.New("no connection available")
 
 // ConnectionList provides an API for protocols to query the ConnectionManager's connections.
 type ConnectionList interface {

--- a/network/transport/v2/conversation.go
+++ b/network/transport/v2/conversation.go
@@ -111,11 +111,11 @@ func (cMan *conversationManager) done(cid conversationID) {
 }
 
 // startConversation sets a conversationID on the envelope and stores the conversation
-func (cMan *conversationManager) startConversation(envelope checkable) (newConversation conversation) {
+func (cMan *conversationManager) startConversation(envelope checkable) conversation {
 	cid := newConversationID()
 
 	envelope.setConversationID(cid)
-	newConversation = conversation{
+	newConversation := conversation{
 		conversationID:   cid,
 		createdAt:        time.Now(),
 		conversationData: envelope,
@@ -126,7 +126,7 @@ func (cMan *conversationManager) startConversation(envelope checkable) (newConve
 
 	cMan.conversations[cid.String()] = newConversation
 
-	return
+	return newConversation
 }
 
 func (cMan *conversationManager) check(envelope isEnvelope_Message) error {

--- a/network/transport/v2/conversation.go
+++ b/network/transport/v2/conversation.go
@@ -50,6 +50,8 @@ type conversation struct {
 	conversationID   conversationID
 	createdAt        time.Time
 	conversationData checkable
+	// additionalInfo can be used to check if a conversation is done
+	additionalInfo map[string]interface{}
 }
 
 type checkable interface {
@@ -64,13 +66,13 @@ type conversationable interface {
 
 type conversationManager struct {
 	mutex         sync.RWMutex
-	conversations map[string]conversation
+	conversations map[string]*conversation
 	validity      time.Duration
 }
 
 func newConversationManager(validity time.Duration) *conversationManager {
 	return &conversationManager{
-		conversations: map[string]conversation{},
+		conversations: map[string]*conversation{},
 		validity:      validity,
 	}
 }
@@ -111,14 +113,15 @@ func (cMan *conversationManager) done(cid conversationID) {
 }
 
 // startConversation sets a conversationID on the envelope and stores the conversation
-func (cMan *conversationManager) startConversation(envelope checkable) conversation {
+func (cMan *conversationManager) startConversation(envelope checkable) *conversation {
 	cid := newConversationID()
 
 	envelope.setConversationID(cid)
-	newConversation := conversation{
+	newConversation := &conversation{
 		conversationID:   cid,
 		createdAt:        time.Now(),
 		conversationData: envelope,
+		additionalInfo:   map[string]interface{}{},
 	}
 
 	cMan.mutex.Lock()

--- a/network/transport/v2/conversation.go
+++ b/network/transport/v2/conversation.go
@@ -21,7 +21,7 @@ package v2
 
 import (
 	"context"
-	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -32,40 +32,34 @@ import (
 
 var maxValidity = 30 * time.Second
 
-type conversationID uuid.UUID
+type conversationID string
 
 func newConversationID() conversationID {
-	return conversationID(uuid.New())
-}
-
-func parseConversationID(bytes []byte) (cid conversationID, err error) {
-	var u uuid.UUID
-	u, err = uuid.FromBytes(bytes)
-	if err != nil {
-		return
-	}
-	cid = conversationID(u)
-	return
+	return conversationID(uuid.New().String())
 }
 
 func (cid conversationID) slice() []byte {
-	// error not possible when marshalling
-	bytes, _ := uuid.UUID(cid).MarshalBinary()
-	return bytes
+	return []byte(cid)
 }
 
 func (cid conversationID) String() string {
-	return hex.EncodeToString(cid.slice())
+	return string(cid)
 }
 
 type conversation struct {
 	conversationID   conversationID
 	createdAt        time.Time
-	conversationData conversationData
+	conversationData checkable
 }
 
-type conversationData interface {
+type checkable interface {
+	conversationable
 	checkResponse(envelope isEnvelope_Message) error
+}
+
+type conversationable interface {
+	setConversationID(cid conversationID)
+	conversationID() []byte
 }
 
 type conversationManager struct {
@@ -116,22 +110,15 @@ func (cMan *conversationManager) done(cid conversationID) {
 	delete(cMan.conversations, cid.String())
 }
 
-// conversationFromEnvelope sets a conversationID on the envelope and stores the conversation
-func (cMan *conversationManager) conversationFromEnvelope(envelope isEnvelope_Message) (newConversation conversation) {
+// startConversation sets a conversationID on the envelope and stores the conversation
+func (cMan *conversationManager) startConversation(envelope checkable) (newConversation conversation) {
 	cid := newConversationID()
 
-	switch t := envelope.(type) {
-	case *Envelope_TransactionListQuery:
-		t.TransactionListQuery.ConversationID = cid.slice()
-		newConversation = conversation{
-			conversationID: cid,
-			createdAt:      time.Now(),
-			conversationData: transactionListConversation{
-				msg: t,
-			},
-		}
-	default:
-		return
+	envelope.setConversationID(cid)
+	newConversation = conversation{
+		conversationID:   cid,
+		createdAt:        time.Now(),
+		conversationData: envelope,
 	}
 
 	cMan.mutex.Lock()
@@ -143,19 +130,13 @@ func (cMan *conversationManager) conversationFromEnvelope(envelope isEnvelope_Me
 }
 
 func (cMan *conversationManager) check(envelope isEnvelope_Message) error {
-	var cidBytes []byte
-
-	switch t := envelope.(type) {
-	case *Envelope_TransactionList:
-		cidBytes = t.TransactionList.ConversationID
-	default:
-		return fmt.Errorf("invalid response msg type: %s", t)
+	otherEnvelope, ok := envelope.(conversationable)
+	if !ok {
+		return errors.New("expecting envelope to contain be a conversation response type message")
 	}
 
-	cid, err := parseConversationID(cidBytes)
-	if err != nil {
-		return fmt.Errorf("failed to parse conversationID: %w", err)
-	}
+	cidBytes := otherEnvelope.conversationID()
+	cid := conversationID(cidBytes)
 
 	cMan.mutex.RLock()
 	defer cMan.mutex.RUnlock()
@@ -167,15 +148,22 @@ func (cMan *conversationManager) check(envelope isEnvelope_Message) error {
 	}
 }
 
-type transactionListConversation struct {
-	msg *Envelope_TransactionListQuery
+func (envelope *Envelope_TransactionListQuery) setConversationID(cid conversationID) {
+	envelope.TransactionListQuery.ConversationID = cid.slice()
 }
 
-func (c transactionListConversation) checkResponse(envelope isEnvelope_Message) error {
-	// envelope type already checked in cMan.check()
-	otherEnvelope := envelope.(*Envelope_TransactionList)
+func (envelope *Envelope_TransactionListQuery) conversationID() []byte {
+	return envelope.TransactionListQuery.ConversationID
+}
 
-	payloadRequest := c.msg.TransactionListQuery
+func (envelope *Envelope_TransactionListQuery) checkResponse(other isEnvelope_Message) error {
+	// envelope type already checked in cMan.check()
+	otherEnvelope, ok := other.(*Envelope_TransactionList)
+	if !ok {
+		return errors.New("checking wrong envelope type")
+	}
+
+	payloadRequest := envelope.TransactionListQuery
 	payloadResponse := otherEnvelope.TransactionList
 
 	// as map for easy finding
@@ -194,4 +182,12 @@ func (c transactionListConversation) checkResponse(envelope isEnvelope_Message) 
 	}
 
 	return nil
+}
+
+func (envelope *Envelope_TransactionList) setConversationID(cid conversationID) {
+	envelope.TransactionList.ConversationID = cid.slice()
+}
+
+func (envelope *Envelope_TransactionList) conversationID() []byte {
+	return envelope.TransactionList.ConversationID
 }

--- a/network/transport/v2/conversation_test.go
+++ b/network/transport/v2/conversation_test.go
@@ -79,7 +79,7 @@ func TestConversationManager_start(t *testing.T) {
 		cMan.mutex.Lock()
 		defer cMan.mutex.Unlock()
 		return len(cMan.conversations) == 0, nil
-	}, 100*time.Millisecond, "timeout while waiting for conversations to clear")
+	}, time.Second, "timeout while waiting for conversations to clear")
 }
 
 func TestConversationManager_done(t *testing.T) {

--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -198,6 +198,8 @@ func (p *protocol) handleTransactionList(peer transport.Peer, envelope *Envelope
 		}
 	}
 
+	// TODO done is not called on the cMan since we don't know if we received all chunks
+
 	return nil
 }
 

--- a/network/transport/v2/handlers_test.go
+++ b/network/transport/v2/handlers_test.go
@@ -21,6 +21,7 @@ package v2
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -289,6 +290,259 @@ func TestProtocol_handleGossip(t *testing.T) {
 		})
 
 		assert.EqualError(t, err, "failed to handle Gossip message: custom")
+	})
+}
+
+func TestProtocol_handleTransactionList(t *testing.T) {
+	tx, _, _ := dag.CreateTestTransaction(0)
+	h1 := tx.Ref()
+	data := tx.Data()
+	payload := []byte{2}
+	request := &Envelope_TransactionListQuery{TransactionListQuery: &TransactionListQuery{Refs: [][]byte{h1.Slice()}}}
+
+	t.Run("ok", func(t *testing.T) {
+		p, mocks := newTestProtocol(t, nil)
+		conversation := p.cMan.conversationFromEnvelope(request)
+		mocks.State.EXPECT().IsPresent(context.Background(), h1).Return(false, nil)
+		mocks.State.EXPECT().Add(context.Background(), tx, payload).Return(nil)
+
+		err := p.handleTransactionList(peer, &Envelope_TransactionList{
+			TransactionList: &TransactionList{
+				ConversationID: conversation.conversationID.slice(),
+				Transactions: []*Transaction{
+					{
+						Hash:    h1.Slice(),
+						Data:    data,
+						Payload: payload,
+					},
+				},
+			},
+		})
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("ok - duplicate", func(t *testing.T) {
+		p, mocks := newTestProtocol(t, nil)
+		conversation := p.cMan.conversationFromEnvelope(request)
+		mocks.State.EXPECT().IsPresent(context.Background(), h1).Return(true, nil)
+
+		err := p.handleTransactionList(peer, &Envelope_TransactionList{
+			TransactionList: &TransactionList{
+				ConversationID: conversation.conversationID.slice(),
+				Transactions: []*Transaction{
+					{
+						Hash:    h1.Slice(),
+						Data:    data,
+						Payload: payload,
+					},
+				},
+			},
+		})
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("error - State.Add failed", func(t *testing.T) {
+		p, mocks := newTestProtocol(t, nil)
+		conversation := p.cMan.conversationFromEnvelope(request)
+		mocks.State.EXPECT().IsPresent(context.Background(), h1).Return(false, nil)
+		mocks.State.EXPECT().Add(context.Background(), tx, payload).Return(errors.New("custom"))
+
+		err := p.handleTransactionList(peer, &Envelope_TransactionList{
+			TransactionList: &TransactionList{
+				ConversationID: conversation.conversationID.slice(),
+				Transactions: []*Transaction{
+					{
+						Hash:    h1.Slice(),
+						Data:    data,
+						Payload: payload,
+					},
+				},
+			},
+		})
+
+		assert.EqualError(t, err, fmt.Sprintf("unable to add received transaction to DAG (tx=%s): custom", tx.Ref().String()))
+	})
+
+	t.Run("error - invalid transaction", func(t *testing.T) {
+		p, _ := newTestProtocol(t, nil)
+		conversation := p.cMan.conversationFromEnvelope(request)
+
+		err := p.handleTransactionList(peer, &Envelope_TransactionList{
+			TransactionList: &TransactionList{
+				ConversationID: conversation.conversationID.slice(),
+				Transactions: []*Transaction{{
+					Data: []byte{1},
+					Hash: h1.Slice(),
+				}},
+			},
+		})
+
+		assert.EqualError(t, err, fmt.Sprintf("received transaction is invalid (peer=%s, ref=%s): unable to parse transaction: invalid compact serialization format: invalid number of segments", peer.String(), h1.String()))
+	})
+
+	t.Run("error - missing conversationID", func(t *testing.T) {
+		p, _ := newTestProtocol(t, nil)
+
+		err := p.handleTransactionList(peer, &Envelope_TransactionList{
+			TransactionList: &TransactionList{},
+		})
+
+		assert.EqualError(t, err, "invalid conversationID: invalid UUID (got 0 bytes)")
+	})
+
+	t.Run("error - unknown conversationID", func(t *testing.T) {
+		p, _ := newTestProtocol(t, nil)
+		conversationID := newConversationID()
+
+		err := p.handleTransactionList(peer, &Envelope_TransactionList{
+			TransactionList: &TransactionList{
+				ConversationID: conversationID.slice(),
+			},
+		})
+
+		assert.EqualError(t, err, fmt.Sprintf("unknown or expired conversation (id=%s)", conversationID.String()))
+	})
+}
+
+func TestProtocol_handleTransactionListQuery(t *testing.T) {
+	conversationID := newConversationID()
+	dagT1, _, _ := dag.CreateTestTransaction(1)
+	dagT2, _, _ := dag.CreateTestTransaction(2, dagT1)
+	h1 := dagT1.Ref()
+	h2 := dagT2.Ref()
+	t1 := Transaction{
+		Hash:    h2.Slice(),
+		Data:    dagT1.Data(),
+		Payload: []byte{1},
+	}
+	t2 := Transaction{
+		Hash:    h1.Slice(),
+		Data:    dagT2.Data(),
+		Payload: []byte{2},
+	}
+
+	mockWithConnection := func(t *testing.T) (*protocol, protocolMocks, *grpc.MockConnection) {
+		p, mocks := newTestProtocol(t, nil)
+		mockConnection := grpc.NewMockConnection(mocks.Controller)
+		mocks.ConnectionList.EXPECT().Get(grpc.ByConnected(), gomock.Any()).Return(mockConnection)
+		return p, mocks, mockConnection
+	}
+
+	t.Run("ok - send 2 transactions sorted on LC", func(t *testing.T) {
+		p, mocks, mockConnection := mockWithConnection(t)
+		expectedTransactions := []*Transaction{&t1, &t2}
+		mocks.State.EXPECT().GetTransaction(context.Background(), h1).Return(dagT1, nil)
+		mocks.State.EXPECT().GetTransaction(context.Background(), h2).Return(dagT2, nil)
+		mocks.State.EXPECT().ReadPayload(context.Background(), dagT1.PayloadHash()).Return(t1.Payload, nil)
+		mocks.State.EXPECT().ReadPayload(context.Background(), dagT2.PayloadHash()).Return(t2.Payload, nil)
+		mockConnection.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(arg0 interface{}, arg1 interface{}) error {
+			envelope, ok := arg1.(*Envelope)
+			if !assert.True(t, ok) {
+				return nil
+			}
+			msg, ok := envelope.Message.(*Envelope_TransactionList)
+			if !assert.True(t, ok) {
+				return nil
+			}
+			assert.Equal(t, conversationID.slice(), msg.TransactionList.ConversationID)
+			assert.Equal(t, expectedTransactions, msg.TransactionList.Transactions)
+
+			return nil
+		})
+
+		err := p.Handle(peer, &Envelope{
+			Message: &Envelope_TransactionListQuery{&TransactionListQuery{
+				ConversationID: conversationID.slice(),
+				Refs:           [][]byte{h2.Slice(), h1.Slice()}, // reverse order to test sorting
+			}},
+		})
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("ok - tx not present", func(t *testing.T) {
+		p, mocks, _ := mockWithConnection(t)
+		mocks.State.EXPECT().GetTransaction(context.Background(), h1).Return(nil, nil)
+
+		err := p.Handle(peer, &Envelope{
+			Message: &Envelope_TransactionListQuery{&TransactionListQuery{
+				ConversationID: conversationID.slice(),
+				Refs:           [][]byte{h1.Slice(), h2.Slice()},
+			}},
+		})
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("error - on State.GetTransaction", func(t *testing.T) {
+		p, mocks := newTestProtocol(t, nil)
+		mocks.State.EXPECT().GetTransaction(context.Background(), h1).Return(nil, errors.New("custom"))
+
+		err := p.Handle(peer, &Envelope{
+			Message: &Envelope_TransactionListQuery{&TransactionListQuery{
+				ConversationID: conversationID.slice(),
+				Refs:           [][]byte{h1.Slice()}, // reverse order to test sorting
+			}},
+		})
+
+		assert.Error(t, err)
+	})
+
+	t.Run("error - on State.ReadPayload", func(t *testing.T) {
+		p, mocks := newTestProtocol(t, nil)
+		mocks.State.EXPECT().GetTransaction(context.Background(), h1).Return(dagT1, nil)
+		mocks.State.EXPECT().ReadPayload(context.Background(), dagT1.PayloadHash()).Return(nil, errors.New("custom"))
+
+		err := p.Handle(peer, &Envelope{
+			Message: &Envelope_TransactionListQuery{&TransactionListQuery{
+				ConversationID: conversationID.slice(),
+				Refs:           [][]byte{h1.Slice()}, // reverse order to test sorting
+			}},
+		})
+
+		assert.Error(t, err)
+	})
+
+	t.Run("ok - missing payload", func(t *testing.T) {
+		p, mocks, _ := mockWithConnection(t)
+		mocks.State.EXPECT().GetTransaction(context.Background(), h1).Return(dagT1, nil)
+		mocks.State.EXPECT().GetTransaction(context.Background(), h2).Return(dagT2, nil)
+		mocks.State.EXPECT().ReadPayload(context.Background(), dagT1.PayloadHash()).Return(nil, nil)
+
+		err := p.Handle(peer, &Envelope{
+			Message: &Envelope_TransactionListQuery{&TransactionListQuery{
+				ConversationID: conversationID.slice(),
+				Refs:           [][]byte{h2.Slice(), h1.Slice()}, // reverse order to test sorting
+			}},
+		})
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("ok - empty request", func(t *testing.T) {
+		p, _ := newTestProtocol(t, nil)
+
+		err := p.Handle(peer, &Envelope{
+			Message: &Envelope_TransactionListQuery{&TransactionListQuery{
+				ConversationID: conversationID.slice(),
+			}},
+		})
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("error - invalid conversationID", func(t *testing.T) {
+		p, _ := newTestProtocol(t, nil)
+
+		err := p.Handle(peer, &Envelope{
+			Message: &Envelope_TransactionListQuery{&TransactionListQuery{
+				ConversationID: []byte{},
+			}},
+		})
+
+		assert.Error(t, err)
 	})
 }
 

--- a/network/transport/v2/handlers_test.go
+++ b/network/transport/v2/handlers_test.go
@@ -391,6 +391,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.NotNil(t, p.cMan.conversations[conversation.conversationID.String()])
+		assert.Len(t, p.cMan.conversations[conversation.conversationID.String()].additionalInfo["refs"], 1)
 	})
 
 	t.Run("error - State.IsPresent failed", func(t *testing.T) {

--- a/network/transport/v2/protocol_integration_test.go
+++ b/network/transport/v2/protocol_integration_test.go
@@ -1,0 +1,173 @@
+/*
+ * Nuts node
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package v2
+
+import (
+	"context"
+	"fmt"
+	"hash/crc32"
+	"path"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nuts-foundation/go-did/did"
+	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	"github.com/nuts-foundation/nuts-node/network/dag"
+	"github.com/nuts-foundation/nuts-node/network/log"
+	"github.com/nuts-foundation/nuts-node/network/transport"
+	"github.com/nuts-foundation/nuts-node/network/transport/grpc"
+	"github.com/nuts-foundation/nuts-node/test"
+	"github.com/nuts-foundation/nuts-node/test/io"
+	"github.com/nuts-foundation/nuts-node/vdr/doc"
+	"github.com/nuts-foundation/nuts-node/vdr/store"
+	vdr "github.com/nuts-foundation/nuts-node/vdr/types"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+const integrationTestTimeout = 10 * time.Second
+const integrationTestPayloadType = "application/did+json"
+
+// TestProtocolV2_Pagination tests whether TransactionList messages are paginated when the transactions on the DAG
+// about 15 transactions fit into a message with max size 4k
+func TestProtocolV2_Pagination(t *testing.T) {
+	prevMaxSize := grpc.MaxMessageSizeInBytes
+	grpc.MaxMessageSizeInBytes = 4 * 1024
+	const numberOfTransactions = 30
+	t.Cleanup(func() {
+		grpc.MaxMessageSizeInBytes = prevMaxSize
+	})
+
+	node1 := startNode(t, "pagination_node1")
+	node2 := startNode(t, "pagination_node2")
+
+	t.Logf("Creating %d transactions...", numberOfTransactions)
+	rootTX, _, _ := dag.CreateTestTransaction(1)
+	err := node1.state.Add(context.Background(), rootTX, []byte{0, 0, 0, 1})
+	if !assert.NoError(t, err) {
+		return
+	}
+	prev := rootTX
+	transactions := make([]dag.Transaction, numberOfTransactions)
+	transactions[0] = rootTX
+	for i := 0; i < numberOfTransactions-1; i++ { // minus 1 to subtract root TX
+		tx, _, _ := dag.CreateTestTransaction(uint32(i+2), prev)
+		err := node1.state.Add(context.Background(), tx, []byte{0, 0, 0, byte(i + 2)})
+		if !assert.NoError(t, err) {
+			return
+		}
+		prev = tx
+		transactions[i+1] = tx
+	}
+
+	node2.connectionManager.Connect(nameToAddress("pagination_node1"))
+	// Wait until nodes are connected
+	if !test.WaitFor(t, func() (bool, error) {
+		return len(node1.connectionManager.Peers()) == 1 && len(node2.connectionManager.Peers()) == 1, nil
+	}, integrationTestTimeout, "time-out while waiting for node 1 and 2 to have a peer") {
+		return
+	}
+
+	// manually request
+	hashes := make([]hash.SHA256Hash, numberOfTransactions)
+	for i, tx := range transactions {
+		hashes[i] = tx.Ref()
+	}
+	err = node2.protocol.sendTransactionListQuery("pagination_node1", hashes)
+	assert.NoError(t, err)
+
+	test.WaitFor(t, func() (bool, error) {
+		txs := node2.countTXs()
+		t.Logf("received %d transactions", txs)
+		return txs == numberOfTransactions, nil
+	}, integrationTestTimeout, "node2 didn't receive all transactions")
+}
+
+type integrationTestContext struct {
+	protocol          *protocol
+	receivedTXs       []dag.Transaction
+	mux               *sync.Mutex
+	state             dag.State
+	connectionManager transport.ConnectionManager
+}
+
+func (i *integrationTestContext) countTXs() int {
+	i.mux.Lock()
+	defer i.mux.Unlock()
+	return len(i.receivedTXs)
+}
+func startNode(t *testing.T, name string, configurers ...func(config *Config)) *integrationTestContext {
+	var vdrStore vdr.Store
+	var keyStore nutsCrypto.KeyStore
+
+	log.Logger().Infof("Starting node: %s", name)
+	logrus.SetLevel(logrus.DebugLevel)
+
+	testDirectory := path.Join(io.TestDirectory(t), name)
+
+	ctx := &integrationTestContext{
+		mux: &sync.Mutex{},
+	}
+
+	ctx.state, _ = dag.NewState(testDirectory)
+	ctx.state.Subscribe(dag.TransactionPayloadAddedEvent, integrationTestPayloadType, func(tx dag.Transaction, payload []byte) error {
+		log.Logger().Infof("transaction %s arrived at %s", string(payload), name)
+		ctx.mux.Lock()
+		defer ctx.mux.Unlock()
+		ctx.receivedTXs = append(ctx.receivedTXs, tx)
+		return nil
+	})
+	ctx.state.Start()
+
+	cfg := &Config{
+		GossipInterval: 500,
+		Datadir:        testDirectory,
+	}
+	for _, c := range configurers {
+		c(cfg)
+	}
+	peerID := transport.PeerID(name)
+	listenAddress := fmt.Sprintf("localhost:%d", nameToPort(name))
+	ctx.protocol = New(*cfg, transport.FixedNodeDIDResolver{}, ctx.state, doc.Resolver{Store: vdrStore}, keyStore).(*protocol)
+
+	authenticator := grpc.NewTLSAuthenticator(doc.NewServiceResolver(&doc.Resolver{Store: store.NewMemoryStore()}))
+	ctx.connectionManager = grpc.NewGRPCConnectionManager(grpc.NewConfig(listenAddress, peerID), &transport.FixedNodeDIDResolver{NodeDID: did.DID{}}, authenticator, ctx.protocol)
+
+	ctx.protocol.Configure(peerID)
+	if err := ctx.connectionManager.Start(); err != nil {
+		t.Fatal(err)
+	}
+	ctx.protocol.Start()
+	t.Cleanup(func() {
+		ctx.protocol.Stop()
+		ctx.connectionManager.Stop()
+	})
+	return ctx
+}
+
+func nameToPort(name string) int {
+	return int(crc32.ChecksumIEEE([]byte(name))%9000 + 1000)
+}
+
+func nameToAddress(name string) string {
+	return fmt.Sprintf("localhost:%d", nameToPort(name))
+}

--- a/network/transport/v2/senders.go
+++ b/network/transport/v2/senders.go
@@ -104,22 +104,25 @@ func chunkTransactionList(transactions []*Transaction) [][]*Transaction {
 	startIndex := 0
 	endIndex := 0
 
+	// TODO to be tested in practise
 	max := grpc.MaxMessageSizeInBytes - 256 // 256 chosen as overhead per message
 
 	for _, tx := range transactions {
-		endIndex++
-		newSize = currentSize + len(tx.Hash) + len(tx.Payload) + len(tx.Data)
+		txSize := len(tx.Hash) + len(tx.Payload) + len(tx.Data)
+		newSize = currentSize + txSize
 
 		if newSize > max {
 			chunked = append(chunked, transactions[startIndex:endIndex])
-			currentSize = 0
+			currentSize = txSize
 			startIndex = endIndex
+		} else {
+			currentSize = newSize
 		}
-		startIndex++
+		endIndex++
 	}
 
 	// any trailing messages
-	if endIndex != len(transactions) {
+	if startIndex != len(transactions) {
 		chunked = append(chunked, transactions[startIndex:])
 	}
 

--- a/network/transport/v2/senders.go
+++ b/network/transport/v2/senders.go
@@ -51,7 +51,9 @@ func (p *protocol) sendTransactionListQuery(id transport.PeerID, refs []hash.SHA
 		return grpc.ErrNoConnection
 	}
 
-	// there shouldn't be more than a ~650 in there, this will fit in a single message
+	// there shouldn't be more than ~650 in there, this will fit in a single message
+	// 650 is based on the maximum number of TXs that can be determined by a single IBLT decode operation.
+	// Any mismatches beyond that point will be handled by TransactionRangeQueries
 	refsAsBytes := make([][]byte, len(refs))
 	for i, ref := range refs {
 		refsAsBytes[i] = ref.Slice()

--- a/network/transport/v2/senders.go
+++ b/network/transport/v2/senders.go
@@ -66,6 +66,8 @@ func (p *protocol) sendTransactionListQuery(id transport.PeerID, refs []hash.SHA
 	}
 
 	conversation := p.cMan.startConversation(envelope)
+	conversation.additionalInfo["refs"] = refs
+
 	// todo convert to trace logging
 	log.Logger().Infof("requesting transactions from peer (peer=%s, conversationID=%s)", id, conversation.conversationID.String())
 

--- a/network/transport/v2/senders_test.go
+++ b/network/transport/v2/senders_test.go
@@ -1,0 +1,149 @@
+/*
+ * Nuts node
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package v2
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	"github.com/nuts-foundation/nuts-node/network/transport"
+	"github.com/nuts-foundation/nuts-node/network/transport/grpc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProtocol_sendGossip(t *testing.T) {
+	peerID := transport.PeerID("1")
+	refsAsBytes := [][]byte{hash.EmptyHash().Slice()}
+
+	t.Run("ok", func(t *testing.T) {
+		proto, mocks := newTestProtocol(t, nil)
+		mockConnection := grpc.NewMockConnection(mocks.Controller)
+		mocks.ConnectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByPeerID(peerID)).Return(mockConnection)
+		mockConnection.EXPECT().Send(proto, &Envelope{Message: &Envelope_Gossip{
+			Gossip: &Gossip{
+				Transactions: refsAsBytes,
+			},
+		}})
+
+		success := proto.sendGossip(peerID, []hash.SHA256Hash{hash.EmptyHash()})
+
+		assert.True(t, success)
+	})
+	t.Run("error - no connection available", func(t *testing.T) {
+		proto, mocks := newTestProtocol(t, nil)
+		mocks.ConnectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByPeerID(peerID)).Return(nil)
+
+		success := proto.sendGossip(peerID, []hash.SHA256Hash{hash.EmptyHash()})
+
+		assert.False(t, success)
+	})
+}
+
+func TestProtocol_sendTransactionList(t *testing.T) {
+	peerID := transport.PeerID("1")
+	conversationID := newConversationID()
+	largeTransaction := Transaction{
+		Data: make([]byte, grpc.MaxMessageSizeInBytes/2),
+	}
+	transactions := []*Transaction{&largeTransaction, &largeTransaction}
+
+	t.Run("ok", func(t *testing.T) {
+		proto, mocks := newTestProtocol(t, nil)
+		mockConnection := grpc.NewMockConnection(mocks.Controller)
+		mocks.ConnectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByPeerID(peerID)).Return(mockConnection)
+		mockConnection.EXPECT().Send(proto, &Envelope{Message: &Envelope_TransactionList{
+			TransactionList: &TransactionList{
+				ConversationID: conversationID.slice(),
+				Transactions:   []*Transaction{&largeTransaction},
+			},
+		}}).Times(2)
+
+		err := proto.sendTransactionList(peerID, conversationID, transactions)
+
+		assert.NoError(t, err)
+	})
+	t.Run("error - on send", func(t *testing.T) {
+		proto, mocks := newTestProtocol(t, nil)
+		mockConnection := grpc.NewMockConnection(mocks.Controller)
+		mocks.ConnectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByPeerID(peerID)).Return(mockConnection)
+		mockConnection.EXPECT().Send(proto, &Envelope{Message: &Envelope_TransactionList{
+			TransactionList: &TransactionList{
+				ConversationID: conversationID.slice(),
+				Transactions:   []*Transaction{&largeTransaction},
+			},
+		}}).Return(errors.New("custom"))
+
+		err := proto.sendTransactionList(peerID, conversationID, transactions)
+
+		assert.Error(t, err)
+	})
+	t.Run("error - no connection available", func(t *testing.T) {
+		proto, mocks := newTestProtocol(t, nil)
+		mocks.ConnectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByPeerID(peerID)).Return(nil)
+
+		err := proto.sendTransactionList(peerID, newConversationID(), []*Transaction{})
+
+		assert.NotNil(t, err)
+	})
+}
+
+func Test_chunkTransactionList(t *testing.T) {
+	t.Run("no chunks", func(t *testing.T) {
+		transactions := []*Transaction{{}, {}}
+
+		chunks := chunkTransactionList(transactions)
+
+		if !assert.Len(t, chunks, 1) {
+			return
+		}
+		assert.Len(t, chunks[0], 2)
+	})
+
+	t.Run("2 large chunks", func(t *testing.T) {
+		largeTransaction := Transaction{
+			Data: make([]byte, grpc.MaxMessageSizeInBytes/2),
+		}
+		transactions := []*Transaction{&largeTransaction, &largeTransaction}
+
+		chunks := chunkTransactionList(transactions)
+
+		if !assert.Len(t, chunks, 2) {
+			return
+		}
+		assert.Len(t, chunks[0], 1)
+		assert.Len(t, chunks[1], 1)
+	})
+
+	t.Run("complex set", func(t *testing.T) {
+		transactions := []*Transaction{
+			{Data: make([]byte, 100000)},
+			{Data: make([]byte, 256000)},
+			{Data: make([]byte, 100000)},
+			{Data: make([]byte, 256000)}, // doesn't fit
+			{Data: make([]byte, 15000)},
+			{Data: make([]byte, 256000)}, // doesn't fit
+		}
+
+		chunks := chunkTransactionList(transactions)
+
+		assert.Len(t, chunks, 3)
+	})
+}


### PR DESCRIPTION
Closes #832 

There are some todo's in there. They are a reminder to change after the entire v2 protocol is implemented and tested.

During implementation, some questions regarding the protocol came up:

- [x] Do we always need to respond on a TransactionListQuery? If we have nothing to send, can't we just ignore the message? This might make stuff easier?
- [x] Nothing is specced on what to do when a transaction (or payload) is missing. The current implementation stops adding transactions to the message based on LC values. It sends what it can. This also links to the next point.
- [x] How to mark the conversation as done? If we do not know for sure how many chunks are to be expected.
- [x] What to do with received transactions where the payload is missing? This is also not specced

TODO:
- [x] integration test with lots of TXs.
