### PR TITLE
Logging: alter statements to use fields rather than formatted messages

### DIFF
--- a/auth/api/v1/api.go
+++ b/auth/api/v1/api.go
@@ -445,7 +445,7 @@ func (w Wrapper) IntrospectAccessToken(ctx echo.Context) error {
 			if err != nil {
 				log.Logger().
 					WithError(err).
-					WithField("credentialID", credentialID).
+					WithField(core.LogFieldCredentialID, credentialID).
 					Warn("Error while resolving credential")
 				continue
 			}

--- a/auth/api/v1/api.go
+++ b/auth/api/v1/api.go
@@ -443,7 +443,10 @@ func (w Wrapper) IntrospectAccessToken(ctx echo.Context) error {
 		for _, credentialID := range claims.Credentials {
 			credential, err := w.resolveCredential(credentialID)
 			if err != nil {
-				log.Logger().WithError(err).Warnf("Error while resolving credential (id=%s)", credentialID)
+				log.Logger().
+					WithError(err).
+					WithField("credentialID", credentialID).
+					Warn("Error while resolving credential")
 				continue
 			}
 			resolvedVCs = append(resolvedVCs, *credential)

--- a/auth/log/logger.go
+++ b/auth/log/logger.go
@@ -19,10 +19,11 @@
 package log
 
 import (
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/sirupsen/logrus"
 )
 
-var _logger = logrus.StandardLogger().WithField("module", "Auth")
+var _logger = logrus.StandardLogger().WithField(core.LogFieldModule, "Auth")
 
 // Logger returns a logger which should be used for logging in this engine. It adds fields so
 // log entries from this engine can be recognized as such.

--- a/auth/services/irma/irmaconfig.go
+++ b/auth/services/irma/irmaconfig.go
@@ -75,7 +75,9 @@ func GetIrmaServer(validatorConfig ValidatorConfig, irmaConfig *irma.Configurati
 		DisableSchemesUpdate: !validatorConfig.AutoUpdateIrmaSchemas,
 	}
 
-	log.Logger().Debugf("Initializing IRMA library (baseURL=%s)...", config.URL)
+	log.Logger().
+		WithField("url", config.URL).
+		Debug("Initializing IRMA library...")
 
 	return irmaserver.New(config)
 }

--- a/auth/services/irma/irmaconfig.go
+++ b/auth/services/irma/irmaconfig.go
@@ -75,9 +75,7 @@ func GetIrmaServer(validatorConfig ValidatorConfig, irmaConfig *irma.Configurati
 		DisableSchemesUpdate: !validatorConfig.AutoUpdateIrmaSchemas,
 	}
 
-	log.Logger().
-		WithField("url", config.URL).
-		Debug("Initializing IRMA library...")
+	log.Logger().Debugf("Initializing IRMA library (baseURL=%s)...", config.URL)
 
 	return irmaserver.New(config)
 }

--- a/auth/services/irma/signer.go
+++ b/auth/services/irma/signer.go
@@ -93,12 +93,14 @@ func (v Service) StartSigningSession(rawContractText string) (contract.SessionPo
 
 	// Start an IRMA session
 	sessionPointer, token, _, err := v.IrmaSessionHandler.StartSession(signatureRequest, func(result *server.SessionResult) {
-		log.Logger().Debugf("session done, result: %s", server.ToJson(result))
+		log.Logger().Debug("Session done")
+		log.Logger().Trace(server.ToJson(result))
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error while creating session: %w", err)
 	}
-	log.Logger().Debugf("session created with token: %s", token)
+	log.Logger().Debug("Session created")
+	log.Logger().Tracef("Token: %s", token)
 
 	// Return the sessionPointer and sessionId
 	challenge := SessionPtr{
@@ -109,7 +111,7 @@ func (v Service) StartSigningSession(rawContractText string) (contract.SessionPo
 	if log.Logger().Level >= logrus.DebugLevel {
 		printQrCode(string(jsonResult))
 	}
-	log.Logger().Debugf("sessionPointer: %s", string(jsonResult))
+	log.Logger().Tracef("SessionPointer: %s", string(jsonResult))
 
 	return challenge, nil
 }

--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -245,7 +245,10 @@ func (s *service) validateRequester(context *validationContext) error {
 	actualName := context.contractVerificationResult.ContractAttribute(contract.LegalEntityAttr)
 	actualCity := context.contractVerificationResult.ContractAttribute(contract.LegalEntityCityAttr)
 	if actualName != context.requesterName || actualCity != context.requesterCity {
-		log.Logger().Warnf("Token request validation failed, legal entity mismatch (expected name=%s, actual name=%s, expected city=%s, actual city=%s)", context.requesterName, actualName, context.requesterCity, actualCity)
+		log.Logger().
+			WithField("organizationName", context.requesterName).
+			WithField("organizationCity", context.requesterCity).
+			Warnf("Token request validation failed, organization name/city does not match (given name=%s, given city=%s)", actualName, actualCity)
 		return errors.New("legal entity mismatch")
 	}
 	return nil

--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -245,10 +245,7 @@ func (s *service) validateRequester(context *validationContext) error {
 	actualName := context.contractVerificationResult.ContractAttribute(contract.LegalEntityAttr)
 	actualCity := context.contractVerificationResult.ContractAttribute(contract.LegalEntityCityAttr)
 	if actualName != context.requesterName || actualCity != context.requesterCity {
-		log.Logger().
-			WithField("organizationName", context.requesterName).
-			WithField("organizationCity", context.requesterCity).
-			Warnf("Token request validation failed, organization name/city does not match (given name=%s, given city=%s)", actualName, actualCity)
+		log.Logger().Warnf("Token request validation failed, legal entity mismatch (expected name=%s, actual name=%s, expected city=%s, actual city=%s)", context.requesterName, actualName, context.requesterCity, actualCity)
 		return errors.New("legal entity mismatch")
 	}
 	return nil

--- a/core/echo.go
+++ b/core/echo.go
@@ -257,7 +257,7 @@ func loggerMiddleware(config loggerConfig) echo.MiddlewareFunc {
 				"method":    req.Method,
 				"uri":       req.RequestURI,
 				"status":    status,
-			}).Info("request")
+			}).Info("HTTP request")
 			return
 		}
 	}

--- a/core/echo.go
+++ b/core/echo.go
@@ -172,14 +172,11 @@ func (c MultiEcho) Start() error {
 // Shutdown stops all Echo servers.
 func (c MultiEcho) Shutdown() {
 	for address, echoServer := range c.interfaces {
-		logrus.
-			WithField("address", address).
-			Trace("Stopping interface")
+		logrus.Tracef("Stopping interface: %s", address)
 		if err := echoServer.Shutdown(context.Background()); err != nil {
 			logrus.
 				WithError(err).
-				WithField("address", address).
-				Error("Unable to shutdown interface")
+				Errorf("Unable to shutdown interface: %s", address)
 		}
 	}
 }

--- a/core/echo.go
+++ b/core/echo.go
@@ -210,7 +210,7 @@ func getGroup(path string) string {
 	return ""
 }
 
-var _logger = logrus.StandardLogger().WithField("module", "http-server")
+var _logger = logrus.StandardLogger().WithField(LogFieldModule, "http-server")
 
 // Logger returns a logger which should be used for logging in this engine. It adds fields so
 // log entries from this engine can be recognized as such.

--- a/core/echo.go
+++ b/core/echo.go
@@ -172,9 +172,14 @@ func (c MultiEcho) Start() error {
 // Shutdown stops all Echo servers.
 func (c MultiEcho) Shutdown() {
 	for address, echoServer := range c.interfaces {
-		logrus.Tracef("Stopping interface: %s", address)
+		logrus.
+			WithField("address", address).
+			Trace("Stopping interface")
 		if err := echoServer.Shutdown(context.Background()); err != nil {
-			logrus.Errorf("Unable to shutdown interface (address=%s): %v", address, err)
+			logrus.
+				WithError(err).
+				WithField("address", address).
+				Error("Unable to shutdown interface")
 		}
 	}
 }

--- a/core/echo_errors.go
+++ b/core/echo_errors.go
@@ -178,7 +178,7 @@ func getContextLogger(ctx echo.Context) *logrus.Entry {
 	fields := logrus.Fields{}
 	moduleName := ctx.Get(ModuleNameContextKey)
 	if moduleName != nil {
-		fields["module"] = moduleName
+		fields[LogFieldModule] = moduleName
 	}
 	operationID := ctx.Get(OperationIDContextKey)
 	if operationID != nil {

--- a/core/echo_errors.go
+++ b/core/echo_errors.go
@@ -69,7 +69,9 @@ func createHTTPErrorHandler() echo.HTTPErrorHandler {
 				logger.Error(err)
 			}
 		} else {
-			logger.Warnf("Unable to send error back to client, response already committed: %v", err)
+			logger.
+				WithError(err).
+				Warn("Unable to send error back to client, response already committed")
 		}
 	}
 }

--- a/core/engine.go
+++ b/core/engine.go
@@ -60,7 +60,7 @@ type System struct {
 	EchoCreator func(cfg HTTPConfig, strictmode, rateLimiter bool) (EchoServer, error)
 }
 
-var coreLogger = logrus.StandardLogger().WithField("module", "core")
+var coreLogger = logrus.StandardLogger().WithField(LogFieldModule, "core")
 
 // Load loads the config and injects config values into engines
 func (system *System) Load(flags *pflag.FlagSet) error {

--- a/core/logging.go
+++ b/core/logging.go
@@ -1,0 +1,62 @@
+package core
+
+const (
+	// LogFieldModule is the log field for the module name.
+	LogFieldModule = "module"
+
+	// LogFieldEventType is the log field key for event types from the events module.
+	LogFieldEventType = "eventType"
+	// LogFieldEventSubject is the log field key for event subjects from the events module.
+	LogFieldEventSubject = "eventSubject"
+	// LogFieldEventSubscriber is the log field key for event subscribers from the events module.
+	LogFieldEventSubscriber = "eventSubscriber"
+
+	// LogFieldCredentialID is the log field key for the ID of a Verifiable Credential from the VCR module.
+	LogFieldCredentialID = "credentialID"
+	// LogFieldCredentialType is the log field key for the type of a Verifiable Credential from the VCR module.
+	LogFieldCredentialType = "credentialType"
+	// LogFieldCredentialIssuer is the log field key for the issuer of a Verifiable Credential from the VCR module.
+	LogFieldCredentialIssuer = "credentialIssuer"
+
+	// LogFieldStore is the log field key for the name of a store managed by the storage module.
+	LogFieldStore = "store"
+	// LogFieldStoreShelf is the log field key for the name of a shelf, in a store managed by the storage module.
+	LogFieldStoreShelf = "storeShelf"
+
+	// LogFieldKeyID is the log field key for the unique ID of a key from the VDR or crypto module.
+	LogFieldKeyID = "keyID"
+
+	// LogFieldDID is the log field key for the ID of a DID document from the VDR module.
+	LogFieldDID = "did"
+	// LogFieldServiceID is the log field key for the ID of a DID document service from the VDR module.
+	LogFieldServiceID = "serviceID"
+	// LogFieldServiceType is the log field key for the type of a DID document service from the VDR module.
+	LogFieldServiceType = "serviceType"
+	// LogFieldServiceEndpoint is the log field key of the ID of the endpoint of a DID document service from the VDR module.
+	LogFieldServiceEndpoint = "serviceEndpoint"
+
+	// LogFieldNodeAddress is the log field key for node's (gRPC) address from the network module.
+	LogFieldNodeAddress = "nodeAddr"
+	// LogFieldProtocolVersion is the log field key for the protocol version from the network module.
+	LogFieldProtocolVersion = "protocolVersion"
+	// LogFieldMessageType is the log field key for the type, of a received/sent message from the network module.
+	LogFieldMessageType = "messageType"
+	// LogFieldConversationID is the log field key for the conversation ID of messages from the network module.
+	LogFieldConversationID = "conversationID"
+	// LogFieldPeerID is the log field key for peer IDs from the network module.
+	LogFieldPeerID = "peerID"
+	// LogFieldPeerAddr is the log field key for peer addresses from the network module.
+	LogFieldPeerAddr = "peerAddr"
+	// LogFieldPeerNodeDID is the log field key for a peer's authenticated node DID from the network module.
+	LogFieldPeerNodeDID = "peerDID"
+	// LogFieldTransactionRef is the log field key for a transaction reference from the network module.
+	LogFieldTransactionRef = "txRef"
+	// LogFieldTransactionType is the log field key for the payload type, of a transaction from the network module.
+	LogFieldTransactionType = "txType"
+	// LogFieldTransactionIsPrivate is the log field key for marker whether a transaction is private, from the network module.
+	LogFieldTransactionIsPrivate = "txIsPrivate"
+	// LogFieldTransactionPayloadHash is the log field key for the payload (hash) of a transaction from the network module.
+	LogFieldTransactionPayloadHash = "txPayloadHash"
+	// LogFieldTransactionPayloadLength is the log field key for the payload (length in bytes) of a transaction from the network module.
+	LogFieldTransactionPayloadLength = "txPayloadLen"
+)

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -73,7 +73,7 @@ func (client *Crypto) Config() interface{} {
 
 func (client *Crypto) setupFSBackend(config core.ServerConfig) error {
 	log.Logger().Info("Setting up FileSystem backend for storage of private key material. " +
-		"Discouraged for production use unless backups and encryption is properly set up. If not, consider using the Vault backend.")
+		"Discouraged for production use unless backups and encryption is properly set up. Consider using the Hashicorp Vault backend.")
 	fsPath := path.Join(config.Datadir, "crypto")
 	var err error
 	client.Storage, err = storage.NewFileSystemBackend(fsPath)
@@ -139,7 +139,7 @@ func generateKeyPairAndKID(namingFunc KIDNamingFunc) (*ecdsa.PrivateKey, string,
 		return nil, "", err
 	}
 	log.Logger().
-		WithField("keyID", kid).
+		WithField(core.LogFieldKeyID, kid).
 		Info("Generated new key pair")
 	return keyPair, kid, nil
 }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -72,7 +72,7 @@ func (client *Crypto) Config() interface{} {
 }
 
 func (client *Crypto) setupFSBackend(config core.ServerConfig) error {
-	log.Logger().Infof("Setting up FileSystem backend for storage of private key material. " +
+	log.Logger().Info("Setting up FileSystem backend for storage of private key material. " +
 		"Discouraged for production use unless backups and encryption is properly set up. If not, consider using the Vault backend.")
 	fsPath := path.Join(config.Datadir, "crypto")
 	var err error
@@ -138,7 +138,9 @@ func generateKeyPairAndKID(namingFunc KIDNamingFunc) (*ecdsa.PrivateKey, string,
 	if err != nil {
 		return nil, "", err
 	}
-	log.Logger().Infof("Generated new key pair (id=%s)", kid)
+	log.Logger().
+		WithField("kid", kid).
+		Info("Generated new key pair (id=%s)", kid)
 	return keyPair, kid, nil
 }
 

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -139,7 +139,7 @@ func generateKeyPairAndKID(namingFunc KIDNamingFunc) (*ecdsa.PrivateKey, string,
 		return nil, "", err
 	}
 	log.Logger().
-		WithField("kid", kid).
+		WithField("keyID", kid).
 		Info("Generated new key pair (id=%s)", kid)
 	return keyPair, kid, nil
 }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -140,7 +140,7 @@ func generateKeyPairAndKID(namingFunc KIDNamingFunc) (*ecdsa.PrivateKey, string,
 	}
 	log.Logger().
 		WithField("keyID", kid).
-		Info("Generated new key pair (id=%s)", kid)
+		Info("Generated new key pair")
 	return keyPair, kid, nil
 }
 

--- a/crypto/log/logger.go
+++ b/crypto/log/logger.go
@@ -19,10 +19,11 @@
 package log
 
 import (
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/sirupsen/logrus"
 )
 
-var _logger = logrus.StandardLogger().WithField("module", "Crypto")
+var _logger = logrus.StandardLogger().WithField(core.LogFieldModule, "Crypto")
 
 // Logger returns a logger with the module field set to 'Crypto'
 func Logger() *logrus.Entry {

--- a/crypto/storage/vault.go
+++ b/crypto/storage/vault.go
@@ -161,7 +161,9 @@ func (v vaultKVStorage) ListPrivateKeys() []string {
 	path := privateKeyListPath(v.config.PathPrefix)
 	response, err := v.client.ReadWithData(path, map[string][]string{"list": {"true"}})
 	if err != nil {
-		log.Logger().Errorf("Could not list private keys in Vault: %v", err)
+		log.Logger().
+			WithError(err).
+			Error("Could not list private keys in Vault")
 		return nil
 	}
 	if response == nil {

--- a/didman/didman.go
+++ b/didman/didman.go
@@ -369,7 +369,10 @@ func (d *didman) resolveOrganizationDIDDocuments(organizations []vc.VerifiableCr
 		}
 		if document == nil {
 			// DID Document might be deactivated, so just log a warning and omit this entry from the search.
-			log.Logger().Warnf("Unable to resolve organization DID Document (DID=%s): %v", organizationDID, err)
+			log.Logger().
+				WithError(err).
+				WithField("did", organizationDID.String()).
+				Warn("Unable to resolve organization DID Document")
 			continue
 		}
 		didDocuments[j] = document

--- a/didman/didman.go
+++ b/didman/didman.go
@@ -86,10 +86,18 @@ func (d *didman) Name() string {
 }
 
 func (d *didman) AddEndpoint(id did.DID, serviceType string, u url.URL) (*did.Service, error) {
-	log.Logger().Debugf("Adding endpoint (did: %s, type: %s, url: %s)", id.String(), serviceType, u.String())
+	log.Logger().
+		WithField("did", id.String()).
+		WithField("serviceType", id.String()).
+		WithField("serviceEndpoint", u.String()).
+		Debug("Adding endpoint")
 	service, err := d.addService(id, serviceType, u.String(), nil)
 	if err == nil {
-		log.Logger().Infof("Endpoint added (did: %s, type: %s, url: %s)", id.String(), serviceType, u.String())
+		log.Logger().
+			WithField("did", id.String()).
+			WithField("serviceType", id.String()).
+			WithField("serviceEndpoint", u.String()).
+			Info("Endpoint added")
 	}
 	return service, err
 }
@@ -138,7 +146,11 @@ func (d *didman) AddCompoundService(id did.DID, serviceType string, endpoints ma
 
 	service, err := d.addService(id, serviceType, serviceEndpoint, nil)
 	if err == nil {
-		log.Logger().Infof("Compound service added (did: %s, type: %s, endpoints: %s)", id.String(), serviceType, endpoints)
+		log.Logger().
+			WithField("did", id.String()).
+			WithField("serviceType", id.String()).
+			WithField("serviceEndpoint", endpoints).
+			Info("Compound service added")
 	}
 
 	return service, err
@@ -226,7 +238,9 @@ func (d *didman) DeleteService(serviceID ssi.URI) error {
 
 	err = d.vdr.Update(*id, meta.Hash, *doc, nil)
 	if err == nil {
-		log.Logger().Infof("Service removed (id: %s)", serviceID.String())
+		log.Logger().
+			WithField("serviceID", id.String()).
+			Info("Service removed")
 	}
 	return err
 }
@@ -254,7 +268,9 @@ func (d *didman) UpdateContactInformation(id did.DID, information ContactInforma
 		doc.Service = doc.Service[0:i]
 	})
 	if err == nil {
-		log.Logger().Infof("Contact Information Endpoint added (did: %s)", id.String())
+		log.Logger().
+			WithField("did", id.String()).
+			Info("Contact Information Endpoint added")
 	}
 	return &information, err
 }

--- a/didman/didman.go
+++ b/didman/didman.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/nuts-foundation/nuts-node/core"
 	"net/url"
 
 	ssi "github.com/nuts-foundation/go-did"
@@ -87,16 +88,16 @@ func (d *didman) Name() string {
 
 func (d *didman) AddEndpoint(id did.DID, serviceType string, u url.URL) (*did.Service, error) {
 	log.Logger().
-		WithField("did", id.String()).
-		WithField("serviceType", id.String()).
-		WithField("serviceEndpoint", u.String()).
+		WithField(core.LogFieldDID, id.String()).
+		WithField(core.LogFieldServiceType, serviceType).
+		WithField(core.LogFieldServiceEndpoint, u.String()).
 		Debug("Adding endpoint")
 	service, err := d.addService(id, serviceType, u.String(), nil)
 	if err == nil {
 		log.Logger().
-			WithField("did", id.String()).
-			WithField("serviceType", id.String()).
-			WithField("serviceEndpoint", u.String()).
+			WithField(core.LogFieldDID, id.String()).
+			WithField(core.LogFieldServiceType, serviceType).
+			WithField(core.LogFieldServiceEndpoint, u.String()).
 			Info("Endpoint added")
 	}
 	return service, err
@@ -134,9 +135,9 @@ func (d *didman) GetCompoundServices(id did.DID) ([]did.Service, error) {
 
 func (d *didman) AddCompoundService(id did.DID, serviceType string, endpoints map[string]ssi.URI) (*did.Service, error) {
 	log.Logger().
-		WithField("did", id.String()).
-		WithField("serviceType", serviceType).
-		WithField("serviceEndpoint", fmt.Sprintf("%v", endpoints)).
+		WithField(core.LogFieldDID, id.String()).
+		WithField(core.LogFieldServiceType, serviceType).
+		WithField(core.LogFieldServiceEndpoint, endpoints).
 		Debug("Adding compound service")
 	if err := d.validateCompoundServiceEndpoint(endpoints); err != nil {
 		return nil, err
@@ -151,9 +152,9 @@ func (d *didman) AddCompoundService(id did.DID, serviceType string, endpoints ma
 	service, err := d.addService(id, serviceType, serviceEndpoint, nil)
 	if err == nil {
 		log.Logger().
-			WithField("did", id.String()).
-			WithField("serviceType", id.String()).
-			WithField("serviceEndpoint", endpoints).
+			WithField(core.LogFieldDID, id.String()).
+			WithField(core.LogFieldServiceType, serviceType).
+			WithField(core.LogFieldServiceEndpoint, endpoints).
 			Info("Compound service added")
 	}
 
@@ -206,7 +207,7 @@ func (d *didman) GetCompoundServiceEndpoint(id did.DID, compoundServiceType stri
 
 func (d *didman) DeleteService(serviceID ssi.URI) error {
 	log.Logger().
-		WithField("serviceID", serviceID.String()).
+		WithField(core.LogFieldServiceID, serviceID.String()).
 		Debug("Deleting service")
 	id, err := did.ParseDIDURL(serviceID.String())
 	if err != nil {
@@ -245,7 +246,7 @@ func (d *didman) DeleteService(serviceID ssi.URI) error {
 	err = d.vdr.Update(*id, meta.Hash, *doc, nil)
 	if err == nil {
 		log.Logger().
-			WithField("serviceID", id.String()).
+			WithField(core.LogFieldServiceID, serviceID.String()).
 			Info("Service removed")
 	}
 	return err
@@ -254,7 +255,7 @@ func (d *didman) DeleteService(serviceID ssi.URI) error {
 func (d *didman) UpdateContactInformation(id did.DID, information ContactInformation) (*ContactInformation, error) {
 
 	log.Logger().
-		WithField("did", id.String()).
+		WithField(core.LogFieldDID, id.String()).
 		Debugf("Updating contact information service: %v", information)
 
 	// transform ContactInformation to map[string]interface{}
@@ -278,7 +279,7 @@ func (d *didman) UpdateContactInformation(id did.DID, information ContactInforma
 	})
 	if err == nil {
 		log.Logger().
-			WithField("did", id.String()).
+			WithField(core.LogFieldDID, id.String()).
 			Info("Contact Information Endpoint added")
 	}
 	return &information, err
@@ -380,7 +381,7 @@ func (d *didman) resolveOrganizationDIDDocuments(organizations []vc.VerifiableCr
 			// DID Document might be deactivated, so just log a warning and omit this entry from the search.
 			log.Logger().
 				WithError(err).
-				WithField("did", organizationDID.String()).
+				WithField(core.LogFieldDID, organizationDID.String()).
 				Warn("Unable to resolve organization DID Document")
 			continue
 		}

--- a/didman/didman.go
+++ b/didman/didman.go
@@ -247,7 +247,7 @@ func (d *didman) DeleteService(serviceID ssi.URI) error {
 	if err == nil {
 		log.Logger().
 			WithField(core.LogFieldServiceID, serviceID.String()).
-			Info("Service removed")
+			Info("Service deleted")
 	}
 	return err
 }
@@ -256,7 +256,7 @@ func (d *didman) UpdateContactInformation(id did.DID, information ContactInforma
 
 	log.Logger().
 		WithField(core.LogFieldDID, id.String()).
-		Debugf("Updating contact information service: %v", information)
+		Debugf("Updating contact information service")
 
 	// transform ContactInformation to map[string]interface{}
 	serviceEndpoint := map[string]interface{}{
@@ -280,7 +280,7 @@ func (d *didman) UpdateContactInformation(id did.DID, information ContactInforma
 	if err == nil {
 		log.Logger().
 			WithField(core.LogFieldDID, id.String()).
-			Info("Contact Information Endpoint added")
+			Info("Contact Information service added/updated")
 	}
 	return &information, err
 }

--- a/didman/didman.go
+++ b/didman/didman.go
@@ -133,7 +133,11 @@ func (d *didman) GetCompoundServices(id did.DID) ([]did.Service, error) {
 }
 
 func (d *didman) AddCompoundService(id did.DID, serviceType string, endpoints map[string]ssi.URI) (*did.Service, error) {
-	log.Logger().Debugf("Adding compound service (did: %s, type: %s, endpoints: %v)", id.String(), serviceType, endpoints)
+	log.Logger().
+		WithField("did", id.String()).
+		WithField("serviceType", serviceType).
+		WithField("serviceEndpoint", fmt.Sprintf("%v", endpoints)).
+		Debug("Adding compound service")
 	if err := d.validateCompoundServiceEndpoint(endpoints); err != nil {
 		return nil, err
 	}
@@ -201,7 +205,9 @@ func (d *didman) GetCompoundServiceEndpoint(id did.DID, compoundServiceType stri
 }
 
 func (d *didman) DeleteService(serviceID ssi.URI) error {
-	log.Logger().Debugf("Deleting service (id: %s)", serviceID.String())
+	log.Logger().
+		WithField("serviceID", serviceID.String()).
+		Debug("Deleting service")
 	id, err := did.ParseDIDURL(serviceID.String())
 	if err != nil {
 		return err
@@ -246,7 +252,10 @@ func (d *didman) DeleteService(serviceID ssi.URI) error {
 }
 
 func (d *didman) UpdateContactInformation(id did.DID, information ContactInformation) (*ContactInformation, error) {
-	log.Logger().Debugf("Updating contact information service (did: %s, info: %v)", id.String(), information)
+
+	log.Logger().
+		WithField("did", id.String()).
+		Debugf("Updating contact information service: %v", information)
 
 	// transform ContactInformation to map[string]interface{}
 	serviceEndpoint := map[string]interface{}{

--- a/didman/log/logger.go
+++ b/didman/log/logger.go
@@ -19,10 +19,11 @@
 package log
 
 import (
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/sirupsen/logrus"
 )
 
-var _logger = logrus.StandardLogger().WithField("module", "Didman")
+var _logger = logrus.StandardLogger().WithField(core.LogFieldModule, "Didman")
 
 // Logger returns a logger with the module field set to the ModuleName
 func Logger() *logrus.Entry {

--- a/events/conn.go
+++ b/events/conn.go
@@ -80,7 +80,7 @@ func NewNATSConnectionPool(config Config) *NATSConnectionPool {
 
 // Acquire returns a NATS connection and JetStream context, it will connect if not already connected
 func (pool *NATSConnectionPool) Acquire(ctx context.Context) (Conn, JetStreamContext, error) {
-	log.Logger().Trace("trying to acquire a NATS connection")
+	log.Logger().Trace("Trying to acquire a NATS connection")
 
 	// If the connection is already set, return it
 	data := pool.conn.Load()
@@ -103,7 +103,7 @@ func (pool *NATSConnectionPool) Acquire(ctx context.Context) (Conn, JetStreamCon
 	// We're the leader, let's connect!
 	addr := fmt.Sprintf("%s:%d", pool.config.Hostname, pool.config.Port)
 
-	log.Logger().Tracef("connectionState to %s", addr)
+	log.Logger().Tracef("ConnectionState to %s", addr)
 
 	for {
 		conn, err := pool.connectFunc(
@@ -135,7 +135,7 @@ func (pool *NATSConnectionPool) Acquire(ctx context.Context) (Conn, JetStreamCon
 }
 
 func (pool *NATSConnectionPool) Shutdown() {
-	log.Logger().Trace("shutting down NATS connection pool")
+	log.Logger().Trace("Shutting down NATS connection pool")
 
 	// Just make sure no other connections are trying to connect while we're not connected
 	if pool.connecting.Swap(true) == nil {

--- a/events/conn.go
+++ b/events/conn.go
@@ -120,7 +120,10 @@ func (pool *NATSConnectionPool) Acquire(ctx context.Context) (Conn, JetStreamCon
 			}
 		}
 
-		log.Logger().Errorf("failed to connect to %s: %s", addr, err.Error())
+		log.Logger().
+			WithError(err).
+			WithField("address", addr).
+			Error("Failed to connect")
 
 		select {
 		case <-ctx.Done():

--- a/events/conn.go
+++ b/events/conn.go
@@ -122,8 +122,7 @@ func (pool *NATSConnectionPool) Acquire(ctx context.Context) (Conn, JetStreamCon
 
 		log.Logger().
 			WithError(err).
-			WithField("address", addr).
-			Error("Failed to connect")
+			Errorf("Failed to connect to %s", addr)
 
 		select {
 		case <-ctx.Done():

--- a/events/log/logger.go
+++ b/events/log/logger.go
@@ -19,10 +19,11 @@
 package log
 
 import (
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/sirupsen/logrus"
 )
 
-var _logger = logrus.StandardLogger().WithField("module", "events")
+var _logger = logrus.StandardLogger().WithField(core.LogFieldModule, "events")
 
 // Logger returns a logger which should be used for logging in this engine. It adds fields so
 // log entries from this engine can be recognized as such.

--- a/jsonld/log/logger.go
+++ b/jsonld/log/logger.go
@@ -19,10 +19,11 @@
 package log
 
 import (
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/sirupsen/logrus"
 )
 
-var _logger = logrus.StandardLogger().WithField("module", "JSONLD")
+var _logger = logrus.StandardLogger().WithField(core.LogFieldModule, "JSONLD")
 
 // Logger returns the logger for the network engine.
 func Logger() *logrus.Entry {

--- a/network/dag/dag.go
+++ b/network/dag/dag.go
@@ -329,7 +329,9 @@ func (d *dag) addSingle(tx stoabs.WriteTx, transaction Transaction) error {
 		return err
 	}
 	if exists(transactions, ref) {
-		log.Logger().Tracef("Transaction %s already exists, not adding it again.", ref)
+		log.Logger().
+			WithField("txRef", ref).
+			Trace("Transaction already exists, not adding it again.")
 		return nil
 	}
 	if len(transaction.Previous()) == 0 {
@@ -380,7 +382,9 @@ func indexClockValue(tx stoabs.WriteTx, transaction Transaction) error {
 		return err
 	}
 
-	log.Logger().Tracef("storing transaction logical clock, txRef: %s, clock: %d", ref.String(), clockKey)
+	log.Logger().
+		WithField("txRef", ref).
+		Tracef("Storing transaction logical clock (LC: %d)", clockKey)
 
 	return nil
 }

--- a/network/dag/dag.go
+++ b/network/dag/dag.go
@@ -330,7 +330,7 @@ func (d *dag) addSingle(tx stoabs.WriteTx, transaction Transaction) error {
 	}
 	if exists(transactions, ref) {
 		log.Logger().
-			WithField("txRef", ref).
+			WithField(core.LogFieldTransactionRef, ref).
 			Trace("Transaction already exists, not adding it again.")
 		return nil
 	}
@@ -383,7 +383,7 @@ func indexClockValue(tx stoabs.WriteTx, transaction Transaction) error {
 	}
 
 	log.Logger().
-		WithField("txRef", ref).
+		WithField(core.LogFieldTransactionRef, ref).
 		Tracef("Storing transaction logical clock (LC: %d)", clockKey)
 
 	return nil

--- a/network/dag/dag.go
+++ b/network/dag/dag.go
@@ -237,7 +237,9 @@ func (d *dag) add(tx stoabs.WriteTx, transactions ...Transaction) error {
 func (d dag) getNumberOfTransactions(tx stoabs.ReadTx) uint64 {
 	value, err := tx.GetShelfReader(metadataShelf).Get(stoabs.BytesKey(numberOfTransactionsKey))
 	if err != nil {
-		log.Logger().Errorf("Unable to retrieve number of transactions: %v", err)
+		log.Logger().
+			WithError(err).
+			Error("Unable to retrieve number of transactions")
 		return 0
 	}
 	if value != nil {
@@ -260,7 +262,9 @@ func (d dag) setNumberOfTransactions(tx stoabs.WriteTx, count uint64) error {
 func (d dag) getHighestClockValue(tx stoabs.ReadTx) uint32 {
 	value, err := tx.GetShelfReader(metadataShelf).Get(stoabs.BytesKey(highestClockValue))
 	if err != nil {
-		log.Logger().Errorf("Unable to retrieve highest LC value: %v", err)
+		log.Logger().
+			WithError(err).
+			Error("Unable to retrieve highest LC value")
 		return 0
 	}
 	if value == nil {
@@ -282,7 +286,9 @@ func (d dag) getHighestClockLegacy(tx stoabs.ReadTx) uint32 {
 		return nil
 	}, stoabs.Uint32Key(0))
 	if err != nil {
-		log.Logger().Errorf("failed to read clock shelf: %s", err)
+		log.Logger().
+			WithError(err).
+			Error("Failed to read clock shelf")
 		return 0
 	}
 	return clock

--- a/network/dag/notifier.go
+++ b/network/dag/notifier.go
@@ -291,7 +291,9 @@ func (p *notifier) retry(event Event) {
 			retry.Context(ctx),
 			retry.LastErrorOnly(true),
 			retry.OnRetry(func(n uint, err error) {
-				log.Logger().Debugf("retrying event (count=%d) with ref: %s", n, event.Hash.String())
+				log.Logger().
+					WithField("txRef", event.Hash.String()).
+					Debugf("Retrying event (attempt %d/%d)", n, maxRetries)
 			}),
 		)
 		if err != nil {

--- a/network/dag/notifier.go
+++ b/network/dag/notifier.go
@@ -295,7 +295,11 @@ func (p *notifier) retry(event Event) {
 			}),
 		)
 		if err != nil {
-			log.Logger().Errorf("retry for %s receiver failed (ref=%s): %v", p.name, event.Hash.String(), err)
+			log.Logger().
+				WithError(err).
+				WithField("txRef", event.Hash.String()).
+				WithField("eventSubscriber", p.name).
+				Errorf("Retry failed")
 		}
 	}(p.ctx)
 }
@@ -328,7 +332,11 @@ func (p *notifier) notifyNow(event Event) error {
 	}
 
 	if finished, err := p.receiver(*dbEvent); err != nil {
-		log.Logger().Errorf("Retry for %s receiver failed (ref=%s): %v", p.name, dbEvent.Hash.String(), err)
+		log.Logger().
+			WithError(err).
+			WithField("txRef", dbEvent.Hash.String()).
+			WithField("eventSubscriber", p.name).
+			Errorf("Retry failed")
 	} else if finished {
 		return p.Finished(dbEvent.Hash)
 	}

--- a/network/dag/notifier.go
+++ b/network/dag/notifier.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"github.com/avast/retry-go/v4"
 	"github.com/nuts-foundation/go-stoabs"
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network/log"
 	"time"
@@ -292,15 +293,15 @@ func (p *notifier) retry(event Event) {
 			retry.LastErrorOnly(true),
 			retry.OnRetry(func(n uint, err error) {
 				log.Logger().
-					WithField("txRef", event.Hash.String()).
+					WithField(core.LogFieldTransactionRef, event.Hash.String()).
 					Debugf("Retrying event (attempt %d/%d)", n, maxRetries)
 			}),
 		)
 		if err != nil {
 			log.Logger().
 				WithError(err).
-				WithField("txRef", event.Hash.String()).
-				WithField("eventSubscriber", p.name).
+				WithField(core.LogFieldTransactionRef, event.Hash.String()).
+				WithField(core.LogFieldEventSubscriber, p.name).
 				Errorf("Retry failed")
 		}
 	}(p.ctx)
@@ -336,8 +337,8 @@ func (p *notifier) notifyNow(event Event) error {
 	if finished, err := p.receiver(*dbEvent); err != nil {
 		log.Logger().
 			WithError(err).
-			WithField("txRef", dbEvent.Hash.String()).
-			WithField("eventSubscriber", p.name).
+			WithField(core.LogFieldTransactionRef, dbEvent.Hash.String()).
+			WithField(core.LogFieldEventSubscriber, p.name).
 			Errorf("Retry failed")
 	} else if finished {
 		return p.Finished(dbEvent.Hash)

--- a/network/dag/pal.go
+++ b/network/dag/pal.go
@@ -97,13 +97,17 @@ func (epal EncryptedPAL) Decrypt(keyAgreementKIDs []string, decryptor crypto.Dec
 outer:
 	for _, encrypted := range epal {
 		for _, kak := range keyAgreementKIDs {
-			log.Logger().Tracef("Trying key %s to decrypt PAL header...", kak)
+			log.Logger().
+				WithField("keyID", kak).
+				Trace("Trying key to decrypt PAL header...")
 			decrypted, err = decryptor.Decrypt(kak, encrypted)
 			if errors.Is(err, crypto.ErrPrivateKeyNotFound) {
 				return nil, fmt.Errorf("private key of DID keyAgreement not found (kid=%s)", kak)
 			}
 			if err != nil {
-				log.Logger().Tracef("Unsuccessful: %v", err)
+				log.Logger().
+					WithError(err).
+					Trace("Unsuccessful")
 			} else {
 				break outer
 			}

--- a/network/dag/pal.go
+++ b/network/dag/pal.go
@@ -23,6 +23,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"github.com/nuts-foundation/nuts-node/core"
 	"strings"
 
 	"github.com/nuts-foundation/go-did/did"
@@ -98,7 +99,7 @@ outer:
 	for _, encrypted := range epal {
 		for _, kak := range keyAgreementKIDs {
 			log.Logger().
-				WithField("keyID", kak).
+				WithField(core.LogFieldKeyID, kak).
 				Trace("Trying key to decrypt PAL header...")
 			decrypted, err = decryptor.Decrypt(kak, encrypted)
 			if errors.Is(err, crypto.ErrPrivateKeyNotFound) {

--- a/network/dag/payloadstore.go
+++ b/network/dag/payloadstore.go
@@ -38,7 +38,9 @@ type payloadStore struct{}
 func (store payloadStore) isPayloadPresent(tx stoabs.ReadTx, payloadHash hash.SHA256Hash) bool {
 	data, err := store.readPayload(tx, payloadHash)
 	if err != nil {
-		log.Logger().Errorf("failed to verify payload existence: %s", err)
+		log.Logger().
+			WithError(err).
+			Error("Failed to verify payload existence")
 		return false
 	}
 	return len(data) > 0

--- a/network/dag/state.go
+++ b/network/dag/state.go
@@ -178,7 +178,9 @@ func (s *state) loadTrees(ctx context.Context) {
 		}
 		return nil
 	}); err != nil {
-		log.Logger().Errorf("Failed to load the XOR and IBLT trees: %s", err)
+		log.Logger().
+			WithError(err).
+			Errorf("Failed to load the XOR and IBLT trees")
 	}
 	log.Logger().Trace("Loaded the XOR and IBLT trees")
 }

--- a/network/log/logger.go
+++ b/network/log/logger.go
@@ -19,10 +19,11 @@
 package log
 
 import (
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/sirupsen/logrus"
 )
 
-var _logger = logrus.StandardLogger().WithField("module", "Network")
+var _logger = logrus.StandardLogger().WithField(core.LogFieldModule, "Network")
 
 // Logger returns the logger for the network engine.
 func Logger() *logrus.Entry {

--- a/network/network.go
+++ b/network/network.go
@@ -297,7 +297,7 @@ func (n *Network) Start() error {
 			}
 			log.Logger().
 				WithError(err).
-				WithField("did", nodeDID.String()).
+				WithField(core.LogFieldDID, nodeDID.String()).
 				Error("Node DID is invalid, exchanging private TXs will not work")
 		}
 	}
@@ -345,7 +345,7 @@ func (n *Network) connectToKnownNodes(nodeDID did.DID) error {
 				if err = service.UnmarshalServiceEndpoint(&nutsCommStr); err != nil {
 					log.Logger().
 						WithError(err).
-						WithField("did", node.ID.String()).
+						WithField(core.LogFieldDID, node.ID.String()).
 						Warn("Failed to extract NutsComm address from service")
 					continue inner
 				}
@@ -353,14 +353,14 @@ func (n *Network) connectToKnownNodes(nodeDID did.DID) error {
 				if err != nil {
 					log.Logger().
 						WithError(err).
-						WithField("did", node.ID.String()).
-						WithField("address", nutsCommStr).
+						WithField(core.LogFieldDID, node.ID.String()).
+						WithField(core.LogFieldNodeAddress, nutsCommStr).
 						Warn("Invalid NutsComm address in service")
 					continue inner
 				}
 				log.Logger().
-					WithField("nodeAddress", address).
-					WithField("did", nodeDID.String()).
+					WithField(core.LogFieldNodeAddress, address).
+					WithField(core.LogFieldDID, nodeDID.String()).
 					Info("Discovered Nuts node")
 				n.connectionManager.Connect(address)
 			}
@@ -422,8 +422,8 @@ func (n *Network) publish(eventType EventType, transaction dag.Transaction, payl
 		if err := receiver(transaction, payload); err != nil {
 			log.Logger().
 				WithError(err).
-				WithField("txRef", transaction.Ref()).
-				WithField("txType", transaction.PayloadType()).
+				WithField(core.LogFieldTransactionRef, transaction.Ref()).
+				WithField(core.LogFieldTransactionType, transaction.PayloadType()).
 				Error("Transaction subscriber returned an error")
 		}
 	}
@@ -456,11 +456,11 @@ func (n *Network) ListTransactionsInRange(startInclusive uint32, endExclusive ui
 func (n *Network) CreateTransaction(template Template) (dag.Transaction, error) {
 	payloadHash := hash.SHA256Sum(template.Payload)
 	log.Logger().
-		WithField("txType", template.Type).
-		WithField("txPayloadHash", payloadHash).
-		WithField("txPayloadLen", len(template.Payload)).
-		WithField("txIsPrivate", len(template.Participants) > 0).
-		WithField("keyID", template.Key.KID()).
+		WithField(core.LogFieldTransactionType, template.Type).
+		WithField(core.LogFieldTransactionPayloadHash, payloadHash).
+		WithField(core.LogFieldTransactionPayloadLength, len(template.Payload)).
+		WithField(core.LogFieldTransactionIsPrivate, len(template.Participants) > 0).
+		WithField(core.LogFieldKeyID, template.Key.KID()).
 		Debug("Creating transaction")
 
 	// Assert that all additional prevs are present and its Payload is there
@@ -531,9 +531,9 @@ func (n *Network) CreateTransaction(template Template) (dag.Transaction, error) 
 		return nil, fmt.Errorf("unable to add newly created transaction to State: %w", err)
 	}
 	log.Logger().
-		WithField("txRef", transaction.Ref()).
-		WithField("txType", template.Type).
-		WithField("txPayloadLen", len(template.Payload)).
+		WithField(core.LogFieldTransactionRef, transaction.Ref()).
+		WithField(core.LogFieldTransactionType, template.Type).
+		WithField(core.LogFieldTransactionPayloadLength, len(template.Payload)).
 		Info("Transaction created")
 	return transaction, nil
 }
@@ -655,8 +655,8 @@ func (n *Network) Reprocess(contentType string) {
 					if err != nil {
 						log.Logger().
 							WithError(err).
-							WithField("txRef", tx.Ref()).
-							WithField("eventSubject", subject).
+							WithField(core.LogFieldTransactionRef, tx.Ref()).
+							WithField(core.LogFieldEventSubject, subject).
 							Error("Failed to publish transaction")
 						return
 					}
@@ -666,15 +666,15 @@ func (n *Network) Reprocess(contentType string) {
 					}
 					data, _ := json.Marshal(twp)
 					log.Logger().
-						WithField("txRef", tx.Ref()).
-						WithField("eventSubject", subject).
+						WithField(core.LogFieldTransactionRef, tx.Ref()).
+						WithField(core.LogFieldEventSubject, subject).
 						Trace("Publishing transaction")
 					_, err = js.PublishAsync(subject, data)
 					if err != nil {
 						log.Logger().
 							WithError(err).
-							WithField("txRef", tx.Ref()).
-							WithField("eventSubject", subject).
+							WithField(core.LogFieldTransactionRef, tx.Ref()).
+							WithField(core.LogFieldEventSubject, subject).
 							Error("Failed to publish transaction")
 						return
 					}

--- a/network/network.go
+++ b/network/network.go
@@ -455,7 +455,13 @@ func (n *Network) ListTransactionsInRange(startInclusive uint32, endExclusive ui
 // CreateTransaction creates a new transaction from the given template.
 func (n *Network) CreateTransaction(template Template) (dag.Transaction, error) {
 	payloadHash := hash.SHA256Sum(template.Payload)
-	log.Logger().Debugf("Creating transaction (payload hash=%s,type=%s,length=%d,signingKey=%s,private=%v)", payloadHash, template.Type, len(template.Payload), template.Key.KID(), len(template.Participants) > 0)
+	log.Logger().
+		WithField("txType", template.Type).
+		WithField("txPayloadHash", payloadHash).
+		WithField("txPayloadLen", len(template.Payload)).
+		WithField("txIsPrivate", len(template.Participants) > 0).
+		WithField("kid", template.Key.KID()).
+		Debug("Creating transaction")
 
 	// Assert that all additional prevs are present and its Payload is there
 	ctx := context.Background()

--- a/network/network.go
+++ b/network/network.go
@@ -147,10 +147,10 @@ func (n *Network) Configure(config core.ServerConfig) error {
 	} else if !config.Strictmode {
 		// If node DID is not set we can wire the automatic node DID resolver, which makes testing/workshops/development easier.
 		// Might cause unexpected behavior though, so it can't be used in strict mode.
-		log.Logger().Infof("Node DID not set, will be auto-discovered.")
+		log.Logger().Info("Node DID not set, will be auto-discovered.")
 		n.nodeDIDResolver = transport.NewAutoNodeDIDResolver(n.privateKeyResolver, n.didDocumentFinder)
 	} else {
-		log.Logger().Warnf("Node DID not set, sending/receiving private transactions is disabled.")
+		log.Logger().Warn("Node DID not set, sending/receiving private transactions is disabled.")
 	}
 
 	// Configure protocols
@@ -348,7 +348,10 @@ func (n *Network) connectToKnownNodes(nodeDID did.DID) error {
 					log.Logger().Warnf("invalid NutsComm address from service (did=%s, str=%s): %v", node.ID.String(), nutsCommStr, err)
 					continue inner
 				}
-				log.Logger().Infof("Discovered Nuts node (address=%s), published by %s", address, node.ID)
+				log.Logger().
+					WithField("nodeAddress", address).
+					WithField("nodeDID", nodeDID).
+					Info("Discovered Nuts node")
 				n.connectionManager.Connect(address)
 			}
 		}
@@ -507,7 +510,11 @@ func (n *Network) CreateTransaction(template Template) (dag.Transaction, error) 
 	if err = n.state.Add(ctx, transaction, template.Payload); err != nil {
 		return nil, fmt.Errorf("unable to add newly created transaction to State: %w", err)
 	}
-	log.Logger().Infof("Transaction created (ref=%s,type=%s,length=%d)", transaction.Ref(), template.Type, len(template.Payload))
+	log.Logger().
+		WithField("txRef", transaction.Ref()).
+		WithField("txType", template.Type).
+		WithField("txPayloadLen", template.Payload).
+		Info("Transaction created")
 	return transaction, nil
 }
 

--- a/network/network.go
+++ b/network/network.go
@@ -533,7 +533,7 @@ func (n *Network) CreateTransaction(template Template) (dag.Transaction, error) 
 	log.Logger().
 		WithField("txRef", transaction.Ref()).
 		WithField("txType", template.Type).
-		WithField("txPayloadLen", template.Payload).
+		WithField("txPayloadLen", len(template.Payload)).
 		Info("Transaction created")
 	return transaction, nil
 }

--- a/network/network.go
+++ b/network/network.go
@@ -297,7 +297,7 @@ func (n *Network) Start() error {
 			}
 			log.Logger().
 				WithError(err).
-				WithField("did", nodeDID).
+				WithField("did", nodeDID.String()).
 				Error("Node DID is invalid, exchanging private TXs will not work")
 		}
 	}
@@ -360,7 +360,7 @@ func (n *Network) connectToKnownNodes(nodeDID did.DID) error {
 				}
 				log.Logger().
 					WithField("nodeAddress", address).
-					WithField("did", nodeDID).
+					WithField("did", nodeDID.String()).
 					Info("Discovered Nuts node")
 				n.connectionManager.Connect(address)
 			}

--- a/network/network.go
+++ b/network/network.go
@@ -460,7 +460,7 @@ func (n *Network) CreateTransaction(template Template) (dag.Transaction, error) 
 		WithField("txPayloadHash", payloadHash).
 		WithField("txPayloadLen", len(template.Payload)).
 		WithField("txIsPrivate", len(template.Participants) > 0).
-		WithField("kid", template.Key.KID()).
+		WithField("keyID", template.Key.KID()).
 		Debug("Creating transaction")
 
 	// Assert that all additional prevs are present and its Payload is there
@@ -665,7 +665,10 @@ func (n *Network) Reprocess(contentType string) {
 						Payload:     payload,
 					}
 					data, _ := json.Marshal(twp)
-					log.Logger().Tracef("Publishing transaction (subject=%s, ref=%s)", subject, tx.Ref().String())
+					log.Logger().
+						WithField("txRef", tx.Ref()).
+						WithField("eventSubject", subject).
+						Trace("Publishing transaction")
 					_, err = js.PublishAsync(subject, data)
 					if err != nil {
 						log.Logger().

--- a/network/network.go
+++ b/network/network.go
@@ -340,17 +340,24 @@ func (n *Network) connectToKnownNodes(nodeDID did.DID) error {
 			if service.Type == transport.NutsCommServiceType {
 				var nutsCommStr string
 				if err = service.UnmarshalServiceEndpoint(&nutsCommStr); err != nil {
-					log.Logger().Warnf("failed to extract NutsComm address from service (did=%s): %v", node.ID.String(), err)
+					log.Logger().
+						WithError(err).
+						WithField("did", node.ID.String()).
+						Warn("Failed to extract NutsComm address from service")
 					continue inner
 				}
 				address, err := transport.ParseAddress(nutsCommStr)
 				if err != nil {
-					log.Logger().Warnf("invalid NutsComm address from service (did=%s, str=%s): %v", node.ID.String(), nutsCommStr, err)
+					log.Logger().
+						WithError(err).
+						WithField("did", node.ID.String()).
+						WithField("address", nutsCommStr).
+						Warn("Invalid NutsComm address in service")
 					continue inner
 				}
 				log.Logger().
 					WithField("nodeAddress", address).
-					WithField("nodeDID", nodeDID).
+					WithField("did", nodeDID).
 					Info("Discovered Nuts node")
 				n.connectionManager.Connect(address)
 			}

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -882,7 +882,7 @@ func startNode(t *testing.T, name string, testDirectory string, opts ...func(cfg
 	_ = instance.Subscribe(t.Name(), func(event dag.Event) (bool, error) {
 		mutex.Lock()
 		defer mutex.Unlock()
-		log.Logger().Infof("transaction %s arrived at %s", string(event.Payload), name)
+		log.Logger().Infof("Transaction %s arrived at %s", string(event.Payload), name)
 		receivedTransactions[name] = append(receivedTransactions[name], event.Transaction)
 		return true, nil
 	}, WithSelectionFilter(func(event dag.Event) bool {

--- a/network/transport/grpc/authenticator.go
+++ b/network/transport/grpc/authenticator.go
@@ -21,6 +21,7 @@ package grpc
 import (
 	"fmt"
 	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/network/log"
 	"github.com/nuts-foundation/nuts-node/network/transport"
 	"github.com/nuts-foundation/nuts-node/vdr/doc"
@@ -82,14 +83,14 @@ func (t tlsAuthenticator) Authenticate(nodeDID did.DID, grpcPeer grpcPeer.Peer, 
 	err = peerCertificate.VerifyHostname(nutsCommURL.Hostname())
 	if err == nil {
 		log.Logger().
-			WithField("did", nodeDID).
+			WithField(core.LogFieldDID, nodeDID).
 			Debug("Connection successfully authenticated")
 		peer.NodeDID = nodeDID
 		return peer, nil
 	}
 
 	log.Logger().
-		WithField("did", nodeDID).
+		WithField(core.LogFieldDID, nodeDID).
 		Debugf("DNS names in peer certificate: %s", strings.Join(peerCertificate.DNSNames, ", "))
 	return withOverride(peer, fmt.Errorf("none of the DNS names in the peer's TLS certificate match the NutsComm endpoint (nodeDID=%s)", nodeDID))
 }

--- a/network/transport/grpc/authenticator.go
+++ b/network/transport/grpc/authenticator.go
@@ -81,12 +81,16 @@ func (t tlsAuthenticator) Authenticate(nodeDID did.DID, grpcPeer grpcPeer.Peer, 
 	// Check whether one of the DNS names matches one of the NutsComm endpoints
 	err = peerCertificate.VerifyHostname(nutsCommURL.Hostname())
 	if err == nil {
-		log.Logger().Debugf("Connection successfully authenticated (nodeDID=%s)", nodeDID)
+		log.Logger().
+			WithField("did", nodeDID).
+			Debug("Connection successfully authenticated")
 		peer.NodeDID = nodeDID
 		return peer, nil
 	}
 
-	log.Logger().Debugf("DNS names in peer certificate: %s", strings.Join(peerCertificate.DNSNames, ", "))
+	log.Logger().
+		WithField("did", nodeDID).
+		Debugf("DNS names in peer certificate: %s", strings.Join(peerCertificate.DNSNames, ", "))
 	return withOverride(peer, fmt.Errorf("none of the DNS names in the peer's TLS certificate match the NutsComm endpoint (nodeDID=%s)", nodeDID))
 }
 

--- a/network/transport/grpc/authenticator.go
+++ b/network/transport/grpc/authenticator.go
@@ -50,7 +50,9 @@ type tlsAuthenticator struct {
 func (t tlsAuthenticator) Authenticate(nodeDID did.DID, grpcPeer grpcPeer.Peer, peer transport.Peer) (transport.Peer, error) {
 	withOverride := func(peer transport.Peer, err error) (transport.Peer, error) {
 		if peer.AcceptUnauthenticated {
-			log.Logger().Warnf("Connection manually authenticated, authentication error: %v", err)
+			log.Logger().
+				WithError(err).
+				Warn("Connection manually authenticated with authentication error")
 			peer.NodeDID = nodeDID
 			return peer, nil
 		}

--- a/network/transport/grpc/backoff.go
+++ b/network/transport/grpc/backoff.go
@@ -160,7 +160,9 @@ func (p persistingBackoff) write(backoff time.Duration) {
 		return writer.Put(stoabs.BytesKey(p.peerAddress), buf.Bytes())
 	})
 	if err != nil {
-		log.Logger().Errorf("Failed to persist backoff: %v", err)
+		log.Logger().
+			WithError(err).
+			Error("Failed to persist backoff")
 	}
 }
 
@@ -177,7 +179,9 @@ func (p persistingBackoff) read() persistedBackoff {
 		return gob.NewDecoder(bytes.NewReader(data)).Decode(&result)
 	})
 	if err != nil {
-		log.Logger().Errorf("Failed to read persisted backoff: %v", err)
+		log.Logger().
+			WithError(err).
+			Error("Failed to read persisted backoff")
 	}
 	return result
 }

--- a/network/transport/grpc/connection.go
+++ b/network/transport/grpc/connection.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/core"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -239,13 +240,13 @@ func (mc *conn) startReceiving(protocol Protocol, stream Stream) {
 				errStatus, isStatusError := status.FromError(err)
 				if errors.Is(err, io.EOF) || (isStatusError && errStatus.Code() == codes.Canceled) {
 					log.Logger().
-						WithField("protocolVersion", protocol.Version()).
+						WithField(core.LogFieldProtocolVersion, protocol.Version()).
 						WithFields(peer.ToFields()).
 						Info("Peer closed connection")
 				} else {
 					log.Logger().
 						WithError(err).
-						WithField("protocolVersion", protocol.Version()).
+						WithField(core.LogFieldProtocolVersion, protocol.Version()).
 						WithFields(peer.ToFields()).
 						Warn("Peer connection error")
 				}
@@ -257,9 +258,9 @@ func (mc *conn) startReceiving(protocol Protocol, stream Stream) {
 			if err != nil {
 				log.Logger().
 					WithError(err).
-					WithField("protocolVersion", protocol.Version()).
+					WithField(core.LogFieldProtocolVersion, protocol.Version()).
 					WithFields(peer.ToFields()).
-					WithField("messageType", fmt.Sprintf("%T", protocol.UnwrapMessage(message))).
+					WithField(core.LogFieldMessageType, fmt.Sprintf("%T", protocol.UnwrapMessage(message))).
 					Warn("Error handling message")
 			}
 		}
@@ -290,9 +291,9 @@ func (mc *conn) startSending(protocol Protocol, stream Stream) {
 				if err != nil {
 					log.Logger().
 						WithError(err).
-						WithField("protocolVersion", protocol.Version()).
+						WithField(core.LogFieldProtocolVersion, protocol.Version()).
 						WithFields(mc.Peer().ToFields()).
-						WithField("messageType", fmt.Sprintf("%T", envelope)).
+						WithField(core.LogFieldMessageType, fmt.Sprintf("%T", envelope)).
 						Warn("Unable to send message, message is dropped")
 				}
 			}
@@ -304,7 +305,7 @@ func (mc *conn) startSending(protocol Protocol, stream Stream) {
 			if err != nil {
 				log.Logger().
 					WithError(err).
-					WithField("protocolVersion", protocol.Version()).
+					WithField(core.LogFieldProtocolVersion, protocol.Version()).
 					Warn("Error while closing client for gRPC stream")
 			}
 		}

--- a/network/transport/grpc/connection.go
+++ b/network/transport/grpc/connection.go
@@ -240,13 +240,13 @@ func (mc *conn) startReceiving(protocol Protocol, stream Stream) {
 				if errors.Is(err, io.EOF) || (isStatusError && errStatus.Code() == codes.Canceled) {
 					log.Logger().
 						WithField("protocol", protocol.MethodName()).
-						WithField("peer", peer).
+						WithField("peer", peer.String()).
 						Info("Peer closed connection")
 				} else {
 					log.Logger().
 						WithError(err).
 						WithField("protocol", protocol.MethodName()).
-						WithField("peer", peer).
+						WithField("peer", peer.String()).
 						Warn("Peer connection error")
 				}
 				cancel()
@@ -258,7 +258,7 @@ func (mc *conn) startReceiving(protocol Protocol, stream Stream) {
 				log.Logger().
 					WithError(err).
 					WithField("protocol", protocol.MethodName()).
-					WithField("peer", peer).
+					WithField("peer", peer.String()).
 					WithField("messageType", fmt.Sprintf("%T", protocol.UnwrapMessage(message))).
 					Warn("Error handling message")
 			}
@@ -291,7 +291,7 @@ func (mc *conn) startSending(protocol Protocol, stream Stream) {
 					log.Logger().
 						WithError(err).
 						WithField("protocol", protocol.MethodName()).
-						WithField("peer", mc.Peer()).
+						WithField("peer", mc.Peer().String()).
 						WithField("messageType", fmt.Sprintf("%T", envelope)).
 						Warn("Unable to send message, message is dropped")
 				}

--- a/network/transport/grpc/connection.go
+++ b/network/transport/grpc/connection.go
@@ -238,7 +238,10 @@ func (mc *conn) startReceiving(protocol Protocol, stream Stream) {
 			if err != nil {
 				errStatus, isStatusError := status.FromError(err)
 				if errors.Is(err, io.EOF) || (isStatusError && errStatus.Code() == codes.Canceled) {
-					log.Logger().Infof("%s: Peer closed connection (peer=%s)", protocol.MethodName(), peer)
+					log.Logger().
+						WithField("protocol", protocol.MethodName()).
+						WithField("peer", peer).
+						Info("Peer closed connection")
 				} else {
 					log.Logger().Warnf("%s: Peer connection error (peer=%s): %v", protocol.MethodName(), peer, err)
 				}

--- a/network/transport/grpc/connection.go
+++ b/network/transport/grpc/connection.go
@@ -239,14 +239,14 @@ func (mc *conn) startReceiving(protocol Protocol, stream Stream) {
 				errStatus, isStatusError := status.FromError(err)
 				if errors.Is(err, io.EOF) || (isStatusError && errStatus.Code() == codes.Canceled) {
 					log.Logger().
-						WithField("protocol", protocol.MethodName()).
-						WithField("peer", peer.String()).
+						WithField("protocolVersion", protocol.Version()).
+						WithFields(peer.ToFields()).
 						Info("Peer closed connection")
 				} else {
 					log.Logger().
 						WithError(err).
-						WithField("protocol", protocol.MethodName()).
-						WithField("peer", peer.String()).
+						WithField("protocolVersion", protocol.Version()).
+						WithFields(peer.ToFields()).
 						Warn("Peer connection error")
 				}
 				cancel()
@@ -257,8 +257,8 @@ func (mc *conn) startReceiving(protocol Protocol, stream Stream) {
 			if err != nil {
 				log.Logger().
 					WithError(err).
-					WithField("protocol", protocol.MethodName()).
-					WithField("peer", peer.String()).
+					WithField("protocolVersion", protocol.Version()).
+					WithFields(peer.ToFields()).
 					WithField("messageType", fmt.Sprintf("%T", protocol.UnwrapMessage(message))).
 					Warn("Error handling message")
 			}
@@ -290,8 +290,8 @@ func (mc *conn) startSending(protocol Protocol, stream Stream) {
 				if err != nil {
 					log.Logger().
 						WithError(err).
-						WithField("protocol", protocol.MethodName()).
-						WithField("peer", mc.Peer().String()).
+						WithField("protocolVersion", protocol.Version()).
+						WithFields(mc.Peer().ToFields()).
 						WithField("messageType", fmt.Sprintf("%T", envelope)).
 						Warn("Unable to send message, message is dropped")
 				}
@@ -304,7 +304,7 @@ func (mc *conn) startSending(protocol Protocol, stream Stream) {
 			if err != nil {
 				log.Logger().
 					WithError(err).
-					WithField("protocol", protocol.MethodName()).
+					WithField("protocolVersion", protocol.Version()).
 					Warn("Error while closing client for gRPC stream")
 			}
 		}

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -225,7 +225,7 @@ func (s *grpcConnectionManager) RegisterObserver(observer transport.StreamStateO
 
 func (s *grpcConnectionManager) notifyObservers(peer transport.Peer, protocol transport.Protocol, state transport.StreamState) {
 	log.Logger().
-		WithField("peer", peer).
+		WithField("peer", peer.String()).
 		WithField("protocolVersion", protocol.Version()).
 		WithField("connectionState", state).
 		Debug("Observed stream state change")
@@ -288,7 +288,7 @@ func (s *grpcConnectionManager) openOutboundStreams(connection Connection, grpcC
 		peer := connection.Peer() // work with a copy of peer to avoid race condition due to disconnect() resetting it
 		log.Logger().
 			WithField("protocol", fmt.Sprintf("%T", prot)).
-			WithField("peer", peer).
+			WithField("peer", peer.String()).
 			Debug("Opened gRPC stream")
 		s.notifyObservers(peer, protocol, transport.StateConnected)
 
@@ -365,7 +365,7 @@ func (s *grpcConnectionManager) openOutboundStream(connection Connection, protoc
 	if !connection.registerStream(protocol, clientStream) {
 		// This can happen when the peer connected to us previously, and now we connect back to them.
 		log.Logger().
-			WithField("peer", peer).
+			WithField("peer", peer.String()).
 			Warn("We connected to a peer that we're already connected to")
 		return nil, fatalError{error: ErrAlreadyConnected}
 	}
@@ -379,7 +379,7 @@ func (s *grpcConnectionManager) authenticate(nodeDID did.DID, peer transport.Pee
 		if err != nil {
 			log.Logger().
 				WithError(err).
-				WithField("peer", peer).
+				WithField("peer", peer.String()).
 				WithField("did", nodeDID).
 				Warn("Peer node DID could not be authenticated")
 			// Error message is spec'd by RFC017, because it is returned to the peer
@@ -424,7 +424,7 @@ func (s *grpcConnectionManager) handleInboundStream(protocol Protocol, inboundSt
 		Address: peerFromCtx.Addr.String(),
 	}
 	log.Logger().
-		WithField("peer", peer).
+		WithField("peer", peer.String()).
 		WithField("protocol", fmt.Sprintf("%T", inboundStream)).
 		Debug("New inbound stream from peer")
 	peer, err = s.authenticate(nodeDID, peer, peerFromCtx)
@@ -487,7 +487,7 @@ func (s *grpcConnectionManager) startTracking(address string, connection Connect
 		if err != nil {
 			log.Logger().
 				WithError(err).
-				WithField("peer", connection.Peer()).
+				WithField("peer", connection.Peer().String()).
 				Error("Error while setting up outbound gRPC streams, disconnecting")
 			connection.disconnect()
 			_ = grpcConn.Close()

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -168,7 +168,9 @@ func (s *grpcConnectionManager) Start() error {
 		}
 	}(s.grpcServer, s.listener)
 
-	log.Logger().Infof("gRPC server started on %s", s.config.listenAddress)
+	log.Logger().
+		WithField("address", s.config.listenAddress).
+		Info("gRPC server started")
 	return nil
 }
 
@@ -205,7 +207,9 @@ func (s grpcConnectionManager) Connect(peerAddress string, options ...transport.
 	}
 	connection, isNew := s.connections.getOrRegister(s.ctx, peer, s.dialer)
 	if !isNew {
-		log.Logger().Infof("A connection for %s already exists.", peer.Address)
+		log.Logger().
+			WithField("address", peer.Address).
+			Info("Connection for peer already exists.")
 		return
 	}
 	s.startTracking(peer.Address, connection)

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -392,7 +392,9 @@ func (s *grpcConnectionManager) authenticate(nodeDID did.DID, peer transport.Pee
 
 func (s *grpcConnectionManager) handleInboundStream(protocol Protocol, inboundStream grpc.ServerStream) error {
 	peerFromCtx, _ := grpcPeer.FromContext(inboundStream.Context())
-	log.Logger().Tracef("New peer connected from %s", peerFromCtx.Addr)
+	log.Logger().
+		WithField("address", peerFromCtx.Addr).
+		Trace("New peer connected")
 
 	// Send our headers
 	md, err := s.constructMetadata()

--- a/network/transport/grpc/outbound_connector.go
+++ b/network/transport/grpc/outbound_connector.go
@@ -111,7 +111,10 @@ func (c *outboundConnector) start() {
 			if err != nil {
 				// either tryConnect or connectedCallback returned an error
 				waitPeriod := c.backoff.Backoff()
-				log.Logger().Infof("Couldn't connect to peer, reconnecting in %d seconds (peer=%s,err=%v)", int(waitPeriod.Seconds()), c.address, err)
+				log.Logger().
+					WithField("address", c.address).
+					WithError(err).
+					Infof("Couldn't connect to peer, reconnecting in %d seconds", int(waitPeriod.Seconds()))
 				sleepWithCancel(cancelCtx, waitPeriod)
 			}
 		}
@@ -126,7 +129,9 @@ func (c *outboundConnector) stop() {
 }
 
 func (c *outboundConnector) tryConnect() (*grpcLib.ClientConn, error) {
-	log.Logger().Infof("Connecting to peer: %s", c.address)
+	log.Logger().
+		WithField("address", c.address).
+		Info("Connecting to peer")
 	atomic.AddUint32(c.attempts, 1)
 	c.lastAttempt.Store(time.Now())
 
@@ -150,7 +155,9 @@ func (c *outboundConnector) tryConnect() (*grpcLib.ClientConn, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect: %w", err)
 	}
-	log.Logger().Infof("Connected to peer (outbound): %s", c.address)
+	log.Logger().
+		WithField("address", c.address).
+		Info("Connected to peer (outbound)")
 	return grpcConn, nil
 }
 

--- a/network/transport/grpc/outbound_connector.go
+++ b/network/transport/grpc/outbound_connector.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/network/log"
 	"github.com/nuts-foundation/nuts-node/network/transport"
 	grpcLib "google.golang.org/grpc"
@@ -112,7 +113,7 @@ func (c *outboundConnector) start() {
 				// either tryConnect or connectedCallback returned an error
 				waitPeriod := c.backoff.Backoff()
 				log.Logger().
-					WithField("address", c.address).
+					WithField(core.LogFieldPeerAddr, c.address).
 					WithError(err).
 					Infof("Couldn't connect to peer, reconnecting in %d seconds", int(waitPeriod.Seconds()))
 				sleepWithCancel(cancelCtx, waitPeriod)
@@ -130,7 +131,7 @@ func (c *outboundConnector) stop() {
 
 func (c *outboundConnector) tryConnect() (*grpcLib.ClientConn, error) {
 	log.Logger().
-		WithField("address", c.address).
+		WithField(core.LogFieldPeerAddr, c.address).
 		Info("Connecting to peer")
 	atomic.AddUint32(c.attempts, 1)
 	c.lastAttempt.Store(time.Now())
@@ -156,7 +157,7 @@ func (c *outboundConnector) tryConnect() (*grpcLib.ClientConn, error) {
 		return nil, fmt.Errorf("unable to connect: %w", err)
 	}
 	log.Logger().
-		WithField("address", c.address).
+		WithField(core.LogFieldPeerAddr, c.address).
 		Info("Connected to peer (outbound)")
 	return grpcConn, nil
 }

--- a/network/transport/types.go
+++ b/network/transport/types.go
@@ -21,6 +21,7 @@ package transport
 import (
 	"errors"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"net/url"
 	"time"
 
@@ -58,6 +59,15 @@ type Peer struct {
 	NodeDID did.DID
 	// AcceptUnauthenticated indicates if a connection may be made with this Peer even if the NodeDID could not be authenticated.
 	AcceptUnauthenticated bool
+}
+
+// ToFields returns the peer as a map of fields, to be used when logging the peer details.
+func (p Peer) ToFields() logrus.Fields {
+	return map[string]interface{}{
+		"peerID":   p.ID.String(),
+		"peerAddr": p.Address,
+		"peerDID":  p.NodeDID.String(),
+	}
 }
 
 // String returns the peer as string.

--- a/network/transport/types.go
+++ b/network/transport/types.go
@@ -21,6 +21,7 @@ package transport
 import (
 	"errors"
 	"fmt"
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/sirupsen/logrus"
 	"net/url"
 	"time"
@@ -64,9 +65,9 @@ type Peer struct {
 // ToFields returns the peer as a map of fields, to be used when logging the peer details.
 func (p Peer) ToFields() logrus.Fields {
 	return map[string]interface{}{
-		"peerID":   p.ID.String(),
-		"peerAddr": p.Address,
-		"peerDID":  p.NodeDID.String(),
+		core.LogFieldPeerID:      p.ID.String(),
+		core.LogFieldPeerAddr:    p.Address,
+		core.LogFieldPeerNodeDID: p.NodeDID.String(),
 	}
 }
 

--- a/network/transport/types_test.go
+++ b/network/transport/types_test.go
@@ -19,6 +19,7 @@
 package transport
 
 import (
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -44,4 +45,17 @@ func Test_ParseAddress(t *testing.T) {
 		assert.Empty(t, addr)
 		assert.EqualError(t, err, "invalid URL scheme")
 	})
+}
+
+func TestPeer_ToFields(t *testing.T) {
+	peer := Peer{
+		ID:      "abc",
+		Address: "def",
+		NodeDID: did.MustParseDID("did:abc:123"),
+	}
+
+	assert.Len(t, peer.ToFields(), 3)
+	assert.Equal(t, "abc", peer.ToFields()["peerID"])
+	assert.Equal(t, "def", peer.ToFields()["peerAddr"])
+	assert.Equal(t, "did:abc:123", peer.ToFields()["peerDID"])
 }

--- a/network/transport/v2/gossip/manager.go
+++ b/network/transport/v2/gossip/manager.go
@@ -87,7 +87,9 @@ func (m *manager) GossipReceived(id transport.PeerID, refs ...hash.SHA256Hash) {
 
 	peer, ok := m.peers[string(id)]
 	if !ok {
-		log.Logger().Errorf("received gossip from peer, but gossip administration is missing, peer=%s", string(id))
+		log.Logger().
+			WithField("peerID", id).
+			Error("Received gossip from peer, but gossip administration is missing")
 		return
 	}
 

--- a/network/transport/v2/gossip/manager.go
+++ b/network/transport/v2/gossip/manager.go
@@ -21,6 +21,7 @@ package gossip
 
 import (
 	"context"
+	"github.com/nuts-foundation/nuts-node/core"
 	"sync"
 	"time"
 
@@ -88,7 +89,7 @@ func (m *manager) GossipReceived(id transport.PeerID, refs ...hash.SHA256Hash) {
 	peer, ok := m.peers[string(id)]
 	if !ok {
 		log.Logger().
-			WithField("peerID", id).
+			WithField(core.LogFieldPeerID, id).
 			Error("Received gossip from peer, but gossip administration is missing")
 		return
 	}

--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -50,7 +50,11 @@ func (p *protocol) Handle(peer transport.Peer, raw interface{}) error {
 
 	err := p.handle(peer, envelope)
 	if err != nil {
-		log.Logger().Errorf("Error handling %T (peer=%s): %s", envelope.Message, peer, err)
+		log.Logger().
+			WithError(err).
+			WithField("peer", peer).
+			WithField("messageType", fmt.Sprintf("%T", envelope.Message)).
+			Error("Error handling message")
 		// Only return allowed errors
 		for _, allowedError := range allowedErrors {
 			if err == allowedError {
@@ -68,7 +72,11 @@ type handleFunc func(peer transport.Peer, envelope *Envelope) error
 func handleASync(peer transport.Peer, envelope *Envelope, f handleFunc) error {
 	go func() {
 		if err := f(peer, envelope); err != nil {
-			log.Logger().Errorf("Error handling %T (peer=%s): %s", envelope.Message, peer, err)
+			log.Logger().
+				WithError(err).
+				WithField("peer", peer).
+				WithField("messageType", fmt.Sprintf("%T", envelope.Message)).
+				Error("Error handling message")
 		}
 	}()
 	return nil
@@ -145,7 +153,11 @@ func (p *protocol) handleTransactionPayloadQuery(peer transport.Peer, envelope *
 
 		pal, err := p.decryptPAL(epal)
 		if err != nil {
-			log.Logger().Errorf("Peer requested private transaction but decoding failed (peer=%s,tx=%s): %v", peer, tx.Ref(), err)
+			log.Logger().
+				WithError(err).
+				WithField("peer", peer).
+				WithField("txRef", tx.Ref()).
+				Error("Peer requested private transaction but decryption failed")
 			return p.send(peer, emptyResponse)
 		}
 

--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -47,7 +47,7 @@ var allowedErrors = []error{
 func (p *protocol) Handle(peer transport.Peer, raw interface{}) error {
 	envelope := raw.(*Envelope)
 	log.Logger().
-		WithField("peer", peer.String()).
+		WithFields(peer.ToFields()).
 		WithField("messageType", fmt.Sprintf("%T", envelope.Message)).
 		Trace("Handling message from peer")
 
@@ -55,7 +55,7 @@ func (p *protocol) Handle(peer transport.Peer, raw interface{}) error {
 	if err != nil {
 		log.Logger().
 			WithError(err).
-			WithField("peer", peer.String()).
+			WithFields(peer.ToFields()).
 			WithField("messageType", fmt.Sprintf("%T", envelope.Message)).
 			Error("Error handling message")
 		// Only return allowed errors
@@ -77,7 +77,7 @@ func handleASync(peer transport.Peer, envelope *Envelope, f handleFunc) error {
 		if err := f(peer, envelope); err != nil {
 			log.Logger().
 				WithError(err).
-				WithField("peer", peer.String()).
+				WithFields(peer.ToFields()).
 				WithField("messageType", fmt.Sprintf("%T", envelope.Message)).
 				Error("Error handling message")
 		}
@@ -104,7 +104,7 @@ func (p *protocol) handle(peer transport.Peer, envelope *Envelope) error {
 		default:
 			// when 100 lists are waiting to be processed
 			log.Logger().
-				WithField("peer", peer.String()).
+				WithFields(peer.ToFields()).
 				Warn("Can't handle TransactionList message from peer: channel full")
 		}
 
@@ -132,7 +132,7 @@ func (p *protocol) handleTransactionPayloadQuery(peer transport.Peer, envelope *
 	ctx := context.Background()
 
 	log.Logger().
-		WithField("peer", peer.String()).
+		WithFields(peer.ToFields()).
 		WithField("conversationID", msg.ConversationID).
 		WithField("txRef", hash.FromSlice(msg.TransactionRef)).
 		Trace("Handling TransactionPayloadQuery")
@@ -151,7 +151,7 @@ func (p *protocol) handleTransactionPayloadQuery(peer transport.Peer, envelope *
 		if peer.NodeDID.Empty() {
 			// Connection isn't authenticated
 			log.Logger().
-				WithField("peer", peer.String()).
+				WithFields(peer.ToFields()).
 				WithField("txRef", tx.Ref()).
 				Warn("Peer requested private transaction over unauthenticated connection")
 			return p.send(peer, emptyResponse)
@@ -162,7 +162,7 @@ func (p *protocol) handleTransactionPayloadQuery(peer transport.Peer, envelope *
 		if err != nil {
 			log.Logger().
 				WithError(err).
-				WithField("peer", peer.String()).
+				WithFields(peer.ToFields()).
 				WithField("txRef", tx.Ref()).
 				Error("Peer requested private transaction but decryption failed")
 			return p.send(peer, emptyResponse)
@@ -171,7 +171,7 @@ func (p *protocol) handleTransactionPayloadQuery(peer transport.Peer, envelope *
 		// We weren't able to decrypt the PAL, so it wasn't meant for us
 		if pal == nil {
 			log.Logger().
-				WithField("peer", peer.String()).
+				WithFields(peer.ToFields()).
 				WithField("txRef", tx.Ref()).
 				Warn("Peer requested private transaction we can't decode")
 			return p.send(peer, emptyResponse)
@@ -179,7 +179,7 @@ func (p *protocol) handleTransactionPayloadQuery(peer transport.Peer, envelope *
 
 		if !pal.Contains(peer.NodeDID) {
 			log.Logger().
-				WithField("peer", peer.String()).
+				WithFields(peer.ToFields()).
 				WithField("txRef", tx.Ref()).
 				Warn("Peer requested private transaction illegally")
 			return p.send(peer, emptyResponse)
@@ -200,7 +200,7 @@ func (p *protocol) handleTransactionPayload(peer transport.Peer, envelope *Envel
 	ref := hash.FromSlice(msg.TransactionRef)
 
 	log.Logger().
-		WithField("peer", peer.String()).
+		WithFields(peer.ToFields()).
 		WithField("conversationID", msg.ConversationID).
 		WithField("txRef", ref).
 		Trace("Handling TransactionPayload")
@@ -236,7 +236,7 @@ func (p *protocol) handleTransactionRangeQuery(peer transport.Peer, envelope *En
 	msg := envelope.GetTransactionRangeQuery()
 
 	log.Logger().
-		WithField("peer", peer.String()).
+		WithFields(peer.ToFields()).
 		WithField("conversationID", msg.ConversationID).
 		Trace("Handling TransactionRangeQuery")
 
@@ -263,7 +263,7 @@ func (p *protocol) handleGossip(peer transport.Peer, envelope *Envelope) error {
 	ctx := context.Background()
 
 	log.Logger().
-		WithField("peer", peer.String()).
+		WithFields(peer.ToFields()).
 		Trace("Handling Gossip", peer.ID.String())
 
 	xor, clock := p.state.XOR(ctx, math.MaxUint32)
@@ -296,7 +296,7 @@ func (p *protocol) handleGossip(peer transport.Peer, envelope *Envelope) error {
 	}
 	refs = refs[:i]
 	log.Logger().
-		WithField("peer", peer.String()).
+		WithFields(peer.ToFields()).
 		Debugf("Received %d new transaction references via Gossip from peer", len(refs))
 
 	// request missing refs
@@ -311,11 +311,11 @@ func (p *protocol) handleGossip(peer transport.Peer, envelope *Envelope) error {
 	// send State if node is missing more refs than referenced in this Gossip
 	if len(refs) == 0 {
 		log.Logger().
-			WithField("peer", peer.String()).
+			WithFields(peer.ToFields()).
 			Debug("XOR is different from peer but Gossip contained no new transactions")
 	} else {
 		log.Logger().
-			WithField("peer", peer.String()).
+			WithFields(peer.ToFields()).
 			Debug("XOR is different from peer and peer's clock is equal or higher")
 	}
 	return p.sender.sendState(peer.ID, xor, clock)
@@ -329,7 +329,7 @@ func (p *protocol) handleTransactionListQuery(peer transport.Peer, envelope *Env
 	cid := conversationID(msg.ConversationID)
 
 	log.Logger().
-		WithField("peer", peer.String()).
+		WithFields(peer.ToFields()).
 		WithField("conversationID", cid).
 		Trace("Handling TransactionListQuery")
 
@@ -339,7 +339,7 @@ func (p *protocol) handleTransactionListQuery(peer transport.Peer, envelope *Env
 
 	if len(requestedRefs) == 0 {
 		log.Logger().
-			WithField("peer", peer.String()).
+			WithFields(peer.ToFields()).
 			Warn("Peer sent request for 0 transactions")
 		return nil
 	}
@@ -357,7 +357,7 @@ func (p *protocol) handleTransactionListQuery(peer transport.Peer, envelope *Env
 			unsorted = append(unsorted, transaction)
 		} else {
 			log.Logger().
-				WithField("peer", peer.String()).
+				WithFields(peer.ToFields()).
 				WithField("txRef", ref.String()).
 				Warn("Peer requested transaction we don't have")
 		}
@@ -405,7 +405,7 @@ func (p *protocol) handleState(peer transport.Peer, envelope *Envelope) error {
 	cid := conversationID(msg.ConversationID)
 
 	log.Logger().
-		WithField("peer", peer.String()).
+		WithFields(peer.ToFields()).
 		WithField("conversationID", cid).
 		Trace("Handling State from peer")
 
@@ -429,7 +429,7 @@ func (p *protocol) handleTransactionSet(peer transport.Peer, envelope *Envelope)
 	data := handlerData{}
 
 	log.Logger().
-		WithField("peer", peer.String()).
+		WithFields(peer.ToFields()).
 		WithField("conversationID", cid).
 		Trace("Handling TransactionSet from peer")
 
@@ -466,7 +466,7 @@ func (p *protocol) handleTransactionSet(peer transport.Peer, envelope *Envelope)
 	if err != nil {
 		if errors.Is(err, tree.ErrDecodeNotPossible) {
 			log.Logger().
-				WithField("peer", peer.String()).
+				WithFields(peer.ToFields()).
 				WithField("conversationID", cid.String()).
 				Debugf("Peer IBLT decode failed")
 
@@ -479,7 +479,7 @@ func (p *protocol) handleTransactionSet(peer transport.Peer, envelope *Envelope)
 			xor, _ := p.state.XOR(ctx, math.MaxUint32)
 
 			log.Logger().
-				WithField("peer", peer.String()).
+				WithFields(peer.ToFields()).
 				WithField("conversationID", cid.String()).
 				Debug("Requesting state of previous page")
 			return p.sender.sendState(peer.ID, xor, previousPageLimit)
@@ -498,7 +498,7 @@ func (p *protocol) handleTransactionSet(peer transport.Peer, envelope *Envelope)
 	peerPageNum, localPageNum, reqPageNum := clockToPageNum(msg.LC), clockToPageNum(localLC), clockToPageNum(msg.LCReq)
 	if peerPageNum > reqPageNum {
 		log.Logger().
-			WithField("peer", peer.String()).
+			WithFields(peer.ToFields()).
 			Debugf("Peer has higher LC values, requesting transactions by range (%d<%d)", reqPageNum, peerPageNum)
 
 		if localPageNum > reqPageNum {

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -217,7 +217,10 @@ func (p *protocol) gossipTransaction(event dag.Event) (bool, error) {
 
 func (p *protocol) sendGossip(id transport.PeerID, refs []hash.SHA256Hash, xor hash.SHA256Hash, clock uint32) bool {
 	if err := p.sendGossipMsg(id, refs, xor, clock); err != nil {
-		log.Logger().Errorf("failed to send Gossip message (peer=%s): %v", id, err)
+		log.Logger().
+			WithError(err).
+			WithField("peerID", id.String()).
+			Error("failed to send Gossip message")
 		return false
 	}
 
@@ -294,7 +297,9 @@ func (p protocol) Diagnostics() []core.DiagnosticResult {
 	// Feels weird to ignore the error here but diagnostics shouldn't fail
 	failedJobs, err := p.privatePayloadReceiver.GetFailedEvents()
 	if err != nil {
-		log.Logger().Errorf("failed to get failed jobs: %v", err)
+		log.Logger().
+			WithError(err).
+			Error("Failed to get failed jobs")
 	}
 
 	return []core.DiagnosticResult{&core.GenericDiagnosticResult{

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -270,7 +270,7 @@ func (p *protocol) handlePrivateTxRetry(event dag.Event) (bool, error) {
 			if err != nil {
 				log.Logger().
 					WithError(err).
-					WithField("peer", conn.Peer().String()).
+					WithFields(conn.Peer().ToFields()).
 					WithField("txRef", event.Hash.String()).
 					Warn("Failed to send TransactionPayloadQuery msg to private TX participant")
 			} else {

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -237,7 +237,9 @@ func (p *protocol) handlePrivateTxRetry(event dag.Event) (bool, error) {
 
 	if payload != nil {
 		// stop retrying
-		log.Logger().Debugf("Transaction payload already present, not querying (tx=%s)", event.Hash)
+		log.Logger().
+			WithField("txRef", event.Hash.String()).
+			Debug("Transaction payload already present, not querying")
 		return true, nil
 	}
 

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -263,7 +263,11 @@ func (p *protocol) handlePrivateTxRetry(event dag.Event) (bool, error) {
 			}}, false)
 
 			if err != nil {
-				log.Logger().Warnf("Failed to send TransactionPayloadQuery msg to private TX participant (tx=%s, PAL=%v): %v", event.Hash.String(), pal, err)
+				log.Logger().
+					WithError(err).
+					WithField("peer", conn.Peer()).
+					WithField("txRef", event.Hash.String()).
+					Warn("Failed to send TransactionPayloadQuery msg to private TX participant")
 			} else {
 				sent = true
 			}

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -219,7 +219,7 @@ func (p *protocol) sendGossip(id transport.PeerID, refs []hash.SHA256Hash, xor h
 	if err := p.sendGossipMsg(id, refs, xor, clock); err != nil {
 		log.Logger().
 			WithError(err).
-			WithField("peerID", id.String()).
+			WithField(core.LogFieldPeerID, id.String()).
 			Error("failed to send Gossip message")
 		return false
 	}
@@ -238,7 +238,7 @@ func (p *protocol) handlePrivateTxRetry(event dag.Event) (bool, error) {
 	if payload != nil {
 		// stop retrying
 		log.Logger().
-			WithField("txRef", event.Hash.String()).
+			WithField(core.LogFieldTransactionRef, event.Hash.String()).
 			Debug("Transaction payload already present, not querying")
 		return true, nil
 	}
@@ -271,7 +271,7 @@ func (p *protocol) handlePrivateTxRetry(event dag.Event) (bool, error) {
 				log.Logger().
 					WithError(err).
 					WithFields(conn.Peer().ToFields()).
-					WithField("txRef", event.Hash.String()).
+					WithField(core.LogFieldTransactionRef, event.Hash.String()).
 					Warn("Failed to send TransactionPayloadQuery msg to private TX participant")
 			} else {
 				sent = true

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -270,7 +270,7 @@ func (p *protocol) handlePrivateTxRetry(event dag.Event) (bool, error) {
 			if err != nil {
 				log.Logger().
 					WithError(err).
-					WithField("peer", conn.Peer()).
+					WithField("peer", conn.Peer().String()).
 					WithField("txRef", event.Hash.String()).
 					Warn("Failed to send TransactionPayloadQuery msg to private TX participant")
 			} else {

--- a/network/transport/v2/protocol_integration_test.go
+++ b/network/transport/v2/protocol_integration_test.go
@@ -142,7 +142,7 @@ func startNode(t *testing.T, name string, configurers ...func(config *Config)) *
 
 	ctx.state, _ = dag.NewState(bboltStore)
 	ctx.state.Notifier(t.Name(), func(event dag.Event) (bool, error) {
-		log.Logger().Infof("transaction %s arrived at %s", string(event.Payload), name)
+		log.Logger().Infof("Transaction %s arrived at %s", string(event.Payload), name)
 		ctx.mux.Lock()
 		defer ctx.mux.Unlock()
 		ctx.receivedTXs = append(ctx.receivedTXs, event.Transaction)

--- a/network/transport/v2/protocol_test.go
+++ b/network/transport/v2/protocol_test.go
@@ -368,6 +368,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 		}, nil, nil)
 		mocks.Decrypter.EXPECT().Decrypt(keyDID.String(), []byte{1}).Return([]byte(peerDID.String()), nil)
 		conn := grpc.NewMockConnection(mocks.Controller)
+		conn.EXPECT().Peer()
 		conn.EXPECT().Send(proto, &Envelope{Message: &Envelope_TransactionPayloadQuery{
 			TransactionPayloadQuery: &TransactionPayloadQuery{
 				TransactionRef: txOk.Ref().Slice(),

--- a/network/transport/v2/senders.go
+++ b/network/transport/v2/senders.go
@@ -52,7 +52,7 @@ func (p *protocol) sendGossipMsg(id transport.PeerID, refs []hash.SHA256Hash, xo
 		refsAsBytes[i] = ref.Slice()
 	}
 
-	log.Logger().Tracef("GOSSIP: LC=%d, xor=%s, xor refs=%s, refs=%v", clock, xor, hash.EmptyHash().Xor(refs...), refs)
+	log.Logger().Tracef("Sending gossip: LC=%d, xor=%s, xor refs=%s, refs=%v", clock, xor, hash.EmptyHash().Xor(refs...), refs)
 
 	return conn.Send(p, &Envelope{Message: &Envelope_Gossip{
 		Gossip: &Gossip{

--- a/network/transport/v2/senders.go
+++ b/network/transport/v2/senders.go
@@ -250,7 +250,7 @@ func (p *protocol) broadcastDiagnostics(diagnostics transport.Diagnostics) {
 		if err != nil {
 			log.Logger().
 				WithError(err).
-				WithField("peer", curr.Peer().String()).
+				WithFields(curr.Peer().ToFields()).
 				Error("Error broadcasting diagnostics")
 		}
 	}

--- a/network/transport/v2/senders.go
+++ b/network/transport/v2/senders.go
@@ -85,12 +85,17 @@ func (p *protocol) sendTransactionListQuery(id transport.PeerID, refs []hash.SHA
 
 	conversation := p.cMan.startConversation(msg, id)
 	if conversation == nil {
-		log.Logger().Debugf("did not request a TransactionList while another conversation is in progress (peer=%s)", id.String())
+		log.Logger().
+			WithField("peerID", id).
+			Debug("Did not request a TransactionList while another conversation is in progress")
 		return nil
 	}
 	conversation.set("refs", refs)
 
-	log.Logger().Debugf("requesting transactionList from peer (peer=%s, conversationID=%s, #=%d)", id, conversation.conversationID.String(), len(refs))
+	log.Logger().
+		WithField("peerID", id).
+		WithField("conversationID", conversation.conversationID.String()).
+		Debugf("Requesting transactionList from peer (%d transactions)", len(refs))
 
 	return conn.Send(p, &Envelope{Message: msg}, false)
 }
@@ -134,11 +139,16 @@ func (p *protocol) sendTransactionRangeQuery(id transport.PeerID, lcStart uint32
 
 	conversation := p.cMan.startConversation(msg, id)
 	if conversation == nil {
-		log.Logger().Debugf("did not request a TransactionRange while another conversation is in progress (peer=%s, start=%d, end=%d)", id.String(), lcStart, lcEnd)
+		log.Logger().
+			WithField("peerID", id).
+			Debugf("Did not request a TransactionRange while another conversation is in progress (start=%d, end=%d)", lcStart, lcEnd)
 		return nil
 	}
 
-	log.Logger().Debugf("requesting transaction range (peer=%s, conversationID=%s, start=%d, end=%d)", id.String(), conversation.conversationID.String(), lcStart, lcEnd)
+	log.Logger().
+		WithField("peerID", id).
+		WithField("conversationID", conversation.conversationID.String()).
+		Debugf("Requesting transaction range (start=%d, end=%d)", lcStart, lcEnd)
 
 	return conn.Send(p, &Envelope{Message: msg}, false)
 }
@@ -190,11 +200,16 @@ func (p *protocol) sendState(id transport.PeerID, xor hash.SHA256Hash, clock uin
 	}
 	conversation := p.cMan.startConversation(msg, id)
 	if conversation == nil {
-		log.Logger().Debugf("did not request State while another conversation is in progress (peer=%s)", id.String())
+		log.Logger().
+			WithField("peerID", id).
+			Debug("Did not request State while another conversation is in progress")
 		return nil
 	}
 
-	log.Logger().Debugf("requesting state from peer (peer=%s, conversationID=%s)", id, conversation.conversationID.String())
+	log.Logger().
+		WithField("peerID", id).
+		WithField("conversationID", conversation.conversationID.String()).
+		Debug("Requesting state from peer")
 
 	return conn.Send(p, &Envelope{Message: msg}, false)
 }

--- a/network/transport/v2/senders.go
+++ b/network/transport/v2/senders.go
@@ -20,6 +20,7 @@
 package v2
 
 import (
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network/dag/tree"
 	"github.com/nuts-foundation/nuts-node/network/log"
@@ -86,15 +87,15 @@ func (p *protocol) sendTransactionListQuery(id transport.PeerID, refs []hash.SHA
 	conversation := p.cMan.startConversation(msg, id)
 	if conversation == nil {
 		log.Logger().
-			WithField("peerID", id).
+			WithField(core.LogFieldPeerID, id).
 			Debug("Did not request a TransactionList while another conversation is in progress")
 		return nil
 	}
 	conversation.set("refs", refs)
 
 	log.Logger().
-		WithField("peerID", id).
-		WithField("conversationID", conversation.conversationID.String()).
+		WithField(core.LogFieldPeerID, id).
+		WithField(core.LogFieldConversationID, conversation.conversationID.String()).
 		Debugf("Requesting transactionList from peer (%d transactions)", len(refs))
 
 	return conn.Send(p, &Envelope{Message: msg}, false)
@@ -140,14 +141,14 @@ func (p *protocol) sendTransactionRangeQuery(id transport.PeerID, lcStart uint32
 	conversation := p.cMan.startConversation(msg, id)
 	if conversation == nil {
 		log.Logger().
-			WithField("peerID", id).
+			WithField(core.LogFieldPeerID, id).
 			Debugf("Did not request a TransactionRange while another conversation is in progress (start=%d, end=%d)", lcStart, lcEnd)
 		return nil
 	}
 
 	log.Logger().
-		WithField("peerID", id).
-		WithField("conversationID", conversation.conversationID.String()).
+		WithField(core.LogFieldPeerID, id).
+		WithField(core.LogFieldConversationID, conversation.conversationID.String()).
 		Debugf("Requesting transaction range (start=%d, end=%d)", lcStart, lcEnd)
 
 	return conn.Send(p, &Envelope{Message: msg}, false)
@@ -201,14 +202,14 @@ func (p *protocol) sendState(id transport.PeerID, xor hash.SHA256Hash, clock uin
 	conversation := p.cMan.startConversation(msg, id)
 	if conversation == nil {
 		log.Logger().
-			WithField("peerID", id).
+			WithField(core.LogFieldPeerID, id).
 			Debug("Did not request State while another conversation is in progress")
 		return nil
 	}
 
 	log.Logger().
-		WithField("peerID", id).
-		WithField("conversationID", conversation.conversationID.String()).
+		WithField(core.LogFieldPeerID, id).
+		WithField(core.LogFieldConversationID, conversation.conversationID.String()).
 		Debug("Requesting state from peer")
 
 	return conn.Send(p, &Envelope{Message: msg}, false)

--- a/network/transport/v2/senders.go
+++ b/network/transport/v2/senders.go
@@ -250,7 +250,7 @@ func (p *protocol) broadcastDiagnostics(diagnostics transport.Diagnostics) {
 		if err != nil {
 			log.Logger().
 				WithError(err).
-				WithField("peer", curr).
+				WithField("peer", curr.Peer().String()).
 				Error("Error broadcasting diagnostics")
 		}
 	}

--- a/network/transport/v2/senders.go
+++ b/network/transport/v2/senders.go
@@ -233,7 +233,10 @@ func (p *protocol) broadcastDiagnostics(diagnostics transport.Diagnostics) {
 	for _, curr := range p.connectionList.AllMatching(grpc.ByConnected()) {
 		err := curr.Send(p, envelope, false)
 		if err != nil {
-			log.Logger().Errorf("error broadcasting diagnostics (peer=%s): %s", curr.Peer(), err)
+			log.Logger().
+				WithError(err).
+				WithField("peer", curr).
+				Error("Error broadcasting diagnostics")
 		}
 	}
 }

--- a/network/transport/v2/senders_test.go
+++ b/network/transport/v2/senders_test.go
@@ -359,7 +359,7 @@ func TestProtocol_broadcastDiagnostics(t *testing.T) {
 	// Second connection returns an error, which is just logged
 	conn2 := grpc.NewMockConnection(mocks.Controller)
 	conn2.EXPECT().Send(proto, envelope, false).Return(errors.New("error"))
-	conn2.EXPECT().Peer().Return(transport.Peer{})
+	conn2.EXPECT().Peer()
 	mocks.ConnectionList.EXPECT().AllMatching(grpc.ByConnected()).Return([]grpc.Connection{conn1, conn2})
 
 	proto.broadcastDiagnostics(transport.Diagnostics{

--- a/network/transport/v2/transactionlist_handler.go
+++ b/network/transport/v2/transactionlist_handler.go
@@ -81,7 +81,10 @@ func (p *protocol) handleTransactionList(peer transport.Peer, envelope *Envelope
 	cid := conversationID(msg.ConversationID)
 	data := handlerData{}
 
-	log.Logger().Tracef("Handling handleTransactionList from peer (peer=%s, conversationID=%s, message=%d/%d)", peer.ID, cid, msg.MessageNumber, msg.TotalMessages)
+	log.Logger().
+		WithField("peer", peer).
+		WithField("conversationID", cid).
+		Tracef("Handling handleTransactionList from peer (message=%d/%d)", msg.MessageNumber, msg.TotalMessages)
 
 	// check if response matches earlier request
 	if _, err := p.cMan.check(subEnvelope, data); err != nil {

--- a/network/transport/v2/transactionlist_handler.go
+++ b/network/transport/v2/transactionlist_handler.go
@@ -66,7 +66,7 @@ func (tlh *transactionListHandler) start() {
 				if err := tlh.fn(pe.peer, pe.envelope); err != nil {
 					log.Logger().
 						WithError(err).
-						WithField("peer", pe.peer.String()).
+						WithFields(pe.peer.ToFields()).
 						WithField("messageType", fmt.Sprintf("%T", pe.envelope.Message)).
 						Error("Error handling message")
 				}
@@ -82,7 +82,7 @@ func (p *protocol) handleTransactionList(peer transport.Peer, envelope *Envelope
 	data := handlerData{}
 
 	log.Logger().
-		WithField("peer", peer.String()).
+		WithFields(peer.ToFields()).
 		WithField("conversationID", cid).
 		Tracef("Handling handleTransactionList from peer (message=%d/%d)", msg.MessageNumber, msg.TotalMessages)
 
@@ -106,7 +106,7 @@ func (p *protocol) handleTransactionList(peer transport.Peer, envelope *Envelope
 			if errors.Is(err, dag.ErrPreviousTransactionMissing) {
 				p.cMan.done(cid)
 				log.Logger().
-					WithField("peer", peer.String()).
+					WithFields(peer.ToFields()).
 					WithField("conversationID", cid).
 					WithField("txRef", tx.Ref()).
 					Warn("Ignoring remainder of TransactionList due to missing prevs")

--- a/network/transport/v2/transactionlist_handler.go
+++ b/network/transport/v2/transactionlist_handler.go
@@ -66,7 +66,7 @@ func (tlh *transactionListHandler) start() {
 				if err := tlh.fn(pe.peer, pe.envelope); err != nil {
 					log.Logger().
 						WithError(err).
-						WithField("peer", pe.peer).
+						WithField("peer", pe.peer.String()).
 						WithField("messageType", fmt.Sprintf("%T", pe.envelope.Message)).
 						Error("Error handling message")
 				}
@@ -82,7 +82,7 @@ func (p *protocol) handleTransactionList(peer transport.Peer, envelope *Envelope
 	data := handlerData{}
 
 	log.Logger().
-		WithField("peer", peer).
+		WithField("peer", peer.String()).
 		WithField("conversationID", cid).
 		Tracef("Handling handleTransactionList from peer (message=%d/%d)", msg.MessageNumber, msg.TotalMessages)
 
@@ -106,7 +106,7 @@ func (p *protocol) handleTransactionList(peer transport.Peer, envelope *Envelope
 			if errors.Is(err, dag.ErrPreviousTransactionMissing) {
 				p.cMan.done(cid)
 				log.Logger().
-					WithField("peer", peer).
+					WithField("peer", peer.String()).
 					WithField("conversationID", cid).
 					WithField("txRef", tx.Ref()).
 					Warn("Ignoring remainder of TransactionList due to missing prevs")

--- a/network/transport/v2/transactionlist_handler.go
+++ b/network/transport/v2/transactionlist_handler.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/nuts-foundation/nuts-node/core"
 	"math"
 
 	"github.com/nuts-foundation/nuts-node/network/dag"
@@ -67,7 +68,7 @@ func (tlh *transactionListHandler) start() {
 					log.Logger().
 						WithError(err).
 						WithFields(pe.peer.ToFields()).
-						WithField("messageType", fmt.Sprintf("%T", pe.envelope.Message)).
+						WithField(core.LogFieldMessageType, fmt.Sprintf("%T", pe.envelope.Message)).
 						Error("Error handling message")
 				}
 			}
@@ -83,7 +84,7 @@ func (p *protocol) handleTransactionList(peer transport.Peer, envelope *Envelope
 
 	log.Logger().
 		WithFields(peer.ToFields()).
-		WithField("conversationID", cid).
+		WithField(core.LogFieldConversationID, cid).
 		Tracef("Handling handleTransactionList from peer (message=%d/%d)", msg.MessageNumber, msg.TotalMessages)
 
 	// check if response matches earlier request
@@ -107,8 +108,8 @@ func (p *protocol) handleTransactionList(peer transport.Peer, envelope *Envelope
 				p.cMan.done(cid)
 				log.Logger().
 					WithFields(peer.ToFields()).
-					WithField("conversationID", cid).
-					WithField("txRef", tx.Ref()).
+					WithField(core.LogFieldConversationID, cid).
+					WithField(core.LogFieldTransactionRef, tx.Ref()).
 					Warn("Ignoring remainder of TransactionList due to missing prevs")
 				xor, clock := p.state.XOR(ctx, math.MaxUint32)
 				return p.sender.sendState(peer.ID, xor, clock)

--- a/network/transport/v2/transactionlist_handler.go
+++ b/network/transport/v2/transactionlist_handler.go
@@ -98,7 +98,11 @@ func (p *protocol) handleTransactionList(peer transport.Peer, envelope *Envelope
 		if err = p.state.Add(ctx, tx, msg.Transactions[i].Payload); err != nil {
 			if errors.Is(err, dag.ErrPreviousTransactionMissing) {
 				p.cMan.done(cid)
-				log.Logger().Warnf("ignoring remainder of TransactionList due to missing prevs (conversation=%s, Tx with missing prevs=%s)", cid, tx.Ref())
+				log.Logger().
+					WithField("peer", peer).
+					WithField("conversationID", cid).
+					WithField("txRef", tx.Ref()).
+					Warn("Ignoring remainder of TransactionList due to missing prevs")
 				xor, clock := p.state.XOR(ctx, math.MaxUint32)
 				return p.sender.sendState(peer.ID, xor, clock)
 			}

--- a/network/transport/v2/transactionlist_handler.go
+++ b/network/transport/v2/transactionlist_handler.go
@@ -64,7 +64,11 @@ func (tlh *transactionListHandler) start() {
 				return
 			case pe := <-tlh.ch:
 				if err := tlh.fn(pe.peer, pe.envelope); err != nil {
-					log.Logger().Errorf("Error handling %T (peer=%s): %s", pe.envelope.Message, pe.peer, err)
+					log.Logger().
+						WithError(err).
+						WithField("peer", pe.peer).
+						WithField("messageType", fmt.Sprintf("%T", pe.envelope.Message)).
+						Error("Error handling message")
 				}
 			}
 		}

--- a/storage/bbolt.go
+++ b/storage/bbolt.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/go-stoabs/bbolt"
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/storage/log"
 	bboltLib "go.etcd.io/bbolt"
 	"os"
@@ -76,7 +77,7 @@ func createBBoltDatabase(datadir string, config BBoltConfig) (*bboltDatabase, er
 func (b bboltDatabase) createStore(moduleName string, storeName string) (stoabs.KVStore, error) {
 	fullStoreName := path.Join(moduleName, storeName)
 	log.Logger().
-		WithField("store", fullStoreName).
+		WithField(core.LogFieldStore, fullStoreName).
 		Debug("Creating BBolt store")
 	databasePath := path.Join(b.datadir, fullStoreName) + bboltDbExtension
 	store, err := bbolt.CreateBBoltStore(databasePath, stoabs.WithLockAcquireTimeout(lockAcquireTimeout))
@@ -96,7 +97,7 @@ func (b bboltDatabase) startBackup(fullStoreName string, store stoabs.KVStore) {
 	}
 	interval := b.config.Backup.Interval
 	log.Logger().
-		WithField("store", fullStoreName).
+		WithField(core.LogFieldStore, fullStoreName).
 		Infof("BBolt database will be backuped at interval of %s", interval)
 	ticker := time.NewTicker(interval)
 
@@ -111,7 +112,7 @@ func (b bboltDatabase) startBackup(fullStoreName string, store stoabs.KVStore) {
 				if err != nil {
 					log.Logger().
 						WithError(err).
-						WithField("store", fullStoreName).
+						WithField(core.LogFieldStore, fullStoreName).
 						Errorf("Unable to complete BBolt backup")
 				}
 			case _ = <-shutdown:
@@ -125,7 +126,7 @@ func (b bboltDatabase) startBackup(fullStoreName string, store stoabs.KVStore) {
 func (b bboltDatabase) performBackup(fullStoreName string, store stoabs.KVStore) error {
 	backupFilePath := path.Join(b.config.Backup.Directory, fullStoreName+bboltDbExtension)
 	log.Logger().
-		WithField("store", fullStoreName).
+		WithField(core.LogFieldStore, fullStoreName).
 		Debugf("Starting BBolt database backup to: %s", backupFilePath)
 	startTime := time.Now()
 	wipFilePath := backupFilePath + ".work"
@@ -178,7 +179,7 @@ func (b bboltDatabase) performBackup(fullStoreName string, store stoabs.KVStore)
 			return err
 		}
 		log.Logger().
-			WithField("store", fullStoreName).
+			WithField(core.LogFieldStore, fullStoreName).
 			Debugf("BBolt database backup finished in %s", time.Now().Sub(startTime))
 		return nil
 	})

--- a/storage/bbolt_test.go
+++ b/storage/bbolt_test.go
@@ -14,6 +14,7 @@ import (
 
 const moduleName = "test"
 const storeName = "store"
+const fullStoreName = moduleName + "/" + storeName
 
 var key = stoabs.BytesKey{1, 2, 3}
 var value = []byte{4, 5, 6}
@@ -35,12 +36,12 @@ func Test_bboltDatabase_performBackup(t *testing.T) {
 			return writer.Put(key, value)
 		})
 
-		err := db.performBackup(moduleName, storeName, store)
+		err := db.performBackup(fullStoreName, store)
 
 		if !assert.NoError(t, err) {
 			return
 		}
-		backupFile := path.Join(backupDir, db.getRelativeStorePath(moduleName, storeName))
+		backupFile := path.Join(backupDir, fullStoreName+bboltDbExtension)
 		if !assert.FileExists(t, backupFile) {
 			return
 		}
@@ -73,15 +74,15 @@ func Test_bboltDatabase_performBackup(t *testing.T) {
 		_ = store.WriteShelf(ctx, "data", func(writer stoabs.Writer) error {
 			return writer.Put(key, value)
 		})
-		_ = db.performBackup(moduleName, storeName, store)
+		_ = db.performBackup(fullStoreName, store)
 
 		_ = store.WriteShelf(ctx, "data", func(writer stoabs.Writer) error {
 			return writer.Put(key, newValue)
 		})
-		_ = db.performBackup(moduleName, storeName, store)
+		_ = db.performBackup(fullStoreName, store)
 
 		// Close the store, reopen backup
-		backupFile := path.Join(backupDir, db.getRelativeStorePath(moduleName, storeName))
+		backupFile := path.Join(backupDir, fullStoreName+bboltDbExtension)
 		_ = store.Close(context.Background())
 		store, _ = bbolt.CreateBBoltStore(backupFile)
 
@@ -120,7 +121,7 @@ func Test_bboltDatabase_startBackup(t *testing.T) {
 		db.close()
 
 		db.shutdownWatcher.Wait()
-		assert.FileExists(t, path.Join(backupDir, db.getRelativeStorePath(moduleName, storeName)))
+		assert.FileExists(t, path.Join(backupDir, fullStoreName+bboltDbExtension))
 	})
 }
 

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -78,7 +78,7 @@ func (e engine) Shutdown() error {
 		if err != nil {
 			log.Logger().
 				WithError(err).
-				WithField("store", storeName).
+				WithField(core.LogFieldStore, storeName).
 				Error("Failed to close store")
 			failures = true
 		}

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -76,7 +76,10 @@ func (e engine) Shutdown() error {
 	for storeName, store := range e.stores {
 		err := shutdown(store)
 		if err != nil {
-			log.Logger().Errorf("Failed to close store '%s': %s", storeName, err)
+			log.Logger().
+				WithError(err).
+				WithField("store", storeName).
+				Error("Failed to close store")
 			failures = true
 		}
 	}

--- a/storage/log/logger.go
+++ b/storage/log/logger.go
@@ -19,10 +19,11 @@
 package log
 
 import (
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/sirupsen/logrus"
 )
 
-var _logger = logrus.StandardLogger().WithField("module", "Storage")
+var _logger = logrus.StandardLogger().WithField(core.LogFieldModule, "Storage")
 
 // Logger returns the logger for the storage engine.
 func Logger() *logrus.Entry {

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -60,7 +60,7 @@ func createRedisDatabase(config RedisConfig) (*redisDatabase, error) {
 func (b redisDatabase) createStore(moduleName string, storeName string) (stoabs.KVStore, error) {
 	log.Logger().
 		WithField("store", path.Join(moduleName, storeName)).
-		Debug("Creating Redis store (module=%s,store=%s)", moduleName, storeName)
+		Debug("Creating Redis store")
 	var prefixParts []string
 	if len(b.databaseName) > 0 {
 		prefixParts = append(prefixParts, b.databaseName)

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-redis/redis/v9"
 	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/go-stoabs/redis7"
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/storage/log"
 	"path"
 	"strings"
@@ -59,7 +60,7 @@ func createRedisDatabase(config RedisConfig) (*redisDatabase, error) {
 
 func (b redisDatabase) createStore(moduleName string, storeName string) (stoabs.KVStore, error) {
 	log.Logger().
-		WithField("store", path.Join(moduleName, storeName)).
+		WithField(core.LogFieldStore, path.Join(moduleName, storeName)).
 		Debug("Creating Redis store")
 	var prefixParts []string
 	if len(b.databaseName) > 0 {

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/go-stoabs/redis7"
 	"github.com/nuts-foundation/nuts-node/storage/log"
+	"path"
 	"strings"
 )
 
@@ -57,7 +58,9 @@ func createRedisDatabase(config RedisConfig) (*redisDatabase, error) {
 }
 
 func (b redisDatabase) createStore(moduleName string, storeName string) (stoabs.KVStore, error) {
-	log.Logger().Debugf("Creating Redis store (module=%s,store=%s)", moduleName, storeName)
+	log.Logger().
+		WithField("store", path.Join(moduleName, storeName)).
+		Debug("Creating Redis store (module=%s,store=%s)", moduleName, storeName)
 	var prefixParts []string
 	if len(b.databaseName) > 0 {
 		prefixParts = append(prefixParts, b.databaseName)

--- a/vcr/ambassador.go
+++ b/vcr/ambassador.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/nats-io/nats.go"
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/events"
 	"github.com/nuts-foundation/nuts-node/vcr/verifier"
 
@@ -119,7 +120,7 @@ func (n ambassador) handleReprocessEvent(msg *nats.Msg) {
 	if err := msg.Ack(); err != nil {
 		log.Logger().
 			WithError(err).
-			WithField("evenSubject", msg.Subject).
+			WithField(core.LogFieldEventSubject, msg.Subject).
 			Error("Failed to process event: failed to ack message")
 		return
 	}
@@ -127,7 +128,7 @@ func (n ambassador) handleReprocessEvent(msg *nats.Msg) {
 	if err := json.Unmarshal(jsonBytes, &twp); err != nil {
 		log.Logger().
 			WithError(err).
-			WithField("evenSubject", msg.Subject).
+			WithField(core.LogFieldEventSubject, msg.Subject).
 			Error("Failed to process event: failed to unmarshall data")
 		return
 	}
@@ -137,7 +138,7 @@ func (n ambassador) handleReprocessEvent(msg *nats.Msg) {
 		if err := callback(twp.Transaction, twp.Payload); err != nil {
 			log.Logger().
 				WithError(err).
-				WithField("evenSubject", msg.Subject).
+				WithField(core.LogFieldEventSubject, msg.Subject).
 				Error("Failed to process event")
 			return
 		}
@@ -164,7 +165,7 @@ func (n ambassador) getCallbackFn(contentType string) func(dag.Transaction, []by
 // payload should be a json encoded vc.VerifiableCredential
 func (n ambassador) vcCallback(tx dag.Transaction, payload []byte) error {
 	log.Logger().
-		WithField("txRef", tx.Ref()).
+		WithField(core.LogFieldTransactionRef, tx.Ref()).
 		Debug("Processing VC received from Nuts Network")
 
 	target := vc.VerifiableCredential{}
@@ -184,7 +185,7 @@ func (n ambassador) vcCallback(tx dag.Transaction, payload []byte) error {
 // payload should be a json encoded Revocation
 func (n ambassador) jsonLDRevocationCallback(tx dag.Transaction, payload []byte) error {
 	log.Logger().
-		WithField("txRef", tx.Ref()).
+		WithField(core.LogFieldTransactionRef, tx.Ref()).
 		Debug("Processing VC revocation received from Nuts Network")
 
 	r := credential.Revocation{}

--- a/vcr/ambassador.go
+++ b/vcr/ambassador.go
@@ -163,7 +163,9 @@ func (n ambassador) getCallbackFn(contentType string) func(dag.Transaction, []by
 // The VCR is used to verify the contents of the credential.
 // payload should be a json encoded vc.VerifiableCredential
 func (n ambassador) vcCallback(tx dag.Transaction, payload []byte) error {
-	log.Logger().Debugf("Processing VC received from Nuts Network (ref=%s)", tx.Ref())
+	log.Logger().
+		WithField("txRef", tx.Ref()).
+		Debug("Processing VC received from Nuts Network")
 
 	target := vc.VerifiableCredential{}
 	if err := json.Unmarshal(payload, &target); err != nil {
@@ -181,7 +183,9 @@ func (n ambassador) vcCallback(tx dag.Transaction, payload []byte) error {
 // The VCR is used to verify the contents of the revocation.
 // payload should be a json encoded Revocation
 func (n ambassador) jsonLDRevocationCallback(tx dag.Transaction, payload []byte) error {
-	log.Logger().Debugf("Processing VC revocation received from Nuts Network (ref=%s)", tx.Ref())
+	log.Logger().
+		WithField("txRef", tx.Ref()).
+		Debug("Processing VC revocation received from Nuts Network")
 
 	r := credential.Revocation{}
 	if err := json.Unmarshal(payload, &r); err != nil {

--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -185,7 +185,9 @@ func (i issuer) Revoke(credentialID ssi.URI) (*credential.Revocation, error) {
 		return nil, fmt.Errorf("unable to store revocation: %w", err)
 	}
 
-	log.Logger().Infof("Verifiable Credential revoked (id=%s)", credentialToRevoke.ID)
+	log.Logger().
+		WithField("credentialID", credentialToRevoke.ID).
+		Info("Verifiable Credential revoked")
 	return revocation, nil
 }
 

--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -186,7 +186,7 @@ func (i issuer) Revoke(credentialID ssi.URI) (*credential.Revocation, error) {
 	}
 
 	log.Logger().
-		WithField("credentialID", credentialToRevoke.ID).
+		WithField(core.LogFieldCredentialID, credentialToRevoke.ID).
 		Info("Verifiable Credential revoked")
 	return revocation, nil
 }

--- a/vcr/issuer/leia_store.go
+++ b/vcr/issuer/leia_store.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/go-stoabs"
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/vcr/log"
 
 	ssi "github.com/nuts-foundation/go-did"
@@ -202,7 +203,7 @@ func (s leiaIssuerStore) handleRestore(collection leia.Collection, backupShelf s
 
 	if !storePresent {
 		log.Logger().
-			WithField("storageShelf", backupShelf).
+			WithField(core.LogFieldStoreShelf, backupShelf).
 			Info("Missing index for shelf, rebuilding")
 		// empty node, backup has been restored, refill store
 		return s.backupStore.ReadShelf(context.Background(), backupShelf, func(reader stoabs.Reader) error {
@@ -213,7 +214,7 @@ func (s leiaIssuerStore) handleRestore(collection leia.Collection, backupShelf s
 	}
 
 	log.Logger().
-		WithField("storageShelf", backupShelf).
+		WithField(core.LogFieldStoreShelf, backupShelf).
 		Info("Missing store for shelf, creating from index")
 
 	// else !backupPresent, process per 100

--- a/vcr/issuer/leia_store.go
+++ b/vcr/issuer/leia_store.go
@@ -201,7 +201,9 @@ func (s leiaIssuerStore) handleRestore(collection leia.Collection, backupShelf s
 	}
 
 	if !storePresent {
-		log.Logger().Infof("Missing index for %s, rebuilding", backupShelf)
+		log.Logger().
+			WithField("storageShelf", backupShelf).
+			Info("Missing index for shelf, rebuilding")
 		// empty node, backup has been restored, refill store
 		return s.backupStore.ReadShelf(context.Background(), backupShelf, func(reader stoabs.Reader) error {
 			return reader.Iterate(func(key stoabs.Key, value []byte) error {
@@ -210,7 +212,9 @@ func (s leiaIssuerStore) handleRestore(collection leia.Collection, backupShelf s
 		})
 	}
 
-	log.Logger().Infof("Missing store for %s, creating from index", backupShelf)
+	log.Logger().
+		WithField("storageShelf", backupShelf).
+		Info("Missing store for shelf, creating from index")
 
 	// else !backupPresent, process per 100
 	query := leia.New(leia.NotNil(leia.NewJSONPath(jsonSearchPath)))

--- a/vcr/issuer/network_publisher.go
+++ b/vcr/issuer/network_publisher.go
@@ -101,7 +101,10 @@ func (p networkPublisher) PublishCredential(verifiableCredential vc.VerifiableCr
 	if err != nil {
 		return fmt.Errorf("failed to publish credential, error while creating transaction: %w", err)
 	}
-	log.Logger().Infof("Verifiable Credential published (id=%s,type=%s)", verifiableCredential.ID, verifiableCredential.Type)
+	log.Logger().
+		WithField("credentialID", verifiableCredential.ID).
+		WithField("credentialType", verifiableCredential.Type).
+		Info("Verifiable Credential published")
 
 	return nil
 }

--- a/vcr/issuer/network_publisher.go
+++ b/vcr/issuer/network_publisher.go
@@ -24,6 +24,7 @@ import (
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/network"
 	"github.com/nuts-foundation/nuts-node/network/transport"
@@ -102,8 +103,8 @@ func (p networkPublisher) PublishCredential(verifiableCredential vc.VerifiableCr
 		return fmt.Errorf("failed to publish credential, error while creating transaction: %w", err)
 	}
 	log.Logger().
-		WithField("credentialID", verifiableCredential.ID).
-		WithField("credentialType", verifiableCredential.Type).
+		WithField(core.LogFieldCredentialID, verifiableCredential.ID).
+		WithField(core.LogFieldCredentialType, verifiableCredential.Type).
 		Info("Verifiable Credential published")
 
 	return nil

--- a/vcr/log/log.go
+++ b/vcr/log/log.go
@@ -19,10 +19,11 @@
 package log
 
 import (
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/sirupsen/logrus"
 )
 
-var _logger = logrus.StandardLogger().WithField("module", "VCR")
+var _logger = logrus.StandardLogger().WithField(core.LogFieldModule, "VCR")
 
 // Logger returns a logger which should be used for logging in this engine. It adds fields so
 // log entries from this engine can be recognized as such.

--- a/vcr/store.go
+++ b/vcr/store.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/nuts-foundation/nuts-node/core"
 	"reflect"
 	"time"
 
@@ -47,7 +48,7 @@ func (c *vcr) StoreCredential(credential vc.VerifiableCredential, validAt *time.
 		if err == nil {
 			if reflect.DeepEqual(existingCredential, credential) {
 				log.Logger().
-					WithField("credentialID", *credential.ID).
+					WithField(core.LogFieldCredentialID, *credential.ID).
 					Info("Credential already exists", credential.ID)
 				return nil
 			}
@@ -70,8 +71,8 @@ func (c *vcr) writeCredential(subject vc.VerifiableCredential) error {
 	vcType := credential.ExtractTypes(subject)[0]
 
 	log.Logger().
-		WithField("credentialID", subject.ID).
-		WithField("credentialType", vcType).
+		WithField(core.LogFieldCredentialID, subject.ID).
+		WithField(core.LogFieldCredentialType, vcType).
 		Debug("Writing credential to store")
 	log.Logger().Tracef("%+v", subject)
 

--- a/vcr/store.go
+++ b/vcr/store.go
@@ -69,7 +69,10 @@ func (c *vcr) writeCredential(subject vc.VerifiableCredential) error {
 	// validation has made sure there's exactly one!
 	vcType := credential.ExtractTypes(subject)[0]
 
-	log.Logger().Debugf("Writing %s to store", vcType)
+	log.Logger().
+		WithField("credentialID", subject.ID).
+		WithField("credentialType", vcType).
+		Debug("Writing credential to store")
 	log.Logger().Tracef("%+v", subject)
 
 	doc, _ := json.Marshal(subject)

--- a/vcr/store.go
+++ b/vcr/store.go
@@ -46,7 +46,9 @@ func (c *vcr) StoreCredential(credential vc.VerifiableCredential, validAt *time.
 		existingCredential, err := c.find(*credential.ID)
 		if err == nil {
 			if reflect.DeepEqual(existingCredential, credential) {
-				log.Logger().Infof("Credential already exists (id=%s)", credential.ID)
+				log.Logger().
+					WithField("credentialID", *credential.ID).
+					Info("Credential already exists", credential.ID)
 				return nil
 			}
 			return fmt.Errorf("credential with same ID but different content already exists (id=%s)", credential.ID)

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -324,7 +324,10 @@ func (c *vcr) find(ID ssi.URI) (vc.VerifiableCredential, error) {
 func (c *vcr) Trust(credentialType ssi.URI, issuer ssi.URI) error {
 	err := c.trustConfig.AddTrust(credentialType, issuer)
 	if err != nil {
-		log.Logger().Infof("Added trust for Verifiable Credential issuer (type=%s, issuer=%s)", credentialType, issuer)
+		log.Logger().
+			WithField("credentialType", credentialType).
+			WithField("issuer", issuer).
+			Info("Added trust for Verifiable Credential issuer")
 	}
 	return err
 }
@@ -332,7 +335,10 @@ func (c *vcr) Trust(credentialType ssi.URI, issuer ssi.URI) error {
 func (c *vcr) Untrust(credentialType ssi.URI, issuer ssi.URI) error {
 	err := c.trustConfig.RemoveTrust(credentialType, issuer)
 	if err != nil {
-		log.Logger().Infof("Untrusted for Verifiable Credential issuer (type=%s, issuer=%s)", credentialType, issuer)
+		log.Logger().
+			WithField("credentialType", credentialType).
+			WithField("issuer", issuer).
+			Info("Untrusted for Verifiable Credential issuer")
 	}
 	return err
 }

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -389,7 +389,9 @@ func (c *vcr) Untrusted(credentialType ssi.URI) ([]ssi.URI, error) {
 	})
 	if err != nil {
 		if errors.Is(err, leia.ErrNoIndex) {
-			log.Logger().Warnf("No index with field 'issuer' found for %s", credentialType.String())
+			log.Logger().
+				WithField("credentialType", credentialType).
+				Warn("No index with field 'issuer' found for credential")
 
 			return nil, types.ErrInvalidCredential
 		}

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -329,8 +329,8 @@ func (c *vcr) Trust(credentialType ssi.URI, issuer ssi.URI) error {
 	err := c.trustConfig.AddTrust(credentialType, issuer)
 	if err != nil {
 		log.Logger().
-			WithField("credentialType", credentialType).
-			WithField("issuer", issuer).
+			WithField(core.LogFieldCredentialType, credentialType).
+			WithField(core.LogFieldCredentialIssuer, issuer).
 			Info("Added trust for Verifiable Credential issuer")
 	}
 	return err
@@ -340,8 +340,8 @@ func (c *vcr) Untrust(credentialType ssi.URI, issuer ssi.URI) error {
 	err := c.trustConfig.RemoveTrust(credentialType, issuer)
 	if err != nil {
 		log.Logger().
-			WithField("credentialType", credentialType).
-			WithField("issuer", issuer).
+			WithField(core.LogFieldCredentialType, credentialType).
+			WithField(core.LogFieldCredentialIssuer, issuer).
 			Info("Untrusted for Verifiable Credential issuer")
 	}
 	return err
@@ -394,7 +394,7 @@ func (c *vcr) Untrusted(credentialType ssi.URI) ([]ssi.URI, error) {
 	if err != nil {
 		if errors.Is(err, leia.ErrNoIndex) {
 			log.Logger().
-				WithField("credentialType", credentialType).
+				WithField(core.LogFieldCredentialType, credentialType).
 				Warn("No index with field 'issuer' found for credential")
 
 			return nil, types.ErrInvalidCredential

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -172,11 +172,15 @@ func (c *vcr) Start() error {
 func (c *vcr) Shutdown() error {
 	err := c.issuerStore.Close()
 	if err != nil {
-		log.Logger().Errorf("Unable to close issuer store: %v", err)
+		log.Logger().
+			WithError(err).
+			Error("Unable to close issuer store")
 	}
 	err = c.verifierStore.Close()
 	if err != nil {
-		log.Logger().Errorf("Unable to close verifier store: %v", err)
+		log.Logger().
+			WithError(err).
+			Error("Unable to close verifier store")
 	}
 	return c.store.Close()
 }

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/nats-io/nats.go"
+	"github.com/nuts-foundation/nuts-node/core"
 	"sort"
 	"time"
 
@@ -149,7 +150,7 @@ var thumbprintAlg = crypto.SHA256
 // Duplicates are handled as updates and will be merged. Merging two exactly the same DID Documents results in the original document.
 func (n *ambassador) callback(tx dag.Transaction, payload []byte) error {
 	log.Logger().
-		WithField("txRef", tx.Ref()).
+		WithField(core.LogFieldTransactionRef, tx.Ref()).
 		Debug("Processing DID document received from Nuts Network")
 	if err := checkTransactionIntegrity(tx); err != nil {
 		return fmt.Errorf("could not process new DID Document: %w", err)
@@ -162,7 +163,7 @@ func (n *ambassador) callback(tx dag.Transaction, payload []byte) error {
 	}
 	if processed {
 		log.Logger().
-			WithField("txRef", tx.Ref()).
+			WithField(core.LogFieldTransactionRef, tx.Ref()).
 			Debug("Skipping DID document, already exists")
 		return nil
 	}
@@ -185,8 +186,8 @@ func (n *ambassador) callback(tx dag.Transaction, payload []byte) error {
 
 func (n *ambassador) handleCreateDIDDocument(transaction dag.Transaction, proposedDIDDocument did.Document) error {
 	log.Logger().
-		WithField("txRef", transaction.Ref()).
-		WithField("did", proposedDIDDocument.ID).
+		WithField(core.LogFieldTransactionRef, transaction.Ref()).
+		WithField(core.LogFieldDID, proposedDIDDocument.ID).
 		Debug("Handling DID document creation")
 	// Check if the DID matches the fingerprint of the tx signing key:
 	if transaction.SigningKey() == nil {
@@ -247,8 +248,8 @@ func (n *ambassador) handleCreateDIDDocument(transaction dag.Transaction, propos
 	}
 
 	log.Logger().
-		WithField("txRef", transaction.Ref()).
-		WithField("did", proposedDIDDocument.ID.String()).
+		WithField(core.LogFieldTransactionRef, transaction.Ref()).
+		WithField(core.LogFieldDID, proposedDIDDocument.ID.String()).
 		Info("DID document registered")
 
 	return nil
@@ -256,8 +257,8 @@ func (n *ambassador) handleCreateDIDDocument(transaction dag.Transaction, propos
 
 func (n *ambassador) handleUpdateDIDDocument(transaction dag.Transaction, proposedDIDDocument did.Document) error {
 	log.Logger().
-		WithField("txRef", transaction.Ref()).
-		WithField("did", proposedDIDDocument.ID).
+		WithField(core.LogFieldTransactionRef, transaction.Ref()).
+		WithField(core.LogFieldDID, proposedDIDDocument.ID).
 		Debug("Handling DID document update")
 	// Resolve latest version of DID Document
 	currentDIDDocument, currentDIDMeta, err := n.didStore.Resolve(proposedDIDDocument.ID, &types.ResolveMetadata{AllowDeactivated: true})
@@ -331,8 +332,8 @@ func (n *ambassador) handleUpdateDIDDocument(transaction dag.Transaction, propos
 	err = n.didStore.Update(proposedDIDDocument.ID, currentDIDMeta.Hash, proposedDIDDocument, &documentMetadata)
 	if err == nil {
 		log.Logger().
-			WithField("txRef", transaction.Ref()).
-			WithField("did", proposedDIDDocument.ID).
+			WithField(core.LogFieldTransactionRef, transaction.Ref()).
+			WithField(core.LogFieldDID, proposedDIDDocument.ID).
 			Info("DID document updated")
 	}
 	return err

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -148,7 +148,9 @@ var thumbprintAlg = crypto.SHA256
 // payload should be a json encoded did.document
 // Duplicates are handled as updates and will be merged. Merging two exactly the same DID Documents results in the original document.
 func (n *ambassador) callback(tx dag.Transaction, payload []byte) error {
-	log.Logger().Debugf("Processing DID document received from Nuts Network (ref=%s)", tx.Ref())
+	log.Logger().
+		WithField("txRef", tx.Ref()).
+		Debug("Processing DID document received from Nuts Network")
 	if err := checkTransactionIntegrity(tx); err != nil {
 		return fmt.Errorf("could not process new DID Document: %w", err)
 	}
@@ -159,7 +161,9 @@ func (n *ambassador) callback(tx dag.Transaction, payload []byte) error {
 		return fmt.Errorf("could not process new DID Document: %w", err)
 	}
 	if processed {
-		log.Logger().Debugf("Skipping DID document, already exists (tx=%s)", tx.Ref().String())
+		log.Logger().
+			WithField("txRef", tx.Ref()).
+			Debug("Skipping DID document, already exists")
 		return nil
 	}
 
@@ -180,7 +184,10 @@ func (n *ambassador) callback(tx dag.Transaction, payload []byte) error {
 }
 
 func (n *ambassador) handleCreateDIDDocument(transaction dag.Transaction, proposedDIDDocument did.Document) error {
-	log.Logger().Debugf("Handling DID document creation (tx=%s,did=%s)", transaction.Ref(), proposedDIDDocument.ID)
+	log.Logger().
+		WithField("txRef", transaction.Ref()).
+		WithField("did", proposedDIDDocument.ID).
+		Debug("Handling DID document creation")
 	// Check if the DID matches the fingerprint of the tx signing key:
 	if transaction.SigningKey() == nil {
 		return fmt.Errorf("callback could not process new DID Document: signingKey for new DID Documents must be set")
@@ -248,7 +255,10 @@ func (n *ambassador) handleCreateDIDDocument(transaction dag.Transaction, propos
 }
 
 func (n *ambassador) handleUpdateDIDDocument(transaction dag.Transaction, proposedDIDDocument did.Document) error {
-	log.Logger().Debugf("Handling DID document update (tx=%s,did=%s)", transaction.Ref(), proposedDIDDocument.ID)
+	log.Logger().
+		WithField("txRef", transaction.Ref()).
+		WithField("did", proposedDIDDocument.ID).
+		Debug("Handling DID document update")
 	// Resolve latest version of DID Document
 	currentDIDDocument, currentDIDMeta, err := n.didStore.Resolve(proposedDIDDocument.ID, &types.ResolveMetadata{AllowDeactivated: true})
 	if err != nil {

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -233,7 +233,10 @@ func (n *ambassador) handleCreateDIDDocument(transaction dag.Transaction, propos
 		return fmt.Errorf("unable to register DID document: %w", err)
 	}
 
-	log.Logger().Infof("DID document registered (tx=%s,did=%s)", transaction.Ref(), proposedDIDDocument.ID)
+	log.Logger().
+		WithField("txRef", transaction.Ref()).
+		WithField("did", proposedDIDDocument.ID.String()).
+		Info("DID document registered")
 
 	return nil
 }
@@ -311,7 +314,10 @@ func (n *ambassador) handleUpdateDIDDocument(transaction dag.Transaction, propos
 	}
 	err = n.didStore.Update(proposedDIDDocument.ID, currentDIDMeta.Hash, proposedDIDDocument, &documentMetadata)
 	if err == nil {
-		log.Logger().Infof("DID document updated (tx=%s,did=%s)", transaction.Ref(), proposedDIDDocument.ID)
+		log.Logger().
+			WithField("txRef", transaction.Ref()).
+			WithField("did", proposedDIDDocument.ID).
+			Info("DID document updated")
 	}
 	return err
 }

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -109,17 +109,23 @@ func (n *ambassador) handleReprocessEvent(msg *nats.Msg) {
 	twp := events.TransactionWithPayload{}
 
 	if err := msg.Ack(); err != nil {
-		log.Logger().Errorf("Failed to process REPROCESS.application/did+json event: failed to ack message: %v", err)
+		log.Logger().
+			WithError(err).
+			Error("Failed to process REPROCESS.application/did+json event: failed to ack message")
 		return
 	}
 
 	if err := json.Unmarshal(jsonBytes, &twp); err != nil {
-		log.Logger().Errorf("Failed to process REPROCESS.application/did+json event: failed to unmarshall data: %v", err)
+		log.Logger().
+			WithError(err).
+			Error("Failed to process REPROCESS.application/did+json event: failed to unmarshall data")
 		return
 	}
 
 	if err := n.callback(twp.Transaction, twp.Payload); err != nil {
-		log.Logger().Errorf("Failed to process REPROCESS.application/did+json event: %v", err)
+		log.Logger().
+			WithError(err).
+			Error("Failed to process REPROCESS.application/did+json event")
 		return
 	}
 

--- a/vdr/log/logger.go
+++ b/vdr/log/logger.go
@@ -19,10 +19,11 @@
 package log
 
 import (
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/sirupsen/logrus"
 )
 
-var _logger = logrus.StandardLogger().WithField("module", "VDR")
+var _logger = logrus.StandardLogger().WithField(core.LogFieldModule, "VDR")
 
 // Logger returns a logger which should be used for logging in this engine. It adds fields so
 // log entries from this engine can be recognized as such.

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -156,7 +156,9 @@ func (r VDR) Create(options types.DIDCreationOptions) (*did.Document, crypto.Key
 
 // Update updates a DID Document based on the DID and current hash
 func (r VDR) Update(id did.DID, current hash.SHA256Hash, next did.Document, _ *types.DocumentMetadata) error {
-	log.Logger().Debugf("Updating DID Document (DID=%s)", id)
+	log.Logger().
+		WithField("did", id).
+		Debug("Updating DID Document")
 	resolverMetadata := &types.ResolveMetadata{
 		Hash:             &current,
 		AllowDeactivated: true,

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -147,7 +147,9 @@ func (r VDR) Create(options types.DIDCreationOptions) (*did.Document, crypto.Key
 		return nil, nil, fmt.Errorf("could not store DID document in network: %w", err)
 	}
 
-	log.Logger().Infof("New DID Document created (DID=%s)", doc.ID)
+	log.Logger().
+		WithField("did", doc.ID).
+		Info("New DID Document created")
 
 	return doc, key, nil
 }
@@ -201,7 +203,9 @@ func (r VDR) Update(id did.DID, current hash.SHA256Hash, next did.Document, _ *t
 	tx := network.TransactionTemplate(didDocumentType, payload, key).WithAdditionalPrevs(previousTransactions)
 	_, err = r.network.CreateTransaction(tx)
 	if err == nil {
-		log.Logger().Infof("DID Document updated (DID=%s)", id)
+		log.Logger().
+			WithField("did", id).
+			Info("DID Document updated")
 	} else {
 		log.Logger().WithError(err).Warn("Unable to update DID document")
 		if errors.Is(err, crypto.ErrPrivateKeyNotFound) {

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -148,7 +148,7 @@ func (r VDR) Create(options types.DIDCreationOptions) (*did.Document, crypto.Key
 	}
 
 	log.Logger().
-		WithField("did", doc.ID).
+		WithField(core.LogFieldDID, doc.ID).
 		Info("New DID Document created")
 
 	return doc, key, nil
@@ -157,7 +157,7 @@ func (r VDR) Create(options types.DIDCreationOptions) (*did.Document, crypto.Key
 // Update updates a DID Document based on the DID and current hash
 func (r VDR) Update(id did.DID, current hash.SHA256Hash, next did.Document, _ *types.DocumentMetadata) error {
 	log.Logger().
-		WithField("did", id).
+		WithField(core.LogFieldDID, id).
 		Debug("Updating DID Document")
 	resolverMetadata := &types.ResolveMetadata{
 		Hash:             &current,
@@ -206,7 +206,7 @@ func (r VDR) Update(id did.DID, current hash.SHA256Hash, next did.Document, _ *t
 	_, err = r.network.CreateTransaction(tx)
 	if err == nil {
 		log.Logger().
-			WithField("did", id).
+			WithField(core.LogFieldDID, id).
 			Info("DID Document updated")
 	} else {
 		log.Logger().WithError(err).Warn("Unable to update DID document")


### PR DESCRIPTION
Part of https://github.com/nuts-foundation/nuts-node/issues/40

In addition, peer is now logged as 3 separate fields, `peerID`, `peerAddr` and `peerDID`:

```
{"level":"debug","module":"Network","msg":"Received 1 new transaction references via Gossip from peer","peerAddr":"127.0.0.1:61954","peerDID":"","peerID":"974484a7-c371-46fd-a3bc-0331a33a4b16","time":"2022-08-01T11:23:07+02:00"}
```