### PR TITLE
remove setting field to nil after shutdown

### DIFF
--- a/network/dag/state.go
+++ b/network/dag/state.go
@@ -174,7 +174,6 @@ func (s *state) Shutdown() error {
 		if err != nil {
 			return err
 		}
-		s.db = nil
 	}
 
 	return nil

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -131,7 +131,6 @@ func TestState_Shutdown(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	assert.Nil(t, txState.db)
 }
 
 func TestState_Start(t *testing.T) {


### PR DESCRIPTION
This causes a race condition during test and does not add any extra functionality. The DB connection is non-recoverable.