### PR TITLE
Add debug option to vc search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,11 +23,13 @@ data
 # MacOS
 .DS_Store
 
-# ignore generated pem files from running the nuts-node executable.
+# ignore generated pem and key files from running the nuts-node executable.
 /*.pem
+/*.key
 
 # ignore generated database files
 /*.db
 
 /nuts-node
 nuts.yaml
+

--- a/docs/_static/vcr/v2.yaml
+++ b/docs/_static/vcr/v2.yaml
@@ -479,6 +479,9 @@ components:
       required:
         - verifiableCredentials
       properties:
+        expandedQuery:
+          description: Contains the query in JSON-LD expanded form which allows for debugging a request.
+          type: array
         verifiableCredentials:
           type: array
           items:
@@ -498,6 +501,10 @@ components:
       properties:
         allowUntrustedIssuer:
           description: If set to true, VCs from an untrusted issuer are returned.
+          type: boolean
+          default: false
+        debugQuery:
+          description: Debug the query by adding the JSON-LD expanded form to the result set.
           type: boolean
           default: false
     Revocation:

--- a/vcr/api/v2/api.go
+++ b/vcr/api/v2/api.go
@@ -183,7 +183,7 @@ func (w *Wrapper) SearchIssuedVCs(ctx echo.Context, params SearchIssuedVCsParams
 	if err != nil {
 		return err
 	}
-	return ctx.JSON(http.StatusOK, SearchVCResults{result})
+	return ctx.JSON(http.StatusOK, SearchVCResults{VerifiableCredentials: result})
 }
 
 // VerifyVC handles API request to verify a  Verifiable Credential.

--- a/vcr/api/v2/generated.go
+++ b/vcr/api/v2/generated.go
@@ -95,6 +95,9 @@ type IssueVCRequestVisibility string
 type SearchOptions struct {
 	// If set to true, VCs from an untrusted issuer are returned.
 	AllowUntrustedIssuer *bool `json:"allowUntrustedIssuer,omitempty"`
+
+	// Debug the query by adding the JSON-LD expanded form to the result set.
+	DebugQuery *bool `json:"debugQuery,omitempty"`
 }
 
 // result of a Search operation.
@@ -108,6 +111,8 @@ type SearchVCResult struct {
 
 // result of a Search operation.
 type SearchVCResults struct {
+	// Contains the query in JSON-LD expanded form which allows for debugging a request.
+	ExpandedQuery         *[]interface{}   `json:"expandedQuery,omitempty"`
 	VerifiableCredentials []SearchVCResult `json:"verifiableCredentials"`
 }
 

--- a/vcr/api/v2/registry_test.go
+++ b/vcr/api/v2/registry_test.go
@@ -135,7 +135,7 @@ func TestWrapper_SearchVCs(t *testing.T) {
 			_ = json.Unmarshal([]byte(organizationQuery), f)
 		})
 		ctx.vcr.EXPECT().Search(context.Background(), searchTerms, false, gomock.Any()).Return([]vc.VerifiableCredential{}, nil)
-		ctx.echo.EXPECT().JSON(http.StatusOK, SearchVCResults{[]SearchVCResult{}})
+		ctx.echo.EXPECT().JSON(http.StatusOK, SearchVCResults{VerifiableCredentials: []SearchVCResult{}})
 
 		err := ctx.client.SearchVCs(ctx.echo)
 
@@ -163,7 +163,7 @@ func TestWrapper_SearchVCs(t *testing.T) {
 				assert.Equal(t, 2, count)
 			}
 		})
-		ctx.echo.EXPECT().JSON(http.StatusOK, SearchVCResults{[]SearchVCResult{}})
+		ctx.echo.EXPECT().JSON(http.StatusOK, SearchVCResults{VerifiableCredentials: []SearchVCResult{}})
 
 		err := ctx.client.SearchVCs(ctx.echo)
 
@@ -178,7 +178,7 @@ func TestWrapper_SearchVCs(t *testing.T) {
 			_ = json.Unmarshal([]byte(untrustedOrganizationQuery), f)
 		})
 		ctx.vcr.EXPECT().Search(context.Background(), searchTerms, true, gomock.Any()).Return([]vc.VerifiableCredential{}, nil)
-		ctx.echo.EXPECT().JSON(http.StatusOK, SearchVCResults{[]SearchVCResult{}})
+		ctx.echo.EXPECT().JSON(http.StatusOK, SearchVCResults{VerifiableCredentials: []SearchVCResult{}})
 
 		err := ctx.client.SearchVCs(ctx.echo)
 


### PR DESCRIPTION
In order to address #1133 we need to give the developers some tools to debug their queries and explain behavior. This PR adds a debug option for searching for VCs. The JSON-LD operations sometimes are a black box.

When setting the "searchOptions.debugQuery" field to true, the results contains the expanded query using the contexts as configured on that particular node. This makes it easer to debug a search query.

```json
{
    "query": {
        "@context": [
            "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json",
            "https://nuts.nl/credentials/v1",
            "https://www.w3.org/2018/credentials/v1"
        ],
        "type": [
            "VerifiableCredential",
            "NutsOrganizationCredential"
        ],
        "credentialSubject": {
            "organization": {
                "name": "Test"
            }
        }
    },
    "searchOptions": {
        "debugQuery": true,
    }
}
```

Response on the `development` network:

```json
{
    "expandedQuery": [
        {
            "@type": [
                "https://www.w3.org/2018/credentials#VerifiableCredential",
                "https://nuts.nl/credentials/v1#NutsOrganizationCredential"
            ],
            "https://www.w3.org/2018/credentials#credentialSubject": [
                {
                    "http://schema.org/organization": [
                        {
                            "http://schema.org/legalname": [
                                {
                                    "@value": "Test"
                                }
                            ]
                        }
                    ]
                }
            ]
        }
    ],
    "verifiableCredentials": [
        {
            "verifiableCredential": {
                "@context": [
                    "https://nuts.nl/credentials/v1",
                    "https://www.w3.org/2018/credentials/v1",
                    "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json"
                ],
                "credentialSubject": {
                    "id": "did:nuts:exTn68cn5fX9zpv83A9LK9qLkfWhkhhNFNMAbVMpNEm",
                    "organization": {
                        "city": "Enschede",
                        "name": "Ecare PUUR. Test"
                    }
                },
                "id": "did:nuts:A5J5s2nvYpQ9qtMBiPTF3jAg4bKR4oehfTe88mAU6s8N#497d0d46-7f15-46e3-aa7a-18ad7bccb556",
                "issuanceDate": "2022-06-15T08:27:23.392216919Z",
                "issuer": "did:nuts:A5J5s2nvYpQ9qtMBiPTF3jAg4bKR4oehfTe88mAU6s8N",
                "proof": {
                    "created": "2022-06-15T08:27:23.392329121Z",
                    "jws": "eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..t4UEqsQkwEbIdK2gWM3o85pDWkkrwKx8ca1eswAens8xBlK38HX5SdIEKZlDW-sCczyW-KC_u2liaVBQTJjFHw",
                    "proofPurpose": "assertionMethod",
                    "type": "JsonWebSignature2020",
                    "verificationMethod": "did:nuts:A5J5s2nvYpQ9qtMBiPTF3jAg4bKR4oehfTe88mAU6s8N#htLShEKsSZH1ItbtUTU10LJmzVwxY9wHhPnZfGiwFks"
                },
                "type": [
                    "NutsOrganizationCredential",
                    "VerifiableCredential"
                ]
            }
        },
        {
            "verifiableCredential": {
                "@context": [
                    "https://nuts.nl/credentials/v1",
                    "https://www.w3.org/2018/credentials/v1",
                    "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json"
                ],
                "credentialSubject": {
                    "id": "did:nuts:BWffZVGWk7Jvgby2nNLQGbK4s89wGYETPopjm4iqEjeb",
                    "organization": {
                        "city": "Losser",
                        "name": "Ziekenhuis Losser Test"
                    }
                },
                "id": "did:nuts:A23R4F6CpSrY6YWyu2MnY6zhho6xRSvTMW5K3oxbDE5x#3c45c251-c920-405f-9cfb-c557de7f95da",
                "issuanceDate": "2022-06-14T14:42:46.988220326Z",
                "issuer": "did:nuts:A23R4F6CpSrY6YWyu2MnY6zhho6xRSvTMW5K3oxbDE5x",
                "proof": {
                    "created": "2022-06-14T14:42:46.98837013Z",
                    "jws": "eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..K5VwkU836T-DCXdLcPqO2rnlON3QYdg9pkX9EWmi3op6BGieYQzVnNYLNDC_fJPfhBZPxfFNnPWhB2qXnPY0jg",
                    "proofPurpose": "assertionMethod",
                    "type": "JsonWebSignature2020",
                    "verificationMethod": "did:nuts:A23R4F6CpSrY6YWyu2MnY6zhho6xRSvTMW5K3oxbDE5x#hf1-V2FdTb08sUeZkHNhWN9nr_CBOlrh6ckEjQsFCdM"
                },
                "type": [
                    "NutsOrganizationCredential",
                    "VerifiableCredential"
                ]
            }
        }
    ]
}
```