### PR TITLE
send notification from DAG with AND without payload

### DIFF
--- a/echo/echo_integration_test.go
+++ b/echo/echo_integration_test.go
@@ -94,7 +94,7 @@ func startServer(t *testing.T) string {
 	test.WaitFor(t, func() (bool, error) {
 		resp, err := http.Get(fmt.Sprintf("http://localhost%s/status", httpPort))
 		return err == nil && resp.StatusCode == http.StatusOK, nil
-	}, time.Second, "Timeout while waiting for node to become available")
+	}, 5*time.Second, "Timeout while waiting for node to become available")
 
 	t.Cleanup(func() {
 		cancel()

--- a/network/dag/interface.go
+++ b/network/dag/interface.go
@@ -61,9 +61,12 @@ type State interface {
 	IsPresent(context.Context, hash.SHA256Hash) (bool, error)
 	// PayloadHashes applies the visitor function to the payload hashes of all transactions, in random order.
 	PayloadHashes(ctx context.Context, visitor func(payloadHash hash.SHA256Hash) error) error
-	// RegisterObserver allows observers to be notified when a transaction is added to the DAG.
+	// RegisterTransactionObserver allows observers to be notified when a transaction is added to the DAG.
 	// If the observer needs to be called within the transaction, transactional must be true.
-	RegisterObserver(observer Observer, transactional bool)
+	RegisterTransactionObserver(observer Observer, transactional bool)
+	// RegisterPayloadObserver allows observers to be notified when a payload is written to the store.
+	// If the observer needs to be called within the transaction, transactional must be true.
+	RegisterPayloadObserver(observer PayloadObserver, transactional bool)
 	// Subscribe lets an application subscribe to a specific type of transaction. When a new transaction is received
 	// the `receiver` function is called. If an asterisk (`*`) is specified as `payloadType` the receiver is subscribed
 	// to all payload types.
@@ -159,7 +162,10 @@ type PayloadReader interface {
 }
 
 // Observer defines the signature of an observer which can be called by an Observable.
-type Observer func(ctx context.Context, transaction Transaction, payload []byte) error
+type Observer func(ctx context.Context, transaction Transaction) error
+
+// PayloadObserver defines the signature of an observer which can be called by an Observable.
+type PayloadObserver func(ctx context.Context, transaction Transaction, payload []byte) error
 
 // MinTime returns the minimum value for time.Time
 func MinTime() time.Time {

--- a/network/dag/interface.go
+++ b/network/dag/interface.go
@@ -43,7 +43,7 @@ type State interface {
 	// Deprecated: remove with V1 protocol
 	ReadManyPayloads(ctx context.Context, consumer func(context.Context, PayloadReader) error) error
 
-	// Add a transactions to the DAG. If it can't be added an error is returned.
+	// Add a transaction to the DAG. If it can't be added an error is returned.
 	// If the transaction already exists, nothing is added and no observers are notified.
 	// The payload may be passed as well. Allowing for better notification of observers
 	Add(ctx context.Context, transactions Transaction, payload []byte) error

--- a/network/dag/mock.go
+++ b/network/dag/mock.go
@@ -214,16 +214,28 @@ func (mr *MockStateMockRecorder) ReadPayload(ctx, payloadHash interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPayload", reflect.TypeOf((*MockState)(nil).ReadPayload), ctx, payloadHash)
 }
 
-// RegisterObserver mocks base method.
-func (m *MockState) RegisterObserver(observer Observer, transactional bool) {
+// RegisterPayloadObserver mocks base method.
+func (m *MockState) RegisterPayloadObserver(observer PayloadObserver, transactional bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterObserver", observer, transactional)
+	m.ctrl.Call(m, "RegisterPayloadObserver", observer, transactional)
 }
 
-// RegisterObserver indicates an expected call of RegisterObserver.
-func (mr *MockStateMockRecorder) RegisterObserver(observer, transactional interface{}) *gomock.Call {
+// RegisterPayloadObserver indicates an expected call of RegisterPayloadObserver.
+func (mr *MockStateMockRecorder) RegisterPayloadObserver(observer, transactional interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterObserver", reflect.TypeOf((*MockState)(nil).RegisterObserver), observer, transactional)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterPayloadObserver", reflect.TypeOf((*MockState)(nil).RegisterPayloadObserver), observer, transactional)
+}
+
+// RegisterTransactionObserver mocks base method.
+func (m *MockState) RegisterTransactionObserver(observer Observer, transactional bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterTransactionObserver", observer, transactional)
+}
+
+// RegisterTransactionObserver indicates an expected call of RegisterTransactionObserver.
+func (mr *MockStateMockRecorder) RegisterTransactionObserver(observer, transactional interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTransactionObserver", reflect.TypeOf((*MockState)(nil).RegisterTransactionObserver), observer, transactional)
 }
 
 // Shutdown mocks base method.

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -170,7 +170,7 @@ func TestState_Observe(t *testing.T) {
 				ctx := context.Background()
 				txState := createState(t)
 				var actual bool
-				txState.RegisterObserver(func(ctx context.Context, transaction Transaction, _ []byte) error {
+				txState.RegisterTransactionObserver(func(ctx context.Context, transaction Transaction) error {
 					_, actual = storage.BBoltTX(ctx)
 					return nil
 				}, expected)
@@ -187,7 +187,7 @@ func TestState_Observe(t *testing.T) {
 		ctx := context.Background()
 		txState := createState(t)
 		var actual Transaction
-		txState.RegisterObserver(func(ctx context.Context, transaction Transaction, _ []byte) error {
+		txState.RegisterTransactionObserver(func(ctx context.Context, transaction Transaction) error {
 			actual = transaction
 			return nil
 		}, false)
@@ -203,11 +203,12 @@ func TestState_Observe(t *testing.T) {
 		txState := createState(t)
 		var actualTX Transaction
 		var actualPayload []byte
-		txState.RegisterObserver(func(ctx context.Context, transaction Transaction, payload []byte) error {
+		txState.RegisterTransactionObserver(func(ctx context.Context, transaction Transaction) error {
 			actualTX = transaction
-			if payload != nil {
-				actualPayload = payload
-			}
+			return nil
+		}, false)
+		txState.RegisterPayloadObserver(func(ctx context.Context, transaction Transaction, payload []byte) error {
+			actualPayload = payload
 			return nil
 		}, false)
 		expected := CreateTestTransactionWithJWK(1)
@@ -231,7 +232,7 @@ func TestState_Observe(t *testing.T) {
 		ctx := context.Background()
 		txState := createState(t)
 		var actual []byte
-		txState.RegisterObserver(func(ctx context.Context, tx Transaction, payload []byte) error {
+		txState.RegisterPayloadObserver(func(ctx context.Context, tx Transaction, payload []byte) error {
 			actual = payload
 			return nil
 		}, false)

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -205,7 +205,9 @@ func TestState_Observe(t *testing.T) {
 		var actualPayload []byte
 		txState.RegisterObserver(func(ctx context.Context, transaction Transaction, payload []byte) error {
 			actualTX = transaction
-			actualPayload = payload
+			if payload != nil {
+				actualPayload = payload
+			}
 			return nil
 		}, false)
 		expected := CreateTestTransactionWithJWK(1)
@@ -376,7 +378,7 @@ func TestState_treeObserver(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	t.Run("no callback for public transaction without payload", func(t *testing.T) {
+	t.Run("callback for public transaction without payload", func(t *testing.T) {
 		txState := setup(t)
 		tx := CreateTestTransactionWithJWK(1)
 
@@ -387,22 +389,7 @@ func TestState_treeObserver(t *testing.T) {
 		}
 
 		xor, _ := txState.XOR(ctx, 1)
-		assert.True(t, hash.EmptyHash().Equals(xor))
-	})
-
-	t.Run("no callback for private transaction with payload", func(t *testing.T) {
-		txState := setup(t)
-		payload := []byte("payload")
-		tx, _, _ := CreateTestTransactionEx(1, hash.SHA256Sum(payload), [][]byte{{0x1}})
-
-		err := txState.Add(ctx, tx, payload)
-
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		xor, _ := txState.XOR(ctx, 1)
-		assert.True(t, hash.EmptyHash().Equals(xor))
+		assert.False(t, hash.EmptyHash().Equals(xor))
 	})
 }
 

--- a/network/network.go
+++ b/network/network.go
@@ -212,8 +212,8 @@ func (n *Network) Configure(config core.ServerConfig) error {
 		)
 	}
 
-	// register callback from DAG to other engines.
-	n.state.RegisterObserver(n.emitEvents, true)
+	// register callback from DAG to other engines, with payload only.
+	n.state.RegisterPayloadObserver(n.emitEvents, true)
 
 	return nil
 }

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -477,6 +477,11 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 			return
 		}
 		waitForTransaction(t, tx, "node2")
+
+		// assert not only TX is transfered, but state is updates as well
+		xor1, _ := node1.state.XOR(context.Background(), math.MaxUint32)
+		xor2, _ := node2.state.XOR(context.Background(), math.MaxUint32)
+		assert.Equal(t, xor1.String(), xor2.String())
 	})
 
 	t.Run("event received", func(t *testing.T) {

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -161,7 +161,7 @@ func (p *protocol) Configure(_ transport.PeerID) error {
 	p.gManager.RegisterSender(p.sendGossip)
 
 	// called after DAG is committed
-	p.state.RegisterObserver(p.gossipTransaction, false)
+	p.state.RegisterTransactionObserver(p.gossipTransaction, false)
 
 	return nil
 }
@@ -211,7 +211,7 @@ func (p *protocol) connectionStateCallback(peer transport.Peer, state transport.
 }
 
 // gossipTransaction is called when a transaction is added to the DAG
-func (p *protocol) gossipTransaction(ctx context.Context, tx dag.Transaction, _ []byte) error {
+func (p *protocol) gossipTransaction(ctx context.Context, tx dag.Transaction) error {
 	if tx != nil { // can happen when payload is written for private TX
 		xor, clock := p.state.XOR(ctx, math.MaxUint32)
 		p.gManager.TransactionRegistered(tx.Ref(), xor, clock)

--- a/network/transport/v2/protocol_test.go
+++ b/network/transport/v2/protocol_test.go
@@ -101,7 +101,7 @@ func TestDefaultConfig(t *testing.T) {
 func TestProtocol_Configure(t *testing.T) {
 	testDID, _ := did.ParseDID("did:nuts:123")
 	p, mocks := newTestProtocol(t, testDID)
-	mocks.State.EXPECT().RegisterObserver(gomock.Any(), false)
+	mocks.State.EXPECT().RegisterTransactionObserver(gomock.Any(), false)
 
 	assert.NoError(t, p.Configure(""))
 }
@@ -253,7 +253,7 @@ func TestProtocol_gossipTransaction(t *testing.T) {
 	t.Run("ok - no transaction", func(t *testing.T) {
 		proto, _ := newTestProtocol(t, nil)
 
-		proto.gossipTransaction(context.Background(), nil, nil)
+		proto.gossipTransaction(context.Background(), nil)
 	})
 
 	t.Run("ok - to gossipManager", func(t *testing.T) {
@@ -262,7 +262,7 @@ func TestProtocol_gossipTransaction(t *testing.T) {
 		mocks.State.EXPECT().XOR(context.Background(), uint32(math.MaxUint32))
 		mocks.Gossip.EXPECT().TransactionRegistered(tx.Ref(), hash.EmptyHash(), uint32(0))
 
-		proto.gossipTransaction(context.Background(), tx, nil)
+		proto.gossipTransaction(context.Background(), tx)
 	})
 }
 


### PR DESCRIPTION
fixes #1116 

it basically simulates 2 separate notifications: 1 for the TX and 1 for the payload. But when receiving the payload notification you'll want the TX as well.

Now the notifications are equal again for creating and receiving nodes of private TXs

backport to V2