### PR TITLE
VCR: Verify Nuts LD context is present for Nuts and set it by default

### DIFF
--- a/vcr/api/v2/api.go
+++ b/vcr/api/v2/api.go
@@ -21,6 +21,7 @@ package v2
 import (
 	"encoding/json"
 	"errors"
+	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/verifier"
 	"net/http"
 
@@ -83,7 +84,8 @@ func (w Wrapper) IssueVC(ctx echo.Context) error {
 		if publish {
 			return core.InvalidInputError("visibility must be set when publishing credential")
 		}
-	} else { // visibility is set
+	} else {
+		// visibility is set
 		// Visibility can only be used when publishing
 		if !publish {
 			return core.InvalidInputError("visibility setting is only allowed when publishing to the network")
@@ -94,6 +96,12 @@ func (w Wrapper) IssueVC(ctx echo.Context) error {
 		}
 		// Set the actual value
 		public = *issueRequest.Visibility == IssueVCRequestVisibilityPublic
+	}
+
+	// Set default context, if not set
+	if issueRequest.Context == nil {
+		context := credential.NutsContext
+		issueRequest.Context = &context
 	}
 
 	if issueRequest.Type == "" {

--- a/vcr/api/v2/api_test.go
+++ b/vcr/api/v2/api_test.go
@@ -21,6 +21,7 @@ package v2
 import (
 	"errors"
 	"github.com/nuts-foundation/nuts-node/vcr/concept"
+	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/verifier"
 	"net/http"
 	"testing"
@@ -47,6 +48,7 @@ func TestWrapper_IssueVC(t *testing.T) {
 
 	expectedRequestedVC := vc.VerifiableCredential{
 		Type:              []ssi.URI{*credentialType},
+		Context:           []ssi.URI{*credential.NutsContextURI},
 		Issuer:            *issuerURI,
 		CredentialSubject: []interface{}{map[string]interface{}{"id": "did:nuts:456"}},
 	}
@@ -627,7 +629,6 @@ func TestWrapper_VerifyVP(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
-
 
 func TestWrapper_TrustUntrust(t *testing.T) {
 	vc := concept.TestVC()

--- a/vcr/credential/validator.go
+++ b/vcr/credential/validator.go
@@ -104,6 +104,10 @@ func (d nutsOrganizationCredentialValidator) Validate(credential vc.VerifiableCr
 		return failure("type '%s' is required", NutsOrganizationCredentialType)
 	}
 
+	if !credential.ContainsContext(*NutsContextURI) {
+		return failure("context '%s' is required", NutsContextURI.String())
+	}
+
 	// if it fails, length check will trigger
 	_ = credential.UnmarshalCredentialSubject(&target)
 	if len(target) != 1 {
@@ -143,6 +147,10 @@ func (d nutsAuthorizationCredentialValidator) Validate(credential vc.VerifiableC
 
 	if !credential.IsType(*NutsAuthorizationCredentialTypeURI) {
 		return failure("type '%s' is required", NutsAuthorizationCredentialType)
+	}
+
+	if !credential.ContainsContext(*NutsContextURI) {
+		return failure("context '%s' is required", NutsContextURI.String())
 	}
 
 	// if it fails, length check will trigger

--- a/vcr/credential/validator_test.go
+++ b/vcr/credential/validator_test.go
@@ -46,7 +46,7 @@ func TestNutsOrganizationCredentialValidator_Validate(t *testing.T) {
 
 		err := validator.Validate(*v)
 
-		assert.Error(t, err)
+		assert.EqualError(t, err, "validation failed: type 'NutsOrganizationCredential' is required")
 	})
 
 	t.Run("failed - missing default type", func(t *testing.T) {
@@ -55,7 +55,7 @@ func TestNutsOrganizationCredentialValidator_Validate(t *testing.T) {
 
 		err := validator.Validate(*v)
 
-		assert.Error(t, err)
+		assert.EqualError(t, err, "validation failed: type 'VerifiableCredential' is required")
 	})
 
 	t.Run("failed - missing credential subject", func(t *testing.T) {
@@ -64,7 +64,7 @@ func TestNutsOrganizationCredentialValidator_Validate(t *testing.T) {
 
 		err := validator.Validate(*v)
 
-		assert.Error(t, err)
+		assert.EqualError(t, err, "validation failed: single CredentialSubject expected")
 	})
 
 	t.Run("failed - missing organization", func(t *testing.T) {
@@ -75,7 +75,7 @@ func TestNutsOrganizationCredentialValidator_Validate(t *testing.T) {
 
 		err := validator.Validate(*v)
 
-		assert.Error(t, err)
+		assert.EqualError(t, err, "validation failed: 'credentialSubject.organization' is empty")
 	})
 
 	t.Run("failed - missing organization name", func(t *testing.T) {
@@ -89,7 +89,7 @@ func TestNutsOrganizationCredentialValidator_Validate(t *testing.T) {
 
 		err := validator.Validate(*v)
 
-		assert.Error(t, err)
+		assert.EqualError(t, err, "validation failed: 'credentialSubject.name' is empty")
 	})
 
 	t.Run("failed - missing organization city", func(t *testing.T) {
@@ -103,7 +103,7 @@ func TestNutsOrganizationCredentialValidator_Validate(t *testing.T) {
 
 		err := validator.Validate(*v)
 
-		assert.Error(t, err)
+		assert.EqualError(t, err, "validation failed: 'credentialSubject.city' is empty")
 	})
 
 	t.Run("failed - empty organization city", func(t *testing.T) {
@@ -118,7 +118,7 @@ func TestNutsOrganizationCredentialValidator_Validate(t *testing.T) {
 
 		err := validator.Validate(*v)
 
-		assert.Error(t, err)
+		assert.EqualError(t, err, "validation failed: 'credentialSubject.city' is empty")
 	})
 
 	t.Run("failed - empty organization name", func(t *testing.T) {
@@ -133,7 +133,7 @@ func TestNutsOrganizationCredentialValidator_Validate(t *testing.T) {
 
 		err := validator.Validate(*v)
 
-		assert.Error(t, err)
+		assert.EqualError(t, err, "validation failed: 'credentialSubject.name' is empty")
 	})
 
 	t.Run("failed - missing credentialSubject.ID", func(t *testing.T) {
@@ -147,7 +147,7 @@ func TestNutsOrganizationCredentialValidator_Validate(t *testing.T) {
 
 		err := validator.Validate(*v)
 
-		assert.Error(t, err)
+		assert.EqualError(t, err, "validation failed: 'credentialSubject.ID' is nil")
 	})
 
 	t.Run("failed - missing ID", func(t *testing.T) {
@@ -156,7 +156,7 @@ func TestNutsOrganizationCredentialValidator_Validate(t *testing.T) {
 
 		err := validator.Validate(*v)
 
-		assert.Error(t, err)
+		assert.EqualError(t, err, "validation failed: 'ID' is required")
 	})
 
 	t.Run("failed - missing default context", func(t *testing.T) {
@@ -165,16 +165,16 @@ func TestNutsOrganizationCredentialValidator_Validate(t *testing.T) {
 
 		err := validator.Validate(*v)
 
-		assert.Error(t, err)
+		assert.EqualError(t, err, "validation failed: default context is required")
 	})
 
 	t.Run("failed - missing nuts context", func(t *testing.T) {
 		v := validNutsOrganizationCredential()
-		v.Context = []ssi.URI{vc.VerifiableCredentialTypeV1URI()}
+		v.Context = []ssi.URI{stringToURI("https://www.w3.org/2018/credentials/v1")}
 
 		err := validator.Validate(*v)
 
-		assert.Error(t, err)
+		assert.EqualError(t, err, "validation failed: context 'https://nuts.nl/credentials/v1' is required")
 	})
 
 	t.Run("failed - missing issuanceDate", func(t *testing.T) {
@@ -183,7 +183,7 @@ func TestNutsOrganizationCredentialValidator_Validate(t *testing.T) {
 
 		err := validator.Validate(*v)
 
-		assert.Error(t, err)
+		assert.EqualError(t, err, "validation failed: 'issuanceDate' is required")
 	})
 
 	t.Run("failed - missing proof", func(t *testing.T) {
@@ -192,7 +192,7 @@ func TestNutsOrganizationCredentialValidator_Validate(t *testing.T) {
 
 		err := validator.Validate(*v)
 
-		assert.Error(t, err)
+		assert.EqualError(t, err, "validation failed: 'proof' is required")
 	})
 }
 
@@ -235,6 +235,16 @@ func TestNutsAuthorizationCredentialValidator_Validate(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.EqualError(t, err, "validation failed: type 'VerifiableCredential' is required")
+	})
+
+	t.Run("failed - missing Nuts context", func(t *testing.T) {
+		v := validImpliedNutsAuthorizationCredential()
+		v.Context = []ssi.URI{vc.VCContextV1URI()}
+
+		err := validator.Validate(*v)
+
+		assert.Error(t, err)
+		assert.EqualError(t, err, "validation failed: context 'https://nuts.nl/credentials/v1' is required")
 	})
 
 	t.Run("failed - missing authorization VC type", func(t *testing.T) {


### PR DESCRIPTION
As specified by OAS:

> The resolvable context of the credentialSubject as URI. If omitted, the "https://nuts.nl/credentials/v1" context is used. Note: it is not needed to provide the "https://www.w3.org/2018/credentials/v1" context here.