### PR TITLE
Logging: configure X-Forwarded-For in Echo

### DIFF
--- a/core/echo.go
+++ b/core/echo.go
@@ -254,6 +254,9 @@ func createEchoServer(cfg HTTPConfig, strictmode bool) (*echo.Echo, error) {
 	// ErrorHandler
 	echoServer.HTTPErrorHandler = createHTTPErrorHandler()
 
+	// Reverse proxies must set the X-Forwarded-For header to the original client IP.
+	echoServer.IPExtractor = echo.ExtractIPFromXFFHeader()
+
 	// CORS Configuration
 	if cfg.CORS.Enabled() {
 		if strictmode {

--- a/docs/pages/deployment/recommended-deployment.rst
+++ b/docs/pages/deployment/recommended-deployment.rst
@@ -109,6 +109,9 @@ Reverse Proxy
 Process that protects and routes HTTP access (specified above) to the Nuts Node. Typically a standalone HTTP proxy that resides in a DMZ and/or an ingress service on a cloud platform.
 It will act as SSL/TLS terminator, with only a server certificate or requiring a client certificate as well (depending on the endpoint).
 
+The Nuts Node looks for a header called `X-Forwarded-For` to determine the client IP when logging HTTP calls.
+Refer to the documentation of your proxy on how to set this header.
+
 Nuts Node Client
 ^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Part of https://github.com/nuts-foundation/nuts-node/issues/40

I choose hardcoding the use of `X-Forwarded-For` because NGINX and HAProxy have support for it.

NGINX:
```
proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
```

HAProxy:
```
option forwardfor
```

Since you should always run (public/semi-public) HTTP endpoints with a reverse proxy in front, the Nuts Node should never be accessed directly by an external entity. So it's safe to just always assume `X-Forwarded-For` will contain the IP of the remote client (if it's not present it defaults to the IP-layer IP of the client).

And should this not uphold, IP addresses arenot used for authentication or granting access (e.g. allowlist), it is only logged. So no harm done.