### PR TITLE
Logging: skip logging calls to HTTP metrics endpoints

### DIFF
--- a/core/echo.go
+++ b/core/echo.go
@@ -285,7 +285,7 @@ func createEchoServer(cfg HTTPConfig, strictmode, rateLimiter bool) (*echo.Echo,
 	// Use middleware to decode URL encoded path parameters like did%3Anuts%3A123 -> did:nuts:123
 	echoServer.Use(DecodeURIPath)
 
-	echoServer.Use(loggerMiddleware(loggerConfig{Skipper: requestsStatusEndpoint, logger: Logger()}))
+	echoServer.Use(loggerMiddleware(loggerConfig{Skipper: skipLogRequest, logger: Logger()}))
 
 	// Always enabled in strict mode
 	if strictmode || rateLimiter {
@@ -358,6 +358,6 @@ func NewInternalRateLimiterStore(interval time.Duration, limitPerInterval rate.L
 	}
 }
 
-func requestsStatusEndpoint(context echo.Context) bool {
-	return context.Request().RequestURI == "/status"
+func skipLogRequest(context echo.Context) bool {
+	return context.Request().RequestURI == "/status" || context.Request().RequestURI == "/metrics"
 }

--- a/core/echo_test.go
+++ b/core/echo_test.go
@@ -196,11 +196,13 @@ func Test_createEchoServer(t *testing.T) {
 
 }
 
-func Test_requestsStatusEndpoint(t *testing.T) {
+func Test_skipLogRequest(t *testing.T) {
 	req := &http.Request{}
 	ctx := echo.New().NewContext(req, nil)
 	t.Run("matches", func(t *testing.T) {
 		req.RequestURI = "/status"
+		assert.True(t, skipLogRequest(ctx))
+		req.RequestURI = "/metrics"
 		assert.True(t, skipLogRequest(ctx))
 	})
 	t.Run("no match", func(t *testing.T) {

--- a/core/echo_test.go
+++ b/core/echo_test.go
@@ -201,15 +201,15 @@ func Test_requestsStatusEndpoint(t *testing.T) {
 	ctx := echo.New().NewContext(req, nil)
 	t.Run("matches", func(t *testing.T) {
 		req.RequestURI = "/status"
-		assert.True(t, requestsStatusEndpoint(ctx))
+		assert.True(t, skipLogRequest(ctx))
 	})
 	t.Run("no match", func(t *testing.T) {
 		req.RequestURI = "/status/"
-		assert.False(t, requestsStatusEndpoint(ctx))
+		assert.False(t, skipLogRequest(ctx))
 		req.RequestURI = "/status/foo"
-		assert.False(t, requestsStatusEndpoint(ctx))
+		assert.False(t, skipLogRequest(ctx))
 		req.RequestURI = "/foobar"
-		assert.False(t, requestsStatusEndpoint(ctx))
+		assert.False(t, skipLogRequest(ctx))
 	})
 }
 


### PR DESCRIPTION
When scraping them using Prometheus, this causes a lot of logged calls (just like calls to `/status`).