### PR TITLE
Restart node_exporter service

### DIFF
--- a/development/performance_analyzer/entrypoint.sh
+++ b/development/performance_analyzer/entrypoint.sh
@@ -6,7 +6,7 @@ echo "Service 'All': Status"
 rc-status -a
 
 echo "Service 'node-exporter': Starting ..."
-rc-service node-exporter start
+rc-service node-exporter restart
 
 # this script should be set as the docker ENTRYPOINT and provided CMD will be executed below
 echo "Command: '$@'"

--- a/development/performance_analyzer/node-exporter.conf
+++ b/development/performance_analyzer/node-exporter.conf
@@ -4,4 +4,5 @@
 #
 # ARGS="--web.listen-address=':9100'"
 
-ARGS="--web.listen-address=':9100'"
+ARGS="--web.listen-address=':9100' \
+     --web.disable-exporter-metrics"


### PR DESCRIPTION
node-exporter should be restarted so it also works when a docker container is restarted

disabled metrics from node-exporter itself to reduce clutter