### PR TITLE
Ratelimiter: add paths that should also be rate limited

### DIFF
--- a/core/echo_test.go
+++ b/core/echo_test.go
@@ -325,8 +325,9 @@ func TestNewInternalRateLimiter(t *testing.T) {
 			req := httptest.NewRequest(testcase.method, testcase.path, nil)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
+			c.SetPath(testcase.path)
 			_ = rlMiddleware(handler)(c)
-			assert.Equal(t, testcase.expectedStatus, rec.Code)
+			assert.Equalf(t, testcase.expectedStatus, rec.Code, "unexpected HTTP response for %s on %s", testcase.method, testcase.path)
 		}
 	})
 

--- a/docs/main.go
+++ b/docs/main.go
@@ -30,8 +30,6 @@ func main() {
 
 	param := os.Args[1]
 	switch param {
-	case "api":
-		generateCode()
 	case "docs":
 		generateDocs()
 	case "copyright":

--- a/docs/main.go
+++ b/docs/main.go
@@ -30,6 +30,8 @@ func main() {
 
 	param := os.Args[1]
 	switch param {
+	case "api":
+		generateCode()
 	case "docs":
 		generateDocs()
 	case "copyright":


### PR DESCRIPTION
These also cause TXs