### PR TITLE
VCR: Fix OAS response for VC search operation

### DIFF
--- a/docs/_static/vcr/v2.yaml
+++ b/docs/_static/vcr/v2.yaml
@@ -144,7 +144,8 @@ paths:
           description: A list of matching credentials
           content:
             application/json:
-              $ref: '#/components/schemas/SearchVCResults'
+              schema:
+                $ref: '#/components/schemas/SearchVCResults'
         default:
           $ref: '../common/error_response.yaml'
   /internal/vcr/v2/issuer/vc/{id}:

--- a/vcr/api/v2/generated.go
+++ b/vcr/api/v2/generated.go
@@ -904,6 +904,7 @@ func (r IssueVCResponse) StatusCode() int {
 type SearchIssuedVCsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	JSON200      *SearchVCResults
 }
 
 // Status returns HTTPResponse.Status
@@ -1172,6 +1173,16 @@ func ParseSearchIssuedVCsResponse(rsp *http.Response) (*SearchIssuedVCsResponse,
 	response := &SearchIssuedVCsResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SearchVCResults
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
 	}
 
 	return response, nil


### PR DESCRIPTION
The Go generator doesn't fail on this, but for other languages it does.