### PR TITLE
Gossip: Reduce chance of test data race

### DIFF
--- a/network/transport/v2/gossip/manager_test.go
+++ b/network/transport/v2/gossip/manager_test.go
@@ -97,6 +97,7 @@ func TestManager_PeerDisconnected(t *testing.T) {
 		defer goleak.VerifyNone(t)
 
 		gMan := giveMeAgMan(t)
+		gMan.interval = time.Millisecond
 		peer := transport.Peer{ID: "1"}
 		gMan.peers["2"] = gMan.peers["1"]
 
@@ -170,7 +171,7 @@ func TestManager_callSenders(t *testing.T) {
 func giveMeAgMan(t *testing.T) *manager {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(func() { cancel() })
-	gMan := NewManager(ctx, time.Millisecond).(*manager)
+	gMan := NewManager(ctx, time.Second).(*manager)
 
 	return gMan
 }


### PR DESCRIPTION
Several tests directly access a `peerQueue` without a lock. This can coincide with the Gossip manager trying to send Gossip messages and cause a data race.

Only 1 test actually depended on the gossip interval, so test duration is not increased.