### PR TITLE
fix: endpoint urls

### DIFF
--- a/docs/pages/getting-started/0-hello-world-docker.rst
+++ b/docs/pages/getting-started/0-hello-world-docker.rst
@@ -18,6 +18,6 @@ To get started, clone the repository and run the following commands to start the
 
 After the services have started you can try the following endpoints:
 
-- `Nuts Node status page <http://localhost:1323/status/diagnostics/>`_.
-- `Registry Admin Demo login <http://localhost:1304/>`_ (default password: "demo").
-- `Demo EHR login <http://localhost:1303/>`_ (default password: "demo").
+- `Nuts Node status page <http://localhost:1323/status/diagnostics>`_.
+- `Registry Admin Demo login <http://localhost:1303/>`_ (default password: "demo").
+- `Demo EHR login <http://localhost:1304/>`_ (default password: "demo").


### PR DESCRIPTION
* the diagnostics endpoint returns a 404 when called with a trailing slash
* the Registry Admin Demo and Demo EHR urls (ports) were swapped