### PR TITLE
Network: Remove jwk/kid from crit header

### DIFF
--- a/network/dag/signing.go
+++ b/network/dag/signing.go
@@ -90,10 +90,8 @@ func (d transactionSigner) Sign(input UnsignedTransaction, signingTime time.Time
 	}
 
 	if d.attach {
-		headerMap[jws.CriticalKey] = append(headerMap[jws.CriticalKey].([]string), jws.JWKKey)
 		headerMap[jws.JWKKey] = key
 	} else {
-		headerMap[jws.CriticalKey] = append(headerMap[jws.CriticalKey].([]string), jws.KeyIDKey)
 		headerMap[jws.KeyIDKey] = d.key.KID()
 	}
 


### PR DESCRIPTION
fixes #1408 

old transactions still have it in their crit header. No logic has changed so nothing will break.