### PR TITLE
Docs: correct datadir

### DIFF
--- a/docs/pages/getting-started/1-running-docker.rst
+++ b/docs/pages/getting-started/1-running-docker.rst
@@ -39,7 +39,7 @@ This setup uses the following `nuts.yaml` configuration file:
 
 .. code-block:: yaml
 
-  datadir: /opt/nuts
+  datadir: /opt/nuts/data
   network:
     truststorefile: /opt/nuts/truststore.pem
     certfile: /opt/nuts/certificate-and-key.pem


### PR DESCRIPTION
.datadir now matches with the mounted volumes in Docker