### PR TITLE
Echo: remove non-standard logging

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -149,7 +149,6 @@ func startServer(ctx context.Context, system *core.System) error {
 		return system.EchoCreator(cfg, system.Config.Strictmode, system.Config.InternalRateLimiter)
 	}, system.Config.HTTP.HTTPConfig)
 	for httpGroup, httpConfig := range system.Config.HTTP.AltBinds {
-		logrus.Infof("Binding /%s -> %s", httpGroup, httpConfig.Address)
 		if err := echoServer.Bind(httpGroup, httpConfig); err != nil {
 			return err
 		}

--- a/core/echo.go
+++ b/core/echo.go
@@ -139,6 +139,7 @@ func (c *MultiEcho) Add(method, path string, handler echo.HandlerFunc, middlewar
 // Bind binds the given group (first part of the URL) to the given HTTP interface. Calling Bind for the same group twice
 // results in an error being returned.
 func (c *MultiEcho) Bind(group string, interfaceConfig HTTPConfig) error {
+	Logger().Infof("Binding /%s -> %s", group, interfaceConfig.Address)
 	normGroup := strings.ToLower(group)
 	if _, groupExists := c.groups[normGroup]; groupExists {
 		return fmt.Errorf("http bind group already exists: %s", group)
@@ -263,6 +264,7 @@ func loggerMiddleware(config loggerConfig) echo.MiddlewareFunc {
 func createEchoServer(cfg HTTPConfig, strictmode, rateLimiter bool) (*echo.Echo, error) {
 	echoServer := echo.New()
 	echoServer.HideBanner = true
+	echoServer.HidePort = true
 
 	// ErrorHandler
 	echoServer.HTTPErrorHandler = createHTTPErrorHandler()


### PR DESCRIPTION
Removes logging like:

```
⇨ http server started on [::]:80
⇨ https server started on [::]:1324
```

We already logged this kind of info ("Binding /n2n to :1323"), but improved this so it logs the default interface as well.