### PR TITLE
Fix datarace on network.state by not nil-ing it on shutdown

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -562,12 +562,9 @@ func (n *Network) Shutdown() error {
 	n.connectionManager.Stop()
 
 	// Close State and underlying DBs
-	if n.state != nil {
-		err := n.state.Shutdown()
-		if err != nil {
-			return err
-		}
-		n.state = nil
+	err := n.state.Shutdown()
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/network/network.go
+++ b/network/network.go
@@ -561,7 +561,6 @@ func (n *Network) Shutdown() error {
 	}
 	n.connectionManager.Stop()
 
-	// Close State and underlying DBs
 	err := n.state.Shutdown()
 	if err != nil {
 		return err

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -702,7 +702,6 @@ func TestNetwork_Shutdown(t *testing.T) {
 		}
 		err = ctx.network.Shutdown()
 		assert.NoError(t, err)
-		assert.Nil(t, ctx.network.state)
 	})
 
 	t.Run("multiple calls", func(t *testing.T) {


### PR DESCRIPTION
Peer diagnostics collector is called periodically by v2 which reads it, while there might be a Shutdown call in-flight which sets the field to `nil`, causing a nil deref. Now it can still fail because the databases are closed (which is OK, because the node is shutting down anyways), but at least it's not a nil deref due to a data race.

Most correct fix would wait for the protocols  (v2) and its child goroutines (diagnostics collector) to finish, but that would require a lot more code, increasing complexity.