### PR TITLE
Feature/1307 heads to head

### DIFF
--- a/network/dag/dag.go
+++ b/network/dag/dag.go
@@ -150,6 +150,7 @@ func (d *dag) Migrate() error {
 					}
 					if transaction.Clock() >= latestLC {
 						latestHead = ref
+						latestLC = transaction.Clock()
 					}
 				}
 

--- a/network/dag/dag.go
+++ b/network/dag/dag.go
@@ -39,6 +39,9 @@ const numberOfTransactionsKey = "tx_num"
 // highestClockValue is the key of the metadata property that holds the highest lamport clock value of all transactions on the DAG
 const highestClockValue = "lc_high"
 
+// headRefKey is the of the metadata property that holds the latest HEAD of the DAG
+const headRefKey = "head_ref"
+
 // transactionsShelf is the name of the shelf that holds the actual transactions.
 const transactionsShelf = "documents"
 
@@ -53,23 +56,6 @@ const TransactionCountDiagnostic = "transaction_count"
 
 type dag struct {
 	db stoabs.KVStore
-}
-
-type headsStatistic struct {
-	// SHA256Hash is the last consistency hash.
-	heads []hash.SHA256Hash
-}
-
-func (h headsStatistic) Result() interface{} {
-	return h.heads
-}
-
-func (h headsStatistic) Name() string {
-	return "heads"
-}
-
-func (h headsStatistic) String() string {
-	return fmt.Sprintf("%v", h.heads)
 }
 
 type numberOfTransactionsStatistic struct {
@@ -116,6 +102,7 @@ func (d *dag) Migrate() error {
 			return err
 		}
 		// Migrate highest LC value
+		// Todo: remove after V5 release
 		highestLCBytes, err := writer.Get(stoabs.BytesKey(highestClockValue))
 		if err != nil {
 			return err
@@ -129,6 +116,7 @@ func (d *dag) Migrate() error {
 			}
 		}
 		// Migrate number of TXs
+		// Todo: remove after V5 release
 		numberOfTXs, err := writer.Get(stoabs.BytesKey(numberOfTransactionsKey))
 		if err != nil {
 			return err
@@ -141,27 +129,42 @@ func (d *dag) Migrate() error {
 				return err
 			}
 		}
+
+		// Migrate headsLegacy to single head
+		// Todo: remove after V6 release => then remove headsShelf
+		headRef, err := writer.Get(stoabs.BytesKey(headRefKey))
+		if err != nil {
+			return err
+		}
+		if headRef == nil {
+			log.Logger().Info("Head not stored in metadata, migrating...")
+			heads := d.headsLegacy(tx)
+			if len(heads) != 0 { // ignore for empty node
+				err = d.setHead(tx, heads[0])
+				if err != nil {
+					return err
+				}
+			}
+		}
+
 		return nil
 	})
 }
 
 func (d *dag) diagnostics(ctx context.Context) []core.DiagnosticResult {
 	var stats Statistics
-	var heads []hash.SHA256Hash
 	_ = d.db.Read(ctx, func(tx stoabs.ReadTx) error {
 		stats = d.statistics(tx)
-		heads = d.heads(tx)
 		return nil
 	})
 
 	result := make([]core.DiagnosticResult, 0)
-	result = append(result, headsStatistic{heads: heads})
 	result = append(result, numberOfTransactionsStatistic{numberOfTransactions: stats.NumberOfTransactions})
 	result = append(result, dataSizeStatistic{sizeInBytes: stats.DataSize})
 	return result
 }
 
-func (d dag) heads(ctx stoabs.ReadTx) []hash.SHA256Hash {
+func (d dag) headsLegacy(ctx stoabs.ReadTx) []hash.SHA256Hash {
 	result := make([]hash.SHA256Hash, 0)
 	reader := ctx.GetShelfReader(headsShelf)
 	_ = reader.Iterate(func(key stoabs.Key, _ []byte) error {
@@ -212,14 +215,16 @@ func (d *dag) isPresent(tx stoabs.ReadTx, ref hash.SHA256Hash) bool {
 
 func (d *dag) add(tx stoabs.WriteTx, transactions ...Transaction) error {
 	highestLC := d.getHighestClockValue(tx)
+	headRef := hash.EmptyHash()
 
 	for _, transaction := range transactions {
 		if transaction != nil {
 			if err := d.addSingle(tx, transaction); err != nil {
 				return err
 			}
-			if transaction.Clock() > highestLC {
+			if transaction.Clock() > highestLC || transaction.Clock() == 0 {
 				highestLC = transaction.Clock()
+				headRef = transaction.Ref()
 			}
 		}
 	}
@@ -227,6 +232,13 @@ func (d *dag) add(tx stoabs.WriteTx, transactions ...Transaction) error {
 	// update highest LC
 	if err := d.setHighestClockValue(tx, highestLC); err != nil {
 		return err
+	}
+
+	// update head
+	if !headRef.Equals(hash.EmptyHash()) {
+		if err := d.setHead(tx, headRef); err != nil {
+			return err
+		}
 	}
 
 	// update TX count
@@ -257,6 +269,15 @@ func (d dag) setNumberOfTransactions(tx stoabs.WriteTx, count uint64) error {
 	binary.BigEndian.PutUint64(bytes[:], count)
 
 	return writer.Put(stoabs.BytesKey(numberOfTransactionsKey), bytes)
+}
+
+func (d dag) setHead(tx stoabs.WriteTx, ref hash.SHA256Hash) error {
+	writer, err := tx.GetShelfWriter(metadataShelf)
+	if err != nil {
+		return err
+	}
+
+	return writer.Put(stoabs.BytesKey(headRefKey), ref.Slice())
 }
 
 func (d dag) getHighestClockValue(tx stoabs.ReadTx) uint32 {
@@ -294,6 +315,15 @@ func (d dag) getHighestClockLegacy(tx stoabs.ReadTx) uint32 {
 	return clock
 }
 
+func (d dag) getHead(tx stoabs.ReadTx) (hash.SHA256Hash, error) {
+	head, err := tx.GetShelfReader(metadataShelf).Get(stoabs.BytesKey(headRefKey))
+	if err != nil {
+		return hash.EmptyHash(), err
+	}
+
+	return hash.FromSlice(head), nil
+}
+
 // getNumberOfTransactionsLegacy is used for migration.
 // Remove after V5 or V6 release?
 func (d dag) getNumberOfTransactionsLegacy(tx stoabs.ReadTx) uint64 {
@@ -324,7 +354,7 @@ func (d dag) statistics(tx stoabs.ReadTx) Statistics {
 func (d *dag) addSingle(tx stoabs.WriteTx, transaction Transaction) error {
 	ref := transaction.Ref()
 	refKey := stoabs.NewHashKey(ref)
-	transactions, lc, heads, err := getBuckets(tx)
+	transactions, lc, err := getBuckets(tx)
 	if err != nil {
 		return err
 	}
@@ -342,22 +372,7 @@ func (d *dag) addSingle(tx stoabs.WriteTx, transaction Transaction) error {
 	if err := indexClockValue(tx, transaction); err != nil {
 		return fmt.Errorf("unable to calculate LC value for %s: %w", ref, err)
 	}
-	if err := transactions.Put(refKey, transaction.Data()); err != nil {
-		return err
-	}
-	// Store forward references ([C -> prev A, B] is stored as [A -> C, B -> C])
-	for _, prev := range transaction.Previous() {
-		// The TX's previous transactions are probably current heads (if there's no other TX referring to it as prev),
-		// so it should be unmarked as head.
-		if err := heads.Delete(stoabs.NewHashKey(prev)); err != nil {
-			return fmt.Errorf("unable to unmark earlier head: %w", err)
-		}
-	}
-	// Transactions are added in order, so the latest TX is always a head
-	if err := heads.Put(refKey, []byte{1}); err != nil {
-		return fmt.Errorf("unable to mark transaction as head (ref=%s): %w", ref, err)
-	}
-	return nil
+	return transactions.Put(refKey, transaction.Data())
 }
 
 func indexClockValue(tx stoabs.WriteTx, transaction Transaction) error {
@@ -397,14 +412,11 @@ func bytesToCount(clockBytes []byte) uint64 {
 	return binary.BigEndian.Uint64(clockBytes)
 }
 
-func getBuckets(tx stoabs.WriteTx) (transactions, lc, heads stoabs.Writer, err error) {
+func getBuckets(tx stoabs.WriteTx) (transactions, lc stoabs.Writer, err error) {
 	if transactions, err = tx.GetShelfWriter(transactionsShelf); err != nil {
 		return
 	}
 	if lc, err = tx.GetShelfWriter(clockShelf); err != nil {
-		return
-	}
-	if heads, err = tx.GetShelfWriter(headsShelf); err != nil {
 		return
 	}
 	return

--- a/network/dag/dag.go
+++ b/network/dag/dag.go
@@ -140,7 +140,20 @@ func (d *dag) Migrate() error {
 			log.Logger().Info("Head not stored in metadata, migrating...")
 			heads := d.headsLegacy(tx)
 			if len(heads) != 0 { // ignore for empty node
-				err = d.setHead(tx, heads[0])
+				var latestHead hash.SHA256Hash
+				var latestLC uint32
+
+				for _, ref := range heads {
+					transaction, err := getTransaction(ref, tx)
+					if err != nil {
+						return err
+					}
+					if transaction.Clock() >= latestLC {
+						latestHead = ref
+					}
+				}
+
+				err = d.setHead(tx, latestHead)
 				if err != nil {
 					return err
 				}

--- a/network/dag/dag_test.go
+++ b/network/dag/dag_test.go
@@ -157,6 +157,47 @@ func TestDAG_Migrate(t *testing.T) {
 		assert.Equal(t, uint(3), stats.NumberOfTransactions)
 		assert.Equal(t, tx2.Clock(), lc)
 	})
+	t.Run("migrate head to metadata storage", func(t *testing.T) {
+		graph := CreateDAG(t)
+
+		// Setup: add transactions, remove metadata, add to headsShelf
+		addTx(t, graph, txRoot, tx1, tx2)
+		err := graph.db.WriteShelf(ctx, metadataShelf, func(writer stoabs.Writer) error {
+			return writer.Iterate(func(key stoabs.Key, _ []byte) error {
+				return writer.Delete(key)
+			}, stoabs.BytesKey{})
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+		err = graph.db.WriteShelf(ctx, headsShelf, func(writer stoabs.Writer) error {
+			return writer.Put(stoabs.BytesKey(tx2.Ref().Slice()), []byte{1})
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		// Check current head is nil
+		var head hash.SHA256Hash
+		_ = graph.db.Read(ctx, func(tx stoabs.ReadTx) error {
+			head, _ = graph.getHead(tx)
+			return nil
+		})
+		assert.Equal(t, hash.EmptyHash(), head)
+
+		// Migrate
+		err = graph.Migrate()
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		// Assert
+		_ = graph.db.Read(ctx, func(tx stoabs.ReadTx) error {
+			head, _ = graph.getHead(tx)
+			return nil
+		})
+		assert.Equal(t, tx2.Ref(), head)
+	})
 	t.Run("nothing to migrate", func(t *testing.T) {
 		graph := CreateDAG(t)
 		addTx(t, graph, txRoot, tx1, tx2)
@@ -197,6 +238,27 @@ func TestDAG_Add(t *testing.T) {
 		assert.Equal(t, tx.Ref(), visitor.transactions[0].Ref())
 		err = graph.db.Read(ctx, func(dbTx stoabs.ReadTx) error {
 			assert.True(t, graph.isPresent(dbTx, tx.Ref()))
+			return nil
+		})
+		assert.NoError(t, err)
+	})
+	t.Run("updates metadata", func(t *testing.T) {
+		graph := CreateDAG(t)
+		tx1 := CreateTestTransactionWithJWK(0)
+		tx2 := CreateTestTransactionWithJWK(1, tx1)
+
+		addTx(t, graph, tx1)
+		addTx(t, graph, tx2)
+
+		err := graph.db.Read(ctx, func(dbTx stoabs.ReadTx) error {
+			head, err := graph.getHead(dbTx)
+			lc := graph.getHighestClockValue(dbTx)
+			count := graph.getNumberOfTransactions(dbTx)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tx2.Ref(), head)
+			assert.Equal(t, uint32(1), lc)
+			assert.Equal(t, uint64(2), count)
 			return nil
 		})
 		assert.NoError(t, err)

--- a/network/dag/dag_test.go
+++ b/network/dag/dag_test.go
@@ -228,18 +228,6 @@ func TestDAG_Add(t *testing.T) {
 			return nil
 		})
 	})
-	t.Run("error - cyclic graph", func(t *testing.T) {
-		t.Skip("Algorithm for detecting cycles is not yet decided on")
-		// A -> B -> C -> B
-		A := CreateTestTransactionWithJWK(0)
-		B := CreateTestTransactionWithJWK(1, A).(*transaction)
-		C := CreateTestTransactionWithJWK(2, B)
-		B.prevs = append(B.prevs, C.Ref())
-
-		graph := CreateDAG(t)
-		err := addTxErr(graph, A, B, C)
-		assert.EqualError(t, err, "")
-	})
 }
 
 func TestNewDAG_addToLCIndex(t *testing.T) {

--- a/network/dag/dag_test.go
+++ b/network/dag/dag_test.go
@@ -115,7 +115,7 @@ func TestDAG_Migrate(t *testing.T) {
 	ctx := context.Background()
 	txRoot := CreateTestTransactionWithJWK(0)
 	tx1 := CreateTestTransactionWithJWK(1, txRoot)
-	tx2 := CreateTestTransactionWithJWK(2, txRoot)
+	tx2 := CreateTestTransactionWithJWK(2, tx1)
 
 	t.Run("migrate LC value and transaction count to metadata storage", func(t *testing.T) {
 		graph := CreateDAG(t)
@@ -171,7 +171,9 @@ func TestDAG_Migrate(t *testing.T) {
 			return
 		}
 		err = graph.db.WriteShelf(ctx, headsShelf, func(writer stoabs.Writer) error {
-			return writer.Put(stoabs.BytesKey(tx2.Ref().Slice()), []byte{1})
+			_ = writer.Put(stoabs.BytesKey(txRoot.Ref().Slice()), []byte{1})
+			_ = writer.Put(stoabs.BytesKey(tx2.Ref().Slice()), []byte{1})
+			return writer.Put(stoabs.BytesKey(tx1.Ref().Slice()), []byte{1})
 		})
 		if !assert.NoError(t, err) {
 			return

--- a/network/dag/interface.go
+++ b/network/dag/interface.go
@@ -63,8 +63,9 @@ type State interface {
 	// A Notifier should only be created during `configuration` step since the `start` step will redeliver all events that have not been delivered yet.
 	// Returns an error when the Notifier already exists
 	Notifier(name string, receiver ReceiverFn, filters ...NotifierOption) (Notifier, error)
-	// Heads returns the references to all transactions that have not been referenced in the prevs of other transactions.
-	Heads(ctx context.Context) []hash.SHA256Hash
+	// Head returns the reference to a transactions that have not been referenced in the prevs of other transactions.
+	// Returns hash.EmptyHash when no head is stored.
+	Head(ctx context.Context) (hash.SHA256Hash, error)
 	// Shutdown the DB
 	Shutdown() error
 	// Start the publisher and verifier

--- a/network/dag/mock.go
+++ b/network/dag/mock.go
@@ -96,18 +96,19 @@ func (mr *MockStateMockRecorder) GetTransaction(ctx, hash interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransaction", reflect.TypeOf((*MockState)(nil).GetTransaction), ctx, hash)
 }
 
-// Heads mocks base method.
-func (m *MockState) Heads(ctx context.Context) []hash.SHA256Hash {
+// Head mocks base method.
+func (m *MockState) Head(ctx context.Context) (hash.SHA256Hash, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Heads", ctx)
-	ret0, _ := ret[0].([]hash.SHA256Hash)
-	return ret0
+	ret := m.ctrl.Call(m, "Head", ctx)
+	ret0, _ := ret[0].(hash.SHA256Hash)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// Heads indicates an expected call of Heads.
-func (mr *MockStateMockRecorder) Heads(ctx interface{}) *gomock.Call {
+// Head indicates an expected call of Head.
+func (mr *MockStateMockRecorder) Head(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Heads", reflect.TypeOf((*MockState)(nil).Heads), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Head", reflect.TypeOf((*MockState)(nil).Head), ctx)
 }
 
 // IBLT mocks base method.

--- a/network/dag/state.go
+++ b/network/dag/state.go
@@ -252,13 +252,14 @@ func (s *state) ReadPayload(ctx context.Context, hash hash.SHA256Hash) (payload 
 	return
 }
 
-func (s *state) Heads(ctx context.Context) []hash.SHA256Hash {
-	heads := make([]hash.SHA256Hash, 0)
-	_ = s.db.Read(ctx, func(tx stoabs.ReadTx) error {
-		heads = s.graph.heads(tx)
-		return nil
+func (s *state) Head(ctx context.Context) (hash.SHA256Hash, error) {
+	var head hash.SHA256Hash
+	var err error
+	err = s.db.Read(ctx, func(tx stoabs.ReadTx) error {
+		head, err = s.graph.getHead(tx)
+		return err
 	})
-	return heads
+	return head, err
 }
 
 func (s *state) Notifier(name string, receiver ReceiverFn, options ...NotifierOption) (Notifier, error) {

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/nuts-node/test"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"go.uber.org/atomic"

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -34,7 +34,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/go-stoabs/bbolt"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network/dag/tree"
@@ -101,11 +100,14 @@ func TestState_relayingFuncs(t *testing.T) {
 		assert.Equal(t, payload, result)
 	})
 
-	t.Run("State", func(t *testing.T) {
-		heads := txState.Heads(ctx)
+	t.Run("Head", func(t *testing.T) {
+		head, err := txState.Head(ctx)
 
-		assert.Len(t, heads, 1)
-		assert.Equal(t, lastTx.Ref(), heads[0])
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Equal(t, lastTx.Ref(), head)
 	})
 }
 
@@ -299,7 +301,7 @@ func TestState_Diagnostics(t *testing.T) {
 	err := txState.Add(ctx, doc1, payload)
 	assert.NoError(t, err)
 	diagnostics := txState.Diagnostics()
-	assert.Len(t, diagnostics, 4)
+	assert.Len(t, diagnostics, 3)
 	// Assert actual diagnostics
 	lines := make([]string, 0)
 	for _, diagnostic := range diagnostics {
@@ -309,7 +311,6 @@ func TestState_Diagnostics(t *testing.T) {
 	actual := strings.Join(lines, "\n")
 
 	assert.Contains(t, actual, fmt.Sprintf("dag_xor: %s", doc1.Ref()))
-	assert.Contains(t, actual, fmt.Sprintf("heads: [%s]", doc1.Ref()))
 	assert.Contains(t, actual, "transaction_count: 1")
 }
 

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -415,7 +415,7 @@ func TestNetwork_CreateTransaction(t *testing.T) {
 			return
 		}
 
-		cxt.state.EXPECT().Heads(gomock.Any())
+		cxt.state.EXPECT().Head(gomock.Any())
 		cxt.state.EXPECT().Add(gomock.Any(), gomock.Any(), payload)
 
 		_, err = cxt.network.CreateTransaction(TransactionTemplate(payloadType, payload, key).WithAttachKey())
@@ -430,7 +430,7 @@ func TestNetwork_CreateTransaction(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
-		cxt.state.EXPECT().Heads(gomock.Any())
+		cxt.state.EXPECT().Head(gomock.Any())
 		cxt.state.EXPECT().Add(gomock.Any(), gomock.Any(), payload)
 		tx, err := cxt.network.CreateTransaction(TransactionTemplate(payloadType, payload, key))
 		assert.NoError(t, err)
@@ -450,7 +450,7 @@ func TestNetwork_CreateTransaction(t *testing.T) {
 		cxt.state.EXPECT().GetTransaction(gomock.Any(), rootTX.Ref()).Return(rootTX, nil)
 		cxt.state.EXPECT().GetTransaction(gomock.Any(), additionalPrev.Ref()).Return(additionalPrev, nil).Times(2)
 		cxt.state.EXPECT().IsPayloadPresent(gomock.Any(), additionalPrev.PayloadHash()).Return(true, nil)
-		cxt.state.EXPECT().Heads(gomock.Any()).Return([]hash.SHA256Hash{rootTX.Ref()})
+		cxt.state.EXPECT().Head(gomock.Any()).Return(rootTX.Ref(), nil)
 
 		cxt.state.EXPECT().Add(gomock.Any(), gomock.Any(), payload)
 
@@ -507,7 +507,7 @@ func TestNetwork_CreateTransaction(t *testing.T) {
 
 			cxt.network.nodeDIDResolver = &transport.FixedNodeDIDResolver{NodeDID: *nodeDID}
 
-			cxt.state.EXPECT().Heads(gomock.Any())
+			cxt.state.EXPECT().Head(gomock.Any())
 			cxt.state.EXPECT().Add(gomock.Any(), gomock.Any(), payload)
 
 			cxt.keyResolver.EXPECT().ResolveKeyAgreementKey(*sender).Return(senderKey.Public(), nil)
@@ -541,7 +541,7 @@ func TestNetwork_CreateTransaction(t *testing.T) {
 		cxt.state.EXPECT().GetTransaction(gomock.Any(), rootTX.Ref()).Return(nil, errors.New("custom"))
 		cxt.state.EXPECT().GetTransaction(gomock.Any(), additionalPrev.Ref()).Return(additionalPrev, nil)
 		cxt.state.EXPECT().IsPayloadPresent(gomock.Any(), additionalPrev.PayloadHash()).Return(true, nil)
-		cxt.state.EXPECT().Heads(gomock.Any()).Return([]hash.SHA256Hash{rootTX.Ref()})
+		cxt.state.EXPECT().Head(gomock.Any()).Return(rootTX.Ref(), nil)
 
 		_, err := cxt.network.CreateTransaction(TransactionTemplate(payloadType, payload, key).WithAdditionalPrevs([]hash.SHA256Hash{additionalPrev.Ref()}))
 

--- a/network/transport/v2/protocol_integration_test.go
+++ b/network/transport/v2/protocol_integration_test.go
@@ -104,8 +104,8 @@ func TestProtocolV2_Pagination(t *testing.T) {
 	time.Sleep(100 * time.Millisecond) // small timeout for TXs to propagate within the node
 
 	// Confirm that both nodes have the same non-empty XOR
-	assert.NotEqual(t, node1.state.Diagnostics()[3].Result(), hash.EmptyHash())
-	assert.Equal(t, node1.state.Diagnostics()[3].Result(), node2.state.Diagnostics()[3].Result())
+	assert.NotEqual(t, node1.state.Diagnostics()[2].Result(), hash.EmptyHash())
+	assert.Equal(t, node1.state.Diagnostics()[2].Result(), node2.state.Diagnostics()[2].Result())
 }
 
 type integrationTestContext struct {


### PR DESCRIPTION
closes #1307 

A head is stored on the metadata shelf. It is updated when a TX has a higher LC than the current highest LC.
A migration has been added to set it.

Heads has been removed from diagnostics.

Also see nuts-foundation/nuts-specification#198