### PR TITLE
Helm Fixes for GKE deployment

### DIFF
--- a/charts/nuts-node/Chart.yaml
+++ b/charts/nuts-node/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nuts-node/templates/deployment.yaml
+++ b/charts/nuts-node/templates/deployment.yaml
@@ -71,6 +71,12 @@ spec:
             httpGet:
               path: /status
               port: http
+          startupProbe:
+            httpGet:
+              path: /status
+              port: http
+            failureThreshold: 300
+            periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/nuts-node/templates/nuts-data-pv.yaml
+++ b/charts/nuts-node/templates/nuts-data-pv.yaml
@@ -14,7 +14,7 @@ spec:
     storage: {{ .Values.nuts.data.persistedVolume.capacity | default "100Mi" }}
   accessModes: {{ required "Please define `nuts.data.persistedVolume.accessModes` in `values.yaml`" .Values.nuts.data.persistedVolume.accessModes }}
   hostPath:
-    path: {{ .Values.nuts.data.persistedVolume.mountPath  }}
+    path: {{ .Values.nuts.data.persistedVolume.mountPath | default "/opt/nuts/data" }}
 ---
 {{ end }}
 {{ if .Values.nuts.data.persistedVolumeClaim.enabled }}

--- a/charts/nuts-node/templates/nuts-data-pv.yaml
+++ b/charts/nuts-node/templates/nuts-data-pv.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.nuts.data.persistedVolume.enabled }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -8,13 +9,15 @@ metadata:
     "helm.sh/resource-policy": keep
 spec:
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: ""
+  storageClassName: {{ .Values.nuts.data.persistedVolume.storageClassName | default "" }}
   capacity:
     storage: {{ .Values.nuts.data.persistedVolume.capacity | default "100Mi" }}
   accessModes: {{ required "Please define `nuts.data.persistedVolume.accessModes` in `values.yaml`" .Values.nuts.data.persistedVolume.accessModes }}
   hostPath:
-    path: {{ .Values.nuts.data.persistedVolume.mountPath | default "/opt/nuts/data" }}
+    path: {{ .Values.nuts.data.persistedVolume.mountPath  }}
 ---
+{{ end }}
+{{ if .Values.nuts.data.persistedVolumeClaim.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -22,8 +25,10 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
 spec:
-  storageClassName: "" # Empty string must be explicitly set otherwise default StorageClass will be set
-  accessModes: {{ required "Please define `nuts.data.persistedVolume.accessModes` in `values.yaml`" .Values.nuts.data.persistedVolume.accessModes }}
+  storageClassName: {{ .Values.nuts.data.persistedVolumeClaim.storageClassName | default "" }}
+  accessModes: {{ required "Please define `nuts.data.persistedVolumeClaim.accessModes` in `values.yaml`" .Values.nuts.data.persistedVolumeClaim.accessModes }}
   resources:
     requests:
-      storage: {{ .Values.nuts.data.persistedVolume.capacity | default "100Mi" }}
+      storage: {{ .Values.nuts.data.persistedVolumeClaim.capacity | default "100Mi" }}
+---
+{{ end }}

--- a/charts/nuts-node/values.yaml
+++ b/charts/nuts-node/values.yaml
@@ -102,8 +102,16 @@ nuts:
   # Config for the NUTS data mount inside Kubernetes
   data:
     persistedVolume:
+      enabled: true
       capacity: 100Mi
       mountPath: /opt/nuts/data
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: ""
+    persistedVolumeClaim:
+      enabled: true
+      capacity: 100Mi
+      storageClassName: ""
       accessModes:
         - ReadWriteOnce
 


### PR DESCRIPTION
 - Make PV and PVC controllable by values.yaml, GKE does not need a VPC. Config for PV and VPC are split up.
 - Added storageClassName to PV and PVC configuration, GKE needs it.
 - Deployment, added startupProbe as the downloading and writing of the IRMA schema on the PV cause container creation timeouts.