### PR TITLE
VCR: Validate vc.type

### DIFF
--- a/vcr/verifier/verifier.go
+++ b/vcr/verifier/verifier.go
@@ -295,5 +295,5 @@ func (v *verifier) validateType(credential vc.VerifiableCredential) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("verifiable credential does not does not list '%s' as type", vc.VerifiableCredentialTypeV1URI())
+	return fmt.Errorf("verifiable credential does not list '%s' as type", vc.VerifiableCredentialTypeV1URI())
 }

--- a/vcr/verifier/verifier_test.go
+++ b/vcr/verifier/verifier_test.go
@@ -92,7 +92,7 @@ func Test_verifier_Validate(t *testing.T) {
 
 			err := instance.Validate(vc.VerifiableCredential{Type: []ssi.URI{ssi.MustParseURI("foo"), ssi.MustParseURI("bar")}}, nil)
 
-			assert.EqualError(t, err, "verifiable credential does not does not list 'VerifiableCredential' as type")
+			assert.EqualError(t, err, "verifiable credential does not list 'VerifiableCredential' as type")
 		})
 	})
 

--- a/vcr/verifier/verifier_test.go
+++ b/vcr/verifier/verifier_test.go
@@ -77,6 +77,25 @@ func Test_verifier_Validate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("type", func(t *testing.T) {
+		t.Run("incorrect number of types", func(t *testing.T) {
+			ctx := newMockContext(t)
+			instance := ctx.verifier
+
+			err := instance.Validate(vc.VerifiableCredential{Type: []ssi.URI{vc.VerifiableCredentialTypeV1URI()}}, nil)
+
+			assert.EqualError(t, err, "verifiable credential must list exactly 2 types")
+		})
+		t.Run("does not contain v1 context", func(t *testing.T) {
+			ctx := newMockContext(t)
+			instance := ctx.verifier
+
+			err := instance.Validate(vc.VerifiableCredential{Type: []ssi.URI{ssi.MustParseURI("foo"), ssi.MustParseURI("bar")}}, nil)
+
+			assert.EqualError(t, err, "verifiable credential does not does not list 'VerifiableCredential' as type")
+		})
+	})
+
 	t.Run("error - invalid vm", func(t *testing.T) {
 		ctx := newMockContext(t)
 		instance := ctx.verifier


### PR DESCRIPTION
According to RFC011, VCs must have the type `VerifiableCredential` and one additional type.