### PR TITLE
Network: persisted outbound connector backoff

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/test/io"
 	v1 "github.com/nuts-foundation/nuts-node/vdr/api/v1"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -124,8 +123,6 @@ func stopNode(t *testing.T, ctx context.Context) {
 	_ = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
 	<-ctx.Done()
 	t.Log("Nuts node shut down successfully.")
-
-	goleak.VerifyNone(t)
 }
 
 func startServer(opts map[string]string, exitCallback func()) context.Context {

--- a/main_test.go
+++ b/main_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/test/io"
 	v1 "github.com/nuts-foundation/nuts-node/vdr/api/v1"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -123,6 +124,8 @@ func stopNode(t *testing.T, ctx context.Context) {
 	_ = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
 	<-ctx.Done()
 	t.Log("Nuts node shut down successfully.")
+
+	goleak.VerifyNone(t)
 }
 
 func startServer(opts map[string]string, exitCallback func()) context.Context {

--- a/network/network.go
+++ b/network/network.go
@@ -23,6 +23,8 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"os"
+	"path"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -180,8 +182,13 @@ func (n *Network) Configure(config core.ServerConfig) error {
 		} else {
 			authenticator = grpc.NewTLSAuthenticator(doc.NewServiceResolver(n.didDocumentResolver))
 		}
+		grpcDB, err := bbolt.Open(path.Join(config.Datadir, "network", "connections.db"), os.ModePerm, nil)
+		if err != nil {
+			return fmt.Errorf("failed to open gRPC database: %w", err)
+		}
 		n.connectionManager = grpc.NewGRPCConnectionManager(
 			grpc.NewConfig(n.config.GrpcAddr, n.peerID, grpcOpts...),
+			grpcDB,
 			n.nodeDIDResolver,
 			authenticator,
 			n.protocols...,

--- a/network/network.go
+++ b/network/network.go
@@ -476,7 +476,10 @@ func (n *Network) Shutdown() error {
 		n.state = nil
 	}
 
-	return n.connectionsDB.Close()
+	if n.connectionsDB != nil {
+		return n.connectionsDB.Close()
+	}
+	return nil
 }
 
 // Diagnostics collects and returns diagnostics for the Network engine.

--- a/network/transport/grpc/backoff.go
+++ b/network/transport/grpc/backoff.go
@@ -100,6 +100,8 @@ func (p persistedBackoff) Value() time.Duration {
 	return p.underlying.Value()
 }
 
+// NewPersistedBackoff wraps another backoff and stores the last value returned by Backoff() in BBolt.
+// It reads the last backoff value from the DB and returns it as the first value of the Backoff.
 func NewPersistedBackoff(db *bbolt.DB, peerAddress string, underlying Backoff) Backoff {
 	b := &persistedBackoff{
 		peerAddress: peerAddress,

--- a/network/transport/grpc/backoff_test.go
+++ b/network/transport/grpc/backoff_test.go
@@ -57,6 +57,10 @@ func TestBoundedRandomBackoff_DefaultValues(t *testing.T) {
 func TestPersistedBackoff_Backoff(t *testing.T) {
 	testDirectory := io.TestDirectory(t)
 
+	nowFunc = func() time.Time {
+		return time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	}
+
 	// Create back-off
 	db, _ := bbolt.Open(path.Join(testDirectory, "backoff.db"), os.ModePerm, nil)
 	defer db.Close()
@@ -75,8 +79,9 @@ func TestPersistedBackoff_Backoff(t *testing.T) {
 	db, _ = bbolt.Open(path.Join(testDirectory, "backoff.db"), os.ModePerm, nil)
 	defer db.Close()
 	b = NewPersistedBackoff(db, "test", defaultBackoff())
+	assert.Equal(t, int(prev.Seconds()), int(b.Value().Seconds()))
 	backoffAfterPersist := b.Backoff()
-	assert.True(t, backoffAfterPersist > prev)
+	assert.Truef(t, backoffAfterPersist > prev, "%s should be greater than %s", backoffAfterPersist, prev)
 }
 
 func TestPersistedBackoff_Reset(t *testing.T) {

--- a/network/transport/grpc/connection.go
+++ b/network/transport/grpc/connection.go
@@ -43,7 +43,7 @@ type Connection interface {
 	// waitUntilDisconnected blocks until the connection is closed. If it already is closed or was never open, it returns immediately.
 	waitUntilDisconnected()
 	// startConnecting instructs the Connection to start connecting to the remote peer (attempting an outbound connection).
-	startConnecting(address string, config *tls.Config, callback func(grpcConn *grpc.ClientConn) bool)
+	startConnecting(address string, backoff Backoff, config *tls.Config, callback func(grpcConn *grpc.ClientConn) bool)
 	// stopConnecting instructs the Connection to stop connecting to the remote peer.
 	stopConnecting()
 
@@ -261,7 +261,7 @@ func (mc *conn) startSending(protocol Protocol, stream Stream) {
 	}()
 }
 
-func (mc *conn) startConnecting(address string, tlsConfig *tls.Config, connectedCallback func(grpcConn *grpc.ClientConn) bool) {
+func (mc *conn) startConnecting(address string, backoff Backoff, tlsConfig *tls.Config, connectedCallback func(grpcConn *grpc.ClientConn) bool) {
 	mc.mux.Lock()
 	defer mc.mux.Unlock()
 
@@ -272,7 +272,7 @@ func (mc *conn) startConnecting(address string, tlsConfig *tls.Config, connected
 
 	mc.connector = createOutboundConnector(address, mc.dialer, tlsConfig, func() bool {
 		return !mc.IsConnected()
-	}, connectedCallback)
+	}, connectedCallback, backoff)
 	mc.connector.start()
 }
 

--- a/network/transport/grpc/connection_list_test.go
+++ b/network/transport/grpc/connection_list_test.go
@@ -112,7 +112,7 @@ func TestConnectionList_Diagnostics(t *testing.T) {
 		connectionB, _ := cn.getOrRegister(context.Background(), transport.Peer{ID: "b"}, nil)
 		connectionB.(*conn).ctx = context.Background() // simulate connection being active
 		connectionC, _ := cn.getOrRegister(context.Background(), transport.Peer{ID: "c", Address: "localhost:5555"}, grpc.DialContext)
-		connectionC.startConnecting("C", nil, func(grpcConn *grpc.ClientConn) bool {
+		connectionC.startConnecting("C", nil, nil, func(grpcConn *grpc.ClientConn) bool {
 			return false
 		})
 		defer connectionC.stopConnecting()

--- a/network/transport/grpc/connection_list_test.go
+++ b/network/transport/grpc/connection_list_test.go
@@ -112,7 +112,7 @@ func TestConnectionList_Diagnostics(t *testing.T) {
 		connectionB, _ := cn.getOrRegister(context.Background(), transport.Peer{ID: "b"}, nil)
 		connectionB.(*conn).ctx = context.Background() // simulate connection being active
 		connectionC, _ := cn.getOrRegister(context.Background(), transport.Peer{ID: "c", Address: "localhost:5555"}, grpc.DialContext)
-		connectionC.startConnecting("C", nil, nil, func(grpcConn *grpc.ClientConn) bool {
+		connectionC.startConnecting("C", defaultBackoff(), nil, func(grpcConn *grpc.ClientConn) bool {
 			return false
 		})
 		defer connectionC.stopConnecting()

--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -410,7 +410,7 @@ func Test_grpcConnectionManager_openOutboundStreams(t *testing.T) {
 		waiter.Add(1)
 
 		connection, _ := client.connections.getOrRegister(context.Background(), transport.Peer{Address: "server"}, client.dialer)
-		connection.startConnecting("", nil, nil, func(grpcConn *grpc.ClientConn) bool {
+		connection.startConnecting("", defaultBackoff(), nil, func(grpcConn *grpc.ClientConn) bool {
 			err := client.openOutboundStreams(connection, grpcConn)
 			capturedError.Store(err)
 			waiter.Done()

--- a/network/transport/grpc/connection_mock.go
+++ b/network/transport/grpc/connection_mock.go
@@ -131,15 +131,15 @@ func (mr *MockConnectionMockRecorder) setPeer(peer interface{}) *gomock.Call {
 }
 
 // startConnecting mocks base method.
-func (m *MockConnection) startConnecting(address string, config *tls.Config, callback func(*grpc.ClientConn) bool) {
+func (m *MockConnection) startConnecting(address string, backoff Backoff, config *tls.Config, callback func(*grpc.ClientConn) bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "startConnecting", address, config, callback)
+	m.ctrl.Call(m, "startConnecting", address, backoff, config, callback)
 }
 
 // startConnecting indicates an expected call of startConnecting.
-func (mr *MockConnectionMockRecorder) startConnecting(address, config, callback interface{}) *gomock.Call {
+func (mr *MockConnectionMockRecorder) startConnecting(address, backoff, config, callback interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "startConnecting", reflect.TypeOf((*MockConnection)(nil).startConnecting), address, config, callback)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "startConnecting", reflect.TypeOf((*MockConnection)(nil).startConnecting), address, backoff, config, callback)
 }
 
 // stopConnecting mocks base method.

--- a/network/transport/grpc/outbound_connector.go
+++ b/network/transport/grpc/outbound_connector.go
@@ -73,6 +73,9 @@ func (c *outboundConnector) start() {
 	cancelCtx, c.cancelFunc = context.WithCancel(context.Background())
 	c.stopped.Store(false)
 	go func() {
+		// Take into account initial backoff
+		println("Initial backoff", c.backoff.Value().String())
+		sleepWithCancel(cancelCtx, c.backoff.Value())
 		for {
 			if c.stopped.Load().(bool) {
 				return

--- a/network/transport/grpc/outbound_connector.go
+++ b/network/transport/grpc/outbound_connector.go
@@ -74,7 +74,6 @@ func (c *outboundConnector) start() {
 	c.stopped.Store(false)
 	go func() {
 		// Take into account initial backoff
-		println("Initial backoff", c.backoff.Value().String())
 		sleepWithCancel(cancelCtx, c.backoff.Value())
 		for {
 			if c.stopped.Load().(bool) {

--- a/network/transport/grpc/outbound_connector_test.go
+++ b/network/transport/grpc/outbound_connector_test.go
@@ -45,7 +45,6 @@ func Test_connector_tryConnect(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, grpcConn)
 	assert.Equal(t, uint32(1), connector.stats().Attempts)
-	assert.Equal(t, 1, bo.backoffCount)
 }
 
 func Test_connector_start(t *testing.T) {

--- a/network/transport/grpc/test.go
+++ b/network/transport/grpc/test.go
@@ -165,7 +165,7 @@ func (s StubConnection) waitUntilDisconnected() {
 	panic("implement me")
 }
 
-func (s StubConnection) startConnecting(address string, _ *tls.Config, _ func(_ *grpc.ClientConn) bool) {
+func (s StubConnection) startConnecting(address string, _ Backoff, _ *tls.Config, _ func(_ *grpc.ClientConn) bool) {
 	panic("implement me")
 }
 

--- a/network/transport/v2/protocol_integration_test.go
+++ b/network/transport/v2/protocol_integration_test.go
@@ -22,7 +22,9 @@ package v2
 import (
 	"context"
 	"fmt"
+	"go.etcd.io/bbolt"
 	"hash/crc32"
+	"os"
 	"path"
 	"sync"
 	"testing"
@@ -154,7 +156,8 @@ func startNode(t *testing.T, name string, configurers ...func(config *Config)) *
 	ctx.protocol = New(*cfg, transport.FixedNodeDIDResolver{}, ctx.state, doc.Resolver{Store: vdrStore}, keyStore).(*protocol)
 
 	authenticator := grpc.NewTLSAuthenticator(doc.NewServiceResolver(&doc.Resolver{Store: store.NewMemoryStore()}))
-	ctx.connectionManager = grpc.NewGRPCConnectionManager(grpc.NewConfig(listenAddress, peerID), &transport.FixedNodeDIDResolver{NodeDID: did.DID{}}, authenticator, ctx.protocol)
+	connectionsDB, _ := bbolt.Open(path.Join(testDirectory, "connections.db"), os.ModePerm, nil)
+	ctx.connectionManager = grpc.NewGRPCConnectionManager(grpc.NewConfig(listenAddress, peerID), connectionsDB, &transport.FixedNodeDIDResolver{NodeDID: did.DID{}}, authenticator, ctx.protocol)
 
 	ctx.protocol.Configure(peerID)
 	if err := ctx.connectionManager.Start(); err != nil {


### PR DESCRIPTION
Persists the backoff for outbound connectors to BBolt.

Decided to persist the moment (date/time) of the next retry rather than the backoff interval, because then the interval over restarts stays more or less the same. Otherwise it would reconnect immediately after a restart (or just after the max. backoff).

Fixes https://github.com/nuts-foundation/nuts-node/issues/891