### PR TITLE
gRPC sets ip based on X-Forwarded-For header if available

### DIFF
--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -777,7 +777,7 @@ func TestNetworkIntegration_TLSOffloading(t *testing.T) {
 		t.Run("ok", func(t *testing.T) {
 			testDirectory := io.TestDirectory(t)
 			// Start server node (node1)
-			_ = startNode(t, "node1", testDirectory, func(serverCfg *core.ServerConfig, cfg *Config) {
+			node1 := startNode(t, "node1", testDirectory, func(serverCfg *core.ServerConfig, cfg *Config) {
 				serverCfg.TLS.Offload = core.OffloadIncomingTLS
 				serverCfg.TLS.ClientCertHeaderName = "client-cert"
 			})
@@ -798,6 +798,8 @@ func TestNetworkIntegration_TLSOffloading(t *testing.T) {
 				return
 			}
 
+			xffHeader := "8.8.8.8,8.8.4.4,127.0.0.1"
+			outgoingMD.Set("X-Forwarded-For", xffHeader)
 			outgoingMD.Set("client-cert", url.QueryEscape(string(clientCertBytes)))
 			outgoingContext := metadata.NewOutgoingContext(ctx, outgoingMD)
 			client := v2.NewProtocolClient(grpcConn)
@@ -810,6 +812,7 @@ func TestNetworkIntegration_TLSOffloading(t *testing.T) {
 			msg, err := result.Recv()
 			assert.NoError(t, err)
 			assert.NotNil(t, msg)
+			assert.Contains(t, node1.network.Diagnostics()[0].String(), "client(did:nuts:node2)@8.8.4.4")
 		})
 		t.Run("authentication fails", func(t *testing.T) {
 			testDirectory := io.TestDirectory(t)

--- a/network/transport/grpc/authenticator.go
+++ b/network/transport/grpc/authenticator.go
@@ -86,6 +86,8 @@ func (t tlsAuthenticator) Authenticate(nodeDID did.DID, grpcPeer grpcPeer.Peer, 
 			WithField(core.LogFieldDID, nodeDID).
 			Debug("Connection successfully authenticated")
 		peer.NodeDID = nodeDID
+		// Set peer address based on registered NutsComm endpoint
+		peer.Address = nutsCommURL.Host
 		return peer, nil
 	}
 

--- a/network/transport/grpc/authenticator.go
+++ b/network/transport/grpc/authenticator.go
@@ -86,8 +86,6 @@ func (t tlsAuthenticator) Authenticate(nodeDID did.DID, grpcPeer grpcPeer.Peer, 
 			WithField(core.LogFieldDID, nodeDID).
 			Debug("Connection successfully authenticated")
 		peer.NodeDID = nodeDID
-		// Set peer address based on registered NutsComm endpoint
-		peer.Address = nutsCommURL.Host
 		return peer, nil
 	}
 

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -167,9 +167,11 @@ func (s *grpcConnectionManager) Start() error {
 		log.Logger().Info("TLS is disabled, this is very unsecure and only suitable for demo/development environments.")
 	}
 
-	// Chain interceptors. ipExtractor is added last so it is processed first.
+	// Chain interceptors. ipInterceptor is added last, so it processes the stream first.
 	s.serverInterceptors = append(s.serverInterceptors, ipInterceptor)
-	serverOpts = append(serverOpts, grpc.ChainStreamInterceptor(s.serverInterceptors...))
+	if len(s.serverInterceptors) > 0 {
+		serverOpts = append(serverOpts, grpc.ChainStreamInterceptor(s.serverInterceptors...))
+	}
 
 	// Create gRPC server for inbound connectionList and associate it with the protocols
 	s.grpcServer = grpc.NewServer(serverOpts...)

--- a/network/transport/grpc/ip_interceptor.go
+++ b/network/transport/grpc/ip_interceptor.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"net"
+	"net/netip"
 	"strings"
 
 	"google.golang.org/grpc"
@@ -65,11 +66,14 @@ func addrFrom(ip string) net.Addr {
 	if ip == "" {
 		return nil
 	}
-	addr, err := net.ResolveIPAddr("ip", ip)
+	ipAddr, err := netip.ParseAddr(ip)
 	if err != nil {
 		return nil
 	}
-	return addr
+	return &net.IPAddr{
+		IP:   ipAddr.AsSlice(),
+		Zone: ipAddr.Zone(),
+	}
 }
 
 func isInternal(ip net.IP) bool {

--- a/network/transport/grpc/ip_interceptor.go
+++ b/network/transport/grpc/ip_interceptor.go
@@ -1,0 +1,65 @@
+package grpc
+
+import (
+	"net"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+// ipExtractor tries to extract the IP from the X-Forwarded-For header and sets this as the peers address.
+// No address is set if the header is unavailable.
+func ipInterceptor(srv interface{}, serverStream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	peerInfo, _ := peer.FromContext(serverStream.Context())
+	if peerInfo == nil {
+		peerInfo = &peer.Peer{}
+	}
+	if addr := addrFrom(extractIPFromXFFHeader(serverStream)); addr != nil {
+		peerInfo.Addr = addr
+	}
+	ctx := peer.NewContext(serverStream.Context(), peerInfo)
+	return handler(srv, &wrappedServerStream{ctx: ctx, ServerStream: serverStream})
+}
+
+// extractIPFromXFFHeader tries to retrieve the address from X-Forward-For header.
+// Implementation is based on echo.ExtractIPFromXFFHeader().
+func extractIPFromXFFHeader(serverStream grpc.ServerStream) string {
+	ipUnknown := ""
+	md, ok := metadata.FromIncomingContext(serverStream.Context())
+	if !ok {
+		return ipUnknown
+	}
+	xffs := md.Get("X-Forwarded-For")
+	if len(xffs) == 0 {
+		return ipUnknown
+	}
+	ips := append(strings.Split(strings.Join(xffs, ","), ","))
+	for i := len(ips) - 1; i >= 0; i-- {
+		ip := net.ParseIP(strings.TrimSpace(ips[i]))
+		if ip == nil {
+			// Unable to parse IP; cannot trust entire records
+			return ipUnknown
+		}
+		if !isInternal(ip) {
+			return ip.String()
+		}
+	}
+
+	// All of the IPs are trusted; return first element because it is furthest from server (best effort strategy).
+	return strings.TrimSpace(ips[0])
+}
+
+// addrFrom returns nil if ip is not a valid IP
+func addrFrom(ip string) net.Addr {
+	addr, err := net.ResolveIPAddr("ip", ip)
+	if err != nil {
+		return nil
+	}
+	return addr
+}
+
+func isInternal(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsPrivate()
+}

--- a/network/transport/grpc/ip_interceptor.go
+++ b/network/transport/grpc/ip_interceptor.go
@@ -9,6 +9,8 @@ import (
 	"google.golang.org/grpc/peer"
 )
 
+const headerXForwardedFor = "X-Forwarded-For"
+
 // ipInterceptor tries to extract the IP from the X-Forwarded-For header and sets this as the peers address.
 // No address is set if the header is unavailable.
 func ipInterceptor(srv interface{}, serverStream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
@@ -37,7 +39,7 @@ func extractIPFromXFFHeader(serverStream grpc.ServerStream) string {
 	if !ok {
 		return ipUnknown
 	}
-	xffs := md.Get("X-Forwarded-For")
+	xffs := md.Get(headerXForwardedFor)
 	if len(xffs) == 0 {
 		return ipUnknown
 	}

--- a/network/transport/grpc/ip_interceptor.go
+++ b/network/transport/grpc/ip_interceptor.go
@@ -9,21 +9,27 @@ import (
 	"google.golang.org/grpc/peer"
 )
 
-// ipExtractor tries to extract the IP from the X-Forwarded-For header and sets this as the peers address.
+// ipInterceptor tries to extract the IP from the X-Forwarded-For header and sets this as the peers address.
 // No address is set if the header is unavailable.
 func ipInterceptor(srv interface{}, serverStream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	addr := addrFrom(extractIPFromXFFHeader(serverStream))
+	if addr == nil {
+		// Exit without change if there is no X-Forwarded-For in the http header,
+		// or if no IP could be extracted from the header.
+		// This will default to the IP found in lvl 4 header.
+		return handler(srv, serverStream)
+	}
+
 	peerInfo, _ := peer.FromContext(serverStream.Context())
 	if peerInfo == nil {
 		peerInfo = &peer.Peer{}
 	}
-	if addr := addrFrom(extractIPFromXFFHeader(serverStream)); addr != nil {
-		peerInfo.Addr = addr
-	}
+	peerInfo.Addr = addr
 	ctx := peer.NewContext(serverStream.Context(), peerInfo)
 	return handler(srv, &wrappedServerStream{ctx: ctx, ServerStream: serverStream})
 }
 
-// extractIPFromXFFHeader tries to retrieve the address from X-Forward-For header.
+// extractIPFromXFFHeader tries to retrieve the address from X-Forward-For header. Returns an empty string if non found.
 // Implementation is based on echo.ExtractIPFromXFFHeader().
 func extractIPFromXFFHeader(serverStream grpc.ServerStream) string {
 	ipUnknown := ""
@@ -42,17 +48,21 @@ func extractIPFromXFFHeader(serverStream grpc.ServerStream) string {
 			// Unable to parse IP; cannot trust entire records
 			return ipUnknown
 		}
+		// Return first non-internal address
 		if !isInternal(ip) {
 			return ip.String()
 		}
 	}
 
-	// All of the IPs are trusted; return first element because it is furthest from server (best effort strategy).
+	// All IPs are trusted; return first element because it is furthest from server (best effort strategy).
 	return strings.TrimSpace(ips[0])
 }
 
 // addrFrom returns nil if ip is not a valid IP
 func addrFrom(ip string) net.Addr {
+	if ip == "" {
+		return nil
+	}
 	addr, err := net.ResolveIPAddr("ip", ip)
 	if err != nil {
 		return nil

--- a/network/transport/grpc/ip_interceptor_test.go
+++ b/network/transport/grpc/ip_interceptor_test.go
@@ -1,0 +1,85 @@
+package grpc
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+	"net"
+	"strings"
+	"testing"
+)
+
+func Test_ipInterceptor(t *testing.T) {
+	var peerInfo *peer.Peer
+	var success bool
+	serverStream := &stubServerStream{}
+
+	contextWithMD := func(xff string) context.Context {
+		md := metadata.New(map[string]string{
+			headerXForwardedFor: xff,
+		})
+		return metadata.NewIncomingContext(context.Background(), md)
+	}
+
+	var internalIPs = []string{
+		"127.0.0.1",
+		"::1",
+		"169.254.0.0",
+		"192.168.6.29",
+		"10.1.2.3",
+		"fc00::",
+	}
+
+	t.Run("XFF header", func(t *testing.T) {
+		externalXFFAddr, _ := net.ResolveIPAddr("ip", "8.8.4.4")
+		internalXFFAddr, _ := net.ResolveIPAddr("ip", internalIPs[0])
+		peerNoAddres := net.Addr(nil)
+
+		tests := []struct {
+			xffIPs   []string
+			expected net.Addr
+		}{
+			{append([]string{"8.8.8.8", "8.8.4.4"}, internalIPs...), externalXFFAddr},    // should be read right to left, so this is the first external IP
+			{internalIPs, internalXFFAddr},                                               // all are internal, so select the IP the furthest away from server
+			{append([]string{"invalid IP", "8.8.4.4"}, internalIPs...), externalXFFAddr}, // should be read right to left, so this is accepted
+			{append([]string{"8.8.4.4", "invalid IP"}, internalIPs...), peerNoAddres},    // should be read right to left, so this is NOT accepted
+			{append([]string{"8.8.8.8", "localhost"}, internalIPs...), peerNoAddres},     // localhost is not accepted
+			{append([]string{"8.8.8.8", " 8.8.4.4 "}, internalIPs...), externalXFFAddr},  // spaces are trimmed
+			{[]string{}, peerNoAddres},                                                   // empty header
+		}
+
+		for _, tc := range tests {
+			serverStream.ctx = contextWithMD(strings.Join(tc.xffIPs, ","))
+			_ = ipInterceptor(nil, serverStream, nil, func(srv interface{}, wrappedStream grpc.ServerStream) error {
+				peerInfo, success = peer.FromContext(wrappedStream.Context())
+				return nil
+			})
+
+			if success {
+				assert.Equal(t, tc.expected.String(), peerInfo.Addr.String())
+			} else {
+				assert.Nil(t, tc.expected)
+			}
+		}
+	})
+	t.Run("no XXF header", func(t *testing.T) {
+		serverStream.ctx = metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{}))
+		_ = ipInterceptor(nil, serverStream, nil, func(srv interface{}, wrappedStream grpc.ServerStream) error {
+			peerInfo, success = peer.FromContext(wrappedStream.Context())
+			return nil
+		})
+		assert.False(t, success)
+		assert.Nil(t, peerInfo)
+	})
+	t.Run("no metadata in context", func(t *testing.T) {
+		serverStream.ctx = context.Background()
+		_ = ipInterceptor(nil, serverStream, nil, func(srv interface{}, wrappedStream grpc.ServerStream) error {
+			peerInfo, success = peer.FromContext(wrappedStream.Context())
+			return nil
+		})
+		assert.False(t, success)
+		assert.Nil(t, peerInfo)
+	})
+}

--- a/network/transport/grpc/tls_offloading.go
+++ b/network/transport/grpc/tls_offloading.go
@@ -37,11 +37,17 @@ import (
 	"strings"
 )
 
+func newAuthenticationInterceptor(clientCertHeaderName string) grpc.StreamServerInterceptor {
+	return (&tlsOffloadingAuthenticator{
+		clientCertHeaderName: clientCertHeaderName,
+	}).intercept
+}
+
 type tlsOffloadingAuthenticator struct {
 	clientCertHeaderName string
 }
 
-func (t *tlsOffloadingAuthenticator) Intercept(srv interface{}, serverStream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+func (t *tlsOffloadingAuthenticator) intercept(srv interface{}, serverStream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	certificates, err := t.authenticate(serverStream)
 	if err != nil {
 		log.Logger().

--- a/network/transport/grpc/tls_offloading.go
+++ b/network/transport/grpc/tls_offloading.go
@@ -38,9 +38,7 @@ import (
 )
 
 func newAuthenticationInterceptor(clientCertHeaderName string) grpc.StreamServerInterceptor {
-	return (&tlsOffloadingAuthenticator{
-		clientCertHeaderName: clientCertHeaderName,
-	}).intercept
+	return (&tlsOffloadingAuthenticator{clientCertHeaderName: clientCertHeaderName}).intercept
 }
 
 type tlsOffloadingAuthenticator struct {

--- a/network/transport/grpc/tls_offloading_test.go
+++ b/network/transport/grpc/tls_offloading_test.go
@@ -65,13 +65,13 @@ func Test_tlsOffloadingAuthenticator(t *testing.T) {
 		return metadata.NewIncomingContext(context.Background(), md)
 	}
 
-	t.Run("Intercept", func(t *testing.T) {
+	t.Run("intercept", func(t *testing.T) {
 		t.Run("ok", func(t *testing.T) {
 			var peerInfo *peer.Peer
 			var success bool
 			serverStream.ctx = contextWithMD(encodedCert)
 
-			err := auth.Intercept(nil, serverStream, nil, func(srv interface{}, wrappedStream grpc.ServerStream) error {
+			err := auth.intercept(nil, serverStream, nil, func(srv interface{}, wrappedStream grpc.ServerStream) error {
 				peerInfo, success = peer.FromContext(wrappedStream.Context())
 				return nil
 			})
@@ -85,7 +85,7 @@ func Test_tlsOffloadingAuthenticator(t *testing.T) {
 		t.Run("auth fails", func(t *testing.T) {
 			serverStream.ctx = contextWithMD("invalid cert")
 
-			err := auth.Intercept(nil, serverStream, nil, func(srv interface{}, wrappedStream grpc.ServerStream) error {
+			err := auth.intercept(nil, serverStream, nil, func(srv interface{}, wrappedStream grpc.ServerStream) error {
 				t.Fatal("should not be called")
 				return nil
 			})


### PR DESCRIPTION
closes #1389

Behavior matches that of the echo handler
Will still produce IP of the proxy when configured for level 4 forwarding