### PR TITLE
Fix unclear error messages

### DIFF
--- a/jsonld/ldutils.go
+++ b/jsonld/ldutils.go
@@ -265,7 +265,7 @@ func (util LDUtil) Canonicalize(input interface{}) (result interface{}, err erro
 
 	result, err = proc.Normalize(optionsMap, normalizeOptions)
 	if err != nil {
-		return nil, fmt.Errorf("unable to canonicalize document: %w", err)
+		return nil, fmt.Errorf("unable to normalize the json-ld document: %w", err)
 	}
 	return
 }

--- a/jsonld/ldutils.go
+++ b/jsonld/ldutils.go
@@ -265,7 +265,7 @@ func (util LDUtil) Canonicalize(input interface{}) (result interface{}, err erro
 
 	result, err = proc.Normalize(optionsMap, normalizeOptions)
 	if err != nil {
-		return nil, fmt.Errorf("unable to normalize document: %w", err)
+		return nil, fmt.Errorf("unable to canonicalize document: %w", err)
 	}
 	return
 }

--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -111,9 +111,8 @@ func (i issuer) buildVC(credentialOptions vc.VerifiableCredential) (*vc.Verifiab
 		// Differentiate between a DID document not found and some other error:
 		if errors.Is(err, vdr.ErrNotFound) {
 			return nil, core.InvalidInputError(errString, err)
-		} else {
-			return nil, fmt.Errorf(errString, err)
 		}
+		return nil, fmt.Errorf(errString, err)
 	}
 
 	credentialID := ssi.MustParseURI(fmt.Sprintf("%s#%s", issuerDID.String(), uuid.New().String()))

--- a/vcr/issuer/keyresolver.go
+++ b/vcr/issuer/keyresolver.go
@@ -37,7 +37,7 @@ func (r vdrKeyResolver) ResolveAssertionKey(issuerDID did.DID) (crypto.Key, erro
 	// find did document/metadata for originating TXs
 	document, _, err := r.docResolver.Resolve(issuerDID, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve assertionKey: could not resolve did document is vdr: %w", err)
+		return nil, err
 	}
 
 	// resolve an assertionMethod key for issuer

--- a/vcr/issuer/keyresolver_test.go
+++ b/vcr/issuer/keyresolver_test.go
@@ -73,7 +73,7 @@ func Test_vdrKeyResolver_ResolveAssertionKey(t *testing.T) {
 		key, err := sut.ResolveAssertionKey(*issuerDID)
 
 		assert.Nil(t, key)
-		assert.EqualError(t, err, "failed to resolve assertionKey: could not resolve did document is vdr: not found")
+		assert.EqualError(t, err, "not found")
 	})
 
 	t.Run("key not found in crypto", func(t *testing.T) {

--- a/vcr/signature/json_web_signature.go
+++ b/vcr/signature/json_web_signature.go
@@ -19,6 +19,7 @@
 package signature
 
 import (
+	"fmt"
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
@@ -44,7 +45,7 @@ func (s JSONWebSignature2020) CanonicalizeDocument(doc interface{}) ([]byte, err
 
 	res, err := jsonld.LDUtil{s.ContextLoader}.Canonicalize(doc)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("canonicalization failed: %w", err)
 	}
 	return []byte(res.(string)), nil
 }

--- a/vcr/signature/json_web_signature_test.go
+++ b/vcr/signature/json_web_signature_test.go
@@ -82,7 +82,7 @@ func TestJsonWebSignature2020_CanonicalizeDocument(t *testing.T) {
 
 		res, err := sig.CanonicalizeDocument(doc)
 
-		assert.EqualError(t, err, "unable to canonicalize document: loading remote context failed: Dereferencing a URL did not result in a valid JSON-LD context: https://example.org")
+		assert.EqualError(t, err, "canonicalization failed: unable to normalize the json-ld document: loading remote context failed: Dereferencing a URL did not result in a valid JSON-LD context: https://example.org")
 		assert.Nil(t, res)
 	})
 }

--- a/vcr/signature/json_web_signature_test.go
+++ b/vcr/signature/json_web_signature_test.go
@@ -82,7 +82,7 @@ func TestJsonWebSignature2020_CanonicalizeDocument(t *testing.T) {
 
 		res, err := sig.CanonicalizeDocument(doc)
 
-		assert.EqualError(t, err, "unable to normalize document: loading remote context failed: Dereferencing a URL did not result in a valid JSON-LD context: https://example.org")
+		assert.EqualError(t, err, "unable to canonicalize document: loading remote context failed: Dereferencing a URL did not result in a valid JSON-LD context: https://example.org")
 		assert.Nil(t, res)
 	})
 }

--- a/vcr/signature/proof/jsonld.go
+++ b/vcr/signature/proof/jsonld.go
@@ -84,7 +84,7 @@ func NewLDProof(options ProofOptions) *LDProof {
 func (p LDProof) Verify(document Document, suite signature.Suite, key crypto.PublicKey) error {
 	canonicalDocument, err := suite.CanonicalizeDocument(document)
 	if err != nil {
-		return fmt.Errorf("unable to canonicalize document: %w", err)
+		return err
 	}
 
 	preparedProof, err := p.asCanonicalizableMap()
@@ -132,7 +132,7 @@ func (p *LDProof) Sign(document Document, suite signature.Suite, key nutsCrypto.
 
 	canonicalDocument, err := suite.CanonicalizeDocument(document)
 	if err != nil {
-		return nil, fmt.Errorf("unable to canonicalize document: %w", err)
+		return nil, err
 	}
 
 	proofMap, err := p.asCanonicalizableMap()

--- a/vcr/signature/proof/jsonld_test.go
+++ b/vcr/signature/proof/jsonld_test.go
@@ -107,7 +107,7 @@ func TestLDProof_Verify(t *testing.T) {
 		mockSuite := signature.NewMockSuite(ctrl)
 		mockSuite.EXPECT().CanonicalizeDocument(signedDocument.DocumentWithoutProof()).Return(nil, errors.New("foo"))
 		err = ldProof.Verify(signedDocument.DocumentWithoutProof(), mockSuite, pk)
-		assert.EqualError(t, err, "unable to canonicalize document: foo")
+		assert.EqualError(t, err, "foo")
 	})
 
 	t.Run("it handles an error while canonicalizing the proof", func(t *testing.T) {
@@ -224,7 +224,7 @@ func TestLDProof_Sign(t *testing.T) {
 		mockSuite.EXPECT().CanonicalizeDocument(document).Return(nil, errors.New("foo"))
 		mockSuite.EXPECT().GetType().Return(ssi.JsonWebSignature2020)
 		result, err := ldProof.Sign(document, mockSuite, testKey)
-		assert.EqualError(t, err, "unable to canonicalize document: foo")
+		assert.EqualError(t, err, "foo")
 		assert.Nil(t, result)
 	})
 


### PR DESCRIPTION
Fix status code of 500 to 400 when issuer not found
Fix duplicate messages like: "unable to canonicalize document: unable to normalize document: foo"
Fixed typo in error message.