### PR TITLE
remove time based diddoc resolver

### DIFF
--- a/network/dag/mock.go
+++ b/network/dag/mock.go
@@ -391,134 +391,44 @@ func (m *MockPayloadStore) EXPECT() *MockPayloadStoreMockRecorder {
 	return m.recorder
 }
 
-// IsPayloadPresent mocks base method.
-func (m *MockPayloadStore) IsPayloadPresent(tx *bbolt.Tx, payloadHash hash.SHA256Hash) bool {
+// isPayloadPresent mocks base method.
+func (m *MockPayloadStore) isPayloadPresent(tx *bbolt.Tx, payloadHash hash.SHA256Hash) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsPayloadPresent", tx, payloadHash)
+	ret := m.ctrl.Call(m, "isPayloadPresent", tx, payloadHash)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// IsPayloadPresent indicates an expected call of IsPayloadPresent.
-func (mr *MockPayloadStoreMockRecorder) IsPayloadPresent(tx, payloadHash interface{}) *gomock.Call {
+// isPayloadPresent indicates an expected call of isPayloadPresent.
+func (mr *MockPayloadStoreMockRecorder) isPayloadPresent(tx, payloadHash interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPayloadPresent", reflect.TypeOf((*MockPayloadStore)(nil).IsPayloadPresent), tx, payloadHash)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "isPayloadPresent", reflect.TypeOf((*MockPayloadStore)(nil).isPayloadPresent), tx, payloadHash)
 }
 
-// ReadPayload mocks base method.
-func (m *MockPayloadStore) ReadPayload(tx *bbolt.Tx, payloadHash hash.SHA256Hash) []byte {
+// readPayload mocks base method.
+func (m *MockPayloadStore) readPayload(tx *bbolt.Tx, payloadHash hash.SHA256Hash) []byte {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadPayload", tx, payloadHash)
+	ret := m.ctrl.Call(m, "readPayload", tx, payloadHash)
 	ret0, _ := ret[0].([]byte)
 	return ret0
 }
 
-// ReadPayload indicates an expected call of ReadPayload.
-func (mr *MockPayloadStoreMockRecorder) ReadPayload(tx, payloadHash interface{}) *gomock.Call {
+// readPayload indicates an expected call of readPayload.
+func (mr *MockPayloadStoreMockRecorder) readPayload(tx, payloadHash interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPayload", reflect.TypeOf((*MockPayloadStore)(nil).ReadPayload), tx, payloadHash)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "readPayload", reflect.TypeOf((*MockPayloadStore)(nil).readPayload), tx, payloadHash)
 }
 
-// WritePayload mocks base method.
-func (m *MockPayloadStore) WritePayload(tx *bbolt.Tx, payloadHash hash.SHA256Hash, data []byte) error {
+// writePayload mocks base method.
+func (m *MockPayloadStore) writePayload(tx *bbolt.Tx, payloadHash hash.SHA256Hash, data []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WritePayload", tx, payloadHash, data)
+	ret := m.ctrl.Call(m, "writePayload", tx, payloadHash, data)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// WritePayload indicates an expected call of WritePayload.
-func (mr *MockPayloadStoreMockRecorder) WritePayload(tx, payloadHash, data interface{}) *gomock.Call {
+// writePayload indicates an expected call of writePayload.
+func (mr *MockPayloadStoreMockRecorder) writePayload(tx, payloadHash, data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WritePayload", reflect.TypeOf((*MockPayloadStore)(nil).WritePayload), tx, payloadHash, data)
-}
-
-// MockPayloadWriter is a mock of PayloadWriter interface.
-type MockPayloadWriter struct {
-	ctrl     *gomock.Controller
-	recorder *MockPayloadWriterMockRecorder
-}
-
-// MockPayloadWriterMockRecorder is the mock recorder for MockPayloadWriter.
-type MockPayloadWriterMockRecorder struct {
-	mock *MockPayloadWriter
-}
-
-// NewMockPayloadWriter creates a new mock instance.
-func NewMockPayloadWriter(ctrl *gomock.Controller) *MockPayloadWriter {
-	mock := &MockPayloadWriter{ctrl: ctrl}
-	mock.recorder = &MockPayloadWriterMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockPayloadWriter) EXPECT() *MockPayloadWriterMockRecorder {
-	return m.recorder
-}
-
-// WritePayload mocks base method.
-func (m *MockPayloadWriter) WritePayload(transaction Transaction, payloadHash hash.SHA256Hash, data []byte) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WritePayload", transaction, payloadHash, data)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// WritePayload indicates an expected call of WritePayload.
-func (mr *MockPayloadWriterMockRecorder) WritePayload(transaction, payloadHash, data interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WritePayload", reflect.TypeOf((*MockPayloadWriter)(nil).WritePayload), transaction, payloadHash, data)
-}
-
-// MockPayloadReader is a mock of PayloadReader interface.
-type MockPayloadReader struct {
-	ctrl     *gomock.Controller
-	recorder *MockPayloadReaderMockRecorder
-}
-
-// MockPayloadReaderMockRecorder is the mock recorder for MockPayloadReader.
-type MockPayloadReaderMockRecorder struct {
-	mock *MockPayloadReader
-}
-
-// NewMockPayloadReader creates a new mock instance.
-func NewMockPayloadReader(ctrl *gomock.Controller) *MockPayloadReader {
-	mock := &MockPayloadReader{ctrl: ctrl}
-	mock.recorder = &MockPayloadReaderMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockPayloadReader) EXPECT() *MockPayloadReaderMockRecorder {
-	return m.recorder
-}
-
-// IsPayloadPresent mocks base method.
-func (m *MockPayloadReader) IsPayloadPresent(ctx context.Context, payloadHash hash.SHA256Hash) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsPayloadPresent", ctx, payloadHash)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsPayloadPresent indicates an expected call of IsPayloadPresent.
-func (mr *MockPayloadReaderMockRecorder) IsPayloadPresent(ctx, payloadHash interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPayloadPresent", reflect.TypeOf((*MockPayloadReader)(nil).IsPayloadPresent), ctx, payloadHash)
-}
-
-// ReadPayload mocks base method.
-func (m *MockPayloadReader) ReadPayload(ctx context.Context, payloadHash hash.SHA256Hash) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadPayload", ctx, payloadHash)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReadPayload indicates an expected call of ReadPayload.
-func (mr *MockPayloadReaderMockRecorder) ReadPayload(ctx, payloadHash interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPayload", reflect.TypeOf((*MockPayloadReader)(nil).ReadPayload), ctx, payloadHash)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "writePayload", reflect.TypeOf((*MockPayloadStore)(nil).writePayload), tx, payloadHash, data)
 }

--- a/network/dag/verifier.go
+++ b/network/dag/verifier.go
@@ -50,16 +50,9 @@ func NewTransactionSignatureVerifier(resolver types.KeyResolver) Verifier {
 				return err
 			}
 		} else {
-			signingTime := transaction.SigningTime()
 			pk, err := resolver.ResolvePublicKey(transaction.SigningKeyID(), transaction.Previous())
 			if err != nil {
-				if !errors.Is(err, types.ErrNotFound) {
-					return fmt.Errorf("unable to verify transaction signature, can't resolve key by TX ref (kid=%s, tx=%s): %w", transaction.SigningKeyID(), transaction.Ref().String(), err)
-				}
-				pk, err = resolver.ResolvePublicKeyInTime(transaction.SigningKeyID(), &signingTime)
-				if err != nil {
-					return fmt.Errorf("unable to verify transaction signature, can't resolve key by signing time (kid=%s): %w", transaction.SigningKeyID(), err)
-				}
+				return fmt.Errorf("unable to verify transaction signature, can't resolve key by TX ref (kid=%s, tx=%s): %w", transaction.SigningKeyID(), transaction.Ref().String(), err)
 			}
 			signingKey = pk
 		}

--- a/network/dag/verifier_test.go
+++ b/network/dag/verifier_test.go
@@ -134,19 +134,6 @@ func TestTransactionSignatureVerifier(t *testing.T) {
 		assert.Contains(t, err.Error(), "unable to verify transaction signature, can't resolve key by TX ref")
 		assert.Contains(t, err.Error(), "failed")
 	})
-	t.Run("unable to resolve key by hash and time", func(t *testing.T) {
-		d := CreateSignedTestTransaction(1, time.Now(), nil, "foo/bar", false)
-		ctrl := gomock.NewController(t)
-		keyResolver := types.NewMockKeyResolver(ctrl)
-		keyResolver.EXPECT().ResolvePublicKey(gomock.Any(), gomock.Any()).Return(nil, types.ErrNotFound)
-		keyResolver.EXPECT().ResolvePublicKeyInTime(gomock.Any(), gomock.Any()).Return(nil, errors.New("failed"))
-		err := NewTransactionSignatureVerifier(keyResolver)(nil, d)
-		if !assert.Error(t, err) {
-			return
-		}
-		assert.Contains(t, err.Error(), "unable to verify transaction signature, can't resolve key by signing time")
-		assert.Contains(t, err.Error(), "failed")
-	})
 }
 
 func TestSigningTimeVerifier(t *testing.T) {

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -205,18 +205,11 @@ func (n *ambassador) handleUpdateDIDDocument(transaction dag.Transaction, propos
 	// In an update, only the keyID is provided in the network document. Resolve the key from the key store
 	// This should succeed since the signature of the network document has already been verified.
 	var pKey crypto.PublicKey
-	signingTime := transaction.SigningTime()
 	pKey, err = n.keyResolver.ResolvePublicKey(transaction.SigningKeyID(), transaction.Previous())
-	if err != nil {
-		if !errors.Is(err, types.ErrNotFound) {
-			return fmt.Errorf("unable to resolve signingkey: %w", err)
-		}
-		pKey, err = n.keyResolver.ResolvePublicKeyInTime(transaction.SigningKeyID(), &signingTime)
-	}
-
 	if err != nil {
 		return fmt.Errorf("unable to resolve signingkey: %w", err)
 	}
+	
 	signingKey, err := jwk.New(pKey)
 	if err != nil {
 		return fmt.Errorf("could not parse public key into jwk: %w", err)

--- a/vdr/doc/resolvers.go
+++ b/vdr/doc/resolvers.go
@@ -218,13 +218,6 @@ func ExtractAssertionKeyID(doc did.Document) (ssi.URI, error) {
 	return ssi.URI{}, types.ErrKeyNotFound
 }
 
-func (r KeyResolver) ResolvePublicKeyInTime(kid string, validAt *time.Time) (crypto.PublicKey, error) {
-	return r.resolvePublicKey(kid, types.ResolveMetadata{
-		AllowDeactivated: true,
-		ResolveTime:      validAt,
-	})
-}
-
 func (r KeyResolver) ResolvePublicKey(kid string, sourceTransactionsRefs []hash.SHA256Hash) (crypto.PublicKey, error) {
 	// try all keys, continue when err == types.ErrNotFound
 	for _, h := range sourceTransactionsRefs {

--- a/vdr/doc/resolvers_test.go
+++ b/vdr/doc/resolvers_test.go
@@ -432,62 +432,6 @@ func TestResolver_ResolveControllers(t *testing.T) {
 	})
 }
 
-func TestKeyResolver_ResolvePublicKey(t *testing.T) {
-	didStore := store.NewMemoryStore()
-	keyResolver := KeyResolver{Store: didStore}
-	keyCreator := newMockKeyCreator()
-	docCreator := Creator{KeyStore: keyCreator}
-	doc, _, _ := docCreator.Create(DefaultCreationOptions())
-	doc.AddAssertionMethod(doc.VerificationMethod[0])
-	txHash := hash.FromSlice([]byte("hash"))
-	didStore.Write(*doc, types.DocumentMetadata{SourceTransactions: []hash.SHA256Hash{txHash}})
-
-	t.Run("ok", func(t *testing.T) {
-		key, err := keyResolver.ResolvePublicKeyInTime(kid, nil)
-
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		assert.NotNil(t, key)
-	})
-
-	t.Run("ok by hash", func(t *testing.T) {
-		key, err := keyResolver.ResolvePublicKey(kid, []hash.SHA256Hash{txHash})
-
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		assert.NotNil(t, key)
-	})
-
-	t.Run("error - invalid kid", func(t *testing.T) {
-		key, err := keyResolver.ResolvePublicKeyInTime("not_a_did", nil)
-
-		assert.Error(t, err)
-		assert.Nil(t, key)
-	})
-
-	t.Run("error - unknown did", func(t *testing.T) {
-		_, err := keyResolver.ResolvePublicKeyInTime("did:nuts:a", nil)
-
-		if !assert.Error(t, err) {
-			return
-		}
-		assert.Equal(t, types.ErrNotFound, err)
-	})
-
-	t.Run("error - unknown key in document", func(t *testing.T) {
-		_, err := keyResolver.ResolvePublicKeyInTime(kid[:len(kid)-2], nil)
-
-		if !assert.Error(t, err) {
-			return
-		}
-		assert.Equal(t, types.ErrKeyNotFound, err)
-	})
-}
-
 func TestServiceResolver_Resolve(t *testing.T) {
 	meta := &types.DocumentMetadata{Hash: hash.EmptyHash()}
 

--- a/vdr/doc/test.go
+++ b/vdr/doc/test.go
@@ -42,10 +42,6 @@ func (s StaticKeyResolver) ResolvePublicKey(_ string, _ []hash.SHA256Hash) (cryp
 	return s.Key, nil
 }
 
-func (s StaticKeyResolver) ResolvePublicKeyInTime(_ string, _ *time.Time) (crypto.PublicKey, error) {
-	return s.Key, nil
-}
-
 func (s StaticKeyResolver) ResolveSigningKeyID(_ did.DID, _ *time.Time) (string, error) {
 	panic("implement me")
 }

--- a/vdr/types/interface.go
+++ b/vdr/types/interface.go
@@ -95,10 +95,6 @@ type KeyResolver interface {
 	// ResolveKeyAgreementKey look for a valid keyAgreement key for the give DID. If multiple keys are valid, the first one is returned.
 	// An ErrKeyNotFound is returned when no key is found.
 	ResolveKeyAgreementKey(id did.DID) (crypto.PublicKey, error)
-	// ResolvePublicKeyInTime loads the key from a DID Document
-	// It returns ErrKeyNotFound when the key could not be found in the DID Document.
-	// It returns ErrNotFound when the DID Document can't be found.
-	ResolvePublicKeyInTime(kid string, validAt *time.Time) (crypto.PublicKey, error)
 	// ResolvePublicKey loads the key from a DID Document where the DID Document
 	// was created with one of the given tx refs
 	// It returns ErrKeyNotFound when the key could not be found in the DID Document.

--- a/vdr/types/mock.go
+++ b/vdr/types/mock.go
@@ -330,21 +330,6 @@ func (mr *MockKeyResolverMockRecorder) ResolvePublicKey(kid, sourceTransactionsR
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolvePublicKey", reflect.TypeOf((*MockKeyResolver)(nil).ResolvePublicKey), kid, sourceTransactionsRefs)
 }
 
-// ResolvePublicKeyInTime mocks base method.
-func (m *MockKeyResolver) ResolvePublicKeyInTime(kid string, validAt *time.Time) (crypto.PublicKey, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolvePublicKeyInTime", kid, validAt)
-	ret0, _ := ret[0].(crypto.PublicKey)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ResolvePublicKeyInTime indicates an expected call of ResolvePublicKeyInTime.
-func (mr *MockKeyResolverMockRecorder) ResolvePublicKeyInTime(kid, validAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolvePublicKeyInTime", reflect.TypeOf((*MockKeyResolver)(nil).ResolvePublicKeyInTime), kid, validAt)
-}
-
 // ResolveSigningKey mocks base method.
 func (m *MockKeyResolver) ResolveSigningKey(keyID string, validAt *time.Time) (crypto.PublicKey, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
no longer needed now all transactions in all networks have the correct `prevs`