### PR TITLE
VCR: Fix v2 search for NutsAuthorizationCredential

### DIFF
--- a/vcr/api/v2/holder.go
+++ b/vcr/api/v2/holder.go
@@ -119,7 +119,7 @@ func (w *Wrapper) searchAuths(ctx echo.Context, allowUntrusted bool, body []byte
 	}
 
 	// convert to query
-	query, err := w.VCR.Registry().QueryFor(concept.OrganizationConcept)
+	query, err := w.VCR.Registry().QueryFor(concept.AuthorizationConcept)
 	if err != nil {
 		return err
 	}

--- a/vcr/api/v2/holder_test.go
+++ b/vcr/api/v2/holder_test.go
@@ -189,7 +189,7 @@ func TestWrapper_SearchVCs(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
-		assert.Equal(t, concept.OrganizationConcept, capturedQuery.Concept())
+		assert.Equal(t, concept.AuthorizationConcept, capturedQuery.Concept())
 		parts := capturedQuery.Parts()
 		if !assert.Len(t, parts, 1) {
 			return


### PR DESCRIPTION
Currently broken, because it searches for NutsOrganizationCredentials.