### PR TITLE
Auth: improve publicURL error message

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -40,7 +40,7 @@ import (
 )
 
 // ErrMissingPublicURL is returned when the publicUrl is missing from the config
-var ErrMissingPublicURL = errors.New("missing publicUrl")
+var ErrMissingPublicURL = errors.New("auth.publicurl must be set in strictmode")
 
 const contractValidity = 60 * time.Minute
 


### PR DESCRIPTION
current message in logs:
`time="2022-09-13T15:18:54Z" level=error msg="missing publicUrl"`