### PR TITLE
add transaction count metric to prometheus output

### DIFF
--- a/docs/pages/deployment/monitoring.rst
+++ b/docs/pages/deployment/monitoring.rst
@@ -168,6 +168,9 @@ The Nuts service executable exports the following metrics by default. These cove
     # HELP go_threads Number of OS threads created.
     # TYPE go_threads gauge
     go_threads 18
+    # HELP nuts_dag_transaction_count Number of transactions stored in the DAG
+    # TYPE nuts_dag_transaction_count counter
+    nuts_dag_transaction_count 0
     # HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
     # TYPE process_cpu_seconds_total counter
     process_cpu_seconds_total 2.58

--- a/network/dag/dag.go
+++ b/network/dag/dag.go
@@ -48,6 +48,9 @@ const headsShelf = "heads"
 // clockShelf is the name of the shelf that uses the Lamport clock as index to a set of TX refs.
 const clockShelf = "clocks"
 
+// TransactionCountDiagnostic is the name of the diagnostics result for the transaction count
+const TransactionCountDiagnostic = "transaction_count"
+
 type dag struct {
 	db stoabs.KVStore
 }
@@ -78,7 +81,7 @@ func (n numberOfTransactionsStatistic) Result() interface{} {
 }
 
 func (n numberOfTransactionsStatistic) Name() string {
-	return "transaction_count"
+	return TransactionCountDiagnostic
 }
 
 func (n numberOfTransactionsStatistic) String() string {

--- a/network/dag/interface.go
+++ b/network/dag/interface.go
@@ -69,8 +69,6 @@ type State interface {
 	Shutdown() error
 	// Start the publisher and verifier
 	Start() error
-	// Statistics returns data for the statistics page
-	Statistics(ctx context.Context) Statistics
 	// Verify checks the integrity of the DAG. Should be called when it's loaded, e.g. from disk.
 	Verify(ctx context.Context) error
 	// XOR returns the xor of all transaction references between the DAG root and the clock closest to the requested clock value.

--- a/network/dag/interface.go
+++ b/network/dag/interface.go
@@ -109,11 +109,5 @@ type PayloadStore interface {
 	writePayload(tx stoabs.WriteTx, payloadHash hash.SHA256Hash, data []byte) error
 }
 
-// Observer defines the signature of an observer which can be called by an Observable.
-type Observer func(tx stoabs.WriteTx, transaction Transaction) error
-
-// PayloadObserver defines the signature of an observer which can be called by an Observable.
-type PayloadObserver func(transaction Transaction, payload []byte) error
-
 // MaxLamportClock is the highest Lamport Clock value a transaction on the DAG can have.
 const MaxLamportClock = math.MaxUint32

--- a/network/dag/mock.go
+++ b/network/dag/mock.go
@@ -232,20 +232,6 @@ func (mr *MockStateMockRecorder) Start() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockState)(nil).Start))
 }
 
-// Statistics mocks base method.
-func (m *MockState) Statistics(ctx context.Context) Statistics {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Statistics", ctx)
-	ret0, _ := ret[0].(Statistics)
-	return ret0
-}
-
-// Statistics indicates an expected call of Statistics.
-func (mr *MockStateMockRecorder) Statistics(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Statistics", reflect.TypeOf((*MockState)(nil).Statistics), ctx)
-}
-
 // Verify mocks base method.
 func (m *MockState) Verify(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/network/dag/state.go
+++ b/network/dag/state.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
 	"math"
 
 	"github.com/nuts-foundation/go-stoabs"
@@ -43,17 +44,14 @@ const (
 
 // State has references to the DAG and the payload store.
 type state struct {
-	db                               stoabs.KVStore
-	graph                            *dag
-	payloadStore                     PayloadStore
-	transactionalObservers           []Observer
-	nonTransactionalObservers        []Observer
-	transactionalPayloadObservers    []PayloadObserver
-	nonTransactionalPayloadObservers []PayloadObserver
-	txVerifiers                      []Verifier
-	notifiers                        map[string]Notifier
-	xorTree                          *treeStore
-	ibltTree                         *treeStore
+	db               stoabs.KVStore
+	graph            *dag
+	payloadStore     PayloadStore
+	txVerifiers      []Verifier
+	notifiers        map[string]Notifier
+	xorTree          *treeStore
+	ibltTree         *treeStore
+	transactionCount prometheus.Counter
 }
 
 func (s *state) Migrate() error {
@@ -65,17 +63,34 @@ func NewState(db stoabs.KVStore, verifiers ...Verifier) (State, error) {
 	graph := newDAG(db)
 
 	payloadStore := NewPayloadStore()
+	transactionCount := transactionCountCollector()
+	err := prometheus.Register(transactionCount)
+	if err != nil && err.Error() != (prometheus.AlreadyRegisteredError{}).Error() { // No unwrap on prometheus.AlreadyRegisteredError
+		return nil, err
+	}
 	newState := &state{
-		db:           db,
-		graph:        graph,
-		payloadStore: payloadStore,
-		txVerifiers:  verifiers,
-		notifiers:    map[string]Notifier{},
-		xorTree:      newTreeStore(xorShelf, tree.New(tree.NewXor(), PageSize)),
-		ibltTree:     newTreeStore(ibltShelf, tree.New(tree.NewIblt(IbltNumBuckets), PageSize)),
+		db:               db,
+		graph:            graph,
+		payloadStore:     payloadStore,
+		txVerifiers:      verifiers,
+		notifiers:        map[string]Notifier{},
+		xorTree:          newTreeStore(xorShelf, tree.New(tree.NewXor(), PageSize)),
+		ibltTree:         newTreeStore(ibltShelf, tree.New(tree.NewIblt(IbltNumBuckets), PageSize)),
+		transactionCount: transactionCount,
 	}
 
 	return newState, nil
+}
+
+func transactionCountCollector() prometheus.Counter {
+	return prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "nuts",
+			Subsystem: "dag",
+			Name:      "transaction_count",
+			Help:      "Number of transactions stored in the DAG",
+		},
+	)
 }
 
 func (s *state) Add(ctx context.Context, transaction Transaction, payload []byte) error {
@@ -134,6 +149,8 @@ func (s *state) Add(ctx context.Context, transaction Transaction, payload []byte
 		if emitPayloadEvent {
 			s.notify(payloadEvent)
 		}
+	}), stoabs.AfterCommit(func() {
+		s.transactionCount.Inc()
 	}), stoabs.WithWriteLock())
 }
 
@@ -294,11 +311,23 @@ func (s *state) lamportClock(ctx context.Context) uint32 {
 }
 
 func (s *state) Shutdown() error {
+	if s.transactionCount != nil {
+		prometheus.Unregister(s.transactionCount)
+	}
 	return nil
 }
 
 func (s *state) Start() error {
 	s.loadTrees(context.Background())
+
+	err := s.db.Read(context.Background(), func(tx stoabs.ReadTx) error {
+		currentTXCount := s.graph.getNumberOfTransactions(tx)
+		s.transactionCount.Add(float64(currentTXCount))
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to set initial transaction count metric: %w", err)
+	}
 
 	// resume all notifiers
 	for _, curr := range s.notifiers {

--- a/network/dag/state.go
+++ b/network/dag/state.go
@@ -339,15 +339,6 @@ func (s *state) Start() error {
 	return nil
 }
 
-func (s *state) Statistics(ctx context.Context) Statistics {
-	var stats Statistics
-	_ = s.db.Read(ctx, func(tx stoabs.ReadTx) error {
-		stats = s.graph.statistics(tx)
-		return nil
-	})
-	return stats
-}
-
 // Verify can be used to verify the entire DAG.
 // TODO problematic for large sets. Currently not used, see #1216
 func (s *state) Verify(ctx context.Context) error {

--- a/network/dag/state.go
+++ b/network/dag/state.go
@@ -87,7 +87,7 @@ func transactionCountCollector() prometheus.Counter {
 		prometheus.CounterOpts{
 			Namespace: "nuts",
 			Subsystem: "dag",
-			Name:      "transaction_count",
+			Name:      "transactions_total",
 			Help:      "Number of transactions stored in the DAG",
 		},
 	)

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -371,8 +371,6 @@ func TestState_InitialTransactionCountMetric(t *testing.T) {
 	txState := createState(t).(*state)
 	payload := []byte("payload")
 	tx, _, _ := CreateTestTransactionEx(1, hash.SHA256Sum(payload), nil)
-	dagClock := 3 * PageSize / 2
-	tx.(*transaction).lamportClock = dagClock
 	err := txState.Add(ctx, tx, payload)
 	if !assert.NoError(t, err) {
 		return

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -266,7 +266,7 @@ func TestState_Add(t *testing.T) {
 
 func TestState_Diagnostics(t *testing.T) {
 	ctx := context.Background()
-	txState := createState(t)
+	txState := createState(t).(*state)
 	payload := []byte("payload")
 	doc1, _, _ := CreateTestTransactionEx(2, hash.SHA256Sum(payload), nil)
 	err := txState.Add(ctx, doc1, payload)
@@ -279,16 +279,11 @@ func TestState_Diagnostics(t *testing.T) {
 		lines = append(lines, diagnostic.Name()+": "+diagnostic.String())
 	}
 	sort.Strings(lines)
-
-	dbSize := txState.Statistics(context.Background())
-	assert.NotZero(t, dbSize)
-
 	actual := strings.Join(lines, "\n")
-	expected := fmt.Sprintf(`dag_xor: %s
-heads: [%s]
-stored_database_size_bytes: %d
-transaction_count: 1`, doc1.Ref(), doc1.Ref(), dbSize.DataSize)
-	assert.Equal(t, expected, actual)
+
+	assert.Contains(t, actual, fmt.Sprintf("dag_xor: %s", doc1.Ref()))
+	assert.Contains(t, actual, fmt.Sprintf("heads: [%s]", doc1.Ref()))
+	assert.Contains(t, actual, "transaction_count: 1")
 }
 
 func TestState_XOR(t *testing.T) {

--- a/network/network.go
+++ b/network/network.go
@@ -162,7 +162,7 @@ func (n *Network) Configure(config core.ServerConfig) error {
 	var candidateProtocols []transport.Protocol
 	if n.protocols == nil {
 		candidateProtocols = []transport.Protocol{
-			v2.New(v2Cfg, n.nodeDIDResolver, n.state, n.didDocumentResolver, n.decrypter, n.collectDiagnostics, dagStore),
+			v2.New(v2Cfg, n.nodeDIDResolver, n.state, n.didDocumentResolver, n.decrypter, n.collectDiagnosticsForPeers, dagStore),
 		}
 	} else {
 		// Only set protocols if not already set: improves testability
@@ -644,10 +644,18 @@ func (n *Network) Reprocess(contentType string) {
 	}()
 }
 
-func (n *Network) collectDiagnostics() transport.Diagnostics {
+func (n *Network) collectDiagnosticsForPeers() transport.Diagnostics {
+	stateDiagnostics := n.state.Diagnostics()
+	transactionCount := uint(0)
+	for _, diagnostic := range stateDiagnostics {
+		if diagnostic.Name() == dag.TransactionCountDiagnostic {
+			transactionCount = diagnostic.Result().(uint)
+		}
+	}
+
 	result := transport.Diagnostics{
 		Uptime:               time.Now().Sub(n.startTime.Load().(time.Time)),
-		NumberOfTransactions: uint32(n.state.Statistics(context.Background()).NumberOfTransactions),
+		NumberOfTransactions: uint32(transactionCount),
 		SoftwareVersion:      fmt.Sprintf("%s (%s)", core.GitBranch, core.GitCommit),
 		SoftwareID:           softwareID,
 	}

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -832,11 +832,11 @@ func TestNetwork_collectDiagnostics(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	cxt := createNetwork(t, ctrl)
-	cxt.state.EXPECT().Statistics(gomock.Any()).Return(dag.Statistics{NumberOfTransactions: txNum})
+	cxt.state.EXPECT().Diagnostics().Return([]core.DiagnosticResult{core.GenericDiagnosticResult{Title: dag.TransactionCountDiagnostic, Outcome: uint(txNum)}})
 
 	cxt.connectionManager.EXPECT().Peers().Return([]transport.Peer{expectedPeer})
 
-	actual := cxt.network.collectDiagnostics()
+	actual := cxt.network.collectDiagnosticsForPeers()
 
 	assert.Equal(t, expectedID, actual.SoftwareID)
 	assert.Equal(t, expectedVersion, actual.SoftwareVersion)


### PR DESCRIPTION
closes #1287 

adds metric with name: `nuts_dag_transaction_count`
Count is incremented on state.Add()