### PR TITLE
Network: replace lastTransactionTracker with calls to DAG/PayloadStore

### DIFF
--- a/network/dag/interface.go
+++ b/network/dag/interface.go
@@ -57,6 +57,9 @@ type State interface {
 	// RegisterObserver allows observers to be notified when a transaction is added to the DAG.
 	// If the observer needs to be called within the transaction, transactional must be true.
 	RegisterObserver(observer Observer, transactional bool)
+	// GetHeads returns the heads of the DAG which payload is present. If the payload of the last DAG heads is missing,
+	// their prevs are inspected as possible heads to be returned by this function.
+	GetHeads(ctx context.Context) ([]hash.SHA256Hash, error)
 	// Subscribe lets an application subscribe to a specific type of transaction. When a new transaction is received
 	// the `receiver` function is called. If an asterisk (`*`) is specified as `payloadType` the receiver is subscribed
 	// to all payload types.

--- a/network/dag/mock.go
+++ b/network/dag/mock.go
@@ -95,6 +95,21 @@ func (mr *MockStateMockRecorder) GetByPayloadHash(ctx, payloadHash interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByPayloadHash", reflect.TypeOf((*MockState)(nil).GetByPayloadHash), ctx, payloadHash)
 }
 
+// GetHeads mocks base method.
+func (m *MockState) GetHeads(ctx context.Context) ([]hash.SHA256Hash, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHeads", ctx)
+	ret0, _ := ret[0].([]hash.SHA256Hash)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHeads indicates an expected call of GetHeads.
+func (mr *MockStateMockRecorder) GetHeads(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeads", reflect.TypeOf((*MockState)(nil).GetHeads), ctx)
+}
+
 // GetTransaction mocks base method.
 func (m *MockState) GetTransaction(ctx context.Context, hash hash.SHA256Hash) (Transaction, error) {
 	m.ctrl.T.Helper()

--- a/network/dag/publisher.go
+++ b/network/dag/publisher.go
@@ -27,7 +27,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/network/log"
 )
 
-// NewReplayingDAGPublisher creates a DAG publisher that replays the complete DAG to all subscribers when started.
+// NewReplayingDAGPublisher creates a DAG publisher that can replay the complete DAG to all subscribers when started.
 func NewReplayingDAGPublisher(payloadStore PayloadStore, dag *bboltDAG) Publisher {
 	publisher := &replayingDAGPublisher{
 		subscribers:         map[EventType]map[string]Receiver{},

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -46,7 +46,6 @@ import (
 
 	"github.com/nuts-foundation/nuts-node/core"
 	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
-	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network/dag"
 	"github.com/nuts-foundation/nuts-node/network/log"
 	"github.com/nuts-foundation/nuts-node/test/io"
@@ -475,7 +474,6 @@ func startNode(t *testing.T, name string, testDirectory string, opts ...func(cfg
 
 	instance := &Network{
 		config:                 config,
-		lastTransactionTracker: lastTransactionTracker{headRefs: make(map[hash.SHA256Hash]bool), processedTransactions: map[hash.SHA256Hash]bool{}},
 		didDocumentResolver:    doc.Resolver{Store: vdrStore},
 		didDocumentFinder:      doc.Finder{Store: vdrStore},
 		privateKeyResolver:     keyStore,


### PR DESCRIPTION
In preparation of optional DAG replay (https://github.com/nuts-foundation/nuts-node/issues/835).

The `lastTransactionTracker` tracked the last TXs on the DAG with payload, to avoid locally creating a TX which prevs payload(s) were missing, leading to a locally unprocessable transaction. 

This tracker subscribed to the DAG but only kept track in-memory, so to allow disabling DAG replay it had to either start persisting its internal state or replace it altogether.