### PR TITLE
VDR: Let BBoltStore return a name since it's registered as engine

### DIFF
--- a/vdr/store/bbolt.go
+++ b/vdr/store/bbolt.go
@@ -44,6 +44,10 @@ type bboltStore struct {
 	db *bbolt.DB
 }
 
+func (store *bboltStore) Name() string {
+	return "DID Document Store"
+}
+
 // NewBBoltStore returns an instance of a BBolt based VDR store
 func NewBBoltStore() vdr.Store {
 	return &bboltStore{}


### PR DESCRIPTION
Now it's type is logged;

```
time="2022-04-29T09:35:25+01:00" level=info msg="Starting *store.bboltStore" module=core
time="2022-04-29T09:35:25+01:00" level=info msg="Started *store.bboltStore" module=core
```

(which is ugly)