### PR TITLE
Add SearchVCQuery type

### DIFF
--- a/vcr/api/v2/types.go
+++ b/vcr/api/v2/types.go
@@ -20,8 +20,10 @@
 package v2
 
 import (
+	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
+	"time"
 )
 
 // VerifiableCredential is an alias to use from within the API
@@ -36,9 +38,28 @@ type Revocation = credential.Revocation
 // VerifiablePresentation is an alias to use from within the API
 type VerifiablePresentation = vc.VerifiablePresentation
 
+// SearchVCQuery defines a less strict VerifiableCredential struct without proof which can be used to search for VerifiableCredentials.
+// All fields except for the Context are optional
+type SearchVCQuery struct {
+	// Context defines the json-ld context to dereference the URIs
+	Context []ssi.URI `json:"@context"`
+	// ID is an unique identifier for the credential. It is optional
+	ID *ssi.URI `json:"id,omitempty"`
+	// Type holds multiple types for a credential. A credential must always have the 'VerifiableCredential' type.
+	Type []ssi.URI `json:"type,omitempty"`
+	// Issuer refers to the party that issued the credential
+	Issuer *ssi.URI `json:"issuer,omitempty"`
+	// IssuanceDate is a rfc3339 formatted datetime.
+	IssuanceDate *time.Time `json:"issuanceDate,omitempty"`
+	// ExpirationDate is a rfc3339 formatted datetime.
+	ExpirationDate *time.Time `json:"expirationDate,omitempty"`
+	// CredentialSubject holds the actual data for the credential. It must be extracted using the UnmarshalCredentialSubject method and a custom type.
+	CredentialSubject []interface{} `json:"credentialSubject,omitempty"`
+}
+
 // SearchVCRequest is the request body for searching VCs
 type SearchVCRequest struct {
 	// A partial VerifiableCredential in JSON-LD format. Each field will be used to match credentials against. All fields MUST be present.
-	Query         vc.VerifiableCredential `json:"query"`
-	SearchOptions *SearchOptions          `json:"searchOptions,omitempty"`
+	Query         SearchVCQuery  `json:"query"`
+	SearchOptions *SearchOptions `json:"searchOptions,omitempty"`
 }


### PR DESCRIPTION
Instead of using a VerifiableCredential from the go-did library as search param use a custom one which is less strict and allows empty fields.