### PR TITLE
Further group network diagnostics

### DIFF
--- a/core/diagnostics.go
+++ b/core/diagnostics.go
@@ -33,6 +33,31 @@ type DiagnosticResult interface {
 	String() string
 }
 
+// DiagnosticResultMap is a DiagnosticResult that presents the given Items as a map, rather than a list.
+type DiagnosticResultMap struct {
+	Title string
+	Items []DiagnosticResult
+}
+
+// Name returns the of the diagnostic, which is used as key.
+func (g DiagnosticResultMap) Name() string {
+	return g.Title
+}
+
+// Result returns the result of the diagnostic, which is Items converted to a map.
+func (g DiagnosticResultMap) Result() interface{} {
+	result := make(map[string]interface{}, 0)
+	for _, item := range g.Items {
+		result[item.Name()] = item.Result()
+	}
+	return result
+}
+
+// String returns the string representation of Result()
+func (g DiagnosticResultMap) String() string {
+	return fmt.Sprintf("%v", g.Result())
+}
+
 // GenericDiagnosticResult is a simple implementation of the DiagnosticResult interface
 type GenericDiagnosticResult struct {
 	Title   string

--- a/core/diagnostics.go
+++ b/core/diagnostics.go
@@ -40,16 +40,16 @@ type GenericDiagnosticResult struct {
 }
 
 // Result returns the raw outcome of the GenericDiagnosticResult
-func (gdr *GenericDiagnosticResult) Result() interface{} {
+func (gdr GenericDiagnosticResult) Result() interface{} {
 	return gdr.Outcome
 }
 
 // Name returns the name of the GenericDiagnosticResult
-func (gdr *GenericDiagnosticResult) Name() string {
+func (gdr GenericDiagnosticResult) Name() string {
 	return gdr.Title
 }
 
 // String returns the outcome of the GenericDiagnosticResult
-func (gdr *GenericDiagnosticResult) String() string {
+func (gdr GenericDiagnosticResult) String() string {
 	return fmt.Sprintf("%v", gdr.Outcome)
 }

--- a/core/diagnostics_test.go
+++ b/core/diagnostics_test.go
@@ -25,6 +25,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestDiagnosticResultMap_Name(t *testing.T) {
+	gdr := DiagnosticResultMap{Title: "test"}
+
+	assert.Equal(t, "test", gdr.Name())
+}
+
+func TestDiagnosticResultMap_String(t *testing.T) {
+	gdr := DiagnosticResultMap{Items: []DiagnosticResult{GenericDiagnosticResult{Title: "Foo"}}}
+
+	assert.Equal(t, "map[Foo:<nil>]", gdr.String())
+}
+
+func TestDiagnosticResultMap_Result(t *testing.T) {
+	gdr := DiagnosticResultMap{Items: []DiagnosticResult{
+		GenericDiagnosticResult{Title: "Foo", Outcome: 1},
+		GenericDiagnosticResult{Title: "Bar", Outcome: 2},
+	}}
+
+	assert.Equal(t, map[string]interface{}{"Foo": 1, "Bar": 2}, gdr.Result())
+
+}
+
 func TestGenericDiagnosticResult_Name(t *testing.T) {
 	gdr := GenericDiagnosticResult{Title: "test"}
 

--- a/network/dag/bbolt_dag.go
+++ b/network/dag/bbolt_dag.go
@@ -70,7 +70,7 @@ func (d headsStatistic) Result() interface{} {
 }
 
 func (d headsStatistic) Name() string {
-	return "dag_heads"
+	return "heads"
 }
 
 func (d headsStatistic) String() string {
@@ -86,7 +86,7 @@ func (d numberOfTransactionsStatistic) Result() interface{} {
 }
 
 func (d numberOfTransactionsStatistic) Name() string {
-	return "dag_transaction_count"
+	return "transaction_count"
 }
 
 func (d numberOfTransactionsStatistic) String() string {
@@ -102,7 +102,7 @@ func (d dataSizeStatistic) Result() interface{} {
 }
 
 func (d dataSizeStatistic) Name() string {
-	return "dag_stored_database_size_bytes"
+	return "stored_database_size_bytes"
 }
 
 func (d dataSizeStatistic) String() string {

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -250,9 +250,9 @@ func TestState_Diagnostics(t *testing.T) {
 	assert.NotZero(t, dbSize)
 
 	actual := strings.Join(lines, "\n")
-	expected := fmt.Sprintf(`dag_heads: [`+doc1.Ref().String()+`]
-dag_stored_database_size_bytes: %d
-dag_transaction_count: 1`, dbSize.DataSize)
+	expected := fmt.Sprintf(`heads: [`+doc1.Ref().String()+`]
+stored_database_size_bytes: %d
+transaction_count: 1`, dbSize.DataSize)
 	assert.Equal(t, expected, actual)
 }
 

--- a/network/network.go
+++ b/network/network.go
@@ -469,13 +469,24 @@ func (n *Network) Shutdown() error {
 // Diagnostics collects and returns diagnostics for the Network engine.
 func (n *Network) Diagnostics() []core.DiagnosticResult {
 	var results = make([]core.DiagnosticResult, 0)
+	// Connection manager and protocols
 	results = append(results, n.connectionManager.Diagnostics()...)
 	for _, prot := range n.protocols {
 		results = append(results, prot.Diagnostics()...)
 	}
+	// DAG
 	if graph, ok := n.state.(core.Diagnosable); ok {
 		results = append(results, graph.Diagnostics()...)
 	}
+	// NodeDID
+	nodeDID, err := n.nodeDIDResolver.Resolve()
+	if err != nil {
+		log.Logger().Errorf("Unable to resolve node DID for diagnostics: %v", err)
+	}
+	results = append(results, core.GenericDiagnosticResult{
+		Title:   "node_did",
+		Outcome: nodeDID,
+	})
 	return results
 }
 

--- a/network/network.go
+++ b/network/network.go
@@ -470,13 +470,13 @@ func (n *Network) Shutdown() error {
 func (n *Network) Diagnostics() []core.DiagnosticResult {
 	var results = make([]core.DiagnosticResult, 0)
 	// Connection manager and protocols
-	results = append(results, n.connectionManager.Diagnostics()...)
+	results = append(results, core.DiagnosticResultMap{Title: "connections", Items: n.connectionManager.Diagnostics()})
 	for _, prot := range n.protocols {
-		results = append(results, prot.Diagnostics()...)
+		results = append(results, core.DiagnosticResultMap{Title: fmt.Sprintf("protocol_v%d", prot.Version()), Items: prot.Diagnostics()})
 	}
 	// DAG
 	if graph, ok := n.state.(core.Diagnosable); ok {
-		results = append(results, graph.Diagnostics()...)
+		results = append(results, core.DiagnosticResultMap{Title: "state", Items: graph.Diagnostics()})
 	}
 	// NodeDID
 	nodeDID, err := n.nodeDIDResolver.Resolve()

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -122,25 +122,26 @@ func TestNetwork_Subscribe(t *testing.T) {
 }
 
 func TestNetwork_Diagnostics(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	t.Run("ok", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 		cxt := createNetwork(ctrl, func(config *Config) {
 			config.NodeDID = "did:nuts:localio"
 		})
 		// Diagnostics from deps
-		numStats := 6
 		cxt.connectionManager.EXPECT().Diagnostics().Return([]core.DiagnosticResult{stat{}, stat{}})
 		cxt.protocol.EXPECT().Diagnostics().Return([]core.DiagnosticResult{stat{}, stat{}})
+		cxt.protocol.EXPECT().Version().Return(1)
 		cxt.state.EXPECT().Diagnostics().Return([]core.DiagnosticResult{stat{}, stat{}})
-		// Diagnostic with node DID
-		numStats++
-		nodeDIDStat := core.GenericDiagnosticResult{Title: "node_did", Outcome: did.MustParseDID("did:nuts:localio")}
 
 		diagnostics := cxt.network.Diagnostics()
 
-		assert.Len(t, diagnostics, numStats)
-		assert.Contains(t, diagnostics, nodeDIDStat)
+		assert.Len(t, diagnostics, 4)
+		assert.Equal(t, "connections", diagnostics[0].Name())
+		assert.Equal(t, "protocol_v1", diagnostics[1].Name())
+		assert.Equal(t, "state", diagnostics[2].Name())
+		nodeDIDStat := core.GenericDiagnosticResult{Title: "node_did", Outcome: did.MustParseDID("did:nuts:localio")}
+		assert.Equal(t, nodeDIDStat, diagnostics[3])
 	})
 }
 

--- a/network/transport/v1/logic/impl.go
+++ b/network/transport/v1/logic/impl.go
@@ -84,7 +84,7 @@ func (p *protocol) Diagnostics() []core.DiagnosticResult {
 		log.Logger().Errorf("Error while collecting missing payloads: %s", err)
 	}
 	diagnostics = append(diagnostics, &core.GenericDiagnosticResult{
-		Title:   "v1_missing_payload_hashes",
+		Title:   "missing_payload_hashes",
 		Outcome: missingPayloads,
 	})
 

--- a/network/transport/v1/logic/impl_test.go
+++ b/network/transport/v1/logic/impl_test.go
@@ -134,7 +134,7 @@ func Test_Protocol_Diagnostics(t *testing.T) {
 		instance := NewProtocol(nil, nil, nil, nil).(*protocol)
 		instance.missingPayloadCollector = payloadCollector
 		diagnostics := instance.Diagnostics()
-		assert.Equal(t, "v1_missing_payload_hashes", diagnostics[1].Name())
+		assert.Equal(t, "missing_payload_hashes", diagnostics[1].Name())
 		assert.Equal(t, "[0100000000000000000000000000000000000000000000000000000000000000]", diagnostics[1].String())
 	})
 
@@ -146,7 +146,7 @@ func Test_Protocol_Diagnostics(t *testing.T) {
 		instance := NewProtocol(nil, nil, nil, nil).(*protocol)
 		instance.missingPayloadCollector = payloadCollector
 		diagnostics := instance.Diagnostics()
-		assert.Equal(t, "v1_missing_payload_hashes", diagnostics[1].Name())
+		assert.Equal(t, "missing_payload_hashes", diagnostics[1].Name())
 		assert.Empty(t, "", diagnostics[1].String())
 	})
 }

--- a/network/transport/v1/logic/stats.go
+++ b/network/transport/v1/logic/stats.go
@@ -44,7 +44,7 @@ func (d peerOmnihashStatistic) Result() interface{} {
 }
 
 func (d peerOmnihashStatistic) Name() string {
-	return "v1_peer_omnihashes"
+	return "peer_omnihashes"
 }
 
 func (d peerOmnihashStatistic) String() string {


### PR DESCRIPTION
Was previously a relatively flat list, further grouped the diagnostics of `ConnectionManager`, the protocols and DAG state.

New format:
```
network:
    connections:
        connected_peers:
            - id: 7f6f07c3-ec37-4a90-b39b-df9a970c2578
              address: 172.21.0.4:36196
              nodedid: ""
              acceptunauthenticated: false
            - id: 0ec2ffc0-3093-4660-b819-ce821da2877e
              address: 172.21.0.2:38142
              nodedid: ""
              acceptunauthenticated: false
        connected_peers_count: 2
        outbound_connectors: []
        peer_id: d1052df5-29b4-4ac0-ad99-89785b8e8cba
    node_did: ""
    protocol_v1:
        missing_payload_hashes: []
        peer_omnihashes:
            0ec2ffc0-3093-4660-b819-ce821da2877e: ef82d2e2cc6474b77c7a44d1d11b416513b8c7709d199c48f5a30c7f79b50498
            7f6f07c3-ec37-4a90-b39b-df9a970c2578: ef82d2e2cc6474b77c7a44d1d11b416513b8c7709d199c48f5a30c7f79b50498
    protocol_v2:
        payload_fetch_dlq: []
    state:
        heads:
            - ef82d2e2cc6474b77c7a44d1d11b416513b8c7709d199c48f5a30c7f79b50498
        stored_database_size_bytes: 8192
        transaction_count: 1
status:
    git_commit: "0"
    os_arch: linux/amd64
    software_version: master
    uptime: 55m31s
vdr:
    conflicted_did_documents_count: 0
```