### PR TITLE
Run e2e for PRs on V* branches

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'V*'
 
 
 jobs:


### PR DESCRIPTION
Are there cases where this test shouldn't run? (Can we remove filtering completely?)