### PR TITLE
add validation failure to auth token request output

### DIFF
--- a/auth/contract/verifier.go
+++ b/auth/contract/verifier.go
@@ -53,6 +53,8 @@ type VPVerificationResult interface {
 	// Validators must only set the Validity to "VALID" if the whole VP, including the embedded
 	// contract are valid at the given moment in time.
 	Validity() State
+	// Reason returns the reason why the state is INVALID
+	Reason() string
 	// VPType returns the the VP type like "NutsUziPresentation".
 	VPType() string
 	// DisclosedAttribute returns the attribute value used to sign this contract

--- a/auth/services/dummy/dummy.go
+++ b/auth/services/dummy/dummy.go
@@ -124,6 +124,10 @@ func (d dummyVPVerificationResult) Validity() contract.State {
 	return contract.Valid
 }
 
+func (d dummyVPVerificationResult) Reason() string {
+	return ""
+}
+
 func (d dummyVPVerificationResult) VPType() string {
 	return VerifiablePresentationType
 }

--- a/auth/services/irma/irmacontract.go
+++ b/auth/services/irma/irmacontract.go
@@ -170,6 +170,7 @@ func (cv *contractVerifier) verifyAll(signedContract *SignedIrmaContract, checkT
 		res.DisclosedAttributes = signedContract.attributes
 	} else {
 		res.ValidationResult = services.Invalid
+		res.FailureReason = fmt.Sprintf("irma proof invalid: %s", signedContract.proofStatus)
 	}
 
 	var err error
@@ -194,6 +195,7 @@ func (cv *contractVerifier) validateContractContents(signedContract *SignedIrmaC
 	// Validate time frame
 	if err := signedContract.contract.VerifyForGivenTime(checkTime); err != nil {
 		validationResult.ValidationResult = services.Invalid
+		validationResult.FailureReason = err.Error()
 		return validationResult, nil
 	}
 
@@ -237,7 +239,9 @@ func (cv *contractVerifier) verifyRequiredAttributes(signedIrmaContract *SignedI
 			disclosedAttributes = append(disclosedAttributes, k)
 		}
 		validationResult.ValidationResult = services.Invalid
-		log.Logger().Warnf("missing required attributes in signature. found: %v, needed: %v, disclosed: %v", foundAttributes, requiredAttributes, disclosedAttributes)
+		msg := fmt.Sprintf("missing required attributes in signature. found: %v, needed: %v, disclosed: %v", foundAttributes, requiredAttributes, disclosedAttributes)
+		validationResult.FailureReason = msg
+		log.Logger().Warn(msg)
 	}
 
 	return validationResult, nil

--- a/auth/services/irma/irmacontract.go
+++ b/auth/services/irma/irmacontract.go
@@ -170,7 +170,7 @@ func (cv *contractVerifier) verifyAll(signedContract *SignedIrmaContract, checkT
 		res.DisclosedAttributes = signedContract.attributes
 	} else {
 		res.ValidationResult = services.Invalid
-		res.FailureReason = fmt.Sprintf("irma proof invalid: %s", signedContract.proofStatus)
+		res.FailureReason = fmt.Sprintf("IRMA proof invalid: %s", signedContract.proofStatus)
 	}
 
 	var err error

--- a/auth/services/irma/validator.go
+++ b/auth/services/irma/validator.go
@@ -80,6 +80,7 @@ type VPProof struct {
 
 type irmaVPVerificationResult struct {
 	validity            contract.State
+	reason              string
 	vpType              string
 	disclosedAttributes map[string]string
 	contractAttributes  map[string]string
@@ -87,6 +88,10 @@ type irmaVPVerificationResult struct {
 
 func (I irmaVPVerificationResult) Validity() contract.State {
 	return I.validity
+}
+
+func (I irmaVPVerificationResult) Reason() string {
+	return I.reason
 }
 
 func (I irmaVPVerificationResult) VPType() string {
@@ -154,6 +159,7 @@ func (v Service) VerifyVP(vp vc.VerifiablePresentation, checkTime *time.Time) (c
 
 	return irmaVPVerificationResult{
 		validity:            contract.State(cvr.ValidationResult),
+		reason:              cvr.FailureReason,
 		vpType:              string(cvr.ContractFormat),
 		disclosedAttributes: signerAttributes,
 		contractAttributes:  signedContract.Contract().Params,

--- a/auth/services/messages.go
+++ b/auth/services/messages.go
@@ -94,6 +94,7 @@ func (t *NutsAccessToken) FromMap(m map[string]interface{}) error {
 // ContractValidationResult contains the result of a contract validation
 type ContractValidationResult struct {
 	ValidationResult ValidationState `json:"validation_result"`
+	FailureReason    string          `json:"failure_reason"`
 	ContractFormat   ContractFormat  `json:"contract_format"`
 	// DisclosedAttributes contain the attributes used to sign this contract
 	DisclosedAttributes map[string]string `json:"disclosed_attributes"`

--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -205,7 +205,7 @@ func (s *service) CreateAccessToken(request services.CreateAccessTokenRequest) (
 		}
 
 		if context.contractVerificationResult.Validity() != contract.Valid {
-			return nil, errors.New("identity validation failed")
+			return nil, fmt.Errorf("identity validation failed: %s", context.contractVerificationResult.Reason())
 		}
 
 		// checks if the name from the login contract matches with the registered name of the issuer.

--- a/auth/services/oauth/oauth_test.go
+++ b/auth/services/oauth/oauth_test.go
@@ -162,7 +162,7 @@ func TestAuth_CreateAccessToken(t *testing.T) {
 		ctx.privateKeyStore.EXPECT().Exists(authorizerSigningKeyID.String()).Return(true)
 		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(requesterSigningKey.Public(), nil)
 		ctx.keyResolver.EXPECT().ResolveSigningKeyID(authorizerDID, gomock.Any()).MinTimes(1).Return(authorizerSigningKeyID.String(), nil)
-		ctx.contractNotary.EXPECT().VerifyVP(gomock.Any(), nil).Return(services.TestVPVerificationResult{Val: contract.Invalid}, nil)
+		ctx.contractNotary.EXPECT().VerifyVP(gomock.Any(), nil).Return(services.TestVPVerificationResult{Val: contract.Invalid, Cause: "because of reasons"}, nil)
 
 		tokenCtx := validContext()
 		signToken(tokenCtx)
@@ -170,7 +170,7 @@ func TestAuth_CreateAccessToken(t *testing.T) {
 		response, err := ctx.oauthService.CreateAccessToken(services.CreateAccessTokenRequest{RawJwtBearerToken: tokenCtx.rawJwtBearerToken})
 		assert.Nil(t, response)
 		if assert.NotNil(t, err) {
-			assert.Contains(t, err.Error(), "identity validation failed")
+			assert.Contains(t, err.Error(), "identity validation failed: because of reasons")
 		}
 	})
 

--- a/auth/services/oauth/oauth_test.go
+++ b/auth/services/oauth/oauth_test.go
@@ -162,7 +162,7 @@ func TestAuth_CreateAccessToken(t *testing.T) {
 		ctx.privateKeyStore.EXPECT().Exists(authorizerSigningKeyID.String()).Return(true)
 		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(requesterSigningKey.Public(), nil)
 		ctx.keyResolver.EXPECT().ResolveSigningKeyID(authorizerDID, gomock.Any()).MinTimes(1).Return(authorizerSigningKeyID.String(), nil)
-		ctx.contractNotary.EXPECT().VerifyVP(gomock.Any(), nil).Return(services.TestVPVerificationResult{Val: contract.Invalid, Cause: "because of reasons"}, nil)
+		ctx.contractNotary.EXPECT().VerifyVP(gomock.Any(), nil).Return(services.TestVPVerificationResult{Val: contract.Invalid, Reason: "because of reasons"}, nil)
 
 		tokenCtx := validContext()
 		signToken(tokenCtx)

--- a/auth/services/oauth/oauth_test.go
+++ b/auth/services/oauth/oauth_test.go
@@ -162,7 +162,7 @@ func TestAuth_CreateAccessToken(t *testing.T) {
 		ctx.privateKeyStore.EXPECT().Exists(authorizerSigningKeyID.String()).Return(true)
 		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(requesterSigningKey.Public(), nil)
 		ctx.keyResolver.EXPECT().ResolveSigningKeyID(authorizerDID, gomock.Any()).MinTimes(1).Return(authorizerSigningKeyID.String(), nil)
-		ctx.contractNotary.EXPECT().VerifyVP(gomock.Any(), nil).Return(services.TestVPVerificationResult{Val: contract.Invalid, Reason: "because of reasons"}, nil)
+		ctx.contractNotary.EXPECT().VerifyVP(gomock.Any(), nil).Return(services.TestVPVerificationResult{Val: contract.Invalid, FailureReason: "because of reasons"}, nil)
 
 		tokenCtx := validContext()
 		signToken(tokenCtx)

--- a/auth/services/test.go
+++ b/auth/services/test.go
@@ -23,6 +23,7 @@ import "github.com/nuts-foundation/nuts-node/auth/contract"
 
 type TestVPVerificationResult struct {
 	Val         contract.State
+	Cause       string
 	Type        string
 	DAttributes map[string]string
 	CAttributes map[string]string
@@ -30,6 +31,10 @@ type TestVPVerificationResult struct {
 
 func (t TestVPVerificationResult) Validity() contract.State {
 	return t.Val
+}
+
+func (t TestVPVerificationResult) Reason() string {
+	return t.Cause
 }
 
 func (t TestVPVerificationResult) VPType() string {

--- a/auth/services/test.go
+++ b/auth/services/test.go
@@ -23,7 +23,7 @@ import "github.com/nuts-foundation/nuts-node/auth/contract"
 
 type TestVPVerificationResult struct {
 	Val         contract.State
-	Cause       string
+	Reason       string
 	Type        string
 	DAttributes map[string]string
 	CAttributes map[string]string

--- a/auth/services/test.go
+++ b/auth/services/test.go
@@ -34,7 +34,7 @@ func (t TestVPVerificationResult) Validity() contract.State {
 }
 
 func (t TestVPVerificationResult) Reason() string {
-	return t.Cause
+	return t.Reason
 }
 
 func (t TestVPVerificationResult) VPType() string {

--- a/auth/services/test.go
+++ b/auth/services/test.go
@@ -22,11 +22,11 @@ package services
 import "github.com/nuts-foundation/nuts-node/auth/contract"
 
 type TestVPVerificationResult struct {
-	Val         contract.State
-	Reason       string
-	Type        string
-	DAttributes map[string]string
-	CAttributes map[string]string
+	Val           contract.State
+	FailureReason string
+	Type          string
+	DAttributes   map[string]string
+	CAttributes   map[string]string
 }
 
 func (t TestVPVerificationResult) Validity() contract.State {
@@ -34,7 +34,7 @@ func (t TestVPVerificationResult) Validity() contract.State {
 }
 
 func (t TestVPVerificationResult) Reason() string {
-	return t.Reason
+	return t.FailureReason
 }
 
 func (t TestVPVerificationResult) VPType() string {

--- a/auth/services/uzi/validator.go
+++ b/auth/services/uzi/validator.go
@@ -47,6 +47,7 @@ type proof struct {
 
 type uziVPVerificationResult struct {
 	validity            contract.State
+	reason              string
 	vpType              string
 	disclosedAttributes map[string]string
 	contractAttributes  map[string]string
@@ -54,6 +55,10 @@ type uziVPVerificationResult struct {
 
 func (I uziVPVerificationResult) Validity() contract.State {
 	return I.validity
+}
+
+func (I uziVPVerificationResult) Reason() string {
+	return I.reason
 }
 
 func (I uziVPVerificationResult) VPType() string {
@@ -107,6 +112,7 @@ func (u Verifier) VerifyVP(vp vc.VerifiablePresentation, _ *time.Time) (contract
 	if err := u.UziValidator.Verify(signedToken); err != nil {
 		return uziVPVerificationResult{
 			validity: contract.Invalid,
+			reason:   err.Error(),
 		}, nil
 	}
 


### PR DESCRIPTION
fixes #1286 

When result is set to INVALID (from within IRMA mostly), the reason is also filled.