### PR TITLE
Network: also override node DID auth when one of the prerequisites fail

### DIFF
--- a/network/transport/connection_manager.go
+++ b/network/transport/connection_manager.go
@@ -30,7 +30,7 @@ type ConnectionOption func(peer *Peer)
 // The node.DID authentication on a connection will always succeed. Actions that require the node.DID will fail.
 func WithUnauthenticated() ConnectionOption {
 	return func(peer *Peer) {
-		peer.	AcceptUnauthenticated = true
+		peer.AcceptUnauthenticated = true
 	}
 }
 

--- a/network/transport/connection_manager.go
+++ b/network/transport/connection_manager.go
@@ -30,7 +30,7 @@ type ConnectionOption func(peer *Peer)
 // The node.DID authentication on a connection will always succeed. Actions that require the node.DID will fail.
 func WithUnauthenticated() ConnectionOption {
 	return func(peer *Peer) {
-		peer.AcceptUnauthenticated = true
+		peer.	AcceptUnauthenticated = true
 	}
 }
 

--- a/network/transport/grpc/authenticator.go
+++ b/network/transport/grpc/authenticator.go
@@ -51,6 +51,7 @@ func (t tlsAuthenticator) Authenticate(nodeDID did.DID, grpcPeer grpcPeer.Peer, 
 	withOverride := func(peer transport.Peer, err error) (transport.Peer, error) {
 		if peer.AcceptUnauthenticated {
 			log.Logger().Warnf("Connection manually authenticated, authentication error: %v", err)
+			peer.NodeDID = nodeDID
 			return peer, nil
 		}
 		return peer, err

--- a/network/transport/types.go
+++ b/network/transport/types.go
@@ -56,7 +56,7 @@ type Peer struct {
 	// NodeDID holds the DID that the peer uses to identify its node on the network.
 	// It is only set when properly authenticated.
 	NodeDID did.DID
-	// AcceptUnauthenticated indicates if a connection may be made with this Peer even if the NodeDID is not set.
+	// AcceptUnauthenticated indicates if a connection may be made with this Peer even if the NodeDID could not be authenticated.
 	AcceptUnauthenticated bool
 }
 


### PR DESCRIPTION
E.g.: no TLS, missing DID document, no SAN entries in TLS certificate

Currently, new nodes don't authenticate the node DID of their bootstrap nodes because initially, their DID document can't be resolved. After this fix, new nodes just accept the node DIDs of their bootstrap nodes, regardless their TLS certificate/DID documents. In the current situation, the node has to be restarted (or the connection re-established) to authenticate the peer.