### PR TITLE
VCR: Validate that VCs only contain fields that are defined by JSON-LD context

### DIFF
--- a/auth/api/v1/api_test.go
+++ b/auth/api/v1/api_test.go
@@ -584,7 +584,7 @@ func TestWrapper_RequestAccessToken(t *testing.T) {
 				IssuanceDate: time.Now(),
 				CredentialSubject: []interface{}{credential.NutsAuthorizationCredentialSubject{
 					ID: vdr.TestDIDB.String(),
-					LegalBase: credential.LegalBase{
+					LegalBase: &credential.LegalBase{
 						ConsentType: "implied",
 					},
 					PurposeOfUse: "eTransfer",

--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -378,7 +378,7 @@ func (s *service) validateAuthorizationCredentials(context *validationContext) e
 			return fmt.Errorf(errInvalidVCClaim, err)
 		}
 
-		//The credential issuer equals the sub field of the JWT.
+		// The credential issuer equals the sub field of the JWT.
 		if authCred.Issuer.String() != sub {
 			return fmt.Errorf("issuer %s of authorization credential with ID: %s does not match jwt.sub: %s", authCred.Issuer.String(), authCred.ID.String(), sub)
 		}

--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -429,14 +429,6 @@ func (s *service) CreateJwtGrant(request services.CreateJwtGrantRequest) (*servi
 
 	for _, verifiableCredential := range request.Credentials {
 		validator := credential.FindValidator(verifiableCredential, s.jsonldManager.DocumentLoader())
-		if validator == nil {
-			if err := validator.Validate(verifiableCredential); err != nil {
-				return nil, fmt.Errorf("invalid VerifiableCredential: %w", err)
-			}
-
-			continue
-		}
-
 		if err := validator.Validate(verifiableCredential); err != nil {
 			return nil, fmt.Errorf("invalid VerifiableCredential: %w", err)
 		}

--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -428,9 +428,9 @@ func (s *service) CreateJwtGrant(request services.CreateJwtGrantRequest) (*servi
 	}
 
 	for _, verifiableCredential := range request.Credentials {
-		validator := credential.FindValidator(verifiableCredential)
+		validator := credential.FindValidator(verifiableCredential, s.jsonldManager.DocumentLoader())
 		if validator == nil {
-			if err := credential.Validate(verifiableCredential); err != nil {
+			if err := validator.Validate(verifiableCredential); err != nil {
 				return nil, fmt.Errorf("invalid VerifiableCredential: %w", err)
 			}
 

--- a/auth/services/oauth/oauth_test.go
+++ b/auth/services/oauth/oauth_test.go
@@ -668,10 +668,7 @@ func TestService_CreateJwtBearerToken(t *testing.T) {
 		Issuer:       vdr.TestDIDA.URI(),
 		IssuanceDate: time.Now(),
 		CredentialSubject: []interface{}{credential.NutsAuthorizationCredentialSubject{
-			ID: vdr.TestDIDB.String(),
-			LegalBase: credential.LegalBase{
-				ConsentType: "implied",
-			},
+			ID:           vdr.TestDIDB.String(),
 			PurposeOfUse: "eTransfer",
 			Resources: []credential.Resource{
 				{
@@ -714,7 +711,9 @@ func TestService_CreateJwtBearerToken(t *testing.T) {
 
 		token, err := ctx.oauthService.CreateJwtGrant(validRequest)
 
-		assert.NoError(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 		assert.Equal(t, "token", token.BearerToken)
 	})
 

--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -13,8 +13,21 @@ Release date: 2022-10-14
 
 - HTTPS TLS offloading is now also possible at the Nuts node. Checkout the docs on TLS offloading for the details.
     By default this is turned off which corresponds to the current behaviour.
+- Issuing a Verifiable Credential will now fail when it includes a property not defined in its JSON-LD context(s).
+  The behavior was changed because undefined fields are not secured by the JSON-LD proof,
+  which allows an attacker to alter it while the developer assumes it is secured by the signature.
+  It also helps developers noticing they misspelled a property, which it previously accepted but may have caused issues at processing systems downstream.
 
 **Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v4.0.0...v5.0.0
+
+========
+Breaking changes
+========
+
+While Nuts RFC014 (Authorization Credential) required ``legalBase`` to be present in all ``NutsAuthorizationCredential``s,
+this property was missing in the Nuts v1 JSON-LD context. When issuing Verifiable Credentials, now all fields must be defined in its context(s).
+This means, starting this version, the ``legalBase`` property can't used in new v1 ``NutsAuthorizationCredential``s.
+It has been added to the future v2 version of the credential, in which it can be used again.
 
 *****************
 Chestnut update (v4.2.4)

--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -27,7 +27,8 @@ Breaking changes
 While Nuts RFC014 (Authorization Credential) required ``legalBase`` to be present in all ``NutsAuthorizationCredential``s,
 this property was missing in the Nuts v1 JSON-LD context. When issuing Verifiable Credentials, now all fields must be defined in its context(s).
 This means, starting this version, the ``legalBase`` property can't used in new v1 ``NutsAuthorizationCredential``s.
-It has been added to the future v2 version of the credential, in which it can be used again.
+Until the next major version (v6.0.0) it should be removed.
+Then when v6.0.0 is released, upgrade to the v2 JSON-LD context version and re-add the ``legalBase``.
 
 *****************
 Chestnut update (v4.2.4)

--- a/vcr/credential/resolver.go
+++ b/vcr/credential/resolver.go
@@ -21,22 +21,23 @@ package credential
 
 import (
 	"github.com/nuts-foundation/go-did/vc"
+	"github.com/piprate/json-gold/ld"
 )
 
 // FindValidator finds the Validator the provided credential based on its Type
 // When no additional type is provided, it returns the default validator
-func FindValidator(credential vc.VerifiableCredential) Validator {
+func FindValidator(credential vc.VerifiableCredential, documentLoader ld.DocumentLoader) Validator {
 	if vcTypes := ExtractTypes(credential); len(vcTypes) > 0 {
 		for _, t := range vcTypes {
 			switch t {
 			case NutsOrganizationCredentialType:
-				return nutsOrganizationCredentialValidator{}
+				return nutsOrganizationCredentialValidator{documentLoader: documentLoader}
 			case NutsAuthorizationCredentialType:
-				return nutsAuthorizationCredentialValidator{}
+				return nutsAuthorizationCredentialValidator{documentLoader: documentLoader}
 			}
 		}
 	}
-	return defaultCredentialValidator{}
+	return defaultCredentialValidator{documentLoader: documentLoader}
 }
 
 // ExtractTypes extract additional VC types from the VC as strings

--- a/vcr/credential/resolver_test.go
+++ b/vcr/credential/resolver_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFindValidatorAndBuilder(t *testing.T) {
+func TestFindValidator(t *testing.T) {
 	t.Run("an unknown type returns the default validator", func(t *testing.T) {
 		v := FindValidator(vc.VerifiableCredential{}, nil)
 

--- a/vcr/credential/resolver_test.go
+++ b/vcr/credential/resolver_test.go
@@ -28,22 +28,22 @@ import (
 )
 
 func TestFindValidatorAndBuilder(t *testing.T) {
-	t.Run("an unknown type returns the default validator and builder", func(t *testing.T) {
-		v := FindValidator(vc.VerifiableCredential{})
+	t.Run("an unknown type returns the default validator", func(t *testing.T) {
+		v := FindValidator(vc.VerifiableCredential{}, nil)
 
 		assert.NotNil(t, t, v)
 	})
 
 	t.Run("validator and builder found for NutsOrganizationCredential", func(t *testing.T) {
 		vc := validNutsOrganizationCredential()
-		v := FindValidator(*vc)
+		v := FindValidator(*vc, nil)
 
 		assert.NotNil(t, v)
 	})
 
 	t.Run("validator and builder found for NutsAuthorizationCredential", func(t *testing.T) {
 		vc := validV2ImpliedNutsAuthorizationCredential()
-		v := FindValidator(*vc)
+		v := FindValidator(*vc, nil)
 
 		assert.NotNil(t, v)
 	})

--- a/vcr/credential/test.go
+++ b/vcr/credential/test.go
@@ -70,7 +70,7 @@ func validV2NutsAuthorizationCredential(credentialSubject NutsAuthorizationCrede
 func validV2ImpliedNutsAuthorizationCredential() *vc.VerifiableCredential {
 	credentialSubject := NutsAuthorizationCredentialSubject{
 		ID: vdr.TestDIDB.String(),
-		LegalBase: LegalBase{
+		LegalBase: &LegalBase{
 			ConsentType: "implied",
 		},
 		PurposeOfUse: "eTransfer",
@@ -89,9 +89,9 @@ func ValidV2ExplicitNutsAuthorizationCredential() *vc.VerifiableCredential {
 	patient := "urn:oid:2.16.840.1.113883.2.4.6.3:123456780"
 	credentialSubject := NutsAuthorizationCredentialSubject{
 		ID: vdr.TestDIDB.String(),
-		LegalBase: LegalBase{
+		LegalBase: &LegalBase{
 			ConsentType: "explicit",
-			Evidence: Evidence{
+			Evidence: &Evidence{
 				Path: "/1.pdf",
 				Type: "application/pdf",
 			},

--- a/vcr/credential/test.go
+++ b/vcr/credential/test.go
@@ -20,7 +20,6 @@
 package credential
 
 import (
-	"encoding/json"
 	"time"
 
 	ssi "github.com/nuts-foundation/go-did"
@@ -69,7 +68,7 @@ func validV2NutsAuthorizationCredential(credentialSubject NutsAuthorizationCrede
 func validV2ImpliedNutsAuthorizationCredential() *vc.VerifiableCredential {
 	credentialSubject := NutsAuthorizationCredentialSubject{
 		ID: vdr.TestDIDB.String(),
-		LegalBase: LegalBase{
+		LegalBase: &LegalBase{
 			ConsentType: "implied",
 		},
 		PurposeOfUse: "eTransfer",
@@ -88,7 +87,7 @@ func ValidV2ExplicitNutsAuthorizationCredential() *vc.VerifiableCredential {
 	patient := "urn:oid:2.16.840.1.113883.2.4.6.3:123456780"
 	credentialSubject := NutsAuthorizationCredentialSubject{
 		ID: vdr.TestDIDB.String(),
-		LegalBase: LegalBase{
+		LegalBase: &LegalBase{
 			ConsentType: "explicit",
 			Evidence: &Evidence{
 				Path: "/1.pdf",

--- a/vcr/credential/test.go
+++ b/vcr/credential/test.go
@@ -20,6 +20,8 @@
 package credential
 
 import (
+	"encoding/json"
+	"os"
 	"time"
 
 	ssi "github.com/nuts-foundation/go-did"
@@ -89,7 +91,7 @@ func ValidV2ExplicitNutsAuthorizationCredential() *vc.VerifiableCredential {
 		ID: vdr.TestDIDB.String(),
 		LegalBase: &LegalBase{
 			ConsentType: "explicit",
-			Evidence: &Evidence{
+			Evidence: Evidence{
 				Path: "/1.pdf",
 				Type: "application/pdf",
 			},
@@ -105,6 +107,13 @@ func ValidV2ExplicitNutsAuthorizationCredential() *vc.VerifiableCredential {
 		},
 	}
 	return validV2NutsAuthorizationCredential(credentialSubject)
+}
+
+func validNutsOrganizationCredential() *vc.VerifiableCredential {
+	inputVC := vc.VerifiableCredential{}
+	vcJSON, _ := os.ReadFile("../test/vc.json")
+	_ = json.Unmarshal(vcJSON, &inputVC)
+	return &inputVC
 }
 
 func stringToURI(input string) ssi.URI {

--- a/vcr/credential/test.go
+++ b/vcr/credential/test.go
@@ -96,6 +96,13 @@ func ValidV2ExplicitNutsAuthorizationCredential() *vc.VerifiableCredential {
 		},
 		PurposeOfUse: "careViewer",
 		Subject:      &patient,
+		Resources: []Resource{
+			{
+				Path:        "/Task/1",
+				Operations:  []string{"read", "update"},
+				UserContext: false,
+			},
+		},
 	}
 	return validV2NutsAuthorizationCredential(credentialSubject)
 }

--- a/vcr/credential/test.go
+++ b/vcr/credential/test.go
@@ -20,6 +20,7 @@
 package credential
 
 import (
+	"encoding/json"
 	"time"
 
 	ssi "github.com/nuts-foundation/go-did"

--- a/vcr/credential/test.go
+++ b/vcr/credential/test.go
@@ -70,7 +70,7 @@ func validV2NutsAuthorizationCredential(credentialSubject NutsAuthorizationCrede
 func validV2ImpliedNutsAuthorizationCredential() *vc.VerifiableCredential {
 	credentialSubject := NutsAuthorizationCredentialSubject{
 		ID: vdr.TestDIDB.String(),
-		LegalBase: &LegalBase{
+		LegalBase: LegalBase{
 			ConsentType: "implied",
 		},
 		PurposeOfUse: "eTransfer",
@@ -89,7 +89,7 @@ func ValidV2ExplicitNutsAuthorizationCredential() *vc.VerifiableCredential {
 	patient := "urn:oid:2.16.840.1.113883.2.4.6.3:123456780"
 	credentialSubject := NutsAuthorizationCredentialSubject{
 		ID: vdr.TestDIDB.String(),
-		LegalBase: &LegalBase{
+		LegalBase: LegalBase{
 			ConsentType: "explicit",
 			Evidence: Evidence{
 				Path: "/1.pdf",

--- a/vcr/credential/types.go
+++ b/vcr/credential/types.go
@@ -77,7 +77,7 @@ type LegalBase struct {
 	// ConsentType defines the type of consent that has been given (implied or explicit)
 	ConsentType string `json:"consentType"`
 	// Evidence contains a link to a resource when ConsentType == 'explicit'
-	Evidence *Evidence `json:"evidence"`
+	Evidence Evidence `json:"evidence"`
 }
 
 // Evidence is part of the NutsAuthorizationCredential credentialSubject.legalBase

--- a/vcr/credential/types.go
+++ b/vcr/credential/types.go
@@ -63,13 +63,13 @@ type NutsAuthorizationCredentialSubject struct {
 	// ID contains the DID of the subject
 	ID string `json:"id"`
 	// LegalBase contains information about the type of consent that is the basis for the authorization.
-	LegalBase LegalBase `json:"legalBase"`
+	LegalBase *LegalBase `json:"legalBase,omitempty"`
 	// PurposeOfUse refers to the Bolt access policy
 	PurposeOfUse string `json:"purposeOfUse"`
 	// Resources contains additional individual resources that can be accessed.
-	Resources []Resource `json:"resources"`
+	Resources []Resource `json:"resources,omitempty"`
 	// Subject contains a URN referring to the subject of care (not the credential subject)
-	Subject *string `json:"subject"`
+	Subject *string `json:"subject,omitempty"`
 }
 
 // LegalBase is part of the NutsAuthorizationCredential credentialSubject
@@ -77,7 +77,7 @@ type LegalBase struct {
 	// ConsentType defines the type of consent that has been given (implied or explicit)
 	ConsentType string `json:"consentType"`
 	// Evidence contains a link to a resource when ConsentType == 'explicit'
-	Evidence Evidence `json:"evidence"`
+	Evidence *Evidence `json:"evidence,omitempty"`
 }
 
 // Evidence is part of the NutsAuthorizationCredential credentialSubject.legalBase

--- a/vcr/credential/types.go
+++ b/vcr/credential/types.go
@@ -63,13 +63,13 @@ type NutsAuthorizationCredentialSubject struct {
 	// ID contains the DID of the subject
 	ID string `json:"id"`
 	// LegalBase contains information about the type of consent that is the basis for the authorization.
-	LegalBase *LegalBase `json:"legalBase,omitempty"`
+	LegalBase *LegalBase `json:"legalBase"`
 	// PurposeOfUse refers to the Bolt access policy
 	PurposeOfUse string `json:"purposeOfUse"`
 	// Resources contains additional individual resources that can be accessed.
 	Resources []Resource `json:"resources"`
 	// Subject contains a URN referring to the subject of care (not the credential subject)
-	Subject *string `json:"subject,omitempty"`
+	Subject *string `json:"subject"`
 }
 
 // LegalBase is part of the NutsAuthorizationCredential credentialSubject
@@ -77,7 +77,7 @@ type LegalBase struct {
 	// ConsentType defines the type of consent that has been given (implied or explicit)
 	ConsentType string `json:"consentType"`
 	// Evidence contains a link to a resource when ConsentType == 'explicit'
-	Evidence *Evidence `json:"evidence,omitempty"`
+	Evidence *Evidence `json:"evidence"`
 }
 
 // Evidence is part of the NutsAuthorizationCredential credentialSubject.legalBase

--- a/vcr/credential/types.go
+++ b/vcr/credential/types.go
@@ -63,7 +63,7 @@ type NutsAuthorizationCredentialSubject struct {
 	// ID contains the DID of the subject
 	ID string `json:"id"`
 	// LegalBase contains information about the type of consent that is the basis for the authorization.
-	LegalBase *LegalBase `json:"legalBase"`
+	LegalBase LegalBase `json:"legalBase"`
 	// PurposeOfUse refers to the Bolt access policy
 	PurposeOfUse string `json:"purposeOfUse"`
 	// Resources contains additional individual resources that can be accessed.

--- a/vcr/credential/types.go
+++ b/vcr/credential/types.go
@@ -77,7 +77,7 @@ type LegalBase struct {
 	// ConsentType defines the type of consent that has been given (implied or explicit)
 	ConsentType string `json:"consentType"`
 	// Evidence contains a link to a resource when ConsentType == 'explicit'
-	Evidence *Evidence `json:"evidence"`
+	Evidence *Evidence `json:"evidence,omitempty"`
 }
 
 // Evidence is part of the NutsAuthorizationCredential credentialSubject.legalBase

--- a/vcr/credential/types.go
+++ b/vcr/credential/types.go
@@ -63,13 +63,13 @@ type NutsAuthorizationCredentialSubject struct {
 	// ID contains the DID of the subject
 	ID string `json:"id"`
 	// LegalBase contains information about the type of consent that is the basis for the authorization.
-	LegalBase LegalBase `json:"legalBase"`
+	LegalBase *LegalBase `json:"legalBase,omitempty"`
 	// PurposeOfUse refers to the Bolt access policy
 	PurposeOfUse string `json:"purposeOfUse"`
 	// Resources contains additional individual resources that can be accessed.
 	Resources []Resource `json:"resources"`
 	// Subject contains a URN referring to the subject of care (not the credential subject)
-	Subject *string `json:"subject"`
+	Subject *string `json:"subject,omitempty"`
 }
 
 // LegalBase is part of the NutsAuthorizationCredential credentialSubject

--- a/vcr/credential/validator.go
+++ b/vcr/credential/validator.go
@@ -90,7 +90,6 @@ func (d defaultCredentialValidator) Validate(credential vc.VerifiableCredential)
 
 // validateAllFieldsKnown verifies that all fields in the VC are specified by the JSON-LD context.
 func (d defaultCredentialValidator) validateAllFieldsKnown(input vc.VerifiableCredential) error {
-
 	// First expand, then compact and marshal to JSON, then compare
 	inputAsJSON, _ := input.MarshalJSON()
 	inputAsMap := make(map[string]interface{})
@@ -103,12 +102,6 @@ func (d defaultCredentialValidator) validateAllFieldsKnown(input vc.VerifiableCr
 	if err != nil {
 		return fmt.Errorf("unable to compact JSON-LD VC: %w", err)
 	}
-
-	// TODO: For some reason, proof returns out almost empty (everything except `type`) after compacting.
-	// Need to find out why, but maybe not a big issue since its fields are used to check the signature?
-	// So if one of the required fields were missing, signature validation would fail.
-	delete(compactedAsMap, "proof")
-	delete(inputAsMap, "proof")
 	expectedAsJSON, _ := json.Marshal(inputAsMap)
 
 	// Now marshal compacted document to JSON and compare

--- a/vcr/credential/validator.go
+++ b/vcr/credential/validator.go
@@ -303,8 +303,8 @@ func normalizeJSONProperty(input interface{}, setter func(newValue interface{}))
 			// Empty slice, do nothing
 		case 1:
 			// Slice with 1 entry, unslice it
-			newValue := value.Index(0)
-			setter(newValue.Interface())
+			input = value.Index(0).Interface()
+			setter(input)
 		default:
 			// Slice with zero or more entries, iterate
 			normalizeJSONSlice(value)
@@ -313,7 +313,11 @@ func normalizeJSONProperty(input interface{}, setter func(newValue interface{}))
 
 	asMap, isMap := input.(map[string]interface{})
 	if isMap {
-		normalizeJSONMap(asMap)
+		if idValue, hasID := asMap["id"]; hasID && len(asMap) == 1 {
+			setter(idValue)
+		} else {
+			normalizeJSONMap(asMap)
+		}
 	}
 }
 

--- a/vcr/credential/validator.go
+++ b/vcr/credential/validator.go
@@ -109,9 +109,9 @@ func (d defaultCredentialValidator) validateAllFieldsKnown(input vc.VerifiableCr
 	compactedAsJSON, _ := json.Marshal(compactedAsMap)
 
 	if string(expectedAsJSON) != string(compactedAsJSON) {
-		log.Logger().Debugf("VC validation failed, not all fields are defined by JSON-LD context\n"+
-			"  Given VC:      %s\n"+
-			"  Cleaned up VC: %s", string(expectedAsJSON), string(compactedAsJSON))
+		log.Logger().Debug("VC validation failed, not all fields are defined by JSON-LD context")
+		log.Logger().Debugf(" Given VC:      %s", string(expectedAsJSON))
+		log.Logger().Debugf(" Cleaned up VC: %s", string(compactedAsJSON))
 		return failure("not all fields are defined by JSON-LD context")
 	}
 	return nil
@@ -303,8 +303,8 @@ func normalizeJSONProperty(input interface{}, setter func(newValue interface{}))
 			// Empty slice, do nothing
 		case 1:
 			// Slice with 1 entry, unslice it
-			input = value.Index(0)
-			setter(input)
+			newValue := value.Index(0)
+			setter(newValue.Interface())
 		default:
 			// Slice with zero or more entries, iterate
 			normalizeJSONSlice(value)

--- a/vcr/credential/validator.go
+++ b/vcr/credential/validator.go
@@ -201,7 +201,11 @@ func (d nutsAuthorizationCredentialValidator) Validate(credential vc.VerifiableC
 	}
 
 	if credential.ContainsContext(NutsV2ContextURI) {
-		switch cs.LegalBase.ConsentType {
+		var consentType string
+		if cs.LegalBase != nil {
+			consentType = cs.LegalBase.ConsentType
+		}
+		switch consentType {
 		case "implied":
 			// no additional requirements
 			break

--- a/vcr/credential/validator.go
+++ b/vcr/credential/validator.go
@@ -201,11 +201,7 @@ func (d nutsAuthorizationCredentialValidator) Validate(credential vc.VerifiableC
 	}
 
 	if credential.ContainsContext(NutsV2ContextURI) {
-		var legalBase LegalBase
-		if cs.LegalBase != nil {
-			legalBase = *cs.LegalBase
-		}
-		switch legalBase.ConsentType {
+		switch cs.LegalBase.ConsentType {
 		case "implied":
 			// no additional requirements
 			break

--- a/vcr/credential/validator_test.go
+++ b/vcr/credential/validator_test.go
@@ -491,3 +491,17 @@ func TestDefaultCredentialValidator(t *testing.T) {
 		assert.EqualError(t, err, "validation failed: not all fields are defined by JSON-LD context")
 	})
 }
+
+func TestNormalizeJSONMap(t *testing.T) {
+	t.Run("slice in slice", func(t *testing.T) {
+		// Test can't be covered by one of the VC types, so a simple unit test suffices
+		input := `{"outer": [["first"]]}`
+		inputAsMap := make(map[string]interface{})
+		_ = json.Unmarshal([]byte(input), &inputAsMap)
+
+		normalizeJSONMap(inputAsMap)
+
+		actual, _ := json.Marshal(inputAsMap)
+		assert.JSONEq(t, `{"outer":["first"]}`, string(actual))
+	})
+}

--- a/vcr/credential/validator_test.go
+++ b/vcr/credential/validator_test.go
@@ -212,6 +212,7 @@ func TestNutsAuthorizationCredentialValidator_Validate(t *testing.T) {
 
 	t.Run("v1", func(t *testing.T) {
 		t.Run("ok", func(t *testing.T) {
+			logrus.SetLevel(logrus.DebugLevel)
 			v := validV1NutsAuthorizationCredential()
 
 			err := validator.Validate(*v)

--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -69,7 +69,7 @@ func (i issuer) Issue(credentialOptions vc.VerifiableCredential, publish, public
 		return nil, err
 	}
 
-	validator := credential.FindValidator(*createdVC)
+	validator := credential.FindValidator(*createdVC, i.jsonldManager.DocumentLoader())
 	if err := validator.Validate(*createdVC); err != nil {
 		return nil, err
 	}

--- a/vcr/issuer/issuer_test.go
+++ b/vcr/issuer/issuer_test.go
@@ -172,7 +172,7 @@ func Test_issuer_buildVC(t *testing.T) {
 }
 
 func Test_issuer_Issue(t *testing.T) {
-	credentialType := ssi.MustParseURI("TestCredential")
+	credentialType := ssi.MustParseURI("HumanCredential")
 	issuerID := ssi.MustParseURI("did:nuts:123")
 	credentialOptions := vc.VerifiableCredential{
 		Context: []ssi.URI{credential.NutsV1ContextURI},
@@ -198,7 +198,9 @@ func Test_issuer_Issue(t *testing.T) {
 		sut := issuer{keyResolver: keyResolverMock, store: mockStore, jsonldManager: jsonldManager, trustConfig: trustConfig}
 
 		result, err := sut.Issue(credentialOptions, false, true)
-		assert.NoError(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 		assert.Contains(t, result.Type, credentialType, "expected vc to be of right type")
 		proofs, _ := result.Proofs()
 		assert.Equal(t, kid, proofs[0].VerificationMethod.String(), "expected to be signed with the kid")

--- a/vcr/search.go
+++ b/vcr/search.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/nuts-foundation/nuts-node/core"
+	"github.com/nuts-foundation/nuts-node/vcr/log"
 	"reflect"
 	"strings"
 	"time"
@@ -84,6 +86,11 @@ func (c *vcr) Search(ctx context.Context, searchTerms []SearchTerm, allowUntrust
 
 		if err = c.verifier.Verify(foundCredential, allowUntrusted, false, resolveTime); err == nil {
 			VCs = append(VCs, foundCredential)
+		} else {
+			log.Logger().
+				WithError(err).
+				WithField(core.LogFieldCredentialID, foundCredential.ID).
+				Info("Encountered invalid VC, omitting from search results.")
 		}
 	}
 

--- a/vcr/verifier/verifier.go
+++ b/vcr/verifier/verifier.go
@@ -145,7 +145,7 @@ func (v *verifier) Validate(credentialToVerify vc.VerifiableCredential, at *time
 // It currently checks if the credential has the required fields and values, if it is valid at the given time and optional the signature.
 func (v verifier) Verify(credentialToVerify vc.VerifiableCredential, allowUntrusted bool, checkSignature bool, validAt *time.Time) error {
 	// it must have valid content
-	validator := credential.FindValidator(credentialToVerify)
+	validator := credential.FindValidator(credentialToVerify, v.jsonldManager.DocumentLoader())
 	if err := validator.Validate(credentialToVerify); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes https://github.com/nuts-foundation/nuts-node/issues/1032

TODO:

- [x] Find out why proof is (almost) empty after compaction
- [x] Check whether we want VCs received through the network fail on these same rules (or should it only be a sanity check from our API). Answer: no; VCs should be stored, but only fields from context returned/indexed.