### PR TITLE
Add hash.Xor

### DIFF
--- a/crypto/hash/sha256.go
+++ b/crypto/hash/sha256.go
@@ -82,6 +82,16 @@ func (h SHA256Hash) Compare(other SHA256Hash) int {
 	return bytes.Compare(h[:], other[:])
 }
 
+// Xor returns the xor of this Hash and all others. It does not change this Hash.
+func (h SHA256Hash) Xor(others ...SHA256Hash) SHA256Hash {
+	for _, o := range others {
+		for i := range o {
+			h[i] ^= o[i]
+		}
+	}
+	return h
+}
+
 // MarshalJSON marshals the hash as hex-encoded string
 func (h SHA256Hash) MarshalJSON() ([]byte, error) {
 	s := h.String()

--- a/crypto/hash/sha256_test.go
+++ b/crypto/hash/sha256_test.go
@@ -170,3 +170,15 @@ func TestHash_Compare(t *testing.T) {
 		assert.Equal(t, 1, h1.Compare(h2))
 	})
 }
+
+func TestHash_Xor(t *testing.T) {
+	h0 := EmptyHash()
+	h1 := FromSlice([]byte{1})
+	h2 := FromSlice([]byte{2})
+	expected := FromSlice([]byte{3})
+
+	actual := h0.Xor(h1, h2)
+
+	assert.Equal(t, EmptyHash(), h0, "original Hash should not change")
+	assert.Equal(t, expected, actual)
+}

--- a/network/dag/tree/iblt.go
+++ b/network/dag/tree/iblt.go
@@ -289,7 +289,7 @@ func (b *bucket) subtract(o *bucket) {
 }
 
 func (b *bucket) update(key hash.SHA256Hash, hash uint64) {
-	xor(b.keySum[:], b.keySum[:], key[:])
+	b.keySum = b.keySum.Xor(key)
 	b.hashSum ^= hash
 }
 

--- a/network/dag/tree/tree_test.go
+++ b/network/dag/tree/tree_test.go
@@ -119,7 +119,7 @@ func TestTree_GetRoot(t *testing.T) {
 
 		for i := uint32(0); i < N; i++ {
 			rand.Read(ref[:])
-			xor(allRefs[:], allRefs[:], ref[:])
+			allRefs = allRefs.Xor(ref)
 			tr.Insert(ref, N-i)
 		}
 

--- a/network/dag/tree/xor_test.go
+++ b/network/dag/tree/xor_test.go
@@ -24,16 +24,6 @@ import (
 	"testing"
 )
 
-func TestXor_xor(t *testing.T) {
-	h1, h2, hXor := getTwoHashPlusXor()
-	out := Xor{}
-
-	xor(out[:], h1[:], h2[:])
-
-	assert.Equal(t, hXor, out.Hash())
-	assert.NotEqual(t, h1, out) // sanity check
-}
-
 func getTwoHashPlusXor() (h1 hash.SHA256Hash, h2 hash.SHA256Hash, hXor hash.SHA256Hash) {
 	h1 = hash.FromSlice([]byte{1})
 	h2 = hash.FromSlice([]byte{2})


### PR DESCRIPTION
The xor of hashes is needed in more places than the tree package. (currently implemented in transport/v1 & dag/tree, and needed in transport/v2)
This place made the most sense for me to add it as a public method.

Should this be an in-place operation?