### PR TITLE
VCR: SearchVC() unmarshal query as VC instead of map

### DIFF
--- a/makefile
+++ b/makefile
@@ -52,7 +52,7 @@ gen-api:
 	oapi-codegen -generate types,server,client,skip-prune -templates codegen/oapi/ -package v1 -exclude-schemas DIDDocument,DIDDocumentMetadata,Service,VerificationMethod docs/_static/vdr/v1.yaml | gofmt > vdr/api/v1/generated.go
 	oapi-codegen -generate types,server,client -templates codegen/oapi/ -package v1 -exclude-schemas PeerDiagnostics docs/_static/network/v1.yaml | gofmt > network/api/v1/generated.go
 	oapi-codegen -generate types,server,client,skip-prune -templates codegen/oapi/ -package v1 -exclude-schemas VerifiableCredential,CredentialSubject,IssueVCRequest,Revocation docs/_static/vcr/v1.yaml | gofmt > vcr/api/v1/generated.go
-	oapi-codegen -generate types,server,client,skip-prune -templates codegen/oapi/ -package v2 -exclude-schemas VerifiableCredential,CredentialSubject,Revocation,VerifiablePresentation docs/_static/vcr/v2.yaml | gofmt > vcr/api/v2/generated.go
+	oapi-codegen -generate types,server,client,skip-prune -templates codegen/oapi/ -package v2 -exclude-schemas VerifiableCredential,CredentialSubject,Revocation,VerifiablePresentation,SearchVCRequest docs/_static/vcr/v2.yaml | gofmt > vcr/api/v2/generated.go
 	oapi-codegen -generate types,server,client,skip-prune -templates codegen/oapi/ -package v1 -exclude-schemas VerifiableCredential,VerifiablePresentation docs/_static/auth/v1.yaml | gofmt > auth/api/v1/generated.go
 	oapi-codegen -generate types,server,client -templates codegen/oapi/ -package v1 -exclude-schemas ContactInformation,OrganizationSearchResult docs/_static/didman/v1.yaml | gofmt > didman/api/v1/generated.go
 

--- a/vcr/api/v2/generated.go
+++ b/vcr/api/v2/generated.go
@@ -130,13 +130,6 @@ type SearchOptions struct {
 	AllowUntrustedIssuer *bool `json:"allowUntrustedIssuer,omitempty"`
 }
 
-// request body for searching VCs
-type SearchVCRequest struct {
-	// A partial VerifiableCredential in JSON-LD format. Each field will be used to match credentials against. All fields MUST be present.
-	Query         map[string]interface{} `json:"query"`
-	SearchOptions *SearchOptions         `json:"searchOptions,omitempty"`
-}
-
 // result of a Search operation.
 type SearchVCResult struct {
 	// Credential revocation record

--- a/vcr/api/v2/holder.go
+++ b/vcr/api/v2/holder.go
@@ -43,13 +43,12 @@ func (w *Wrapper) SearchVCs(ctx echo.Context) error {
 		untrusted = *request.SearchOptions.AllowUntrustedIssuer
 	}
 
-	searchContexts, ok := request.Query["type"].([]interface{})
-	if !ok {
-		return core.InvalidInputError("failed to determine type, got %s, need list of strings", request.Query["type"])
-	}
-
 	query, _ := json.Marshal(request.Query)
-	for _, c := range searchContexts {
+	var types []string
+	for _, curr := range request.Query.Type {
+		types = append(types, curr.String())
+	}
+	for _, c := range types {
 		switch c {
 		case credential.NutsOrganizationCredentialType:
 			return w.searchOrgs(ctx, untrusted, query)

--- a/vcr/api/v2/holder_test.go
+++ b/vcr/api/v2/holder_test.go
@@ -40,7 +40,7 @@ var organizationQuery = `
 {
 	"query": {
 		"@context": ["https://www.w3.org/2018/credentials/v1","https://nuts.nl/credentials/v1"],
-		"type": "NutsOrganizationCredential",
+		"type": ["VerifiableCredential", "NutsOrganizationCredential"],
 		"credentialSubject":{
 			"id":"did:nuts:123",
 			"organization": {
@@ -56,7 +56,7 @@ var untrustedOrganizationQuery = `
 {
 	"query": {
 		"@context": ["https://www.w3.org/2018/credentials/v1","https://nuts.nl/credentials/v1"],
-		"type": "NutsOrganizationCredential",
+		"type": ["VerifiableCredential", "NutsOrganizationCredential"],
 		"credentialSubject":{
 			"id":"did:nuts:123",
 			"organization": {

--- a/vcr/api/v2/holder_test.go
+++ b/vcr/api/v2/holder_test.go
@@ -40,7 +40,7 @@ var organizationQuery = `
 {
 	"query": {
 		"@context": ["https://www.w3.org/2018/credentials/v1","https://nuts.nl/credentials/v1"],
-		"type": ["VerifiableCredential", "NutsOrganizationCredential"],
+		"type": "NutsOrganizationCredential",
 		"credentialSubject":{
 			"id":"did:nuts:123",
 			"organization": {
@@ -56,7 +56,7 @@ var untrustedOrganizationQuery = `
 {
 	"query": {
 		"@context": ["https://www.w3.org/2018/credentials/v1","https://nuts.nl/credentials/v1"],
-		"type": ["VerifiableCredential", "NutsOrganizationCredential"],
+		"type": "NutsOrganizationCredential",
 		"credentialSubject":{
 			"id":"did:nuts:123",
 			"organization": {

--- a/vcr/api/v2/types.go
+++ b/vcr/api/v2/types.go
@@ -35,3 +35,10 @@ type Revocation = credential.Revocation
 
 // VerifiablePresentation is an alias to use from within the API
 type VerifiablePresentation = vc.VerifiablePresentation
+
+// SearchVCRequest is the request body for searching VCs
+type SearchVCRequest struct {
+	// A partial VerifiableCredential in JSON-LD format. Each field will be used to match credentials against. All fields MUST be present.
+	Query         vc.VerifiableCredential `json:"query"`
+	SearchOptions *SearchOptions          `json:"searchOptions,omitempty"`
+}


### PR DESCRIPTION
Required to properly support variants of data types (single value v.s. list) of VCs.