### PR TITLE
added bbolt TX as param to some bboltDAG methods

### DIFF
--- a/network/dag/bbolt_dag_test.go
+++ b/network/dag/bbolt_dag_test.go
@@ -66,8 +66,7 @@ func TestBBoltDAG_FindBetween(t *testing.T) {
 		// tx1 and tx2's signing time are out-of-order
 		tx1 := CreateSignedTestTransaction(2, time.Now().AddDate(0, 0, 1), nil, "unit/test", true)
 		tx2 := CreateSignedTestTransaction(1, time.Now(), nil, "unit/test", true, tx1)
-		_ = graph.Add(ctx, tx1)
-		_ = graph.Add(ctx, tx2)
+		addTx(t, graph, tx1, tx2)
 
 		actual, err := graph.FindBetween(ctx, time.Now().AddDate(0, 0, -2), time.Now().AddDate(1, 0, 0))
 		if !assert.NoError(t, err) {
@@ -90,10 +89,7 @@ func TestBBoltDAG_findBetweenLC(t *testing.T) {
 		tx3 := CreateSignedTestTransaction(3, time.Now(), nil, "unit/test", true, tx1)
 		tx4 := CreateSignedTestTransaction(4, time.Now(), nil, "unit/test", true, tx2, tx3)
 		tx5 := CreateSignedTestTransaction(5, time.Now(), nil, "unit/test", true, tx4)
-		err := graph.Add(ctx, tx1, tx2, tx3, tx4, tx5)
-		if !assert.NoError(t, err) {
-			return
-		}
+		addTx(t, graph, tx2, tx3, tx4, tx5)
 
 		// LC 1..3 should yield tx2, tx3 and tx4
 		actual, err := graph.findBetweenLC(ctx, 1, 3)
@@ -110,22 +106,26 @@ func TestBBoltDAG_findBetweenLC(t *testing.T) {
 
 func TestBBoltDAG_Get(t *testing.T) {
 	t.Run("found", func(t *testing.T) {
-		ctx := context.Background()
 		graph := CreateDAG(t)
 		transaction := CreateTestTransactionWithJWK(1)
-		_ = graph.Add(ctx, transaction)
-		actual, err := graph.Get(ctx, transaction.Ref())
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.Equal(t, transaction, actual)
+		_ = graph.db.Update(func(tx *bbolt.Tx) error {
+			_ = graph.Add(tx, transaction)
+			actual, err := graph.Get(tx, transaction.Ref())
+			if !assert.NoError(t, err) {
+				return err
+			}
+			assert.Equal(t, transaction, actual)
+			return nil
+		})
 	})
 	t.Run("not found", func(t *testing.T) {
-		ctx := context.Background()
 		graph := CreateDAG(t)
-		actual, err := graph.Get(ctx, hash.SHA256Sum([]byte{1, 2, 3}))
-		assert.NoError(t, err)
-		assert.Nil(t, actual)
+		_ = graph.db.Update(func(tx *bbolt.Tx) error {
+			actual, err := graph.Get(tx, hash.SHA256Sum([]byte{1, 2, 3}))
+			assert.NoError(t, err)
+			assert.Nil(t, actual)
+			return nil
+		})
 	})
 	t.Run("bbolt byte slice is copied", func(t *testing.T) {
 		// This test the fixing of https://github.com/nuts-foundation/nuts-node/issues/488: "Fix and debug strange memory corruption issue".
@@ -134,7 +134,7 @@ func TestBBoltDAG_Get(t *testing.T) {
 		graph := CreateDAG(t)
 		// Create root TX
 		rootTX := CreateTestTransactionWithJWK(0)
-		graph.Add(context.Background(), rootTX)
+		addTx(t, graph, rootTX)
 		// Create and read TXs in parallel to trigger error scenario
 		const numTX = 10
 		wg := sync.WaitGroup{}
@@ -142,16 +142,16 @@ func TestBBoltDAG_Get(t *testing.T) {
 		for i := 0; i < numTX; i++ {
 			go func() {
 				defer wg.Done()
-				cxt := context.Background()
-				tx := CreateTestTransactionWithJWK(uint32(rand.Int31n(100000)), rootTX)
-				if !assert.NoError(t, graph.Add(cxt, tx)) {
-					return
-				}
-				actual, err := graph.Get(cxt, tx.Ref())
-				if !assert.NoError(t, err) {
-					return
-				}
-				_, err = jws.Parse(actual.Data())
+				tx1 := CreateTestTransactionWithJWK(uint32(rand.Int31n(100000)), rootTX)
+				addTx(t, graph, tx1)
+				err := graph.db.View(func(tx *bbolt.Tx) error {
+					actual, err := graph.Get(tx, tx1.Ref())
+					if err != nil {
+						return err
+					}
+					_, err = jws.Parse(actual.Data())
+					return err
+				})
 				if !assert.NoError(t, err) {
 					return
 				}
@@ -167,26 +167,27 @@ func TestBBoltDAG_Add(t *testing.T) {
 		graph := CreateDAG(t)
 		tx := CreateTestTransactionWithJWK(0)
 
-		err := graph.Add(ctx, tx)
+		addTx(t, graph, tx)
 
-		assert.NoError(t, err)
 		visitor := trackingVisitor{}
-		err = graph.Walk(ctx, visitor.Accept, hash.EmptyHash())
+		err := graph.Walk(ctx, visitor.Accept, hash.EmptyHash())
 		if !assert.NoError(t, err) {
 			return
 		}
 		assert.Len(t, visitor.transactions, 1)
 		assert.Equal(t, tx.Ref(), visitor.transactions[0].Ref())
-		present, _ := graph.IsPresent(ctx, tx.Ref())
-		assert.True(t, present)
+		graph.db.View(func(dbTx *bbolt.Tx) error {
+			assert.True(t, graph.IsPresent(dbTx, tx.Ref()))
+			return nil
+		})
+
 	})
 	t.Run("duplicate", func(t *testing.T) {
 		ctx := context.Background()
 		graph := CreateDAG(t)
 		tx := CreateTestTransactionWithJWK(0)
 
-		_ = graph.Add(ctx, tx)
-		err := graph.Add(ctx, tx)
+		err := addTxErr(graph, tx)
 
 		assert.NoError(t, err)
 		// Assert we can find the TX, but make sure it's only there once
@@ -199,8 +200,8 @@ func TestBBoltDAG_Add(t *testing.T) {
 		root1 := CreateTestTransactionWithJWK(1)
 		root2 := CreateTestTransactionWithJWK(2)
 
-		_ = graph.Add(ctx, root1)
-		err := graph.Add(ctx, root2)
+		addTx(t, graph, root1)
+		err := addTxErr(graph, root2)
 		assert.EqualError(t, err, "root transaction already exists")
 		actual, _ := graph.FindBetween(ctx, MinTime(), MaxTime())
 		assert.Len(t, actual, 1)
@@ -208,14 +209,13 @@ func TestBBoltDAG_Add(t *testing.T) {
 	t.Run("error - cyclic graph", func(t *testing.T) {
 		t.Skip("Algorithm for detecting cycles is not yet decided on")
 		// A -> B -> C -> B
-		ctx := context.Background()
 		A := CreateTestTransactionWithJWK(0)
 		B := CreateTestTransactionWithJWK(1, A).(*transaction)
 		C := CreateTestTransactionWithJWK(2, B)
 		B.prevs = append(B.prevs, C.Ref())
 
 		graph := CreateDAG(t)
-		err := graph.Add(ctx, A, B, C)
+		err := addTxErr(graph, A, B, C)
 		assert.EqualError(t, err, "")
 	})
 }
@@ -359,7 +359,7 @@ func TestBBoltDAG_Walk(t *testing.T) {
 		graph := CreateDAG(t)
 		visitor := trackingVisitor{}
 		transaction := CreateTestTransactionWithJWK(1)
-		_ = graph.Add(ctx, transaction)
+		addTx(t, graph, transaction)
 
 		err := graph.Walk(ctx, visitor.Accept, hash.EmptyHash())
 		if !assert.NoError(t, err) {
@@ -377,7 +377,7 @@ func TestBBoltDAG_Walk(t *testing.T) {
 		B := CreateTestTransactionWithJWK(2, A)
 		C := CreateTestTransactionWithJWK(3, A)
 		D := CreateTestTransactionWithJWK(4, C, B)
-		_ = graph.Add(ctx, A, B, C, D)
+		addTx(t, graph, A, B, C, D)
 
 		err := graph.Walk(ctx, visitor.Accept, hash.EmptyHash())
 		if !assert.NoError(t, err) {
@@ -397,7 +397,7 @@ func TestBBoltDAG_GetByPayloadHash(t *testing.T) {
 		ctx := context.Background()
 		graph := CreateDAG(t)
 		transaction := CreateTestTransactionWithJWK(1)
-		_ = graph.Add(ctx, transaction)
+		addTx(t, graph, transaction)
 		actual, err := graph.GetByPayloadHash(ctx, transaction.PayloadHash())
 		assert.Len(t, actual, 1)
 		assert.NoError(t, err)
@@ -421,10 +421,10 @@ func TestBBoltDAG_PayloadHashes(t *testing.T) {
 		// Create some TXs
 		rootTX := CreateTestTransactionWithJWK(0)
 		payloads[rootTX.PayloadHash()] = false
-		_ = graph.Add(ctx, rootTX)
+		addTx(t, graph, rootTX)
 		for i := 1; i < numberOfTXs; i++ {
 			tx := CreateTestTransactionWithJWK(uint32(i), rootTX)
-			_ = graph.Add(ctx, tx)
+			addTx(t, graph, tx)
 			payloads[tx.PayloadHash()] = false
 		}
 
@@ -448,8 +448,7 @@ func TestBBoltDAG_PayloadHashes(t *testing.T) {
 	t.Run("error - visitor returns error", func(t *testing.T) {
 		ctx := context.Background()
 		graph := CreateDAG(t)
-		_ = graph.Add(ctx, CreateTestTransactionWithJWK(0))
-		_ = graph.Add(ctx, CreateTestTransactionWithJWK(1))
+		addTx(t, graph, CreateTestTransactionWithJWK(0))
 		numCalled := 0
 		err := graph.PayloadHashes(ctx, func(payloadHash hash.SHA256Hash) error {
 			numCalled++
@@ -516,20 +515,19 @@ func TestBBoltDAG_getHighestClock(t *testing.T) {
 		tx0, _, _ := CreateTestTransaction(9)
 		tx1, _, _ := CreateTestTransaction(8, tx0)
 		tx2, _, _ := CreateTestTransaction(7, tx1)
-		_ = graph.Add(ctx, tx0, tx1, tx2)
+		addTx(t, graph, tx0, tx1, tx2)
 
 		clock := graph.getHighestClock(ctx)
 
 		assert.Equal(t, uint32(2), clock)
 	})
 	t.Run("out of order transactions", func(t *testing.T) {
-		ctx := context.Background()
 		graph := CreateDAG(t)
 		tx0, _, _ := CreateTestTransaction(9)
 		tx1, _, _ := CreateTestTransaction(8, tx0)
 		tx2, _, _ := CreateTestTransaction(7, tx1)
-		_ = graph.Add(ctx, tx0, tx2)
-		_ = graph.Add(context.Background(), tx1)
+		addTx(t, graph, tx0, tx2)
+		addTx(t, graph, tx1)
 
 		clock := graph.getHighestClock(context.Background())
 

--- a/network/dag/bbolt_payloadstore_test.go
+++ b/network/dag/bbolt_payloadstore_test.go
@@ -19,40 +19,40 @@
 package dag
 
 import (
-	"context"
 	"testing"
 
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/test/io"
 	"github.com/stretchr/testify/assert"
+	"go.etcd.io/bbolt"
 )
 
 func TestBBoltPayloadStore_ReadWrite(t *testing.T) {
 	testDirectory := io.TestDirectory(t)
-	ctx := context.Background()
-	payloadStore := NewBBoltPayloadStore(createBBoltDB(testDirectory))
+	db := createBBoltDB(testDirectory)
+	payloadStore := NewBBoltPayloadStore(db)
 
-	payload := []byte("Hello, World!")
-	hash := hash.SHA256Sum(payload)
-	// Before, payload should not be present
-	present, err := payloadStore.IsPayloadPresent(ctx, hash)
-	if !assert.NoError(t, err) || !assert.False(t, present) {
-		return
-	}
-	// Add payload
-	err = payloadStore.WritePayload(ctx, hash, payload)
-	if !assert.NoError(t, err) {
-		return
-	}
-	// Now it should be present
-	present, err = payloadStore.IsPayloadPresent(ctx, hash)
-	if !assert.NoError(t, err) || !assert.True(t, present, "payload should be present") {
-		return
-	}
-	// Read payload
-	data, err := payloadStore.ReadPayload(ctx, hash)
-	if !assert.NoError(t, err) {
-		return
-	}
-	assert.Equal(t, payload, data)
+	db.Update(func(tx *bbolt.Tx) error {
+		payload := []byte("Hello, World!")
+		hash := hash.SHA256Sum(payload)
+		// Before, payload should not be present
+		present := payloadStore.IsPayloadPresent(tx, hash)
+		if !assert.False(t, present) {
+			return nil
+		}
+		// Add payload
+		err := payloadStore.WritePayload(tx, hash, payload)
+		if !assert.NoError(t, err) {
+			return nil
+		}
+		// Now it should be present
+		present = payloadStore.IsPayloadPresent(tx, hash)
+		if !assert.True(t, present, "payload should be present") {
+			return nil
+		}
+		// Read payload
+		data := payloadStore.ReadPayload(tx, hash)
+		assert.Equal(t, payload, data)
+		return nil
+	})
 }

--- a/network/dag/bbolt_tree_test.go
+++ b/network/dag/bbolt_tree_test.go
@@ -21,11 +21,12 @@ package dag
 import (
 	"context"
 	"encoding/binary"
-	"github.com/nuts-foundation/nuts-node/test"
-	"go.etcd.io/bbolt"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/nuts-foundation/nuts-node/test"
+	"go.etcd.io/bbolt"
 
 	"github.com/stretchr/testify/assert"
 
@@ -196,10 +197,7 @@ func TestBboltTree_buildFromDag(t *testing.T) {
 		db:    dag.db,
 		graph: dag,
 	}
-	err := dag.Add(context.Background(), tx0, tx1a, tx1b, tx2)
-	if !assert.NoError(t, err) {
-		return
-	}
+	addTx(t, dag, tx0, tx1a, tx1b, tx2)
 
 	t.Run("ok - build tree", func(t *testing.T) {
 		store := newBBoltTreeStore(dag.db, "real bucket", tree.New(tree.NewXor(), testLeafSize))

--- a/network/dag/mock.go
+++ b/network/dag/mock.go
@@ -13,6 +13,7 @@ import (
 	core "github.com/nuts-foundation/nuts-node/core"
 	hash "github.com/nuts-foundation/nuts-node/crypto/hash"
 	tree "github.com/nuts-foundation/nuts-node/network/dag/tree"
+	bbolt "go.etcd.io/bbolt"
 )
 
 // MockState is a mock of State interface.
@@ -278,17 +279,17 @@ func (mr *MockStateMockRecorder) Walk(ctx, visitor, startAt interface{}) *gomock
 }
 
 // WritePayload mocks base method.
-func (m *MockState) WritePayload(ctx context.Context, transaction Transaction, payloadHash hash.SHA256Hash, data []byte) error {
+func (m *MockState) WritePayload(transaction Transaction, payloadHash hash.SHA256Hash, data []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WritePayload", ctx, transaction, payloadHash, data)
+	ret := m.ctrl.Call(m, "WritePayload", transaction, payloadHash, data)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WritePayload indicates an expected call of WritePayload.
-func (mr *MockStateMockRecorder) WritePayload(ctx, transaction, payloadHash, data interface{}) *gomock.Call {
+func (mr *MockStateMockRecorder) WritePayload(transaction, payloadHash, data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WritePayload", reflect.TypeOf((*MockState)(nil).WritePayload), ctx, transaction, payloadHash, data)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WritePayload", reflect.TypeOf((*MockState)(nil).WritePayload), transaction, payloadHash, data)
 }
 
 // XOR mocks base method.
@@ -391,47 +392,45 @@ func (m *MockPayloadStore) EXPECT() *MockPayloadStoreMockRecorder {
 }
 
 // IsPayloadPresent mocks base method.
-func (m *MockPayloadStore) IsPayloadPresent(ctx context.Context, payloadHash hash.SHA256Hash) (bool, error) {
+func (m *MockPayloadStore) IsPayloadPresent(tx *bbolt.Tx, payloadHash hash.SHA256Hash) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsPayloadPresent", ctx, payloadHash)
+	ret := m.ctrl.Call(m, "IsPayloadPresent", tx, payloadHash)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // IsPayloadPresent indicates an expected call of IsPayloadPresent.
-func (mr *MockPayloadStoreMockRecorder) IsPayloadPresent(ctx, payloadHash interface{}) *gomock.Call {
+func (mr *MockPayloadStoreMockRecorder) IsPayloadPresent(tx, payloadHash interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPayloadPresent", reflect.TypeOf((*MockPayloadStore)(nil).IsPayloadPresent), ctx, payloadHash)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPayloadPresent", reflect.TypeOf((*MockPayloadStore)(nil).IsPayloadPresent), tx, payloadHash)
 }
 
 // ReadPayload mocks base method.
-func (m *MockPayloadStore) ReadPayload(ctx context.Context, payloadHash hash.SHA256Hash) ([]byte, error) {
+func (m *MockPayloadStore) ReadPayload(tx *bbolt.Tx, payloadHash hash.SHA256Hash) []byte {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadPayload", ctx, payloadHash)
+	ret := m.ctrl.Call(m, "ReadPayload", tx, payloadHash)
 	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // ReadPayload indicates an expected call of ReadPayload.
-func (mr *MockPayloadStoreMockRecorder) ReadPayload(ctx, payloadHash interface{}) *gomock.Call {
+func (mr *MockPayloadStoreMockRecorder) ReadPayload(tx, payloadHash interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPayload", reflect.TypeOf((*MockPayloadStore)(nil).ReadPayload), ctx, payloadHash)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPayload", reflect.TypeOf((*MockPayloadStore)(nil).ReadPayload), tx, payloadHash)
 }
 
 // WritePayload mocks base method.
-func (m *MockPayloadStore) WritePayload(ctx context.Context, payloadHash hash.SHA256Hash, data []byte) error {
+func (m *MockPayloadStore) WritePayload(tx *bbolt.Tx, payloadHash hash.SHA256Hash, data []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WritePayload", ctx, payloadHash, data)
+	ret := m.ctrl.Call(m, "WritePayload", tx, payloadHash, data)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WritePayload indicates an expected call of WritePayload.
-func (mr *MockPayloadStoreMockRecorder) WritePayload(ctx, payloadHash, data interface{}) *gomock.Call {
+func (mr *MockPayloadStoreMockRecorder) WritePayload(tx, payloadHash, data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WritePayload", reflect.TypeOf((*MockPayloadStore)(nil).WritePayload), ctx, payloadHash, data)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WritePayload", reflect.TypeOf((*MockPayloadStore)(nil).WritePayload), tx, payloadHash, data)
 }
 
 // MockPayloadWriter is a mock of PayloadWriter interface.
@@ -458,17 +457,17 @@ func (m *MockPayloadWriter) EXPECT() *MockPayloadWriterMockRecorder {
 }
 
 // WritePayload mocks base method.
-func (m *MockPayloadWriter) WritePayload(ctx context.Context, transaction Transaction, payloadHash hash.SHA256Hash, data []byte) error {
+func (m *MockPayloadWriter) WritePayload(transaction Transaction, payloadHash hash.SHA256Hash, data []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WritePayload", ctx, transaction, payloadHash, data)
+	ret := m.ctrl.Call(m, "WritePayload", transaction, payloadHash, data)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WritePayload indicates an expected call of WritePayload.
-func (mr *MockPayloadWriterMockRecorder) WritePayload(ctx, transaction, payloadHash, data interface{}) *gomock.Call {
+func (mr *MockPayloadWriterMockRecorder) WritePayload(transaction, payloadHash, data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WritePayload", reflect.TypeOf((*MockPayloadWriter)(nil).WritePayload), ctx, transaction, payloadHash, data)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WritePayload", reflect.TypeOf((*MockPayloadWriter)(nil).WritePayload), transaction, payloadHash, data)
 }
 
 // MockPayloadReader is a mock of PayloadReader interface.

--- a/network/dag/publisher.go
+++ b/network/dag/publisher.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network/log"
+	"github.com/nuts-foundation/nuts-node/network/storage"
+	"go.etcd.io/bbolt"
 )
 
 // NewReplayingDAGPublisher creates a DAG publisher that replays the complete DAG to all subscribers when started.
@@ -60,11 +62,11 @@ func (s *replayingDAGPublisher) ConfigureCallbacks(state State) {
 		return s.transactionAdded(ctx, transaction, nil)
 	}, false)
 
-	state.RegisterPayloadObserver(func(ctx context.Context, transaction Transaction, payload []byte) error {
+	state.RegisterPayloadObserver(func(transaction Transaction, payload []byte) error {
 		s.publishMux.Lock()
 		defer s.publishMux.Unlock()
 
-		return s.payloadWritten(ctx, transaction, payload)
+		return s.payloadWritten(context.Background(), transaction, payload)
 	}, false)
 }
 
@@ -139,13 +141,15 @@ func (s *replayingDAGPublisher) publish(ctx context.Context) error {
 	}
 
 	currentRef := front.Value.(hash.SHA256Hash)
-	return s.dag.Walk(ctx, func(ctx context.Context, transaction Transaction) bool {
-		outcome := s.publishTransaction(ctx, transaction)
-		if outcome {
-			remove(s.resumeAt, transaction.Ref())
-		}
-		return outcome
-	}, currentRef)
+	return storage.BBoltTXView(ctx, s.dag.db, func(contextWithTX context.Context, tx *bbolt.Tx) error {
+		return s.dag.Walk(ctx, func(ctx context.Context, transaction Transaction) bool {
+			outcome := s.publishTransaction(tx, transaction)
+			if outcome {
+				remove(s.resumeAt, transaction.Ref())
+			}
+			return outcome
+		}, currentRef)
+	})
 }
 
 func remove(l *list.List, ref hash.SHA256Hash) {
@@ -162,12 +166,8 @@ func remove(l *list.List, ref hash.SHA256Hash) {
 	}
 }
 
-func (s *replayingDAGPublisher) publishTransaction(ctx context.Context, transaction Transaction) bool {
-	payload, err := s.payloadStore.ReadPayload(ctx, transaction.PayloadHash())
-	if err != nil {
-		log.Logger().Errorf("Unable to read payload to publish DAG: (ref=%s) %v", transaction.Ref(), err)
-		return false
-	}
+func (s *replayingDAGPublisher) publishTransaction(tx *bbolt.Tx, transaction Transaction) bool {
+	payload := s.payloadStore.ReadPayload(tx, transaction.PayloadHash())
 
 	if payload == nil {
 		if isBlockingTransaction(transaction) {
@@ -208,27 +208,26 @@ func (s *replayingDAGPublisher) replay() error {
 	s.publishMux.Lock()
 	defer s.publishMux.Unlock()
 
-	err := s.dag.Walk(context.Background(), func(ctx context.Context, tx Transaction) bool {
-		s.emitEvent(TransactionAddedEvent, tx, nil)
-		payload, err := s.payloadStore.ReadPayload(ctx, tx.PayloadHash())
-		if err != nil {
-			log.Logger().Errorf("Error reading payload (tx=%s): %v", tx.Ref(), err)
-		}
-		if payload == nil {
-			if isBlockingTransaction(tx) {
-				// public TX but without payload, TX processing only. Wait for payload.
-				// This is probably a DID Document Create/Update. We need the payload before we process any depending payloads
-				s.resumeAt.PushBack(tx.Ref())
-				return false
+	err := storage.BBoltTXView(context.Background(), s.dag.db, func(contextWithTX context.Context, tx *bbolt.Tx) error {
+		return s.dag.Walk(contextWithTX, func(ctx context.Context, transaction Transaction) bool {
+			s.emitEvent(TransactionAddedEvent, transaction, nil)
+			payload := s.payloadStore.ReadPayload(tx, transaction.PayloadHash())
+			if payload == nil {
+				if isBlockingTransaction(transaction) {
+					// public TX but without payload, TX processing only. Wait for payload.
+					// This is probably a DID Document Create/Update. We need the payload before we process any depending payloads
+					s.resumeAt.PushBack(transaction.Ref())
+					return false
+				}
+			} else {
+				s.emitEvent(TransactionPayloadAddedEvent, transaction, payload)
+				// prevent DID doc updates to come back and haunt us. DID doc updates may reuse a payload hash already seen earlier.
+				// payloadWritten will then also find the old TX
+				s.visitedTransactions[transaction.Ref()] = true
 			}
-		} else {
-			s.emitEvent(TransactionPayloadAddedEvent, tx, payload)
-			// prevent DID doc updates to come back and haunt us. DID doc updates may reuse a payload hash already seen earlier.
-			// payloadWritten will then also find the old TX
-			s.visitedTransactions[tx.Ref()] = true
-		}
-		return true
-	}, hash.EmptyHash())
+			return true
+		}, hash.EmptyHash())
+	})
 	if err != nil {
 		return err
 	}

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -171,7 +171,7 @@ func TestState_Observe(t *testing.T) {
 			actualTX = transaction
 			return nil
 		}, false)
-		txState.RegisterPayloadObserver(func(ctx context.Context, transaction Transaction, payload []byte) error {
+		txState.RegisterPayloadObserver(func(transaction Transaction, payload []byte) error {
 			actualPayload = payload
 			return nil
 		}, false)
@@ -193,16 +193,15 @@ func TestState_Observe(t *testing.T) {
 		assert.EqualError(t, err, "tx.PayloadHash does not match hash of payload")
 	})
 	t.Run("payload added", func(t *testing.T) {
-		ctx := context.Background()
 		txState := createState(t)
 		var actual []byte
-		txState.RegisterPayloadObserver(func(ctx context.Context, tx Transaction, payload []byte) error {
+		txState.RegisterPayloadObserver(func(tx Transaction, payload []byte) error {
 			actual = payload
 			return nil
 		}, false)
 		expected := []byte{1}
 
-		err := txState.WritePayload(ctx, nil, hash.EmptyHash(), expected)
+		err := txState.WritePayload(nil, hash.EmptyHash(), expected)
 
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)

--- a/network/dag/test.go
+++ b/network/dag/test.go
@@ -139,3 +139,27 @@ func CreateDAG(t *testing.T) *bboltDAG {
 	testDirectory := io.TestDirectory(t)
 	return newBBoltDAG(createBBoltDB(testDirectory))
 }
+
+// addTx is a helper to add transactions to the DAG. It creates an Update bbolt TX and panics the test on error
+func addTx(t *testing.T, graph *bboltDAG, transactions ...Transaction) {
+	err := addTxErr(graph, transactions...)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// addTx is a helper to add transactions to the DAG. It creates an Update bbolt TX and returns the error
+func addTxErr(graph *bboltDAG, transactions ...Transaction) error {
+	return graph.db.Update(func(tx *bbolt.Tx) error {
+		return graph.Add(tx, transactions...)
+	})
+}
+
+func writePayload(t *testing.T, payloadStore *bboltPayloadStore, payloadHash hash.SHA256Hash, payload []byte) {
+	err := payloadStore.db.Update(func(tx *bbolt.Tx) error {
+		return payloadStore.WritePayload(tx, payloadHash, payload)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/network/network.go
+++ b/network/network.go
@@ -221,9 +221,9 @@ func (n *Network) Configure(config core.ServerConfig) error {
 // If the transaction fails for some reason (storage) then the event is still emitted. This is ok because the transaction was already validated.
 // Most likely the transaction will be added at a later stage and another event will be emitted.
 // It only emits events when both the payload and transaction are present. This is the case from both state.Add and from state.WritePayload.
-func (n *Network) emitEvents(ctx context.Context, tx dag.Transaction, payload []byte) error {
+func (n *Network) emitEvents(tx dag.Transaction, payload []byte) error {
 	if tx != nil && payload != nil {
-		_, js, err := n.eventPublisher.Pool().Acquire(ctx)
+		_, js, err := n.eventPublisher.Pool().Acquire(context.Background())
 		if err != nil {
 			return fmt.Errorf(errEventFailedMsg, err)
 		}

--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -190,7 +190,7 @@ func (p *protocol) handleTransactionPayload(peer transport.Peer, envelope *Envel
 		// Possible attack: received payload does not match transaction payload hash.
 		return fmt.Errorf("peer sent payload that doesn't match payload hash (tx=%s)", ref)
 	}
-	if err = p.state.WritePayload(ctx, tx, payloadHash, msg.Data); err != nil {
+	if err = p.state.WritePayload(tx, payloadHash, msg.Data); err != nil {
 		return err
 	}
 

--- a/network/transport/v2/handlers_test.go
+++ b/network/transport/v2/handlers_test.go
@@ -75,7 +75,7 @@ func TestProtocol_handleTransactionPayload(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
 
 		mocks.State.EXPECT().GetTransaction(gomock.Any(), tx.Ref()).Return(tx, nil)
-		mocks.State.EXPECT().WritePayload(gomock.Any(), tx, tx.PayloadHash(), payload)
+		mocks.State.EXPECT().WritePayload(tx, tx.PayloadHash(), payload)
 		mocks.PayloadScheduler.EXPECT().Finished(tx.Ref()).Return(nil)
 
 		err := p.handleTransactionPayload(peer, &Envelope{Message: &Envelope_TransactionPayload{&TransactionPayload{TransactionRef: tx.Ref().Slice(), Data: payload}}})


### PR DESCRIPTION
The `State` starts the transaction, bboltDAG reuses this transaction.

This is now done for:
- GetTransaction/Get
- IsPresent
- WritePayload

The goal is to remove the tx from the context. This is required for the DB abstraction layer