### PR TITLE
rewrote VDR persistent store

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -202,7 +202,7 @@ func Test_CreateSystem(t *testing.T) {
 	system.VisitEngines(func(engine core.Engine) {
 		numEngines++
 	})
-	assert.Equal(t, 9, numEngines)
+	assert.Equal(t, 10, numEngines)
 }
 
 func testCommand() *cobra.Command {

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -96,7 +96,7 @@ func (n *ambassador) callback(tx dag.Transaction, payload []byte) error {
 		return fmt.Errorf("could not process new DID Document: %w", err)
 	}
 	if processed {
-		log.Logger().Infof("Skipping DID document, already exists (tx=%s)", tx.Ref().String())
+		log.Logger().Debugf("Skipping DID document, already exists (tx=%s)", tx.Ref().String())
 		return nil
 	}
 

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -206,11 +206,14 @@ func (n *ambassador) handleUpdateDIDDocument(transaction dag.Transaction, propos
 	// In an update, only the keyID is provided in the network document. Resolve the key from the key store
 	// This should succeed since the signature of the network document has already been verified.
 	var pKey crypto.PublicKey
-	if signingTime.After(types.DIDDocumentResolveEpoch) {
-		pKey, err = n.keyResolver.ResolvePublicKey(transaction.SigningKeyID(), transaction.Previous())
-	} else {
+	pKey, err = n.keyResolver.ResolvePublicKey(transaction.SigningKeyID(), transaction.Previous())
+	if err != nil {
+		if !errors.Is(err, types.ErrNotFound) {
+			return fmt.Errorf("unable to resolve signingkey: %w", err)
+		}
 		pKey, err = n.keyResolver.ResolvePublicKeyInTime(transaction.SigningKeyID(), &signingTime)
 	}
+
 	if err != nil {
 		return fmt.Errorf("unable to resolve signingkey: %w", err)
 	}

--- a/vdr/ambassador_test.go
+++ b/vdr/ambassador_test.go
@@ -407,7 +407,7 @@ func TestAmbassador_handleUpdateDIDDocument(t *testing.T) {
 		var pKey crypto2.PublicKey
 		signingKey.Raw(&pKey)
 
-		ctx.didStore.EXPECT().Resolve(didDocument.ID, nil).Return(&storedDocument, currentMetadata, nil)
+		ctx.didStore.EXPECT().Resolve(didDocument.ID, &types.ResolveMetadata{AllowDeactivated: true}).Return(&storedDocument, currentMetadata, nil)
 		ctx.resolver.EXPECT().ResolveControllers(storedDocument, &types.ResolveMetadata{ResolveTime: &tx.signingTime}).Return([]did.Document{storedDocument}, nil)
 		ctx.keyStore.EXPECT().ResolvePublicKey(storedDocument.CapabilityInvocation[0].ID.String(), gomock.Any()).Return(pKey, nil)
 		ctx.didStore.EXPECT().Update(storedDocument.ID, currentMetadata.Hash, deactivatedDocument, &expectedNextMetadata)
@@ -454,7 +454,7 @@ func TestAmbassador_handleUpdateDIDDocument(t *testing.T) {
 		var pKey crypto2.PublicKey
 		signingKey.Raw(&pKey)
 
-		ctx.didStore.EXPECT().Resolve(didDocument.ID, nil).Return(&expectedDocument, currentMetadata, nil)
+		ctx.didStore.EXPECT().Resolve(didDocument.ID, &types.ResolveMetadata{AllowDeactivated: true}).Return(&expectedDocument, currentMetadata, nil)
 		ctx.resolver.EXPECT().ResolveControllers(expectedDocument, &types.ResolveMetadata{ResolveTime: &tx.signingTime}).Return([]did.Document{expectedDocument}, nil)
 		ctx.keyStore.EXPECT().ResolvePublicKey(didDocument.CapabilityInvocation[0].ID.String(), gomock.Any()).Return(pKey, nil)
 		ctx.didStore.EXPECT().Update(didDocument.ID, currentMetadata.Hash, expectedDocument, &expectedNextMetadata)
@@ -497,7 +497,7 @@ func TestAmbassador_handleUpdateDIDDocument(t *testing.T) {
 		var pKey crypto2.PublicKey
 		signingKey.Raw(&pKey)
 
-		ctx.didStore.EXPECT().Resolve(didDocument.ID, nil).Return(&expectedDocument, currentMetadata, nil)
+		ctx.didStore.EXPECT().Resolve(didDocument.ID, &types.ResolveMetadata{AllowDeactivated: true}).Return(&expectedDocument, currentMetadata, nil)
 		ctx.resolver.EXPECT().ResolveControllers(expectedDocument, &types.ResolveMetadata{ResolveTime: &tx.signingTime}).Return([]did.Document{controllerDoc}, nil)
 		ctx.keyStore.EXPECT().ResolvePublicKey(controllerDoc.CapabilityInvocation[0].ID.String(), gomock.Any()).Return(pKey, nil)
 
@@ -540,7 +540,7 @@ func TestAmbassador_handleUpdateDIDDocument(t *testing.T) {
 		var pKey crypto2.PublicKey
 		signingKey.Raw(&pKey)
 
-		ctx.didStore.EXPECT().Resolve(currentDoc.ID, nil).Return(&currentDoc, currentMetadata, nil)
+		ctx.didStore.EXPECT().Resolve(currentDoc.ID, &types.ResolveMetadata{AllowDeactivated: true}).Return(&currentDoc, currentMetadata, nil)
 		ctx.resolver.EXPECT().ResolveControllers(currentDoc, &types.ResolveMetadata{ResolveTime: &tx.signingTime}).Return([]did.Document{currentDoc}, nil)
 		ctx.keyStore.EXPECT().ResolvePublicKey(currentDoc.CapabilityInvocation[0].ID.String(), gomock.Any()).Return(pKey, nil)
 		ctx.didStore.EXPECT().Update(currentDoc.ID, currentMetadata.Hash, newDoc, &expectedNextMetadata)
@@ -608,7 +608,7 @@ func TestAmbassador_handleUpdateDIDDocument(t *testing.T) {
 			SourceTransactions: []hash.SHA256Hash{tx.Ref()},
 		}
 
-		ctx.didStore.EXPECT().Resolve(didDocument.ID, nil).Return(&expectedDocument, currentMetadata, nil)
+		ctx.didStore.EXPECT().Resolve(didDocument.ID, &types.ResolveMetadata{AllowDeactivated: true}).Return(&expectedDocument, currentMetadata, nil)
 		ctx.resolver.EXPECT().ResolveControllers(expectedDocument, &types.ResolveMetadata{ResolveTime: &tx.signingTime}).Return([]did.Document{didDocumentController}, nil)
 		ctx.keyStore.EXPECT().ResolvePublicKey(didDocumentController.CapabilityInvocation[0].ID.String(), gomock.Any()).Return(pKey, nil)
 		ctx.didStore.EXPECT().Update(didDocument.ID, currentMetadata.Hash, expectedDocument, &expectedNextMetadata)
@@ -673,7 +673,7 @@ func TestAmbassador_handleUpdateDIDDocument(t *testing.T) {
 			Hash:    currentPayloadHash,
 		}
 
-		ctx.didStore.EXPECT().Resolve(didDocument.ID, nil).Return(&expectedDocument, currentMetadata, nil)
+		ctx.didStore.EXPECT().Resolve(didDocument.ID, &types.ResolveMetadata{AllowDeactivated: true}).Return(&expectedDocument, currentMetadata, nil)
 		ctx.resolver.EXPECT().ResolveControllers(expectedDocument, &types.ResolveMetadata{ResolveTime: &tx.signingTime}).Return([]did.Document{didDocumentController}, nil)
 		ctx.keyStore.EXPECT().ResolvePublicKey(keyID, gomock.Any()).Return(pKey, nil)
 
@@ -761,7 +761,7 @@ func Test_handleUpdateDIDDocument(t *testing.T) {
 		didDocument, _, _ := newDidDoc()
 		tx := testTransaction{signingTime: time.Now()}
 
-		didStoreMock.EXPECT().Resolve(didDocument.ID, nil).Return(&didDocument, &types.DocumentMetadata{}, nil)
+		didStoreMock.EXPECT().Resolve(didDocument.ID, &types.ResolveMetadata{AllowDeactivated: true}).Return(&didDocument, &types.DocumentMetadata{}, nil)
 		docResolverMock.EXPECT().ResolveControllers(didDocument, &types.ResolveMetadata{ResolveTime: &tx.signingTime}).Return(nil, errors.New("failed"))
 
 		err := am.handleUpdateDIDDocument(&tx, didDocument)

--- a/vdr/ambassador_test.go
+++ b/vdr/ambassador_test.go
@@ -409,7 +409,7 @@ func TestAmbassador_handleUpdateDIDDocument(t *testing.T) {
 
 		ctx.didStore.EXPECT().Resolve(didDocument.ID, nil).Return(&storedDocument, currentMetadata, nil)
 		ctx.resolver.EXPECT().ResolveControllers(storedDocument, &types.ResolveMetadata{ResolveTime: &tx.signingTime}).Return([]did.Document{storedDocument}, nil)
-		ctx.keyStore.EXPECT().ResolvePublicKeyInTime(storedDocument.CapabilityInvocation[0].ID.String(), &tx.signingTime).Return(pKey, nil)
+		ctx.keyStore.EXPECT().ResolvePublicKey(storedDocument.CapabilityInvocation[0].ID.String(), gomock.Any()).Return(pKey, nil)
 		ctx.didStore.EXPECT().Update(storedDocument.ID, currentMetadata.Hash, deactivatedDocument, &expectedNextMetadata)
 
 		err = ctx.ambassador.handleUpdateDIDDocument(tx, deactivatedDocument)
@@ -456,55 +456,7 @@ func TestAmbassador_handleUpdateDIDDocument(t *testing.T) {
 
 		ctx.didStore.EXPECT().Resolve(didDocument.ID, nil).Return(&expectedDocument, currentMetadata, nil)
 		ctx.resolver.EXPECT().ResolveControllers(expectedDocument, &types.ResolveMetadata{ResolveTime: &tx.signingTime}).Return([]did.Document{expectedDocument}, nil)
-		ctx.keyStore.EXPECT().ResolvePublicKeyInTime(didDocument.CapabilityInvocation[0].ID.String(), &tx.signingTime).Return(pKey, nil)
-		ctx.didStore.EXPECT().Update(didDocument.ID, currentMetadata.Hash, expectedDocument, &expectedNextMetadata)
-
-		err = ctx.ambassador.handleUpdateDIDDocument(tx, expectedDocument)
-		assert.NoError(t, err)
-	})
-
-	t.Run("update ok - with hash based resolution", func(t *testing.T) {
-		ctx := newMockContext(t)
-
-		didDocument, signingKey, err := newDidDoc()
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		didDocPayload, _ := json.Marshal(didDocument)
-		payloadHash := hash.SHA256Sum(didDocPayload)
-
-		tx := newTX()
-		tx.signingTime = types.DIDDocumentResolveEpoch.Add(1 * time.Second)
-		tx.signingKeyID = didDocument.CapabilityInvocation[0].ID.String()
-		tx.payloadHash = payloadHash
-
-		expectedDocument := did.Document{}
-		json.Unmarshal(didDocPayload, &expectedDocument)
-
-		currentPayloadHash := hash.SHA256Sum([]byte("currentPayloadHash"))
-
-		// This is the metadata of the current version of the document which will be returned by the resolver
-		currentMetadata := &types.DocumentMetadata{
-			Created: createdAt,
-			Updated: nil,
-			Hash:    currentPayloadHash,
-		}
-
-		// This is the metadata that will be written during the update
-		expectedNextMetadata := types.DocumentMetadata{
-			Created:            createdAt,
-			Updated:            &tx.signingTime,
-			Hash:               payloadHash,
-			PreviousHash:       &currentPayloadHash,
-			SourceTransactions: []hash.SHA256Hash{tx.Ref()},
-		}
-		var pKey crypto2.PublicKey
-		signingKey.Raw(&pKey)
-
-		ctx.didStore.EXPECT().Resolve(didDocument.ID, nil).Return(&expectedDocument, currentMetadata, nil)
-		ctx.resolver.EXPECT().ResolveControllers(expectedDocument, &types.ResolveMetadata{ResolveTime: &tx.signingTime}).Return([]did.Document{expectedDocument}, nil)
-		ctx.keyStore.EXPECT().ResolvePublicKey(didDocument.CapabilityInvocation[0].ID.String(), tx.prevs).Return(pKey, nil)
+		ctx.keyStore.EXPECT().ResolvePublicKey(didDocument.CapabilityInvocation[0].ID.String(), gomock.Any()).Return(pKey, nil)
 		ctx.didStore.EXPECT().Update(didDocument.ID, currentMetadata.Hash, expectedDocument, &expectedNextMetadata)
 
 		err = ctx.ambassador.handleUpdateDIDDocument(tx, expectedDocument)
@@ -547,7 +499,8 @@ func TestAmbassador_handleUpdateDIDDocument(t *testing.T) {
 
 		ctx.didStore.EXPECT().Resolve(didDocument.ID, nil).Return(&expectedDocument, currentMetadata, nil)
 		ctx.resolver.EXPECT().ResolveControllers(expectedDocument, &types.ResolveMetadata{ResolveTime: &tx.signingTime}).Return([]did.Document{controllerDoc}, nil)
-		ctx.keyStore.EXPECT().ResolvePublicKeyInTime(controllerDoc.CapabilityInvocation[0].ID.String(), &tx.signingTime).Return(pKey, nil)
+		ctx.keyStore.EXPECT().ResolvePublicKey(controllerDoc.CapabilityInvocation[0].ID.String(), gomock.Any()).Return(pKey, nil)
+
 		ctx.didStore.EXPECT().Update(didDocument.ID, currentMetadata.Hash, expectedDocument, &expectedNextMetadata)
 
 		err := ctx.ambassador.handleUpdateDIDDocument(tx, expectedDocument)
@@ -589,7 +542,7 @@ func TestAmbassador_handleUpdateDIDDocument(t *testing.T) {
 
 		ctx.didStore.EXPECT().Resolve(currentDoc.ID, nil).Return(&currentDoc, currentMetadata, nil)
 		ctx.resolver.EXPECT().ResolveControllers(currentDoc, &types.ResolveMetadata{ResolveTime: &tx.signingTime}).Return([]did.Document{currentDoc}, nil)
-		ctx.keyStore.EXPECT().ResolvePublicKeyInTime(currentDoc.CapabilityInvocation[0].ID.String(), &tx.signingTime).Return(pKey, nil)
+		ctx.keyStore.EXPECT().ResolvePublicKey(currentDoc.CapabilityInvocation[0].ID.String(), gomock.Any()).Return(pKey, nil)
 		ctx.didStore.EXPECT().Update(currentDoc.ID, currentMetadata.Hash, newDoc, &expectedNextMetadata)
 
 		err := ctx.ambassador.handleUpdateDIDDocument(tx, newDoc)
@@ -657,7 +610,7 @@ func TestAmbassador_handleUpdateDIDDocument(t *testing.T) {
 
 		ctx.didStore.EXPECT().Resolve(didDocument.ID, nil).Return(&expectedDocument, currentMetadata, nil)
 		ctx.resolver.EXPECT().ResolveControllers(expectedDocument, &types.ResolveMetadata{ResolveTime: &tx.signingTime}).Return([]did.Document{didDocumentController}, nil)
-		ctx.keyStore.EXPECT().ResolvePublicKeyInTime(didDocumentController.CapabilityInvocation[0].ID.String(), &tx.signingTime).Return(pKey, nil)
+		ctx.keyStore.EXPECT().ResolvePublicKey(didDocumentController.CapabilityInvocation[0].ID.String(), gomock.Any()).Return(pKey, nil)
 		ctx.didStore.EXPECT().Update(didDocument.ID, currentMetadata.Hash, expectedDocument, &expectedNextMetadata)
 
 		err = ctx.ambassador.handleUpdateDIDDocument(tx, expectedDocument)
@@ -722,7 +675,7 @@ func TestAmbassador_handleUpdateDIDDocument(t *testing.T) {
 
 		ctx.didStore.EXPECT().Resolve(didDocument.ID, nil).Return(&expectedDocument, currentMetadata, nil)
 		ctx.resolver.EXPECT().ResolveControllers(expectedDocument, &types.ResolveMetadata{ResolveTime: &tx.signingTime}).Return([]did.Document{didDocumentController}, nil)
-		ctx.keyStore.EXPECT().ResolvePublicKeyInTime(keyID, &tx.signingTime).Return(pKey, nil)
+		ctx.keyStore.EXPECT().ResolvePublicKey(keyID, gomock.Any()).Return(pKey, nil)
 
 		err = ctx.ambassador.handleUpdateDIDDocument(tx, didDocument)
 		assert.EqualError(t, err, "network document not signed by one of its controllers")
@@ -773,7 +726,7 @@ func TestAmbassador_handleUpdateDIDDocument(t *testing.T) {
 		}
 
 		didStoreMock.EXPECT().Resolve(didDocument.ID, gomock.Any()).Return(&didDocument, &didMetadata, nil)
-		keyStoreMock.EXPECT().ResolvePublicKeyInTime(signingKey.KeyID(), gomock.Any()).Return(pKey, nil)
+		keyStoreMock.EXPECT().ResolvePublicKey(signingKey.KeyID(), gomock.Any()).Return(pKey, nil)
 		didStoreMock.EXPECT().Update(didDocument.ID, hash.EmptyHash(), expectedDocument, &expectedMetadata).Return(nil)
 
 		err = am.handleUpdateDIDDocument(tx, expectedDocument)

--- a/vdr/doc/resolvers.go
+++ b/vdr/doc/resolvers.go
@@ -220,7 +220,8 @@ func ExtractAssertionKeyID(doc did.Document) (ssi.URI, error) {
 
 func (r KeyResolver) ResolvePublicKeyInTime(kid string, validAt *time.Time) (crypto.PublicKey, error) {
 	return r.resolvePublicKey(kid, types.ResolveMetadata{
-		ResolveTime: validAt,
+		AllowDeactivated: true,
+		ResolveTime:      validAt,
 	})
 }
 

--- a/vdr/store/bbolt.go
+++ b/vdr/store/bbolt.go
@@ -135,11 +135,6 @@ func (store *bboltStore) Update(id did.DID, current hash.SHA256Hash, next did.Do
 			return err
 		}
 
-		// check for deactivated
-		if latestMetadata.Deactivated {
-			return vdr.ErrDeactivated
-		}
-
 		// check for hash
 		if !current.Equals(latestMetadata.Metadata.Hash) {
 			return vdr.ErrUpdateOnOutdatedData

--- a/vdr/store/bbolt_test.go
+++ b/vdr/store/bbolt_test.go
@@ -42,6 +42,31 @@ func newBBoltTestStore(t *testing.T) *bboltStore {
 	return store
 }
 
+func TestBboltStore_Configure(t *testing.T) {
+	t.Run("error - unable to create DB", func(t *testing.T) {
+		store := NewBBoltStore().(core.Configurable)
+
+		err := store.Configure(core.ServerConfig{Datadir: "bbolt_test.go"})
+
+		assert.Error(t, err)
+	})
+}
+func TestBBoltStore_Start(t *testing.T) {
+	store := NewBBoltStore().(core.Runnable)
+
+	err := store.Start()
+
+	assert.NoError(t, err)
+}
+
+func TestBBoltStore_Shutdown(t *testing.T) {
+	store := NewBBoltStore().(core.Runnable)
+
+	err := store.Shutdown()
+
+	assert.NoError(t, err)
+}
+
 func TestBBoltStore_Write(t *testing.T) {
 	store := newBBoltTestStore(t)
 	did1, _ := did.ParseDID("did:nuts:1")
@@ -97,156 +122,115 @@ func TestBboltStore_Processed(t *testing.T) {
 }
 
 func TestBBoltStore_Resolve(t *testing.T) {
-	store := newBBoltTestStore(t)
 	did1, _ := did.ParseDID("did:nuts:1")
-	doc := did.Document{
-		ID:         *did1,
-		Controller: []did.DID{*did1},
-	}
-
-	firstHash, _ := hash.ParseHex("452d9e89d5bd5d9225fb6daecd579e7388a166c7661ca04e47fd3cd8446e4619")
-	txHash := hash.FromSlice([]byte("keyTransactionHash"))
-	firstMeta := types.DocumentMetadata{
-		Created:            time.Now().Add(time.Hour * -48),
-		Hash:               firstHash,
-		SourceTransactions: []hash.SHA256Hash{hash.EmptyHash(), txHash},
-	}
-
-	err := store.Write(doc, firstMeta)
-	assert.NoError(t, err)
-
-	latestHash, _ := hash.ParseHex("452d9e89d5bd5d9225fb6daecd579e7388a166c7661ca04e47fd3cd8446e4620")
-	meta := types.DocumentMetadata{
-		Created:            time.Now().Add(time.Hour * -24),
-		Hash:               latestHash,
-		SourceTransactions: []hash.SHA256Hash{hash.EmptyHash(), txHash},
-	}
-
-	err = store.Update(*did1, firstHash, doc, &meta)
-	assert.NoError(t, err)
-
-	t.Run("returns ErrNotFound on unknown did", func(t *testing.T) {
-		did2, _ := did.ParseDID("did:nuts:2")
-		_, _, err := store.Resolve(*did2, nil)
-		assert.Equal(t, types.ErrNotFound, err)
-	})
-
-	t.Run("returns the last document without resolve metadata", func(t *testing.T) {
-		d, m, err := store.Resolve(*did1, nil)
-		if !assert.NoError(t, err) {
-			return
+	t.Run("with preloaded data", func(t *testing.T) {
+		store := newBBoltTestStore(t)
+		doc := did.Document{
+			ID:         *did1,
+			Controller: []did.DID{*did1},
 		}
-		assert.NotNil(t, d)
-		assert.NotNil(t, m)
-		assert.Equal(t, m.Hash, latestHash)
-	})
 
-	t.Run("returns document with resolve metadata - selection on date", func(t *testing.T) {
-		now := time.Now()
-		d, m, err := store.Resolve(*did1, &types.ResolveMetadata{
-			ResolveTime: &now,
-		})
-		if !assert.NoError(t, err) {
-			return
+		firstHash, _ := hash.ParseHex("452d9e89d5bd5d9225fb6daecd579e7388a166c7661ca04e47fd3cd8446e4619")
+		txHash := hash.FromSlice([]byte("keyTransactionHash"))
+		firstMeta := types.DocumentMetadata{
+			Created:            time.Now().Add(time.Hour * -48),
+			Hash:               firstHash,
+			SourceTransactions: []hash.SHA256Hash{hash.EmptyHash(), txHash},
 		}
-		assert.NotNil(t, d)
-		assert.NotNil(t, m)
-	})
 
-	t.Run("returns no document with resolve metadata - selection on date", func(t *testing.T) {
-		before := time.Now().Add(time.Hour * -49)
-		_, _, err := store.Resolve(*did1, &types.ResolveMetadata{
-			ResolveTime: &before,
-		})
-		assert.Equal(t, types.ErrNotFound, err)
-	})
+		err := store.Write(doc, firstMeta)
+		assert.NoError(t, err)
 
-	t.Run("returns document with resolve metadata - selection on hash", func(t *testing.T) {
-		d, m, err := store.Resolve(*did1, &types.ResolveMetadata{
-			Hash: &firstHash,
-		})
-		if !assert.NoError(t, err) {
-			return
+		latestHash, _ := hash.ParseHex("452d9e89d5bd5d9225fb6daecd579e7388a166c7661ca04e47fd3cd8446e4620")
+		meta := types.DocumentMetadata{
+			Created:            time.Now().Add(time.Hour * -24),
+			Hash:               latestHash,
+			SourceTransactions: []hash.SHA256Hash{hash.EmptyHash(), txHash},
 		}
-		assert.NotNil(t, d)
-		assert.NotNil(t, m)
+
+		err = store.Update(*did1, firstHash, doc, &meta)
+		assert.NoError(t, err)
+
+		t.Run("returns ErrNotFound on unknown did", func(t *testing.T) {
+			did2, _ := did.ParseDID("did:nuts:2")
+			_, _, err := store.Resolve(*did2, nil)
+			assert.Equal(t, types.ErrNotFound, err)
+		})
+
+		t.Run("returns the last document without resolve metadata", func(t *testing.T) {
+			d, m, err := store.Resolve(*did1, nil)
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.NotNil(t, d)
+			assert.NotNil(t, m)
+			assert.Equal(t, m.Hash, latestHash)
+		})
+
+		t.Run("returns document with resolve metadata - selection on date", func(t *testing.T) {
+			now := time.Now()
+			d, m, err := store.Resolve(*did1, &types.ResolveMetadata{
+				ResolveTime: &now,
+			})
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.NotNil(t, d)
+			assert.NotNil(t, m)
+		})
+
+		t.Run("returns no document with resolve metadata - selection on date", func(t *testing.T) {
+			before := time.Now().Add(time.Hour * -49)
+			_, _, err := store.Resolve(*did1, &types.ResolveMetadata{
+				ResolveTime: &before,
+			})
+			assert.Equal(t, types.ErrNotFound, err)
+		})
+
+		t.Run("returns document with resolve metadata - selection on hash", func(t *testing.T) {
+			d, m, err := store.Resolve(*did1, &types.ResolveMetadata{
+				Hash: &firstHash,
+			})
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.NotNil(t, d)
+			assert.NotNil(t, m)
+		})
+
+		t.Run("returns document with resolve metadata - selection on KeyTransaction", func(t *testing.T) {
+			d, m, err := store.Resolve(*did1, &types.ResolveMetadata{
+				SourceTransaction: &txHash,
+			})
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.NotNil(t, d)
+			assert.NotNil(t, m)
+		})
+
+		t.Run("returns no document with resolve metadata - selection on KeyTransaction", func(t *testing.T) {
+			_, _, err := store.Resolve(*did1, &types.ResolveMetadata{
+				SourceTransaction: &latestHash,
+			})
+			if !assert.Error(t, err) {
+				return
+			}
+			assert.Equal(t, types.ErrNotFound, err)
+		})
 	})
 
-	t.Run("returns document with resolve metadata - selection on KeyTransaction", func(t *testing.T) {
-		d, m, err := store.Resolve(*did1, &types.ResolveMetadata{
-			SourceTransaction: &txHash,
-		})
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.NotNil(t, d)
-		assert.NotNil(t, m)
-	})
+	t.Run("returns not found for empty DB", func(t *testing.T) {
+		store := newBBoltTestStore(t)
 
-	t.Run("returns no document with resolve metadata - selection on KeyTransaction", func(t *testing.T) {
-		_, _, err := store.Resolve(*did1, &types.ResolveMetadata{
-			SourceTransaction: &latestHash,
-		})
+		_, _, err := store.Resolve(*did1, nil)
+
 		if !assert.Error(t, err) {
 			return
 		}
 		assert.Equal(t, types.ErrNotFound, err)
 	})
-}
 
-func TestBBoltStore_TimeSelectionFilter(t *testing.T) {
-	earlier := time.Now().Add(time.Hour * -24)
-	now := time.Now()
-	later := time.Now().Add(time.Hour * 24)
-
-	metadata := types.ResolveMetadata{
-		ResolveTime: &now,
-	}
-	f := timeSelectionFilter(metadata)
-
-	t.Run("returns false when created later", func(t *testing.T) {
-		entry := memoryEntry{
-			metadata: types.DocumentMetadata{
-				Created: later,
-			},
-		}
-		assert.False(t, f(entry))
-	})
-
-	t.Run("returns true when created earlier", func(t *testing.T) {
-		entry := memoryEntry{
-			metadata: types.DocumentMetadata{
-				Created: earlier,
-			},
-		}
-		assert.True(t, f(entry))
-	})
-
-	t.Run("returns false when next document was updated earlier", func(t *testing.T) {
-		entry := memoryEntry{
-			metadata: types.DocumentMetadata{
-				Created: earlier,
-				Updated: &earlier,
-			},
-			next: &memoryEntry{
-				metadata: types.DocumentMetadata{
-					Created: earlier,
-					Updated: &earlier,
-				},
-			},
-		}
-		assert.False(t, f(entry))
-	})
-
-	t.Run("returns false when document was updated later", func(t *testing.T) {
-		entry := memoryEntry{
-			metadata: types.DocumentMetadata{
-				Created: earlier,
-				Updated: &later,
-			},
-		}
-		assert.False(t, f(entry))
-	})
 }
 
 func TestBBoltStore_Update(t *testing.T) {
@@ -285,20 +269,6 @@ func TestBBoltStore_Update(t *testing.T) {
 		}
 		assert.Nil(t, m.PreviousHash)
 		assert.Equal(t, h, m.Hash)
-	})
-
-	t.Run("updates the previous record", func(t *testing.T) {
-		later := time.Now().Add(time.Hour * 24)
-		meta = types.DocumentMetadata{
-			Hash:    h,
-			Created: time.Now(),
-			Updated: &later,
-		}
-		err := store.Update(*did1, h, doc, &meta)
-		assert.NoError(t, err)
-
-		//s := store.(*memory)
-		//assert.NotNil(t, s.store[did1.String()][0].next)
 	})
 
 	t.Run("returns error when DID document doesn't exist", func(t *testing.T) {

--- a/vdr/store/bbolt_test.go
+++ b/vdr/store/bbolt_test.go
@@ -300,20 +300,6 @@ func TestBBoltStore_Update(t *testing.T) {
 		err := store.Update(*did1, h, doc, &meta)
 		assert.Equal(t, types.ErrUpdateOnOutdatedData, err)
 	})
-
-	t.Run("returns error when DID Document is deactivated", func(t *testing.T) {
-		did1, _ := did.ParseDID("did:nuts:2")
-		doc := did.Document{
-			ID: *did1,
-		}
-		err := store.Write(doc, meta)
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		err = store.Update(*did1, h, doc, &meta)
-		assert.Equal(t, types.ErrDeactivated, err)
-	})
 }
 
 func TestBBoltStore_Parallelism(t *testing.T) {

--- a/vdr/store/memory.go
+++ b/vdr/store/memory.go
@@ -176,6 +176,11 @@ func timeSelectionFilter(metadata vdr.ResolveMetadata) filterFunc {
 	}
 }
 
+// Processed always returns false for in memory DB
+func (m *memory) Processed(hash hash.SHA256Hash) (bool, error) {
+	return false, nil
+}
+
 // Write implements the DocWriteWriter interface and writes a DIDDocument with the provided metadata to the memory store.
 func (m *memory) Write(document did.Document, metadata vdr.DocumentMetadata) error {
 	m.mutex.Lock()

--- a/vdr/store/memory.go
+++ b/vdr/store/memory.go
@@ -216,10 +216,6 @@ func (m *memory) Update(id did.DID, current hash.SHA256Hash, next did.Document, 
 	// latest version is to be updated
 	entry, _ := entries.last()
 
-	if entry.isDeactivated() {
-		return vdr.ErrDeactivated
-	}
-
 	// hashes must match
 	if !current.Equals(entry.metadata.Hash) {
 		return vdr.ErrUpdateOnOutdatedData

--- a/vdr/store/memory_test.go
+++ b/vdr/store/memory_test.go
@@ -236,20 +236,6 @@ func TestMemory_Update(t *testing.T) {
 		err := store.Update(*did1, h, doc, &meta)
 		assert.Equal(t, types.ErrUpdateOnOutdatedData, err)
 	})
-
-	t.Run("returns error when DID Document is deactivated", func(t *testing.T) {
-		did1, _ := did.ParseDID("did:nuts:2")
-		doc := did.Document{
-			ID: *did1,
-		}
-		err := store.Write(doc, meta)
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		err = store.Update(*did1, h, doc, &meta)
-		assert.Equal(t, types.ErrDeactivated, err)
-	})
 }
 
 func TestMemory_Parallelism(t *testing.T) {

--- a/vdr/types/common.go
+++ b/vdr/types/common.go
@@ -53,10 +53,6 @@ var ErrDuplicateService = errors.New("service type is duplicate")
 // ErrServiceNotFound is returned when the service is not found on a DID
 var ErrServiceNotFound = errors.New("service not found in DID Document")
 
-// DIDDocumentResolveEpoch represents the epoch on which DID Document resolving switched from time based to hash based
-// GMT: Saturday, 27 November 2021 08:00:00
-var DIDDocumentResolveEpoch = time.Unix(1638000000, 0)
-
 // ErrServiceReferenceToDeep is returned when a service reference is chain is nested too deeply.
 var ErrServiceReferenceToDeep = errors.New("service references are nested to deeply before resolving to a non-reference")
 

--- a/vdr/types/interface.go
+++ b/vdr/types/interface.go
@@ -112,6 +112,8 @@ type DocIterator func(doc did.Document, metadata DocumentMetadata) error
 
 // Store is the interface that groups all low level VDR DID storage operations.
 type Store interface {
+	// Processed returns true if a DID Document has already been processed for the given TX hash.
+	Processed(hash hash.SHA256Hash) (bool, error)
 	// Resolve returns the DID Document for the provided DID.
 	// If metadata is not provided the latest version is returned.
 	// If metadata is provided then the result is filtered or scoped on that metadata.

--- a/vdr/types/interface.go
+++ b/vdr/types/interface.go
@@ -73,10 +73,9 @@ type DocWriter interface {
 type DocUpdater interface {
 	// Update replaces the DID document identified by DID with the nextVersion
 	// To prevent updating stale data a hash of the current version should be provided.
-	// If the given hash does not represents the current version, a ErrUpdateOnOutdatedData is returned
+	// If the given hash does not represent the current version, a ErrUpdateOnOutdatedData is returned
 	// If the DID Document is not found, ErrNotFound is returned
 	// If the DID Document is not managed by this node, ErrDIDNotManagedByThisNode is returned
-	// If the DID Document is not active, ErrDeactivated is returned
 	Update(id did.DID, current hash.SHA256Hash, next did.Document, metadata *DocumentMetadata) error
 }
 

--- a/vdr/types/mock.go
+++ b/vdr/types/mock.go
@@ -412,6 +412,21 @@ func (mr *MockStoreMockRecorder) Iterate(fn interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Iterate", reflect.TypeOf((*MockStore)(nil).Iterate), fn)
 }
 
+// Processed mocks base method.
+func (m *MockStore) Processed(hash hash.SHA256Hash) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Processed", hash)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Processed indicates an expected call of Processed.
+func (mr *MockStoreMockRecorder) Processed(hash interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Processed", reflect.TypeOf((*MockStore)(nil).Processed), hash)
+}
+
 // Resolve mocks base method.
 func (m *MockStore) Resolve(id did.DID, metadata *ResolveMetadata) (*did.Document, *DocumentMetadata, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
closes #846 
fixes #878 

Added check if transaction has already been processed. Startup is 30 seconds faster on a macBook compared to previous implementation.

I also replaced the fixed date check for resolving key by ref or date. It now first tries by ref and then by date. After v2 by date could be removed

 - [x] test cleanup & coverage increase
 - [x] fix dev network crash: can't find key by date