### PR TITLE
Fix link to production deployment docs on landingpage

### DIFF
--- a/core/landingpage.html
+++ b/core/landingpage.html
@@ -6,7 +6,7 @@
 <h1>Your Nuts Node is running!</h1>
 <p>
     Warning: if you see this message, it means you haven't properly secured your environment for production usage.<br />
-    See <a href="https://nuts-node.readthedocs.io/en/latest/pages/production-configuration.html" target="_blank">Configuring for Production</a> for more information on this topic.
+    See <a href="https://nuts-node.readthedocs.io/en/latest/pages/deployment/production-configuration.html" target="_blank">Configuring for Production</a> for more information on this topic.
 </p>
 <p>
     <a href="status/diagnostics">Node Diagnostics</a>


### PR DESCRIPTION
The link to the production deployment documentation on the landingpage doesn't work. This should fix that.