### PR TITLE
VCR: Add stats on credentials in store

### DIFF
--- a/docs/pages/deployment/monitoring.rst
+++ b/docs/pages/deployment/monitoring.rst
@@ -46,6 +46,13 @@ Returns the status of the various services in ``yaml`` format:
             dag_xor: 6aada4464e380db16d0316e597956fcdaeada0e8f6023be82eeb9c798e1815c6
             stored_database_size_bytes: 106496005
             transaction_count: 9001
+    vcr:
+        credential_count: 7
+        issuer:
+            issued_credentials_count: 0
+            revoked_credentials_count: 0
+        verifier:
+            revocations_count: 18
     status:
         git_commit: d36837bae48b780bfb76134e85b506472fc207a6
         os_arch: linux/amd64
@@ -53,6 +60,13 @@ Returns the status of the various services in ``yaml`` format:
         uptime: 4h14m12s
 
 If you supply ``application/json`` for the ``Accept`` HTTP header it will return the diagnostics in JSON format.
+
+Explanation of ambiguous/complex entries in the diagnostics:
+
+* ``vcr.credential_count`` holds the total number of credentials known to the node (public VCs, and private VCs issued to a DID on the local node)
+* ``vcr.issuer.issued_credentials_count`` holds the total number of credentials issued by the local node
+* ``vcr.issuer.revoked_credentials_count`` holds the total number of revoked credentials issued by the local node
+* ``vcr.verifier.revocations_count`` holds the total number of revoked credentials (public and private VCs)
 
 Metrics
 *******

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/nats-io/nats.go v1.16.0
 	github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b
 	github.com/nuts-foundation/go-did v0.3.0
-	github.com/nuts-foundation/go-leia/v3 v3.1.4
+	github.com/nuts-foundation/go-leia/v3 v3.2.0
 	github.com/nuts-foundation/go-stoabs v1.0.0
 	github.com/piprate/json-gold v0.4.1
 	github.com/privacybydesign/irmago v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -594,6 +594,8 @@ github.com/nuts-foundation/go-did v0.3.0 h1:uZoFnwiAlJgVWWsr8b7tJXSMUgW2bajaLANE
 github.com/nuts-foundation/go-did v0.3.0/go.mod h1:MD2sE53BOvsQHZ9CmGI+EGXPUk1QiU9bUqB062y9+N8=
 github.com/nuts-foundation/go-leia/v3 v3.1.4 h1:Qfcvu5x7o8mOMUzwsM0bQtu/LLjq2o+Fw7ZXVYRZ0NU=
 github.com/nuts-foundation/go-leia/v3 v3.1.4/go.mod h1:Md202F2wpwkXGtOUzyqs0p1Y96+wOY8lpmDT9nuaxE0=
+github.com/nuts-foundation/go-leia/v3 v3.2.0 h1:Z2+QAcvM2A0wlfW0NYa7VcB+u9CE0MmoJm+TZZZqnVQ=
+github.com/nuts-foundation/go-leia/v3 v3.2.0/go.mod h1:Md202F2wpwkXGtOUzyqs0p1Y96+wOY8lpmDT9nuaxE0=
 github.com/nuts-foundation/go-stoabs v1.0.0 h1:1T385ghGzM849VgXYrEIr2EABfIGtjNpRL9S7D/hgmg=
 github.com/nuts-foundation/go-stoabs v1.0.0/go.mod h1:FzYovtpUhAjYFaiVvgFfT06iF0+MRaTgcaqQ6MVIq7Y=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/vcr/issuer/interface.go
+++ b/vcr/issuer/interface.go
@@ -20,6 +20,7 @@ package issuer
 
 import (
 	"errors"
+	"github.com/nuts-foundation/nuts-node/core"
 	"io"
 
 	ssi "github.com/nuts-foundation/go-did"
@@ -66,6 +67,7 @@ var ErrMultipleFound = errors.New("multiple found")
 // Store defines the interface for an issuer store.
 // An implementation stores all the issued credentials and the revocations.
 type Store interface {
+	core.Diagnosable
 	// GetCredential retrieves an issued credential by ID
 	// Returns an ErrNotFound when the credential is not in the store
 	// Returns an ErrMultipleFound when there are multiple credentials with this ID in the store

--- a/vcr/issuer/leia_store.go
+++ b/vcr/issuer/leia_store.go
@@ -307,3 +307,33 @@ func (s leiaIssuerStore) createRevokedIndices(collection leia.Collection) error 
 		leia.NewFieldIndexer(leia.NewJSONPath(credential.RevocationSubjectPath)))
 	return s.revokedCredentials.AddIndex(revocationBySubjectIDIndex)
 }
+
+func (s leiaIssuerStore) Diagnostics() []core.DiagnosticResult {
+	var err error
+	var issuedCredentialCount int
+	issuedCredentialCount, err = s.issuedCredentials.DocumentCount()
+	if err != nil {
+		issuedCredentialCount = -1
+		log.Logger().
+			WithError(err).
+			Warn("unable to retrieve issuedCredentials document count")
+	}
+	var revokedCredentialsCount int
+	revokedCredentialsCount, err = s.revokedCredentials.DocumentCount()
+	if err != nil {
+		revokedCredentialsCount = -1
+		log.Logger().
+			WithError(err).
+			Warn("unable to retrieve revokedCredentials document count")
+	}
+	return []core.DiagnosticResult{
+		core.GenericDiagnosticResult{
+			Title:   "issued_credentials_count",
+			Outcome: issuedCredentialCount,
+		},
+		core.GenericDiagnosticResult{
+			Title:   "revoked_credentials_count",
+			Outcome: revokedCredentialsCount,
+		},
+	}
+}

--- a/vcr/issuer/mock.go
+++ b/vcr/issuer/mock.go
@@ -11,6 +11,7 @@ import (
 	ssi "github.com/nuts-foundation/go-did"
 	did "github.com/nuts-foundation/go-did/did"
 	vc "github.com/nuts-foundation/go-did/vc"
+	core "github.com/nuts-foundation/nuts-node/core"
 	crypto "github.com/nuts-foundation/nuts-node/crypto"
 	credential "github.com/nuts-foundation/nuts-node/vcr/credential"
 )
@@ -207,6 +208,20 @@ func (m *MockStore) Close() error {
 func (mr *MockStoreMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockStore)(nil).Close))
+}
+
+// Diagnostics mocks base method.
+func (m *MockStore) Diagnostics() []core.DiagnosticResult {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Diagnostics")
+	ret0, _ := ret[0].([]core.DiagnosticResult)
+	return ret0
+}
+
+// Diagnostics indicates an expected call of Diagnostics.
+func (mr *MockStoreMockRecorder) Diagnostics() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Diagnostics", reflect.TypeOf((*MockStore)(nil).Diagnostics))
 }
 
 // GetCredential mocks base method.

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -404,3 +404,29 @@ func (c *vcr) Untrusted(credentialType ssi.URI) ([]ssi.URI, error) {
 
 	return untrusted, nil
 }
+
+func (c *vcr) Diagnostics() []core.DiagnosticResult {
+	var credentialCount int
+	var err error
+	credentialCount, err = c.credentialCollection().DocumentCount()
+	if err != nil {
+		credentialCount = -1
+		log.Logger().
+			WithError(err).
+			Warn("unable to retrieve credential document count")
+	}
+	return []core.DiagnosticResult{
+		core.DiagnosticResultMap{
+			Title: "issuer",
+			Items: c.issuerStore.Diagnostics(),
+		},
+		core.DiagnosticResultMap{
+			Title: "verifier",
+			Items: c.verifierStore.Diagnostics(),
+		},
+		core.GenericDiagnosticResult{
+			Title:   "credential_count",
+			Outcome: credentialCount,
+		},
+	}
+}

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -111,6 +111,36 @@ func TestVCR_Start(t *testing.T) {
 	})
 }
 
+func TestVCR_Diagnostics(t *testing.T) {
+	testDirectory := io.TestDirectory(t)
+	instance := NewVCRInstance(
+		nil,
+		nil,
+		nil,
+		network.NewTestNetworkInstance(path.Join(testDirectory, "network")),
+		jsonld.NewTestJSONLDManager(t),
+		events.NewTestManager(t),
+		storage.NewTestStorageEngine(testDirectory),
+	).(*vcr)
+	if err := instance.Configure(core.TestServerConfig(core.ServerConfig{Datadir: testDirectory})); err != nil {
+		t.Fatal(err)
+	}
+	if err := instance.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer instance.Shutdown()
+
+	diagnostics := instance.Diagnostics()
+
+	assert.Len(t, diagnostics, 3)
+	assert.Equal(t, "issuer", diagnostics[0].Name())
+	assert.NotEmpty(t, diagnostics[0].Result())
+	assert.Equal(t, "verifier", diagnostics[1].Name())
+	assert.NotEmpty(t, diagnostics[1].Result())
+	assert.Equal(t, "credential_count", diagnostics[2].Name())
+	assert.Equal(t, 0, diagnostics[2].Result())
+}
+
 func TestVCR_Resolve(t *testing.T) {
 
 	testInstance := func(t2 *testing.T) mockContext {

--- a/vcr/verifier/interface.go
+++ b/vcr/verifier/interface.go
@@ -20,6 +20,7 @@ package verifier
 
 import (
 	"errors"
+	"github.com/nuts-foundation/nuts-node/core"
 	"io"
 	"time"
 
@@ -60,6 +61,7 @@ const verifiableCredentialType = "VerifiableCredential"
 // The store is filled with public information such as revoked credentials,
 // as well as local defined trust relations between issuer and credential type.
 type Store interface {
+	core.Diagnosable
 	// GetRevocations returns all revocations for a credential ID
 	// Returns an ErrNotFound when the revocation is not in the store
 	GetRevocations(id ssi.URI) ([]*credential.Revocation, error)

--- a/vcr/verifier/leia_store.go
+++ b/vcr/verifier/leia_store.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/nuts-foundation/nuts-node/core"
+	"github.com/nuts-foundation/nuts-node/vcr/log"
 
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-leia/v3"
@@ -92,4 +94,22 @@ func (s leiaVerifierStore) createIndices(collection leia.Collection) error {
 	revocationBySubjectIDIndex := collection.NewIndex("revocationBySubjectIDIndex",
 		leia.NewFieldIndexer(leia.NewJSONPath(credential.RevocationSubjectPath)))
 	return s.revocations.AddIndex(revocationBySubjectIDIndex)
+}
+
+func (s leiaVerifierStore) Diagnostics() []core.DiagnosticResult {
+	var count int
+	var err error
+	count, err = s.revocations.DocumentCount()
+	if err != nil {
+		count = -1
+		log.Logger().
+			WithError(err).
+			Warn("unable to retrieve revocations document count")
+	}
+	return []core.DiagnosticResult{
+		core.GenericDiagnosticResult{
+			Title:   "revocations_count",
+			Outcome: count,
+		},
+	}
 }

--- a/vcr/verifier/leia_store_test.go
+++ b/vcr/verifier/leia_store_test.go
@@ -91,3 +91,29 @@ func Test_leiaVerifierStore_GetRevocation(t *testing.T) {
 		assert.Nil(t, result)
 	})
 }
+
+func Test_leiaVerifierStore_Diagnostics(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		testDir := io.TestDirectory(t)
+		verifierStorePath := path.Join(testDir, "vcr", "verifier-store.db")
+		sut, _ := NewLeiaVerifierStore(verifierStorePath)
+
+		actual := sut.Diagnostics()
+		assert.Len(t, actual, 1)
+		assert.Equal(t, "revocations_count", actual[0].Name())
+		assert.Equal(t, 0, actual[0].Result())
+	})
+	t.Run("not empty", func(t *testing.T) {
+		testDir := io.TestDirectory(t)
+		verifierStorePath := path.Join(testDir, "vcr", "verifier-store.db")
+		sut, _ := NewLeiaVerifierStore(verifierStorePath)
+
+		subjectID := ssi.MustParseURI("did:nuts:123#ab-c")
+		revocation := &credential.Revocation{Subject: subjectID}
+		_ = sut.StoreRevocation(*revocation)
+
+		actual := sut.Diagnostics()
+		assert.Len(t, actual, 1)
+		assert.Equal(t, 1, actual[0].Result())
+	})
+}

--- a/vcr/verifier/mock.go
+++ b/vcr/verifier/mock.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	ssi "github.com/nuts-foundation/go-did"
 	vc "github.com/nuts-foundation/go-did/vc"
+	core "github.com/nuts-foundation/nuts-node/core"
 	credential "github.com/nuts-foundation/nuts-node/vcr/credential"
 )
 
@@ -159,6 +160,20 @@ func (m *MockStore) Close() error {
 func (mr *MockStoreMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockStore)(nil).Close))
+}
+
+// Diagnostics mocks base method.
+func (m *MockStore) Diagnostics() []core.DiagnosticResult {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Diagnostics")
+	ret0, _ := ret[0].([]core.DiagnosticResult)
+	return ret0
+}
+
+// Diagnostics indicates an expected call of Diagnostics.
+func (mr *MockStoreMockRecorder) Diagnostics() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Diagnostics", reflect.TypeOf((*MockStore)(nil).Diagnostics))
 }
 
 // GetRevocations mocks base method.


### PR DESCRIPTION
Closes https://github.com/nuts-foundation/nuts-node/issues/1432

E.g.:

```yaml
vcr:
    credential_count: 7
    issuer:
        issued_credentials_count: 0
        revoked_credentials_count: 0
    verifier:
        revocations_count: 18
```