### PR TITLE
expose notifier dlq to metrics/diagnostics/API

### DIFF
--- a/docs/_static/network/v1.yaml
+++ b/docs/_static/network/v1.yaml
@@ -171,8 +171,70 @@ paths:
       responses:
         "202":
           description: "The request was accepted, process was started"
+  /internal/network/v1/events:
+    get:
+      summary: "Lists the state of the internal events"
+      description: >
+        Internal events are used to update network state, retrieve private transactions and update the VDR and VCR.
+        New transactions will cause events to be omitted. In normal operation no events should remain.
+        The diagnostics page displays the number of failed events. If there are any, this API can be used to get the cause.
+        Events are listed by subscriber.
+        
+        error returns:
+        * 500 - internal server error
+      operationId: "ListEvents"
+      tags:
+        - diagnostics
+      responses:
+        "200":
+          description: "Successfully listed the events"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EventSubscriber'
+        default:
+          $ref: '../common/error_response.yaml'
 components:
   schemas:
+    Event:
+      type: object
+      description: Non-completed event. An event represents a transaction that is of interest to a specific part of the Nuts node.
+      required:
+        - hash
+        - retries
+        - transaction
+      properties:
+        'type':
+          description: "'transaction' or 'payload'"
+          type: string
+        hash:
+          description: Hash is the ID of the Event, usually the same as the transaction reference.
+          type: string
+        retries:
+          description: Number of times the event has been retried.
+          type: integer
+        transaction:
+          description: The transaction reference
+          type: string
+        error:
+          description: Lists the error if the event processing failed due to an error.
+          type: string
+    EventSubscriber:
+      type: object
+      description: Non-completed events for a subscriber
+      required:
+        - name
+        - events
+      properties:
+        name:
+          description: Name of the subscriber component
+          type: string
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/Event'
     PeerDiagnostics:
       type: object
       description: Diagnostic information of a peer.

--- a/docs/_static/network/v1.yaml
+++ b/docs/_static/network/v1.yaml
@@ -219,7 +219,7 @@ components:
           description: The transaction reference
           type: string
         error:
-          description: Lists the error if the event processing failed due to an error.
+          description: Lists the last error if the event processing failed due to an error.
           type: string
     EventSubscriber:
       type: object

--- a/network/api/v1/generated.go
+++ b/network/api/v1/generated.go
@@ -16,6 +16,32 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// Non-completed event. An event represents a transaction that is of interest to a specific part of the Nuts node.
+type Event struct {
+	// Lists the error if the event processing failed due to an error.
+	Error *string `json:"error,omitempty"`
+
+	// Hash is the ID of the Event, usually the same as the transaction reference.
+	Hash string `json:"hash"`
+
+	// Number of times the event has been retried.
+	Retries int `json:"retries"`
+
+	// The transaction reference
+	Transaction string `json:"transaction"`
+
+	// 'transaction' or 'payload'
+	Type *string `json:"type,omitempty"`
+}
+
+// Non-completed events for a subscriber
+type EventSubscriber struct {
+	Events []Event `json:"events"`
+
+	// Name of the subscriber component
+	Name string `json:"name"`
+}
+
 // RenderGraphParams defines parameters for RenderGraph.
 type RenderGraphParams struct {
 	// Lamport Clock value from where to start rendering (inclusive). If omitted, rendering starts at the root.
@@ -110,6 +136,9 @@ type ClientInterface interface {
 	// GetPeerDiagnostics request
 	GetPeerDiagnostics(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListEvents request
+	ListEvents(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// Reprocess request
 	Reprocess(ctx context.Context, params *ReprocessParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -137,6 +166,18 @@ func (c *Client) RenderGraph(ctx context.Context, params *RenderGraphParams, req
 
 func (c *Client) GetPeerDiagnostics(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetPeerDiagnosticsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListEvents(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListEventsRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -268,6 +309,33 @@ func NewGetPeerDiagnosticsRequest(server string) (*http.Request, error) {
 	}
 
 	operationPath := fmt.Sprintf("/internal/network/v1/diagnostics/peers")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListEventsRequest generates requests for ListEvents
+func NewListEventsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/internal/network/v1/events")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -476,6 +544,9 @@ type ClientWithResponsesInterface interface {
 	// GetPeerDiagnostics request
 	GetPeerDiagnosticsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetPeerDiagnosticsResponse, error)
 
+	// ListEvents request
+	ListEventsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListEventsResponse, error)
+
 	// Reprocess request
 	ReprocessWithResponse(ctx context.Context, params *ReprocessParams, reqEditors ...RequestEditorFn) (*ReprocessResponse, error)
 
@@ -528,6 +599,28 @@ func (r GetPeerDiagnosticsResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetPeerDiagnosticsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListEventsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]EventSubscriber
+}
+
+// Status returns HTTPResponse.Status
+func (r ListEventsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListEventsResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -637,6 +730,15 @@ func (c *ClientWithResponses) GetPeerDiagnosticsWithResponse(ctx context.Context
 	return ParseGetPeerDiagnosticsResponse(rsp)
 }
 
+// ListEventsWithResponse request returning *ListEventsResponse
+func (c *ClientWithResponses) ListEventsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListEventsResponse, error) {
+	rsp, err := c.ListEvents(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListEventsResponse(rsp)
+}
+
 // ReprocessWithResponse request returning *ReprocessResponse
 func (c *ClientWithResponses) ReprocessWithResponse(ctx context.Context, params *ReprocessParams, reqEditors ...RequestEditorFn) (*ReprocessResponse, error) {
 	rsp, err := c.Reprocess(ctx, params, reqEditors...)
@@ -707,6 +809,32 @@ func ParseGetPeerDiagnosticsResponse(rsp *http.Response) (*GetPeerDiagnosticsRes
 		var dest struct {
 			AdditionalProperties map[string]PeerDiagnostics `json:"-"`
 		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListEventsResponse parses an HTTP response from a ListEventsWithResponse call
+func ParseListEventsResponse(rsp *http.Response) (*ListEventsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListEventsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []EventSubscriber
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -799,6 +927,9 @@ type ServerInterface interface {
 	// Gets diagnostic information about the node's peers
 	// (GET /internal/network/v1/diagnostics/peers)
 	GetPeerDiagnostics(ctx echo.Context) error
+	// Lists the state of the internal events
+	// (GET /internal/network/v1/events)
+	ListEvents(ctx echo.Context) error
 	// Reprocess all transactions of the given type, verify and process
 	// (POST /internal/network/v1/reprocess)
 	Reprocess(ctx echo.Context, params ReprocessParams) error
@@ -849,6 +980,15 @@ func (w *ServerInterfaceWrapper) GetPeerDiagnostics(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetPeerDiagnostics(ctx)
+	return err
+}
+
+// ListEvents converts echo context to params.
+func (w *ServerInterfaceWrapper) ListEvents(ctx echo.Context) error {
+	var err error
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.ListEvents(ctx)
 	return err
 }
 
@@ -958,6 +1098,10 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.GET(baseURL+"/internal/network/v1/diagnostics/peers", func(context echo.Context) error {
 		si.(Preprocessor).Preprocess("GetPeerDiagnostics", context)
 		return wrapper.GetPeerDiagnostics(context)
+	})
+	router.GET(baseURL+"/internal/network/v1/events", func(context echo.Context) error {
+		si.(Preprocessor).Preprocess("ListEvents", context)
+		return wrapper.ListEvents(context)
 	})
 	router.POST(baseURL+"/internal/network/v1/reprocess", func(context echo.Context) error {
 		si.(Preprocessor).Preprocess("Reprocess", context)

--- a/network/dag/interface.go
+++ b/network/dag/interface.go
@@ -63,7 +63,9 @@ type State interface {
 	// A Notifier should only be created during `configuration` step since the `start` step will redeliver all events that have not been delivered yet.
 	// Returns an error when the Notifier already exists
 	Notifier(name string, receiver ReceiverFn, filters ...NotifierOption) (Notifier, error)
-	// Head returns the reference to a transactions that have not been referenced in the prevs of other transactions.
+	// Notifiers returns all registered notifiers
+	Notifiers() []Notifier
+	// Head returns the reference to a transactions that has not been referenced in the prevs of other transactions.
 	// Returns hash.EmptyHash when no head is stored.
 	Head(ctx context.Context) (hash.SHA256Hash, error)
 	// Shutdown the DB

--- a/network/dag/mock.go
+++ b/network/dag/mock.go
@@ -190,6 +190,20 @@ func (mr *MockStateMockRecorder) Notifier(name, receiver interface{}, filters ..
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Notifier", reflect.TypeOf((*MockState)(nil).Notifier), varargs...)
 }
 
+// Notifiers mocks base method.
+func (m *MockState) Notifiers() []Notifier {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Notifiers")
+	ret0, _ := ret[0].([]Notifier)
+	return ret0
+}
+
+// Notifiers indicates an expected call of Notifiers.
+func (mr *MockStateMockRecorder) Notifiers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Notifiers", reflect.TypeOf((*MockState)(nil).Notifiers))
+}
+
 // ReadPayload mocks base method.
 func (m *MockState) ReadPayload(ctx context.Context, payloadHash hash.SHA256Hash) ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/network/dag/notifier.go
+++ b/network/dag/notifier.go
@@ -46,6 +46,8 @@ const (
 // Storing the event in the DB is separated from notifying the subscribers.
 // The event is sent to subscribers after the transaction is committed to prevent timing issues.
 type Notifier interface {
+	// Name returns the name of the notifier
+	Name() string
 	// Save an event that needs to be retried even after a crash.
 	// It will not yet be sent, use Notify to notify the receiver.
 	// The event may be ignored due to configured filters.
@@ -195,6 +197,10 @@ type notifier struct {
 	filters         []NotificationFilter
 	notifiedCounter prometheus.Counter
 	finishedCounter prometheus.Counter
+}
+
+func (p *notifier) Name() string {
+	return p.name
 }
 
 func (p *notifier) shelfName() string {

--- a/network/dag/notifier_mock.go
+++ b/network/dag/notifier_mock.go
@@ -78,6 +78,20 @@ func (mr *MockNotifierMockRecorder) GetFailedEvents() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFailedEvents", reflect.TypeOf((*MockNotifier)(nil).GetFailedEvents))
 }
 
+// Name mocks base method.
+func (m *MockNotifier) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockNotifierMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockNotifier)(nil).Name))
+}
+
 // Notify mocks base method.
 func (m *MockNotifier) Notify(event Event) {
 	m.ctrl.T.Helper()

--- a/network/dag/notifier_test.go
+++ b/network/dag/notifier_test.go
@@ -479,6 +479,7 @@ func TestSubscriber_VariousFlows(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, events, 1)
 		assert.Equal(t, 5, notifiedCounter.count)
+		assert.Equal(t, "error", events[0].Error)
 	})
 }
 

--- a/network/dag/notifier_test.go
+++ b/network/dag/notifier_test.go
@@ -103,7 +103,13 @@ func TestNewSubscriber(t *testing.T) {
 	})
 }
 
-func TestSubscriber_Save(t *testing.T) {
+func TestNotifier_Name(t *testing.T) {
+	n := NewNotifier("test", dummyFunc)
+
+	assert.Equal(t, "test", n.Name())
+}
+
+func TestNotifier_Save(t *testing.T) {
 	ctx := context.Background()
 	transaction, _, _ := CreateTestTransaction(0)
 	payload := "payload"
@@ -255,7 +261,7 @@ func TestSubscriber_Save(t *testing.T) {
 	})
 }
 
-func TestSubscriber_Notify(t *testing.T) {
+func TestNotifier_Notify(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("ignored with inclusion filter", func(t *testing.T) {
@@ -366,7 +372,7 @@ func TestSubscriber_Notify(t *testing.T) {
 	})
 }
 
-func TestSubscriber_Run(t *testing.T) {
+func TestNotifier_Run(t *testing.T) {
 	ctx := context.Background()
 	filePath := io.TestDirectory(t)
 	transaction, _, _ := CreateTestTransaction(0)
@@ -394,7 +400,7 @@ func TestSubscriber_Run(t *testing.T) {
 	}, time.Second, "timeout while waiting for receiver")
 }
 
-func TestSubscriber_VariousFlows(t *testing.T) {
+func TestNotifier_VariousFlows(t *testing.T) {
 	ctx := context.Background()
 	transaction, _, _ := CreateTestTransaction(0)
 	event := Event{Hash: hash.EmptyHash(), Transaction: transaction}

--- a/network/dag/state.go
+++ b/network/dag/state.go
@@ -44,14 +44,16 @@ const (
 
 // State has references to the DAG and the payload store.
 type state struct {
-	db               stoabs.KVStore
-	graph            *dag
-	payloadStore     PayloadStore
-	txVerifiers      []Verifier
-	notifiers        map[string]Notifier
-	xorTree          *treeStore
-	ibltTree         *treeStore
-	transactionCount prometheus.Counter
+	db                  stoabs.KVStore
+	graph               *dag
+	payloadStore        PayloadStore
+	txVerifiers         []Verifier
+	notifiers           map[string]Notifier
+	xorTree             *treeStore
+	ibltTree            *treeStore
+	transactionCount    prometheus.Counter
+	eventsNotifyCount   prometheus.Counter
+	eventsFinishedCount prometheus.Counter
 }
 
 func (s *state) Migrate() error {
@@ -63,20 +65,18 @@ func NewState(db stoabs.KVStore, verifiers ...Verifier) (State, error) {
 	graph := newDAG(db)
 
 	payloadStore := NewPayloadStore()
-	transactionCount := transactionCountCollector()
-	err := prometheus.Register(transactionCount)
+	newState := &state{
+		db:           db,
+		graph:        graph,
+		payloadStore: payloadStore,
+		txVerifiers:  verifiers,
+		notifiers:    map[string]Notifier{},
+		xorTree:      newTreeStore(xorShelf, tree.New(tree.NewXor(), PageSize)),
+		ibltTree:     newTreeStore(ibltShelf, tree.New(tree.NewIblt(IbltNumBuckets), PageSize)),
+	}
+	err := newState.initPrometheusCounters()
 	if err != nil && err.Error() != (prometheus.AlreadyRegisteredError{}).Error() { // No unwrap on prometheus.AlreadyRegisteredError
 		return nil, err
-	}
-	newState := &state{
-		db:               db,
-		graph:            graph,
-		payloadStore:     payloadStore,
-		txVerifiers:      verifiers,
-		notifiers:        map[string]Notifier{},
-		xorTree:          newTreeStore(xorShelf, tree.New(tree.NewXor(), PageSize)),
-		ibltTree:         newTreeStore(ibltShelf, tree.New(tree.NewIblt(IbltNumBuckets), PageSize)),
-		transactionCount: transactionCount,
 	}
 
 	return newState, nil
@@ -91,6 +91,40 @@ func transactionCountCollector() prometheus.Counter {
 			Help:      "Number of transactions stored in the DAG",
 		},
 	)
+}
+
+func (s *state) initPrometheusCounters() error {
+	s.transactionCount = transactionCountCollector()
+	err := prometheus.Register(s.transactionCount)
+	if err != nil && err.Error() != (prometheus.AlreadyRegisteredError{}).Error() { // No unwrap on prometheus.AlreadyRegisteredError
+		return err
+	}
+	s.eventsNotifyCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "nuts",
+			Subsystem: "dag",
+			Name:      "events_notified_total",
+			Help:      "Number of DAG transaction notifications that were emitted (includes retries)",
+		},
+	)
+	err = prometheus.Register(s.transactionCount)
+	if err != nil && err.Error() != (prometheus.AlreadyRegisteredError{}).Error() { // No unwrap on prometheus.AlreadyRegisteredError
+		return err
+	}
+	s.eventsFinishedCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "nuts",
+			Subsystem: "dag",
+			Name:      "events_finished_total",
+			Help:      "Number of DAG transaction notifications that were completed",
+		},
+	)
+	err = prometheus.Register(s.transactionCount)
+	if err != nil && err.Error() != (prometheus.AlreadyRegisteredError{}).Error() { // No unwrap on prometheus.AlreadyRegisteredError
+		return err
+	}
+
+	return nil
 }
 
 func (s *state) Add(ctx context.Context, transaction Transaction, payload []byte) error {
@@ -266,6 +300,7 @@ func (s *state) Notifier(name string, receiver ReceiverFn, options ...NotifierOp
 	if _, exists := s.notifiers[name]; exists {
 		return nil, fmt.Errorf("notifier already exists (name=%s)", name)
 	}
+	options = append(options, withCounters(s.eventsNotifyCount, s.eventsFinishedCount))
 
 	notifier := NewNotifier(name, receiver, options...)
 	s.notifiers[name] = notifier
@@ -382,8 +417,22 @@ func (s *state) notify(event Event) {
 	}
 }
 
+func (s *state) getFailedEvents() []Event {
+	failedEvents := make([]Event, 0)
+	for name, notifier := range s.notifiers {
+		events, err := notifier.GetFailedEvents()
+		if err != nil {
+			log.Logger().Errorf("Failed to retrieve failed events: %v (notifier=%s)", err, name)
+			continue
+		}
+		failedEvents = append(failedEvents, events...)
+	}
+	return failedEvents
+}
+
 func (s *state) Diagnostics() []core.DiagnosticResult {
 	diag := s.graph.diagnostics(context.Background())
 	diag = append(diag, &core.GenericDiagnosticResult{Title: "dag_xor", Outcome: s.xorTree.getRoot().(*tree.Xor).Hash()})
+	diag = append(diag, &core.GenericDiagnosticResult{Title: "failed_events", Outcome: len(s.getFailedEvents())})
 	return diag
 }

--- a/network/dag/state.go
+++ b/network/dag/state.go
@@ -308,6 +308,14 @@ func (s *state) Notifier(name string, receiver ReceiverFn, options ...NotifierOp
 	return notifier, nil
 }
 
+func (s *state) Notifiers() []Notifier {
+	notifiers := make([]Notifier, 0)
+	for _, notifier := range s.notifiers {
+		notifiers = append(notifiers, notifier)
+	}
+	return notifiers
+}
+
 func (s *state) XOR(ctx context.Context, reqClock uint32) (hash.SHA256Hash, uint32) {
 	var data tree.Data
 

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -161,6 +161,17 @@ func TestState_Notifier(t *testing.T) {
 	})
 }
 
+func TestState_Notifiers(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		s := createState(t).(*state)
+		_, _ = s.Notifier(t.Name(), dummyFunc)
+
+		notifiers := s.Notifiers()
+
+		assert.Len(t, notifiers, 1)
+	})
+}
+
 func TestState_WritePayload(t *testing.T) {
 	t.Run("notifies receiver for payload", func(t *testing.T) {
 		txState := createState(t)

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -302,7 +302,7 @@ func TestState_Diagnostics(t *testing.T) {
 	err := txState.Add(ctx, doc1, payload)
 	assert.NoError(t, err)
 	diagnostics := txState.Diagnostics()
-	assert.Len(t, diagnostics, 3)
+	assert.Len(t, diagnostics, 5)
 	// Assert actual diagnostics
 	lines := make([]string, 0)
 	for _, diagnostic := range diagnostics {
@@ -313,6 +313,7 @@ func TestState_Diagnostics(t *testing.T) {
 
 	assert.Contains(t, actual, fmt.Sprintf("dag_xor: %s", doc1.Ref()))
 	assert.Contains(t, actual, "transaction_count: 1")
+	assert.Contains(t, actual, "failed_events: 0")
 }
 
 func TestState_XOR(t *testing.T) {

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -313,7 +313,7 @@ func TestState_Diagnostics(t *testing.T) {
 	err := txState.Add(ctx, doc1, payload)
 	assert.NoError(t, err)
 	diagnostics := txState.Diagnostics()
-	assert.Len(t, diagnostics, 5)
+	assert.Len(t, diagnostics, 4)
 	// Assert actual diagnostics
 	lines := make([]string, 0)
 	for _, diagnostic := range diagnostics {

--- a/network/interface.go
+++ b/network/interface.go
@@ -33,6 +33,8 @@ type Transactions interface {
 	// A filter can be passed as option with the WithSelectionFilter function.
 	// The events for the receiver can be made persistent by passing the network.WithPersistency() option.
 	Subscribe(name string, receiver dag.ReceiverFn, filters ...SubscriberOption) error
+	// Subscribers returns the list of notifiers on the DAG that emit events to subscribers.
+	Subscribers() []dag.Notifier
 	// GetTransactionPayload retrieves the transaction Payload for the given transaction. If the transaction or Payload is not found
 	// nil is returned.
 	GetTransactionPayload(transactionRef hash.SHA256Hash) ([]byte, error)

--- a/network/mock.go
+++ b/network/mock.go
@@ -141,6 +141,20 @@ func (mr *MockTransactionsMockRecorder) Subscribe(name, receiver interface{}, fi
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockTransactions)(nil).Subscribe), varargs...)
 }
 
+// Subscribers mocks base method.
+func (m *MockTransactions) Subscribers() []dag.Notifier {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Subscribers")
+	ret0, _ := ret[0].([]dag.Notifier)
+	return ret0
+}
+
+// Subscribers indicates an expected call of Subscribers.
+func (mr *MockTransactionsMockRecorder) Subscribers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribers", reflect.TypeOf((*MockTransactions)(nil).Subscribers))
+}
+
 // WithPersistency mocks base method.
 func (m *MockTransactions) WithPersistency() SubscriberOption {
 	m.ctrl.T.Helper()

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -950,7 +950,6 @@ func startNode(t *testing.T, name string, testDirectory string, opts ...func(ser
 		nodeDIDResolver:     &transport.FixedNodeDIDResolver{},
 		eventPublisher:      eventPublisher,
 		storeProvider:       storeProvider.GetProvider(ModuleName),
-		subscribers:         map[EventType]map[string]Receiver{},
 	}
 
 	if err := instance.Configure(*serverConfig); err != nil {

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -539,7 +539,7 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 			foundMutex.Lock()
 			defer foundMutex.Unlock()
 			return len(found) > 0, nil
-		}, 10*time.Millisecond, "timeout waiting for message")
+		}, 100*time.Millisecond, "timeout waiting for message")
 	})
 
 	t.Run("third node knows nothing", func(t *testing.T) {

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -837,6 +837,19 @@ func TestNetwork_Reprocess(t *testing.T) {
 	})
 }
 
+func TestNetwork_Subscribers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	cxt := createNetwork(t, ctrl)
+	notifier := dag.NewNotifier("test", func(event dag.Event) (bool, error) {
+		return true, nil
+	})
+	cxt.state.EXPECT().Notifiers().Return([]dag.Notifier{notifier})
+
+	subscribers := cxt.network.Subscribers()
+
+	assert.Len(t, subscribers, 1)
+}
+
 func TestNetwork_collectDiagnostics(t *testing.T) {
 	const txNum = 5
 	const expectedVersion = "development (0)"
@@ -844,7 +857,6 @@ func TestNetwork_collectDiagnostics(t *testing.T) {
 	expectedPeer := transport.Peer{ID: "abc", Address: "123"}
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	cxt := createNetwork(t, ctrl)
 	cxt.state.EXPECT().Diagnostics().Return([]core.DiagnosticResult{core.GenericDiagnosticResult{Title: dag.TransactionCountDiagnostic, Outcome: uint(txNum)}})
 


### PR DESCRIPTION
closes #1260

Doesn't currently add a Delete API. 