### PR TITLE
VCR: Allow searching on VC ID in v2 API

### DIFF
--- a/vcr/api/v2/holder.go
+++ b/vcr/api/v2/holder.go
@@ -63,6 +63,7 @@ func (w *Wrapper) SearchVCs(ctx echo.Context) error {
 func (w *Wrapper) searchOrgs(ctx echo.Context, allowUntrusted bool, body []byte) error {
 	// some helper structs
 	type helper struct {
+		ID                string `json:"id"`
 		CredentialSubject struct {
 			ID           string `json:"id"`
 			Organization struct {
@@ -81,6 +82,9 @@ func (w *Wrapper) searchOrgs(ctx echo.Context, allowUntrusted bool, body []byte)
 	query, err := w.VCR.Registry().QueryFor(concept.OrganizationConcept)
 	if err != nil {
 		return err
+	}
+	if ldQuery.ID != "" {
+		query.AddClause(concept.Eq("id", ldQuery.ID))
 	}
 	if ldQuery.CredentialSubject.Organization.Name != "" {
 		query.AddClause(concept.Prefix("organization.name", ldQuery.CredentialSubject.Organization.Name))
@@ -103,6 +107,7 @@ func (w *Wrapper) searchOrgs(ctx echo.Context, allowUntrusted bool, body []byte)
 func (w *Wrapper) searchAuths(ctx echo.Context, allowUntrusted bool, body []byte) error {
 	// some helper structs that reflect current required query params
 	type helper struct {
+		ID                string `json:"id"`
 		CredentialSubject struct {
 			ID           string `json:"id"`
 			PurposeOfUse string `json:"purposeOfUse"`
@@ -122,6 +127,9 @@ func (w *Wrapper) searchAuths(ctx echo.Context, allowUntrusted bool, body []byte
 	query, err := w.VCR.Registry().QueryFor(concept.OrganizationConcept)
 	if err != nil {
 		return err
+	}
+	if ldQuery.ID != "" {
+		query.AddClause(concept.Eq("id", ldQuery.ID))
 	}
 	if ldQuery.CredentialSubject.ID != "" {
 		query.AddClause(concept.Eq("credentialSubject.id", ldQuery.CredentialSubject.ID))

--- a/vcr/api/v2/holder_test.go
+++ b/vcr/api/v2/holder_test.go
@@ -40,6 +40,7 @@ var organizationQuery = `
 {
 	"query": {
 		"@context": ["https://www.w3.org/2018/credentials/v1","https://nuts.nl/credentials/v1"],
+		"id": "some-id",
 		"type": ["VerifiableCredential", "NutsOrganizationCredential"],
 		"credentialSubject":{
 			"id":"did:nuts:123",
@@ -73,8 +74,9 @@ var untrustedOrganizationQuery = `
 
 var authorizationQuery = `
 {
-	"query": {
+	"query": {	
 		"@context": ["https://www.w3.org/2018/credentials/v1","https://nuts.nl/credentials/v1"],
+		"id": "some-id",
 		"type": ["VerifiableCredential", "NutsAuthorizationCredential"],
 		"credentialSubject":{
 			"id": "did:nuts:123",
@@ -120,18 +122,25 @@ func TestWrapper_SearchVCs(t *testing.T) {
 			return
 		}
 		clauses := parts[0].Clauses
-		if !assert.Len(t, clauses, 3) {
+		if !assert.Len(t, clauses, 4) {
 			return
 		}
-		assert.Equal(t, "prefix", clauses[0].Type())
-		assert.Equal(t, "organization.name", clauses[0].Key())
-		assert.Equal(t, "Zorggroep de Nootjes", clauses[0].Seek())
-		assert.Equal(t, "prefix", clauses[1].Type())
-		assert.Equal(t, "organization.city", clauses[1].Key())
-		assert.Equal(t, "Amandelmere", clauses[1].Seek())
-		assert.Equal(t, "eq", clauses[2].Type())
-		assert.Equal(t, "subject", clauses[2].Key())
-		assert.Equal(t, "did:nuts:123", clauses[2].Seek())
+		idx := 0
+		assert.Equal(t, "eq", clauses[idx].Type())
+		assert.Equal(t, "id", clauses[idx].Key())
+		assert.Equal(t, "some-id", clauses[idx].Seek())
+		idx++
+		assert.Equal(t, "prefix", clauses[idx].Type())
+		assert.Equal(t, "organization.name", clauses[idx].Key())
+		assert.Equal(t, "Zorggroep de Nootjes", clauses[idx].Seek())
+		idx++
+		assert.Equal(t, "prefix", clauses[idx].Type())
+		assert.Equal(t, "organization.city", clauses[idx].Key())
+		assert.Equal(t, "Amandelmere", clauses[idx].Seek())
+		idx++
+		assert.Equal(t, "eq", clauses[idx].Type())
+		assert.Equal(t, "subject", clauses[idx].Key())
+		assert.Equal(t, "did:nuts:123", clauses[idx].Seek())
 	})
 
 	t.Run("ok - untrusted flag", func(t *testing.T) {
@@ -195,21 +204,29 @@ func TestWrapper_SearchVCs(t *testing.T) {
 			return
 		}
 		clauses := parts[0].Clauses
-		if !assert.Len(t, clauses, 4) {
+		if !assert.Len(t, clauses, 5) {
 			return
 		}
-		assert.Equal(t, "eq", clauses[0].Type())
-		assert.Equal(t, "credentialSubject.id", clauses[0].Key())
-		assert.Equal(t, "did:nuts:123", clauses[0].Seek())
-		assert.Equal(t, "eq", clauses[1].Type())
-		assert.Equal(t, "credentialSubject.purposeOfUse", clauses[1].Key())
-		assert.Equal(t, "eOverdracht-receiver", clauses[1].Seek())
-		assert.Equal(t, "eq", clauses[2].Type())
-		assert.Equal(t, "credentialSubject.subject", clauses[2].Key())
-		assert.Equal(t, "urn:oid:2.16.840.1.113883.2.4.6.3:123456782", clauses[2].Seek())
-		assert.Equal(t, "eq", clauses[3].Type())
-		assert.Equal(t, "credentialSubject.resources.#.path", clauses[3].Key())
-		assert.Equal(t, "/Task/123", clauses[3].Seek())
+		idx := 0
+		assert.Equal(t, "eq", clauses[idx].Type())
+		assert.Equal(t, "id", clauses[idx].Key())
+		assert.Equal(t, "some-id", clauses[idx].Seek())
+		idx++
+		assert.Equal(t, "eq", clauses[idx].Type())
+		assert.Equal(t, "credentialSubject.id", clauses[idx].Key())
+		assert.Equal(t, "did:nuts:123", clauses[idx].Seek())
+		idx++
+		assert.Equal(t, "eq", clauses[idx].Type())
+		assert.Equal(t, "credentialSubject.purposeOfUse", clauses[idx].Key())
+		assert.Equal(t, "eOverdracht-receiver", clauses[idx].Seek())
+		idx++
+		assert.Equal(t, "eq", clauses[idx].Type())
+		assert.Equal(t, "credentialSubject.subject", clauses[idx].Key())
+		assert.Equal(t, "urn:oid:2.16.840.1.113883.2.4.6.3:123456782", clauses[idx].Seek())
+		idx++
+		assert.Equal(t, "eq", clauses[idx].Type())
+		assert.Equal(t, "credentialSubject.resources.#.path", clauses[idx].Key())
+		assert.Equal(t, "/Task/123", clauses[idx].Seek())
 	})
 
 	t.Run("error - search auth returns error", func(t *testing.T) {


### PR DESCRIPTION
In v1 we had a `Resolve(ID) VerifiableCredential` function, but in v2 we don't. But since IDs can be used by multiple issuers, its not a bad idea to yield a list when matching VCs by ID. So the v2 `SearchVC` should just be used.

This PR adds support to the v2 API to search on ID.