### PR TITLE
Network: validate discovered NutsComm address

### DIFF
--- a/docs/pages/getting-started/3-configure-your-node.rst
+++ b/docs/pages/getting-started/3-configure-your-node.rst
@@ -37,7 +37,7 @@ There are 4 official Nuts networks:
 Node TLS Certificate
 ====================
 
-Before you can join a network, your node needs a certificate from the correct Certificate Authority (CA). The ``development`` and ``stable`` networks are open for everyone to join. Contrary to the ``production`` network (where we will be using a real Certificate Authority like PKIoverheid) the CA certificate and private key for these networks are available on github. This way you can generate your own certificate.
+Before you can join a network, your node needs a certificate from the correct Certificate Authority (CA). The ``development`` and ``stable`` networks are open for everyone to join. Contrary to the ``test`` and ``production`` networks (where we will be using a real Certificate Authority like PKIoverheid) the CA certificate and private key for these networks are available on github. This way you can generate your own certificate.
 
 To generate the certificate for your own node you need the ``https://github.com/nuts-foundation/nuts-development-network-ca`` repository. It contains handy scripts and the needed key material. For more information how to use, consult the `README <https://github.com/nuts-foundation/nuts-development-network-ca/blob/master/README.md>`_
 
@@ -140,6 +140,10 @@ You can register the ``NutsComm`` endpoint by calling ``addEndpoint`` on the DID
         "endpoint": "grpc://nuts.nl:5555"
     }
 
+.. note::
+
+    The domain registered in the ``NutsComm` endpoint must be listed as a DNS SAN in the node's TLS certificate.
+    Node Discovery will ignore endpoints containing IP-addresses and reserved addresses as specified in `RFC2606 <https://datatracker.ietf.org/doc/html/rfc2606>`_.
 
 Care Organizations
 ******************

--- a/network/network.go
+++ b/network/network.go
@@ -346,7 +346,7 @@ func (n *Network) connectToKnownNodes(nodeDID did.DID) error {
 						Warn("Failed to extract NutsComm address from service")
 					continue inner
 				}
-				address, err := transport.ParseAddress(nutsCommStr)
+				address, err := transport.ParseNutsCommAddress(nutsCommStr)
 				if err != nil {
 					log.Logger().
 						WithError(err).

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -926,7 +926,7 @@ func Test_connectToKnownNodes(t *testing.T) {
 			},
 		}
 		peerDID, _ := did.ParseDID("did:nuts:peer")
-		peerAddress := "peer:5555"
+		peerAddress := "peer.com:5555"
 		peerDocument := did.Document{
 			ID: *peerDID,
 			Service: []did.Service{


### PR DESCRIPTION
closes #1385

Service discovery no longer accepts NutsComm endpoints that consist of reserved TLD's / addresses, or IP addresses.
Behavior of bootstrap nodes is unchanged.

- (How) Should this be documented?