### PR TITLE
e2e tests without earthly

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -70,7 +70,8 @@ jobs:
         run: |
           git clone https://github.com/nuts-foundation/nuts-go-e2e-test.git && \
             cd nuts-go-e2e-test && \
-            find . -type f -name "docker-compose.yml" | xargs -I{} sed -i "s~nutsfoundation/nuts-node:master~ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}~g" {} && \
+            find . -type f -name "docker-compose.yml" | xargs -I{} sed -i \
+              "s~nutsfoundation/nuts-node:master~ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}~g; s~docker-compose exec~docker-compose exec -T~g" {} && \
             ./run-tests.sh
 
       - name: package cleanup

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -71,7 +71,7 @@ jobs:
           git clone https://github.com/nuts-foundation/nuts-go-e2e-test.git && \
             cd nuts-go-e2e-test && \
             find . -type f -name "docker-compose.yml" | xargs -I{} sed -i \
-              "s~nutsfoundation/nuts-node:master~ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}~g; s~docker-compose exec~docker-compose exec -T~g" {} && \
+              's~nutsfoundation/nuts-node:master~ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}~g ; s/docker-compose exec/docker-compose exec -T/g' {} && \
             ./run-tests.sh
 
       - name: package cleanup

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -70,8 +70,8 @@ jobs:
         run: |
           git clone https://github.com/nuts-foundation/nuts-go-e2e-test.git && \
             cd nuts-go-e2e-test && \
-            find . -type f -name "docker-compose.yml" | xargs -I{} sed -i \
-              's~nutsfoundation/nuts-node:master~ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}~g ; s/docker-compose exec/docker-compose exec -T/g' {} && \
+            find . -type f -name "docker-compose.yml" | xargs -I{} sed -i 's~nutsfoundation/nuts-node:master~ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}~g' {} && \
+            find . -type f -name "run-test.sh" | xargs -I{} sed -i 's/docker-compose exec/docker-compose exec -T/g' {} && \
             ./run-tests.sh
 
       - name: package cleanup

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -71,10 +71,7 @@ jobs:
           git clone https://github.com/nuts-foundation/nuts-go-e2e-test.git && \
             cd nuts-go-e2e-test && \
             find . -type f -name "docker-compose.yml" | xargs -I{} sed -i "s~nutsfoundation/nuts-node:master~ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}~g" {} && \
-            sed -i "s~WITH DOCKER~WITH DOCKER --pull ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}~g" Earthfile && \
-            curl -LO https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 && \
-            chmod +x earthly-linux-amd64 && \
-            ./earthly-linux-amd64 -P +all
+            ./run-tests.sh
 
       - name: package cleanup
         uses: bots-house/ghcr-delete-image-action@v1.0.1


### PR DESCRIPTION
Together with https://github.com/nuts-foundation/nuts-go-e2e-test/pull/26 this removes earthly from the e2e tests