### PR TITLE
Network V2: track DAG state with trees

### DIFF
--- a/network/dag/bbolt_tree.go
+++ b/network/dag/bbolt_tree.go
@@ -1,38 +1,141 @@
+/*
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package dag
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
-	"github.com/nuts-foundation/nuts-node/network/dag/tree"
 	"go.etcd.io/bbolt"
+	"time"
+
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	"github.com/nuts-foundation/nuts-node/network/dag/tree"
+	"github.com/nuts-foundation/nuts-node/network/log"
+	"github.com/nuts-foundation/nuts-node/network/storage"
 )
 
-const (
-	ibltBucketName = "treeIBLT"
-	xorBucketName  = "treeXOR"
-	// BucketFillPercent can be much higher than default 0.5 since the keys (unique node ids)
-	// should be added to the bucket in monotonic increasing order, and the values are of fixed size.
-	BucketFillPercent = 0.9
-)
+// treeBucketFillPercent can be much higher than default 0.5 since the keys (unique node ids)
+// should be added to the bucket in monotonic increasing order, and the values are of fixed size.
+const treeBucketFillPercent = 0.9
 
 type bboltTree struct {
-	db *bbolt.DB
+	db                *bbolt.DB
+	bucketFillPercent float64
+	bucketName        string
+	tree              tree.Tree
 }
 
-// newBBoltTreeStore returns an instance of a BBolt based tree store. Buckets managed by this store are filled to BucketFillPercent
-func newBBoltTreeStore(db *bbolt.DB) *bboltTree {
-	return &bboltTree{db: db}
+// newBBoltTreeStore returns an instance of a BBolt based tree store. Buckets managed by this store are filled to treeBucketFillPercent
+func newBBoltTreeStore(db *bbolt.DB, bucketName string, tree tree.Tree) *bboltTree {
+	return &bboltTree{
+		db:                db,
+		bucketFillPercent: treeBucketFillPercent,
+		bucketName:        bucketName,
+		tree:              tree,
+	}
+}
+
+// getRoot returns the tree.Data summary of the entire tree.
+func (store *bboltTree) getRoot() tree.Data {
+	return store.tree.GetRoot()
+}
+
+// getZeroTo returns the tree.Data sum of all tree pages/leaves upto and including the one containing the requested Lamport Clock value.
+// In addition to the data, the highest LC value of this range is returned.
+func (store *bboltTree) getZeroTo(clock uint32) (tree.Data, uint32) {
+	return store.tree.GetZeroTo(clock)
+}
+
+func (store *bboltTree) isEmpty() bool {
+	return store.tree.GetRoot().IsEmpty()
+}
+
+// dagCallback inserts a transaction reference to the in-memory tree and to persistent storage.
+// The tree is not aware of previously seen transactions, so it should be transactional with updates to the dag.
+func (store *bboltTree) dagObserver(ctx context.Context, transaction Transaction, _ []byte) {
+	if transaction != nil { // can happen when payload is written for private TX
+		err := storage.BBoltTXUpdate(ctx, store.db, func(callbackCtx context.Context, tx *bbolt.Tx) error {
+			err := store.tree.Insert(transaction.Ref(), transaction.Clock())
+			if err != nil {
+				return err
+			}
+
+			// Rollback after timeout to bring tree and DAG back in sync.
+			// A call to writeUpdates will persist all uncommitted tree changes. So a failed bboltTx will be dropped by the dag and (eventually) persisted by the tree.
+			c, cancel := context.WithTimeout(context.Background(), 10*time.Second) // << timeout must not be shorter than expected write operation to disk
+			go func() {
+				<-c.Done()
+				err := c.Err()
+				if err == context.DeadlineExceeded {
+					log.Logger().Warnf("deadline exceeded - rollback transaction %s from %s", transaction.Ref(), store.bucketName)
+					if err := store.tree.Delete(transaction.Ref(), transaction.Clock()); err != nil {
+						log.Logger().Errorf("rollback of transaction %s failed - %s is not in sync with DAG", transaction.Ref(), store.bucketName)
+					}
+				}
+			}()
+			tx.OnCommit(func() {
+				cancel()
+			})
+
+			return store.writeUpdates(callbackCtx)
+		})
+		if err != nil {
+			log.Logger().Errorf("failed to add transaction to %s: %s", store.bucketName, err.Error())
+		}
+	}
+}
+
+// buildFromDag builds a tree by walking over the dag and adding all Transaction references to the tree without checking for validity.
+// The tree is stored on disk once it is in sync with the dag.
+// Should only be called on an empty tree.
+func (store *bboltTree) buildFromDag(ctx context.Context, state State) error {
+	if !store.isEmpty() {
+		return fmt.Errorf("failed to build tree on %s - tree is not empty", store.bucketName)
+	}
+
+	err := state.Walk(ctx, func(_ context.Context, transaction Transaction) bool {
+		err := store.tree.Insert(transaction.Ref(), transaction.Clock())
+		return err != nil
+	}, hash.EmptyHash())
+	if err != nil {
+		return err
+	}
+
+	err = store.writeUpdates(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // read fills the tree with data in the bucket.
-// Returns an error the bucket does not exist, or if data in the bucket doesn't match the prototype.
-func (store bboltTree) read(bucketName string, prototype tree.Data) (tree.Tree, error) {
-	tr := tree.New(prototype.New(), 0)
-	return tr, store.db.View(func(tx *bbolt.Tx) error {
+// Returns an error the bucket does not exist, or if data in the bucket doesn't match the tree's Data prototype.
+func (store *bboltTree) read(ctx context.Context) error {
+	return storage.BBoltTXUpdate(ctx, store.db, func(_ context.Context, tx *bbolt.Tx) error {
 		// get bucket
-		bucket := tx.Bucket([]byte(bucketName))
+		bucket := tx.Bucket([]byte(store.bucketName))
 		if bucket == nil {
-			return fmt.Errorf("bucket '%s' not found", bucketName)
+			// should only happen once for a new tree/bucket.
+			log.Logger().Warnf("tree bucket '%s' does not exist", store.bucketName)
+			return nil
 		}
 
 		// get data
@@ -44,29 +147,29 @@ func (store bboltTree) read(bucketName string, prototype tree.Data) (tree.Tree, 
 		})
 
 		// build tree
-		return tr.Load(rawData)
+		return store.tree.Load(rawData)
 	})
 }
 
-// update writes an incremental update to the bucket.
+// writeUpdates writes an incremental update to the bucket.
 // The incremental update is defined as changes to the tree since the last call to Tree.ResetUpdate,
-// which is called when update completes successfully.
-func (store bboltTree) update(bucketName string, tree tree.Tree) error {
-	return store.db.Update(func(tx *bbolt.Tx) error {
-		bucket, err := tx.CreateBucketIfNotExists([]byte(bucketName))
+// which is called when writeUpdates completes successfully.
+func (store *bboltTree) writeUpdates(ctx context.Context) error {
+	return storage.BBoltTXUpdate(ctx, store.db, func(_ context.Context, tx *bbolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists([]byte(store.bucketName))
 		if err != nil {
 			return err
 		}
-		bucket.FillPercent = BucketFillPercent
+		bucket.FillPercent = store.bucketFillPercent
 
 		// get data
-		dirties, orphaned, err := tree.GetUpdates()
+		dirties, orphaned, err := store.tree.GetUpdates()
 		if err != nil {
 			return err
 		}
-		tx.OnCommit(tree.ResetUpdate)
+		tx.OnCommit(store.tree.ResetUpdate)
 
-		// delete orphaned leafs
+		// delete orphaned leaves
 		key := make([]byte, 4)
 		for _, orphan := range orphaned {
 			binary.LittleEndian.PutUint32(key, orphan)

--- a/network/dag/bbolt_tree_test.go
+++ b/network/dag/bbolt_tree_test.go
@@ -1,48 +1,161 @@
+/*
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package dag
 
 import (
-	"github.com/nuts-foundation/nuts-node/network/dag/tree"
+	"context"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	"github.com/nuts-foundation/nuts-node/network/dag/tree"
 	"github.com/nuts-foundation/nuts-node/test/io"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestBboltStore_Update(t *testing.T) {
-	store := newBBoltTestTreeStore(t)
-	testTree := tree.New(tree.NewXor(), 512)
+const testLeafSize = 512
 
-	err := store.update("real bucket", testTree)
-	assert.NoError(t, err)
+func TestBboltTree_writeUpdates(t *testing.T) {
+	db := createBBoltDB(io.TestDirectory(t))
+
+	t.Run("ok - inserts", func(t *testing.T) {
+		store := newBBoltTreeStore(db, "xor tree", tree.New(tree.NewXor(), testLeafSize))
+		_ = store.tree.Insert(hash.FromSlice([]byte("test hash 1")), 0)
+		_ = store.tree.Insert(hash.FromSlice([]byte("test hash 2")), testLeafSize)
+
+		err := store.writeUpdates(context.Background())
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("ok - dropping leaves", func(t *testing.T) {
+		store := newBBoltTreeStore(db, "xor drop leaves", tree.New(tree.NewXor(), testLeafSize))
+		_ = store.tree.Insert(hash.FromSlice([]byte("test hash 1")), 0)
+		_ = store.tree.Insert(hash.FromSlice([]byte("test hash 2")), testLeafSize)
+		store.tree.DropLeaves()
+
+		err := store.writeUpdates(context.Background())
+		assert.NoError(t, err)
+
+		storeRead := newBBoltTreeStore(db, "xor drop leaves", tree.New(tree.NewXor(), testLeafSize))
+		_ = storeRead.read(context.Background())
+
+		data, _ := store.getZeroTo(0)
+		assert.Equal(t, data, storeRead.getRoot())
+	})
 }
 
-func TestBboltStore_Read(t *testing.T) {
-	store := newBBoltTestTreeStore(t)
-	prototype := tree.NewXor()
-	testTree := tree.New(prototype, 512)
-	err := store.update("real bucket", testTree)
+func TestBboltTree_read(t *testing.T) {
+	db := createBBoltDB(io.TestDirectory(t))
+	storeWrite := newBBoltTreeStore(db, "real bucket", tree.New(tree.NewXor(), testLeafSize))
+	_ = storeWrite.tree.Insert(hash.FromSlice([]byte("test hash")), testLeafSize)
+	err := storeWrite.writeUpdates(context.Background())
 	if !assert.NoError(t, err) {
 		return
 	}
 
 	t.Run("ok - read tree successfully", func(t *testing.T) {
-		tr, err := store.read("real bucket", prototype)
+		store := newBBoltTreeStore(db, "real bucket", tree.New(tree.NewXor(), testLeafSize))
+
+		err := store.read(context.Background())
+
 		assert.NoError(t, err)
-		assert.Equal(t, testTree, tr)
+		assert.Equal(t, storeWrite.getRoot(), store.getRoot())
 	})
 
-	t.Run("fail - incorrect bucket", func(t *testing.T) {
-		_, err = store.read("fake bucket", prototype)
-		assert.EqualError(t, err, "bucket 'fake bucket' not found")
+	t.Run("ok - incorrect bucket name results in empty tree", func(t *testing.T) {
+		store := newBBoltTreeStore(db, "fake bucket", tree.New(tree.NewXor(), testLeafSize))
+
+		err := store.read(context.Background())
+
+		assert.NoError(t, err)
+		assert.Equal(t, tree.Data(tree.NewXor()), store.getRoot())
 	})
 
 	t.Run("fail - incorrect prototype", func(t *testing.T) {
-		_, err = store.read("real bucket", tree.NewIblt(0))
-		assert.Error(t, err)
+		store := newBBoltTreeStore(db, "real bucket", tree.New(tree.NewIblt(0), testLeafSize))
+
+		err := store.read(context.Background())
+
+		assert.EqualError(t, err, "invalid data length")
 	})
 }
 
-func newBBoltTestTreeStore(t *testing.T) *bboltTree {
-	testDir := io.TestDirectory(t)
-	return newBBoltTreeStore(createBBoltDB(testDir))
+func TestBboltTree_dagObserver(t *testing.T) {
+	t.Run("write tx", func(t *testing.T) {
+		db := createBBoltDB(io.TestDirectory(t))
+		storeWrite := newBBoltTreeStore(db, "observer bucket", tree.New(tree.NewXor(), testLeafSize))
+		storeRead := newBBoltTreeStore(db, "observer bucket", tree.New(tree.NewXor(), testLeafSize))
+		tx, _, _ := CreateTestTransaction(1)
+
+		storeWrite.dagObserver(context.Background(), tx, nil)
+		err := storeRead.read(context.Background())
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Equal(t, tx.Ref(), storeRead.getRoot().(*tree.Xor).Hash())
+		assert.Equal(t, tx.Ref(), storeWrite.getRoot().(*tree.Xor).Hash())
+	})
+
+	t.Run("don't panic on nil Transaction", func(t *testing.T) {
+		db := createBBoltDB(io.TestDirectory(t))
+		store := newBBoltTreeStore(db, "observer bucket", tree.New(tree.NewXor(), testLeafSize))
+
+		// don't panic
+		store.dagObserver(context.Background(), nil, nil)
+	})
+
+	t.Run("rollback on timeout", func(t *testing.T) {
+		// TODO
+	})
+}
+
+func TestBboltTree_buildFromDag(t *testing.T) {
+	tx, _, _ := CreateTestTransaction(7)
+	dag := CreateDAG(t)
+	dagState := &state{
+		db:    dag.db,
+		graph: dag,
+	}
+	err := dag.Add(context.Background(), tx)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	t.Run("ok - build tree", func(t *testing.T) {
+		store := newBBoltTreeStore(dag.db, "real bucket", tree.New(tree.NewXor(), testLeafSize))
+
+		err := store.buildFromDag(context.Background(), dagState)
+
+		if assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, tx.Ref(), store.getRoot().(*tree.Xor).Hash())
+	})
+
+	t.Run("fail - tree is not empty", func(t *testing.T) {
+		store := newBBoltTreeStore(dag.db, "fail bucket", tree.New(tree.NewXor(), testLeafSize))
+		store.dagObserver(context.Background(), tx, nil)
+
+		err := store.buildFromDag(context.Background(), dagState)
+
+		assert.EqualError(t, err, "failed to build tree on fail bucket - tree is not empty")
+	})
+
 }

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -247,7 +247,7 @@ func TestState_Diagnostics(t *testing.T) {
 	doc1 := CreateTestTransactionWithJWK(2)
 	txState.Add(ctx, doc1, nil)
 	diagnostics := txState.Diagnostics()
-	assert.Len(t, diagnostics, 3)
+	assert.Len(t, diagnostics, 4)
 	// Assert actual diagnostics
 	lines := make([]string, 0)
 	for _, diagnostic := range diagnostics {
@@ -259,9 +259,10 @@ func TestState_Diagnostics(t *testing.T) {
 	assert.NotZero(t, dbSize)
 
 	actual := strings.Join(lines, "\n")
-	expected := fmt.Sprintf(`heads: [`+doc1.Ref().String()+`]
+	expected := fmt.Sprintf(`dag_xor: %s
+heads: [%s]
 stored_database_size_bytes: %d
-transaction_count: 1`, dbSize.DataSize)
+transaction_count: 1`, doc1.Ref(), doc1.Ref(), dbSize.DataSize)
 	assert.Equal(t, expected, actual)
 }
 

--- a/network/dag/tree/iblt.go
+++ b/network/dag/tree/iblt.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package tree
 
 import (
@@ -10,11 +28,10 @@ import (
 )
 
 const (
-	ibltNumBuckets = 1024
-	ibltHc         = uint64(0)
-	ibltHk         = uint32(1)
-	ibltK          = uint8(6)
-	bucketBytes    = 44 // = int32 + uint64 + hash.SHA256HashSize
+	ibltHc      = uint64(0)
+	ibltHk      = uint32(1)
+	ibltK       = uint8(6)
+	bucketBytes = 44 // = int32 + uint64 + hash.SHA256HashSize
 )
 
 // ErrDecodeNotPossible is returned when the Iblt cannot be decoded.
@@ -36,8 +53,11 @@ type Iblt struct {
 	buckets []*bucket
 }
 
-// NewIblt returns an *Iblt with default settings and specified number of buckets.
+// NewIblt returns an *Iblt with default settings and specified number of buckets. numBuckets must be >= Iblt.k
 func NewIblt(numBuckets int) *Iblt {
+	if numBuckets < int(ibltK) {
+		numBuckets = int(ibltK)
+	}
 	return &Iblt{
 		buckets: makeBuckets(numBuckets),
 		hc:      ibltHc,
@@ -163,7 +183,7 @@ outer:
 
 		// if no pures exist, the iblt is empty or cannot be decoded
 		if !updated {
-			if !i.isEmpty() {
+			if !i.IsEmpty() {
 				err = ErrDecodeNotPossible
 			}
 			break
@@ -173,7 +193,7 @@ outer:
 	return remaining, missing, err
 }
 
-func (i Iblt) isEmpty() bool {
+func (i Iblt) IsEmpty() bool {
 	for _, b := range i.buckets {
 		if !b.isEmpty() {
 			return false

--- a/network/dag/tree/tree.go
+++ b/network/dag/tree/tree.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package tree
 
 import (
@@ -15,10 +33,14 @@ type Data interface {
 	Clone() Data
 	// Insert a new transaction reference.
 	Insert(ref hash.SHA256Hash) error
+	// Delete a transaction reference.
+	Delete(ref hash.SHA256Hash) error
 	// Add other Data to this one. Returns an error if the underlying datastructures are incompatible.
 	Add(other Data) error
 	// Subtract other Data from this one. Returns an error if the underlying datastructures are incompatible.
 	Subtract(other Data) error
+	// IsEmpty returns true if the concrete type is in its default/empty state.
+	IsEmpty() bool
 	encoding.BinaryMarshaler
 	encoding.BinaryUnmarshaler
 }
@@ -29,6 +51,8 @@ type Tree interface {
 	// Insert a transaction reference at the specified clock value.
 	// The result of inserting the same ref multiple times is undefined.
 	Insert(ref hash.SHA256Hash, clock uint32) error
+	// Delete a transaction reference without checking if ref is in the Tree
+	Delete(ref hash.SHA256Hash, clock uint32) error
 	// GetRoot returns the accumulated Data for the entire tree
 	GetRoot() Data
 	// GetZeroTo returns the LC value closest to the requested clock value together with Data of the same leaf/page.
@@ -117,6 +141,12 @@ func (t *tree) Load(leaves map[uint32][]byte) error {
 func (t *tree) Insert(ref hash.SHA256Hash, clock uint32) error {
 	return t.updateOrCreatePath(clock, func(n *node) error {
 		return n.data.Insert(ref)
+	})
+}
+
+func (t *tree) Delete(ref hash.SHA256Hash, clock uint32) error {
+	return t.updateOrCreatePath(clock, func(n *node) error {
+		return n.data.Delete(ref)
 	})
 }
 

--- a/network/dag/tree/tree_test.go
+++ b/network/dag/tree/tree_test.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package tree
 
 import (
@@ -36,6 +54,28 @@ func TestTree_Insert(t *testing.T) {
 		tr := newTestTree(NewXor(), testLeafSize)
 
 		_ = tr.Insert(ref, testLeafSize+1)
+
+		assert.Equal(t, ref, tr.root.data.(*Xor).Hash())
+		assert.Equal(t, ref, tr.root.right.data.(*Xor).Hash())
+		assert.Equal(t, hash.EmptyHash(), tr.root.left.data.(*Xor).Hash())
+	})
+}
+
+func TestTree_Delete(t *testing.T) {
+	t.Run("delete single Tx", func(t *testing.T) {
+		ref := hash.FromSlice([]byte{123})
+		tr := newTestTree(NewXor(), testLeafSize)
+
+		_ = tr.Delete(ref, 0)
+
+		assert.Equal(t, ref, tr.root.data.(*Xor).Hash())
+	})
+
+	t.Run("delete single Tx out of tree range", func(t *testing.T) {
+		ref := hash.FromSlice([]byte{123})
+		tr := newTestTree(NewXor(), testLeafSize)
+
+		_ = tr.Delete(ref, testLeafSize+1)
 
 		assert.Equal(t, ref, tr.root.data.(*Xor).Hash())
 		assert.Equal(t, ref, tr.root.right.data.(*Xor).Hash())
@@ -247,7 +287,7 @@ func TestTree_Load(t *testing.T) {
 	t.Run("fail - incorrect data prototype", func(t *testing.T) {
 		tr, _ := filledTestTree(NewXor(), testLeafSize)
 		dirty, _, _ := tr.GetUpdates()
-		loadedTree := New(NewIblt(ibltNumBuckets), 0)
+		loadedTree := New(NewIblt(1024), 0)
 
 		err := loadedTree.Load(dirty)
 

--- a/network/dag/tree/xor.go
+++ b/network/dag/tree/xor.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package tree
 
 import (
@@ -40,6 +58,11 @@ func (x *Xor) Insert(ref hash.SHA256Hash) error {
 	return nil
 }
 
+func (x *Xor) Delete(ref hash.SHA256Hash) error {
+	xor(x[:], x[:], ref[:])
+	return nil
+}
+
 func (x *Xor) Add(data Data) error {
 	return x.Subtract(data)
 }
@@ -52,6 +75,10 @@ func (x *Xor) Subtract(data Data) error {
 	default:
 		return fmt.Errorf("data type mismatch - expected %T, got %T", x, v)
 	}
+}
+
+func (x Xor) IsEmpty() bool {
+	return x == Xor{}
 }
 
 func (x Xor) MarshalBinary() ([]byte, error) {

--- a/network/dag/tree/xor_test.go
+++ b/network/dag/tree/xor_test.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package tree
 
 import (
@@ -91,6 +109,36 @@ func TestXor_Insert(t *testing.T) {
 	})
 }
 
+func TestXor_Delete(t *testing.T) {
+	h1, h2, hXor := getTwoHashPlusXor()
+
+	t.Run("ok - delete 1 hash", func(t *testing.T) {
+		x := Xor{}
+		err := x.Delete(h1)
+
+		assert.NoError(t, err)
+		assert.Equal(t, h1, x.Hash())
+	})
+
+	t.Run("ok - delete 2 hashes", func(t *testing.T) {
+		x := Xor{}
+		_ = x.Delete(h1)
+		err := x.Delete(h2)
+
+		assert.NoError(t, err)
+		assert.Equal(t, hXor, x.Hash())
+	})
+
+	t.Run("ok - delete hash twice", func(t *testing.T) {
+		x := Xor{}
+		_ = x.Delete(h1)
+		err := x.Delete(h1)
+
+		assert.NoError(t, err)
+		assert.Equal(t, Xor{}, x)
+	})
+}
+
 func TestXor_Add(t *testing.T) {
 	h1, h2, hXor := getTwoHashPlusXor()
 
@@ -136,6 +184,18 @@ func TestXor_Subtract(t *testing.T) {
 
 		assert.EqualError(t, err, "data type mismatch - expected *tree.Xor, got *tree.Iblt")
 		assert.Equal(t, Xor(h1), x1)
+	})
+}
+
+func TestXor_IsEmpty(t *testing.T) {
+	t.Run("is empty", func(t *testing.T) {
+		x := NewXor()
+		assert.True(t, x.IsEmpty())
+	})
+
+	t.Run("is not empty", func(t *testing.T) {
+		x := Xor(hash.FromSlice([]byte("not empty")))
+		assert.False(t, x.IsEmpty())
 	})
 }
 


### PR DESCRIPTION
this PR adds
- tracking of DAG state in xor & iblt trees.
- persistent and transactional storage for the trees
- missing copyright notices

I could use some feedback on what to test in `state` and the TODO in `bbolt_tree`