### PR TITLE
change dbsize stats

### DIFF
--- a/network/dag/bbolt_dag.go
+++ b/network/dag/bbolt_dag.go
@@ -87,7 +87,7 @@ func (d numberOfTransactionsStatistic) String() string {
 }
 
 type dataSizeStatistic struct {
-	sizeInBytes int
+	sizeInBytes int64
 }
 
 func (d dataSizeStatistic) Result() interface{} {
@@ -232,15 +232,17 @@ func (dag bboltDAG) walk(tx *bbolt.Tx, visitor visitor, startAt hash.SHA256Hash)
 
 func (dag bboltDAG) statistics(ctx context.Context) Statistics {
 	transactionNum := 0
+	dbSize := int64(0)
 	_ = storage.BBoltTXView(ctx, dag.db, func(_ context.Context, tx *bbolt.Tx) error {
 		if bucket := tx.Bucket([]byte(transactionsBucket)); bucket != nil {
 			transactionNum = bucket.Stats().KeyN
+			dbSize = tx.Size()
 		}
 		return nil
 	})
 	return Statistics{
 		NumberOfTransactions: transactionNum,
-		DataSize:             dag.db.Stats().TxStats.PageAlloc,
+		DataSize:             dbSize,
 	}
 }
 

--- a/network/dag/interface.go
+++ b/network/dag/interface.go
@@ -105,7 +105,7 @@ type Statistics struct {
 	// NumberOfTransactions contains the number of transactions on the DAG
 	NumberOfTransactions int
 	// DataSize contains the size of the DAG in bytes
-	DataSize int
+	DataSize int64
 }
 
 // Publisher defines the interface for types that publish Nuts Network transactions.


### PR DESCRIPTION
According to the docs when making a backup `tx.Size()` is the way to get the exact number of bytes.