### PR TITLE
Network: fix message overhead for chunked TransactionList

### DIFF
--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -479,14 +479,14 @@ func Test_grpcConnectionManager_openOutboundStreams(t *testing.T) {
 		// Bug: peer ID is empty when race condition with disconnect() and notify observers occurs.
 		// See https://github.com/nuts-foundation/nuts-node/issues/978
 		serverCfg, serverListener := newBufconnConfig("server")
-		server := NewGRPCConnectionManager(serverCfg, &transport.FixedNodeDIDResolver{}, nil, &TestProtocol{}).(*grpcConnectionManager)
+		server := NewGRPCConnectionManager(serverCfg, nil, &transport.FixedNodeDIDResolver{}, nil, &TestProtocol{}).(*grpcConnectionManager)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
 		defer server.Stop()
 
 		clientCfg, _ := newBufconnConfig("client", withBufconnDialer(serverListener))
-		client := NewGRPCConnectionManager(clientCfg, &transport.FixedNodeDIDResolver{}, nil, &TestProtocol{}).(*grpcConnectionManager)
+		client := NewGRPCConnectionManager(clientCfg, nil, &transport.FixedNodeDIDResolver{}, nil, &TestProtocol{}).(*grpcConnectionManager)
 		c := createConnection(context.Background(), clientCfg.dialer, transport.Peer{})
 		grpcConn, err := clientCfg.dialer(context.Background(), "server")
 		if !assert.NoError(t, err) {

--- a/network/transport/v2/senders.go
+++ b/network/transport/v2/senders.go
@@ -140,7 +140,6 @@ func chunkTransactionList(transactions []*Transaction) [][]*Transaction {
 	startIndex := 0
 	endIndex := 0
 
-	// TODO to be tested in practise
 	max := grpc.MaxMessageSizeInBytes - transactionListMessageOverhead
 
 	for _, tx := range transactions {

--- a/network/transport/v2/senders.go
+++ b/network/transport/v2/senders.go
@@ -27,6 +27,9 @@ import (
 	"github.com/nuts-foundation/nuts-node/network/transport/grpc"
 )
 
+const transactionListMessageOverhead = 256
+const transactionListTXOverhead = 8
+
 type messageSender interface {
 	sendGossipMsg(id transport.PeerID, refs []hash.SHA256Hash, xor hash.SHA256Hash, clock uint32) error
 	sendTransactionListQuery(id transport.PeerID, refs []hash.SHA256Hash) error
@@ -137,11 +140,11 @@ func chunkTransactionList(transactions []*Transaction) [][]*Transaction {
 	startIndex := 0
 	endIndex := 0
 
-	// 43 bytes for meta overhead and 8 bytes per TX
-	max := grpc.MaxMessageSizeInBytes - 256 // 256 chosen as overhead per message
+	// TODO to be tested in practise
+	max := grpc.MaxMessageSizeInBytes - transactionListMessageOverhead
 
 	for _, tx := range transactions {
-		txSize := len(tx.Payload) + len(tx.Data) + 8
+		txSize := len(tx.Payload) + len(tx.Data) + transactionListTXOverhead
 		newSize = currentSize + txSize
 
 		if newSize > max {


### PR DESCRIPTION
Asserts the (hardcoded) overheads against the actual message size.