### PR TITLE
remove dependency on context for transaction verifiers

### DIFF
--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/network/storage"
 	"github.com/nuts-foundation/nuts-node/test/io"
 	"github.com/stretchr/testify/assert"
+	"go.etcd.io/bbolt"
 )
 
 func TestNewState(t *testing.T) {
@@ -111,7 +112,7 @@ func TestState_Shutdown(t *testing.T) {
 func TestState_Start(t *testing.T) {
 	t.Run("error - verifier failed", func(t *testing.T) {
 		ctx := context.Background()
-		txState := createState(t, func(_ context.Context, _ Transaction, _ State) error {
+		txState := createState(t, func(_ *bbolt.Tx, _ Transaction) error {
 			return errors.New("failed")
 		})
 		tx := CreateTestTransactionWithJWK(0)
@@ -211,7 +212,7 @@ func TestState_Observe(t *testing.T) {
 func TestState_Add(t *testing.T) {
 	t.Run("error for transaction verification failure", func(t *testing.T) {
 		ctx := context.Background()
-		txState := createState(t, func(_ context.Context, tx Transaction, _ State) error {
+		txState := createState(t, func(_ *bbolt.Tx, tx Transaction) error {
 			return errors.New("verification failed")
 		})
 		_ = txState.Start()

--- a/network/dag/verifier_test.go
+++ b/network/dag/verifier_test.go
@@ -34,84 +34,90 @@ import (
 	"github.com/nuts-foundation/nuts-node/vdr/doc"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"github.com/stretchr/testify/assert"
+	"go.etcd.io/bbolt"
 )
 
 func Test_PrevTransactionVerifier(t *testing.T) {
-	root, _, _ := CreateTestTransaction(0)
+	rootPayload := []byte{0}
+	root, _, _ := CreateTestTransactionEx(1, hash.SHA256Sum(rootPayload), nil)
+	ctx := context.Background()
 
 	t.Run("ok - prev is present", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		ctx := context.Background()
-		txState := NewMockState(ctrl)
-		txState.EXPECT().GetTransaction(ctx, root.Ref()).Return(root, nil)
-		tx, _, _ := CreateTestTransaction(1, root)
+		testState := createState(t).(*state)
+		payload := []byte{0}
+		tx, _, _ := CreateTestTransactionEx(1, hash.SHA256Sum(payload), nil, root)
+		_ = testState.Add(ctx, root, rootPayload)
 
-		err := NewPrevTransactionsVerifier()(ctx, tx, txState)
-
-		assert.NoError(t, err)
+		_ = testState.db.View(func(dbTx *bbolt.Tx) error {
+			err := NewPrevTransactionsVerifier()(dbTx, tx)
+			assert.NoError(t, err)
+			return nil
+		})
 	})
+
 	t.Run("failed - prev not present", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		ctx := context.Background()
-		txState := NewMockState(ctrl)
-		txState.EXPECT().GetTransaction(ctx, root.Ref()).Return(nil, nil)
+		testState := createState(t).(*state)
 		tx, _, _ := CreateTestTransaction(1, root)
 
-		err := NewPrevTransactionsVerifier()(ctx, tx, txState)
-
-		assert.Contains(t, err.Error(), "transaction is referring to non-existing previous transaction")
+		_ = testState.db.View(func(dbTx *bbolt.Tx) error {
+			err := NewPrevTransactionsVerifier()(dbTx, tx)
+			assert.Contains(t, err.Error(), "transaction is referring to non-existing previous transaction")
+			return nil
+		})
 	})
+
 	t.Run("error - incorrect lamport clock", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		ctx := context.Background()
-		txState := NewMockState(ctrl)
-		txState.EXPECT().GetTransaction(ctx, root.Ref()).Return(root, nil)
+		testState := createState(t).(*state)
+		_ = testState.Add(ctx, root, rootPayload)
+
 		// malformed TX with LC = 2
 		unsignedTransaction, _ := NewTransaction(hash.EmptyHash(), "application/did+json", []hash.SHA256Hash{root.Ref()}, nil, 2)
 		signer := crypto2.NewTestKey("1")
 		signedTransaction, _ := NewTransactionSigner(signer, true).Sign(unsignedTransaction, time.Now())
 
-		err := NewPrevTransactionsVerifier()(ctx, signedTransaction, txState)
-
-		assert.EqualError(t, err, "transaction has an invalid lamport clock value")
+		_ = testState.db.View(func(dbTx *bbolt.Tx) error {
+			err := NewPrevTransactionsVerifier()(dbTx, signedTransaction)
+			assert.EqualError(t, err, "transaction has an invalid lamport clock value")
+			return nil
+		})
 	})
 }
 
 func TestTransactionSignatureVerifier(t *testing.T) {
 	t.Run("embedded JWK, sign -> verify", func(t *testing.T) {
-		err := NewTransactionSignatureVerifier(nil)(context.Background(), CreateTestTransactionWithJWK(1), nil)
+		err := NewTransactionSignatureVerifier(nil)(nil, CreateTestTransactionWithJWK(1))
 		assert.NoError(t, err)
 	})
 	t.Run("embedded JWK, sign -> marshal -> unmarshal -> verify", func(t *testing.T) {
 		expected, _ := ParseTransaction(CreateTestTransactionWithJWK(1).Data())
-		err := NewTransactionSignatureVerifier(nil)(context.Background(), expected, nil)
+		err := NewTransactionSignatureVerifier(nil)(nil, expected)
 		assert.NoError(t, err)
 	})
 	t.Run("referral with key ID", func(t *testing.T) {
 		transaction, _, publicKey := CreateTestTransaction(1)
 		expected, _ := ParseTransaction(transaction.Data())
-		err := NewTransactionSignatureVerifier(&doc.StaticKeyResolver{Key: publicKey})(context.Background(), expected, nil)
+		err := NewTransactionSignatureVerifier(&doc.StaticKeyResolver{Key: publicKey})(nil, expected)
 		assert.NoError(t, err)
 	})
 	t.Run("wrong key", func(t *testing.T) {
 		attackerKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		transaction, _, _ := CreateTestTransaction(1)
 		expected, _ := ParseTransaction(transaction.Data())
-		err := NewTransactionSignatureVerifier(&doc.StaticKeyResolver{Key: attackerKey.Public()})(context.Background(), expected, nil)
+		err := NewTransactionSignatureVerifier(&doc.StaticKeyResolver{Key: attackerKey.Public()})(nil, expected)
 		assert.EqualError(t, err, "failed to verify message: failed to verify signature using ecdsa")
 	})
 	t.Run("key type is incorrect", func(t *testing.T) {
 		d, _, _ := CreateTestTransaction(1)
 		tx := d.(*transaction)
 		tx.signingKey = jwk.NewSymmetricKey()
-		err := NewTransactionSignatureVerifier(nil)(context.Background(), tx, nil)
+		err := NewTransactionSignatureVerifier(nil)(nil, tx)
 		assert.EqualError(t, err, "failed to verify message: failed to retrieve ecdsa.PublicKey out of []uint8: expected ecdsa.PublicKey or *ecdsa.PublicKey, got []uint8")
 	})
 	t.Run("unable to derive key from JWK", func(t *testing.T) {
 		d, _, _ := CreateTestTransaction(1)
 		transaction := d.(*transaction)
 		transaction.signingKey = jwk.NewOKPPublicKey()
-		err := NewTransactionSignatureVerifier(nil)(context.Background(), transaction, nil)
+		err := NewTransactionSignatureVerifier(nil)(nil, transaction)
 		assert.EqualError(t, err, "failed to build public key: invalid curve algorithm P-invalid")
 	})
 	t.Run("unable to resolve key by hash", func(t *testing.T) {
@@ -120,7 +126,7 @@ func TestTransactionSignatureVerifier(t *testing.T) {
 		keyResolver := types.NewMockKeyResolver(ctrl)
 		keyResolver.EXPECT().ResolvePublicKey(gomock.Any(), gomock.Any()).Return(nil, errors.New("failed"))
 
-		err := NewTransactionSignatureVerifier(keyResolver)(context.Background(), d, nil)
+		err := NewTransactionSignatureVerifier(keyResolver)(nil, d)
 		if !assert.Error(t, err) {
 			return
 		}
@@ -134,7 +140,7 @@ func TestTransactionSignatureVerifier(t *testing.T) {
 		keyResolver := types.NewMockKeyResolver(ctrl)
 		keyResolver.EXPECT().ResolvePublicKey(gomock.Any(), gomock.Any()).Return(nil, types.ErrNotFound)
 		keyResolver.EXPECT().ResolvePublicKeyInTime(gomock.Any(), gomock.Any()).Return(nil, errors.New("failed"))
-		err := NewTransactionSignatureVerifier(keyResolver)(context.Background(), d, nil)
+		err := NewTransactionSignatureVerifier(keyResolver)(nil, d)
 		if !assert.Error(t, err) {
 			return
 		}
@@ -145,22 +151,22 @@ func TestTransactionSignatureVerifier(t *testing.T) {
 
 func TestSigningTimeVerifier(t *testing.T) {
 	t.Run("signed now", func(t *testing.T) {
-		err := NewSigningTimeVerifier()(context.Background(), CreateSignedTestTransaction(1, time.Now(), nil, "test/test", true), nil)
+		err := NewSigningTimeVerifier()(nil, CreateSignedTestTransaction(1, time.Now(), nil, "test/test", true))
 		assert.NoError(t, err)
 	})
 	t.Run("signed in history", func(t *testing.T) {
 		aWhileBack := time.Now().AddDate(-1, 0, 0)
-		err := NewSigningTimeVerifier()(context.Background(), CreateSignedTestTransaction(1, aWhileBack, nil, "test/test", true), nil)
+		err := NewSigningTimeVerifier()(nil, CreateSignedTestTransaction(1, aWhileBack, nil, "test/test", true))
 		assert.NoError(t, err)
 	})
 	t.Run("signed a few hours in the future", func(t *testing.T) {
 		soon := time.Now().Add(time.Hour * 2)
-		err := NewSigningTimeVerifier()(context.Background(), CreateSignedTestTransaction(1, soon, nil, "test/test", true), nil)
+		err := NewSigningTimeVerifier()(nil, CreateSignedTestTransaction(1, soon, nil, "test/test", true))
 		assert.NoError(t, err)
 	})
 	t.Run("error - signed a day in the future", func(t *testing.T) {
 		later := time.Now().Add(time.Hour*24 + time.Minute)
-		err := NewSigningTimeVerifier()(context.Background(), CreateSignedTestTransaction(1, later, nil, "test/test", true), nil)
+		err := NewSigningTimeVerifier()(nil, CreateSignedTestTransaction(1, later, nil, "test/test", true))
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
fixed transaction dependency of TransactionVerifier, it now uses a bbolt.Tx instead of the context.

Another red block fixed:
<img width="1912" alt="Screenshot 2022-05-23 at 09 07 36" src="https://user-images.githubusercontent.com/703298/169829507-f4dbb17a-cbee-4667-9af9-2a8940ca5590.png">

