### PR TITLE
Network: limit node to 1 active conversation per peer

### DIFF
--- a/network/transport/v2/conversation.go
+++ b/network/transport/v2/conversation.go
@@ -26,10 +26,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/nuts-foundation/nuts-node/network/dag"
-
 	"github.com/google/uuid"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	"github.com/nuts-foundation/nuts-node/network/dag"
+	"github.com/nuts-foundation/nuts-node/network/transport"
 )
 
 var maxValidity = 30 * time.Second
@@ -88,16 +88,17 @@ type conversationable interface {
 }
 
 type conversationManager struct {
-	mutex            sync.RWMutex
-	conversations    map[string]*conversation
-	validity         time.Duration
-	lastRangeQueryID conversationID
+	mutex                  sync.RWMutex
+	conversations          map[string]*conversation
+	validity               time.Duration
+	lastPeerConversationID map[transport.PeerID]conversationID
 }
 
 func newConversationManager(validity time.Duration) *conversationManager {
 	return &conversationManager{
-		conversations: map[string]*conversation{},
-		validity:      validity,
+		conversations:          map[string]*conversation{},
+		validity:               validity,
+		lastPeerConversationID: map[transport.PeerID]conversationID{},
 	}
 }
 
@@ -137,7 +138,7 @@ func (cMan *conversationManager) done(cid conversationID) {
 }
 
 // startConversation sets a conversationID on the envelope and stores the conversation
-func (cMan *conversationManager) startConversation(msg checkable) *conversation {
+func (cMan *conversationManager) startConversation(msg checkable, id transport.PeerID) *conversation {
 	cid := newConversationID()
 
 	msg.setConversationID(cid)
@@ -151,20 +152,24 @@ func (cMan *conversationManager) startConversation(msg checkable) *conversation 
 	cMan.mutex.Lock()
 	defer cMan.mutex.Unlock()
 
-	if _, ok := msg.(*Envelope_TransactionRangeQuery); ok {
-		// check if new RangeQuery is allowed
-		if conversation, ok := cMan.conversations[cMan.lastRangeQueryID.String()]; ok {
-			if conversation.createdAt.Add(cMan.validity).After(time.Now()) {
-				return nil
-			}
-		}
-		// set range query timeout
-		cMan.lastRangeQueryID = cid
+	if cMan.hasActiveConversation(id) {
+		return nil
 	}
-
+	cMan.lastPeerConversationID[id] = cid
 	cMan.conversations[cid.String()] = newConversation
 
 	return newConversation
+}
+
+func (cMan *conversationManager) hasActiveConversation(id transport.PeerID) bool {
+	if lastPeerConv, ok := cMan.lastPeerConversationID[id]; ok {
+		if conversation, ok := cMan.conversations[lastPeerConv.String()]; ok {
+			if conversation.createdAt.Add(cMan.validity).After(time.Now()) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (cMan *conversationManager) check(envelope conversationable, data handlerData) (*conversation, error) {

--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network/dag"
+	"github.com/nuts-foundation/nuts-node/network/dag/tree"
 	"github.com/nuts-foundation/nuts-node/network/log"
 	"github.com/nuts-foundation/nuts-node/network/transport"
 )

--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -25,8 +25,6 @@ import (
 	"math"
 	"sort"
 
-	"github.com/nuts-foundation/nuts-node/network/dag/tree"
-
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network/dag"
 	"github.com/nuts-foundation/nuts-node/network/dag/tree"

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/nuts-foundation/nuts-node/core"
@@ -112,7 +111,6 @@ type protocol struct {
 	diagnosticsMan    *peerDiagnosticsManager
 	sender            messageSender
 	listHandler       *transactionListHandler
-	handlerMutex      sync.RWMutex
 }
 
 func (p protocol) CreateClientStream(outgoingContext context.Context, grpcConn grpcLib.ClientConnInterface) (grpcLib.ClientStream, error) {

--- a/network/transport/v2/senders.go
+++ b/network/transport/v2/senders.go
@@ -83,7 +83,11 @@ func (p *protocol) sendTransactionListQuery(id transport.PeerID, refs []hash.SHA
 		},
 	}
 
-	conversation := p.cMan.startConversation(msg)
+	conversation := p.cMan.startConversation(msg, id)
+	if conversation == nil {
+		log.Logger().Debugf("did not request a TransactionList while another conversation is in progress (peer=%s)", id.String())
+		return nil
+	}
 	conversation.set("refs", refs)
 
 	// todo convert to trace logging
@@ -129,9 +133,9 @@ func (p *protocol) sendTransactionRangeQuery(id transport.PeerID, lcStart uint32
 		},
 	}
 
-	conversation := p.cMan.startConversation(msg)
+	conversation := p.cMan.startConversation(msg, id)
 	if conversation == nil {
-		log.Logger().Debugf("did not request a new transaction range while another range query is in progress (peer=%s, start=%d, end=%d)", id.String(), lcStart, lcEnd)
+		log.Logger().Debugf("did not request a TransactionRange while another conversation is in progress (peer=%s, start=%d, end=%d)", id.String(), lcStart, lcEnd)
 		return nil
 	}
 
@@ -185,7 +189,11 @@ func (p *protocol) sendState(id transport.PeerID, xor hash.SHA256Hash, clock uin
 			LC:  clock,
 		},
 	}
-	conversation := p.cMan.startConversation(msg)
+	conversation := p.cMan.startConversation(msg, id)
+	if conversation == nil {
+		log.Logger().Debugf("did not request State while another conversation is in progress (peer=%s)", id.String())
+		return nil
+	}
 
 	// todo convert to trace logging
 	log.Logger().Infof("requesting state from peer (peer=%s, conversationID=%s)", id, conversation.conversationID.String())

--- a/network/transport/v2/senders.go
+++ b/network/transport/v2/senders.go
@@ -128,9 +128,14 @@ func (p *protocol) sendTransactionRangeQuery(id transport.PeerID, lcStart uint32
 			End:   lcEnd,
 		},
 	}
-	cid := p.cMan.startConversation(msg)
 
-	log.Logger().Debugf("requesting transaction range (peer=%s, conversationID=%s, start=%d, end=%d)", id.String(), cid.conversationID.String(), lcStart, lcEnd)
+	conversation := p.cMan.startConversation(msg)
+	if conversation == nil {
+		log.Logger().Debugf("did not request a new transaction range while another range query is in progress (peer=%s, start=%d, end=%d)", id.String(), lcStart, lcEnd)
+		return nil
+	}
+
+	log.Logger().Debugf("requesting transaction range (peer=%s, conversationID=%s, start=%d, end=%d)", id.String(), conversation.conversationID.String(), lcStart, lcEnd)
 
 	return conn.Send(p, &Envelope{Message: msg})
 }

--- a/network/transport/v2/transactionlist_handler.go
+++ b/network/transport/v2/transactionlist_handler.go
@@ -89,9 +89,6 @@ func (p *protocol) handleTransactionList(peer transport.Peer, envelope *Envelope
 		return err
 	}
 
-	p.handlerMutex.Lock()
-	defer p.handlerMutex.Unlock()
-
 	ctx := context.Background()
 	for i, tx := range txs {
 		// TODO does this always trigger fetching missing payloads? (through observer on DAG) Prolly not for v2

--- a/network/transport/v2/transactionlist_handler.go
+++ b/network/transport/v2/transactionlist_handler.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network/dag"
 	"github.com/nuts-foundation/nuts-node/network/log"
 	"github.com/nuts-foundation/nuts-node/network/transport"
@@ -93,10 +92,7 @@ func (p *protocol) handleTransactionList(peer transport.Peer, envelope *Envelope
 	p.handlerMutex.Lock()
 	defer p.handlerMutex.Unlock()
 
-	refsToBeRemoved := map[hash.SHA256Hash]bool{}
-
 	ctx := context.Background()
-	maxLC := uint32(0)
 	for i, tx := range txs {
 		// TODO does this always trigger fetching missing payloads? (through observer on DAG) Prolly not for v2
 		if len(tx.PAL()) == 0 && len(msg.Transactions[i].Payload) == 0 {
@@ -111,10 +107,6 @@ func (p *protocol) handleTransactionList(peer transport.Peer, envelope *Envelope
 			}
 			return fmt.Errorf("unable to add received transaction to DAG (tx=%s): %w", tx.Ref(), err)
 		}
-		if tx.Clock() > maxLC {
-			maxLC = tx.Clock()
-		}
-		refsToBeRemoved[tx.Ref()] = true
 	}
 
 	if msg.MessageNumber >= msg.TotalMessages {

--- a/network/transport/v2/transactionlist_handler_test.go
+++ b/network/transport/v2/transactionlist_handler_test.go
@@ -75,10 +75,11 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 			},
 		}}
 	}
+	peerID := transport.PeerID("peerID")
 
 	t.Run("ok", func(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
-		conversation := p.cMan.startConversation(request)
+		conversation := p.cMan.startConversation(request, peerID)
 		envelope := envelopeWithConversation(conversation)
 		mocks.State.EXPECT().Add(context.Background(), tx, payload).Return(nil)
 
@@ -89,7 +90,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 
 	t.Run("ok - duplicate", func(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
-		conversation := p.cMan.startConversation(request)
+		conversation := p.cMan.startConversation(request, peerID)
 		envelope := envelopeWithConversation(conversation)
 		mocks.State.EXPECT().Add(context.Background(), tx, payload).Return(nil)
 
@@ -100,7 +101,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 
 	t.Run("ok - missing prevs", func(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
-		conversation := p.cMan.startConversation(request)
+		conversation := p.cMan.startConversation(request, peerID)
 		envelope := envelopeWithConversation(conversation)
 		mocks.State.EXPECT().Add(context.Background(), tx, payload).Return(dag.ErrPreviousTransactionMissing)
 		mocks.State.EXPECT().XOR(context.Background(), uint32(math.MaxUint32)).Return(hash.FromSlice([]byte("stateXor")), uint32(7))
@@ -114,7 +115,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 
 	t.Run("ok - conversation marked as done", func(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
-		conversation := p.cMan.startConversation(request)
+		conversation := p.cMan.startConversation(request, peerID)
 		envelope := envelopeWithConversation(conversation)
 		conversation.set("refs", []hash.SHA256Hash{h1})
 		mocks.State.EXPECT().Add(context.Background(), tx, payload).Return(nil)
@@ -129,7 +130,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 		tx2, _, _ := dag.CreateTestTransaction(0)
 		h2 := tx2.Ref()
 		p, mocks := newTestProtocol(t, nil)
-		conversation := p.cMan.startConversation(request)
+		conversation := p.cMan.startConversation(request, peerID)
 		conversation.set("refs", []hash.SHA256Hash{h1, h2})
 		mocks.State.EXPECT().Add(context.Background(), tx, payload).Return(nil)
 
@@ -148,7 +149,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 
 	t.Run("error - State.Add failed", func(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
-		conversation := p.cMan.startConversation(request)
+		conversation := p.cMan.startConversation(request, peerID)
 		envelope := envelopeWithConversation(conversation)
 		mocks.State.EXPECT().Add(context.Background(), tx, payload).Return(errors.New("custom"))
 
@@ -159,7 +160,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 
 	t.Run("error - missing payload for TX without PAL", func(t *testing.T) {
 		p, _ := newTestProtocol(t, nil)
-		conversation := p.cMan.startConversation(request)
+		conversation := p.cMan.startConversation(request, peerID)
 
 		err := p.handleTransactionList(peer, &Envelope{Message: &Envelope_TransactionList{
 			TransactionList: &TransactionList{
@@ -173,7 +174,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 
 	t.Run("error - invalid transaction", func(t *testing.T) {
 		p, _ := newTestProtocol(t, nil)
-		conversation := p.cMan.startConversation(request)
+		conversation := p.cMan.startConversation(request, peerID)
 
 		err := p.handleTransactionList(peer, &Envelope{Message: &Envelope_TransactionList{
 			TransactionList: &TransactionList{


### PR DESCRIPTION
#861 aims to limit the number of conversations to 1, but this would be too strict. 

The `TransactionSet` for example can be followed by `TransactionListQuery` and `TransactionRangeQuery`. It should also be possible request newly Gossiped transactions from multiple peers at the same time. Limiting a node to 1 active range query means that it can only perform set reconciliation with 1 peer at a time.