### PR TITLE
Crypto: adjust ErrKeyNotFound to clearly indicate it concerns private keys

### DIFF
--- a/crypto/api/v1/api.go
+++ b/crypto/api/v1/api.go
@@ -38,7 +38,7 @@ type Wrapper struct {
 // ResolveStatusCode maps errors returned by this API to specific HTTP status codes.
 func (w *Wrapper) ResolveStatusCode(err error) int {
 	return core.ResolveStatusCode(err, map[error]int{
-		crypto.ErrKeyNotFound: http.StatusBadRequest,
+		crypto.ErrPrivateKeyNotFound: http.StatusBadRequest,
 	})
 }
 

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -152,7 +152,7 @@ func (client *Crypto) Resolve(kid string) (Key, error) {
 	keypair, err := client.Storage.GetPrivateKey(kid)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
-			return nil, ErrKeyNotFound
+			return nil, ErrPrivateKeyNotFound
 		}
 		return nil, err
 	}

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -100,7 +100,7 @@ func TestCrypto_Resolve(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		_, err := client.Resolve("no kidding")
 
-		assert.Equal(t, ErrKeyNotFound, err)
+		assert.Equal(t, ErrPrivateKeyNotFound, err)
 	})
 }
 

--- a/crypto/interface.go
+++ b/crypto/interface.go
@@ -23,8 +23,8 @@ import (
 	"errors"
 )
 
-// ErrKeyNotFound is returned when the key should not exists but does
-var ErrKeyNotFound = errors.New("key not found")
+// ErrPrivateKeyNotFound is returned when the private key doesn't exist
+var ErrPrivateKeyNotFound = errors.New("private key not found")
 
 // KIDNamingFunc is a function passed to New() which generates the kid for the pub/priv key
 type KIDNamingFunc func(key crypto.PublicKey) (string, error)
@@ -41,7 +41,7 @@ type KeyResolver interface {
 	// Exists returns if the specified private key exists.
 	// If an error occurs, false is also returned
 	Exists(kid string) bool
-	// Resolve returns a Key for the given KID. ErrKeyNotFound is returned for an unknown KID.
+	// Resolve returns a Key for the given KID. ErrPrivateKeyNotFound is returned for an unknown KID.
 	Resolve(kid string) (Key, error)
 	// List returns the KIDs of the private keys that are present in the KeyStore.
 	List() []string
@@ -64,7 +64,7 @@ type Decrypter interface {
 // JWTSigner is the interface used to sign authorization tokens.
 type JWTSigner interface {
 	// SignJWT creates a signed JWT using the indicated key and map of claims.
-	// Returns ErrKeyNotFound when indicated private key is not present.
+	// Returns ErrPrivateKeyNotFound when indicated private key is not present.
 	SignJWT(claims map[string]interface{}, kid string) (string, error)
 }
 

--- a/crypto/jwx.go
+++ b/crypto/jwx.go
@@ -53,7 +53,7 @@ func (client *Crypto) SignJWT(claims map[string]interface{}, kid string) (token 
 	privateKey, err := client.Storage.GetPrivateKey(kid)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
-			return "", ErrKeyNotFound
+			return "", ErrPrivateKeyNotFound
 		}
 		return "", err
 	}

--- a/crypto/jwx_test.go
+++ b/crypto/jwx_test.go
@@ -171,7 +171,7 @@ func TestCrypto_SignJWT(t *testing.T) {
 	t.Run("returns error for not found", func(t *testing.T) {
 		_, err := client.SignJWT(map[string]interface{}{"iss": "nuts"}, "unknown")
 
-		assert.True(t, errors.Is(err, ErrKeyNotFound))
+		assert.True(t, errors.Is(err, ErrPrivateKeyNotFound))
 	})
 }
 

--- a/crypto/test.go
+++ b/crypto/test.go
@@ -64,7 +64,7 @@ func (m memoryStorage) ListPrivateKeys() []string {
 func (m memoryStorage) GetPrivateKey(kid string) (crypto.Signer, error) {
 	pk, ok := m[kid]
 	if !ok {
-		return nil, ErrKeyNotFound
+		return nil, ErrPrivateKeyNotFound
 	}
 	return pk.(crypto.Signer), nil
 }

--- a/network/dag/pal.go
+++ b/network/dag/pal.go
@@ -99,7 +99,7 @@ outer:
 		for _, kak := range keyAgreementKIDs {
 			log.Logger().Tracef("Trying key %s to decrypt PAL header...", kak)
 			decrypted, err = decryptor.Decrypt(kak, encrypted)
-			if errors.Is(err, crypto.ErrKeyNotFound) {
+			if errors.Is(err, crypto.ErrPrivateKeyNotFound) {
 				return nil, fmt.Errorf("private key of DID keyAgreement not found (kid=%s)", kak)
 			}
 			if err != nil {

--- a/network/transport/v2/protocol_test.go
+++ b/network/transport/v2/protocol_test.go
@@ -408,7 +408,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 				{VerificationMethod: &did.VerificationMethod{ID: *keyDID}},
 			},
 		}, nil, nil)
-		mocks.Decrypter.EXPECT().Decrypt(keyDID.String(), []byte{1}).Return(nil, crypto.ErrKeyNotFound)
+		mocks.Decrypter.EXPECT().Decrypt(keyDID.String(), []byte{1}).Return(nil, crypto.ErrPrivateKeyNotFound)
 
 		err := proto.handlePrivateTxRetryErr(txOk.Ref())
 
@@ -571,7 +571,7 @@ func TestProtocol_decryptPAL(t *testing.T) {
 				{VerificationMethod: &did.VerificationMethod{ID: *keyDID}},
 			},
 		}, nil, nil)
-		mocks.Decrypter.EXPECT().Decrypt(keyDID.String(), []byte{1}).Return(nil, crypto.ErrKeyNotFound)
+		mocks.Decrypter.EXPECT().Decrypt(keyDID.String(), []byte{1}).Return(nil, crypto.ErrPrivateKeyNotFound)
 
 		_, err := proto.decryptPAL(tx.PAL())
 		assert.EqualError(t, err, fmt.Sprintf("private key of DID keyAgreement not found (kid=%s)", keyDID.String()))

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -196,7 +196,7 @@ func (r VDR) Update(id did.DID, current hash.SHA256Hash, next did.Document, _ *t
 		log.Logger().Infof("DID Document updated (DID=%s)", id)
 	} else {
 		log.Logger().WithError(err).Warn("Unable to update DID document")
-		if errors.Is(err, crypto.ErrKeyNotFound) {
+		if errors.Is(err, crypto.ErrPrivateKeyNotFound) {
 			return types.ErrDIDNotManagedByThisNode
 		}
 	}
@@ -223,7 +223,7 @@ func (r VDR) resolveControllerWithKey(doc did.Document) (did.Document, crypto.Ke
 		}
 	}
 
-	if errors.Is(err, crypto.ErrKeyNotFound) {
+	if errors.Is(err, crypto.ErrPrivateKeyNotFound) {
 		return did.Document{}, nil, types.ErrDIDNotManagedByThisNode
 	}
 

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -185,7 +185,7 @@ func TestVDR_Update(t *testing.T) {
 		currentDIDDocument := nextDIDDocument
 		currentDIDDocument.AddCapabilityInvocation(&did.VerificationMethod{ID: *keyID})
 		ctx.mockStore.EXPECT().Resolve(*id, gomock.Any()).Times(1).Return(&currentDIDDocument, &types.DocumentMetadata{}, nil)
-		ctx.mockKeyStore.EXPECT().Resolve(keyID.String()).Return(nil, crypto.ErrKeyNotFound)
+		ctx.mockKeyStore.EXPECT().Resolve(keyID.String()).Return(nil, crypto.ErrPrivateKeyNotFound)
 
 		err := ctx.vdr.Update(*id, currentHash, nextDIDDocument, nil)
 
@@ -345,7 +345,7 @@ func TestVDR_resolveControllerKey(t *testing.T) {
 		controller.AddCapabilityInvocation(&did.VerificationMethod{ID: *keyID})
 		ctx.mockStore.EXPECT().Resolve(*controllerId, gomock.Any()).Return(&controller, nil, nil).Times(2)
 		gomock.InOrder(
-			ctx.mockKeyStore.EXPECT().Resolve(keyID.String()).Return(nil, crypto.ErrKeyNotFound),
+			ctx.mockKeyStore.EXPECT().Resolve(keyID.String()).Return(nil, crypto.ErrPrivateKeyNotFound),
 			ctx.mockKeyStore.EXPECT().Resolve(keyID.String()).Return(crypto.NewTestKey(keyID.String()), nil),
 		)
 
@@ -378,7 +378,7 @@ func TestVDR_resolveControllerKey(t *testing.T) {
 		currentDIDDocument := did.Document{ID: *id, Controller: []did.DID{*controllerId, *controllerId}}
 		controller.AddCapabilityInvocation(&did.VerificationMethod{ID: *keyID})
 		ctx.mockStore.EXPECT().Resolve(*controllerId, gomock.Any()).Return(&controller, nil, nil).Times(2)
-		ctx.mockKeyStore.EXPECT().Resolve(keyID.String()).Return(nil, crypto.ErrKeyNotFound).Times(2)
+		ctx.mockKeyStore.EXPECT().Resolve(keyID.String()).Return(nil, crypto.ErrPrivateKeyNotFound).Times(2)
 
 		_, _, err := ctx.vdr.resolveControllerWithKey(currentDIDDocument)
 


### PR DESCRIPTION
Otherwise one could assume it's because a DID document is missing a verification method.