### PR TITLE
Network test fix: assert on number of completed rollback TXs

### DIFF
--- a/network/dag/bbolt_tree_test.go
+++ b/network/dag/bbolt_tree_test.go
@@ -139,11 +139,12 @@ func TestBboltTree_dagObserver(t *testing.T) {
 			observerRollbackTimeOut = defaultObserverRollbackTimeOut
 		}()
 
+		assert.Equal(t, uint32(0), atomic.LoadUint32(store.numRollbacks))
 		store.dagObserver(ctx, tx, nil)
 		assert.Equal(t, tx.Ref(), store.getRoot().(*tree.Xor).Hash())
 
 		test.WaitFor(t, func() (bool, error) {
-			return atomic.LoadUint32(store.activeRollbackRoutines) == 0, nil
+			return atomic.LoadUint32(store.numRollbacks) == 1, nil
 		}, 5*time.Second, "timeout while waiting for go routine to exit")
 		assert.Equal(t, hash.EmptyHash(), store.getRoot().(*tree.Xor).Hash())
 

--- a/network/transport/grpc/outbound_connector_test.go
+++ b/network/transport/grpc/outbound_connector_test.go
@@ -68,8 +68,10 @@ func Test_connector_start(t *testing.T) {
 
 		<-connected // wait for connected
 
-		resetCounts, _ := bo.counts()
-		assert.Equal(t, 1, resetCounts)
+		test.WaitFor(t, func() (bool, error) {
+			resetCounts, _ := bo.counts()
+			return resetCounts == 1, nil
+		}, 5 * time.Second, "waiting for backoff.Reset() to be called")
 	})
 	t.Run("not connecting when already connected", func(t *testing.T) {
 		calls := make(chan struct{}, 10)


### PR DESCRIPTION
This way it's not influenced by timing or externally started goroutines