### PR TITLE
Network: add Prometheus metrics for sent/received messages and peer count

### DIFF
--- a/network/transport/grpc/interface.go
+++ b/network/transport/grpc/interface.go
@@ -41,6 +41,8 @@ type Protocol interface {
 	Handle(peer transport.Peer, envelope interface{}) error
 	// UnwrapMessage is used to extract the inner message from the envelope.
 	UnwrapMessage(envelope interface{}) interface{}
+	// GetMessageType returns a string key identifying the message type.
+	GetMessageType(envelope interface{}) string
 }
 
 // Stream bundles common functions from grpc.ServerStream and grpc.ClientStream, providing a common interface.

--- a/network/transport/grpc/interface_mock.go
+++ b/network/transport/grpc/interface_mock.go
@@ -95,6 +95,20 @@ func (mr *MockProtocolMockRecorder) Diagnostics() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Diagnostics", reflect.TypeOf((*MockProtocol)(nil).Diagnostics))
 }
 
+// GetMessageType mocks base method.
+func (m *MockProtocol) GetMessageType(envelope interface{}) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMessageType", envelope)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetMessageType indicates an expected call of GetMessageType.
+func (mr *MockProtocolMockRecorder) GetMessageType(envelope interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMessageType", reflect.TypeOf((*MockProtocol)(nil).GetMessageType), envelope)
+}
+
 // Handle mocks base method.
 func (m *MockProtocol) Handle(peer transport.Peer, envelope interface{}) error {
 	m.ctrl.T.Helper()

--- a/network/transport/grpc/stats_test.go
+++ b/network/transport/grpc/stats_test.go
@@ -19,8 +19,12 @@
 package grpc
 
 import (
+	"errors"
+	"github.com/golang/mock/gomock"
 	"github.com/magiconair/properties/assert"
 	"github.com/nuts-foundation/nuts-node/network/transport"
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 	"testing"
 )
 
@@ -46,4 +50,68 @@ func Test_OwnPeerIDStatistic(t *testing.T) {
 	assert.Equal(t, statistic.Result(), transport.PeerID("bla"))
 	assert.Equal(t, statistic.String(), "bla")
 	assert.Equal(t, statistic.Name(), "peer_id")
+}
+
+func Test_PrometheusStreamWrapper(t *testing.T) {
+	assertCount := func(t *testing.T, counter *prometheus.CounterVec, labels []string, count float64) {
+		t.Helper()
+		metric := &io_prometheus_client.Metric{}
+		_ = counter.WithLabelValues(labels...).Write(metric)
+		assert.Equal(t, count, *metric.Counter.Value)
+	}
+
+	t.Run("Send", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		stream := NewMockStream(ctrl)
+		stream.EXPECT().SendMsg(gomock.Any())
+		prot := &TestProtocol{}
+		counter := prometheus.NewCounterVec(prometheus.CounterOpts{Namespace: "t", Subsystem: "es", Name: "t"}, []string{"version", "type"})
+		wrapper := prometheusStreamWrapper{
+			stream:              stream,
+			protocol:            prot,
+			sentMessagesCounter: counter,
+		}
+
+		envelope := prot.CreateEnvelope().(*TestMessage)
+		_ = wrapper.SendMsg(envelope)
+
+		assertCount(t, counter, []string{"v0", "TestMessage"}, 1)
+	})
+	t.Run("Receive", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			stream := NewMockStream(ctrl)
+			stream.EXPECT().RecvMsg(gomock.Any())
+			prot := &TestProtocol{}
+			counter := prometheus.NewCounterVec(prometheus.CounterOpts{Namespace: "t", Subsystem: "es", Name: "t"}, []string{"version", "type"})
+			wrapper := prometheusStreamWrapper{
+				stream:              stream,
+				protocol:            prot,
+				recvMessagesCounter: counter,
+			}
+
+			envelope := prot.CreateEnvelope().(*TestMessage)
+			_ = wrapper.RecvMsg(envelope)
+
+			assertCount(t, counter, []string{"v0", "TestMessage"}, 1)
+		})
+		t.Run("no count on receive error", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			stream := NewMockStream(ctrl)
+			stream.EXPECT().RecvMsg(gomock.Any()).Return(errors.New("failure"))
+			prot := &TestProtocol{}
+			counter := prometheus.NewCounterVec(prometheus.CounterOpts{Namespace: "t", Subsystem: "es", Name: "t"}, []string{"version", "type"})
+			wrapper := prometheusStreamWrapper{
+				stream:              stream,
+				protocol:            prot,
+				recvMessagesCounter: counter,
+			}
+
+			envelope := prot.CreateEnvelope().(*TestMessage)
+			_ = wrapper.RecvMsg(envelope)
+
+			assertCount(t, counter, []string{"v0", "TestMessage"}, 0)
+		})
+	})
+
 }

--- a/network/transport/grpc/testprotocol_impl.pb.go
+++ b/network/transport/grpc/testprotocol_impl.pb.go
@@ -72,7 +72,6 @@ func (s *TestProtocol) UnwrapMessage(envelope interface{}) interface{} {
 	panic("implement me")
 }
 
-// UnwrapMessage is not implemented.
 func (s *TestProtocol) GetMessageType(envelope interface{}) string {
 	return "TestMessage"
 }

--- a/network/transport/grpc/testprotocol_impl.pb.go
+++ b/network/transport/grpc/testprotocol_impl.pb.go
@@ -72,6 +72,11 @@ func (s *TestProtocol) UnwrapMessage(envelope interface{}) interface{} {
 	panic("implement me")
 }
 
+// UnwrapMessage is not implemented.
+func (s *TestProtocol) GetMessageType(envelope interface{}) string {
+	return "TestMessage"
+}
+
 func (s *TestProtocol) DoStuff(serverStream Test_DoStuffServer) error {
 	s.inboundCalled = true
 	return s.acceptor(serverStream)

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -42,22 +42,6 @@ import (
 
 var _ grpc.Protocol = (*protocol)(nil)
 
-// messages lists all messages of the protocol, used for testing and asserting all cases are covered.
-var messages = []isEnvelope_Message{
-	// broadcasts
-	&Envelope_Gossip{&Gossip{}},
-	&Envelope_DiagnosticsBroadcast{&Diagnostics{}},
-	// requests
-	&Envelope_State{&State{}},
-	&Envelope_TransactionListQuery{&TransactionListQuery{}},
-	&Envelope_TransactionRangeQuery{&TransactionRangeQuery{}},
-	&Envelope_TransactionPayloadQuery{&TransactionPayloadQuery{}},
-	// responses
-	&Envelope_TransactionSet{&TransactionSet{}},
-	&Envelope_TransactionList{&TransactionList{}},
-	&Envelope_TransactionPayload{&TransactionPayload{}},
-}
-
 // Config specifies config for protocol v2
 type Config struct {
 	// Datadir from core.Config


### PR DESCRIPTION
Closes of https://github.com/nuts-foundation/nuts-node/issues/539

Example output:

```
# HELP nuts_network_grpc_messages_received Number of gRPC messages received per protocol and message type.
# TYPE nuts_network_grpc_messages_received counter
nuts_network_grpc_messages_received{message_type="DiagnosticsBroadcast",protocol="v2"} 2
nuts_network_grpc_messages_received{message_type="Gossip",protocol="v2"} 31
nuts_network_grpc_messages_received{message_type="State",protocol="v2"} 1
nuts_network_grpc_messages_received{message_type="TransactionList",protocol="v2"} 1
nuts_network_grpc_messages_received{message_type="TransactionListQuery",protocol="v2"} 1
nuts_network_grpc_messages_received{message_type="TransactionPayload",protocol="v2"} 1
nuts_network_grpc_messages_received{message_type="TransactionPayloadQuery",protocol="v2"} 1
nuts_network_grpc_messages_received{message_type="TransactionSet",protocol="v2"} 1
# HELP nuts_network_grpc_messages_sent Number of gRPC messages sent per protocol and message type.
# TYPE nuts_network_grpc_messages_sent counter
nuts_network_grpc_messages_sent{message_type="DiagnosticsBroadcast",protocol="v2"} 2
nuts_network_grpc_messages_sent{message_type="Gossip",protocol="v2"} 28
nuts_network_grpc_messages_sent{message_type="State",protocol="v2"} 1
nuts_network_grpc_messages_sent{message_type="TransactionList",protocol="v2"} 1
nuts_network_grpc_messages_sent{message_type="TransactionListQuery",protocol="v2"} 1
nuts_network_grpc_messages_sent{message_type="TransactionPayload",protocol="v2"} 1
nuts_network_grpc_messages_sent{message_type="TransactionPayloadQuery",protocol="v2"} 1
nuts_network_grpc_messages_sent{message_type="TransactionSet",protocol="v2"} 1
# HELP nuts_network_peers Number of connected gRPC peers.
# TYPE nuts_network_peers gauge
nuts_network_peers 1
```