### PR TITLE
Storage: support Redis Sentinel

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -60,16 +60,14 @@ func loadFromEnv(configMap *koanf.Koanf) error {
 		key := strings.Replace(strings.ToLower(strings.TrimPrefix(rawKey, defaultEnvPrefix)), defaultEnvDelimiter, defaultDelimiter, -1)
 
 		// Support multiple values separated by a comma
-		if strings.Contains(rawValue, configValueListSeparator) {
-			values := strings.Split(rawValue, configValueListSeparator)
-			for i, value := range values {
-				values[i] = strings.TrimSpace(value)
-			}
-			return key, values
+		values := splitWithEscaping(rawValue, configValueListSeparator, "\\")
+		for i, value := range values {
+			values[i] = strings.TrimSpace(value)
 		}
-
-		// Just a single value
-		return key, rawValue
+		if len(values) == 1 {
+			return key, values[0]
+		}
+		return key, values
 	})
 	return configMap.Load(e, nil)
 }
@@ -78,4 +76,14 @@ func loadFromEnv(configMap *koanf.Koanf) error {
 // Als sets default value for all flags in the provided pflag.FlagSet if the values do not yet exist in the configMap.
 func loadFromFlagSet(configMap *koanf.Koanf, flags *pflag.FlagSet) error {
 	return configMap.Load(posflag.Provider(flags, defaultDelimiter, configMap), nil)
+}
+
+// splitWithEscaping see https://codereview.stackexchange.com/questions/259270/golang-splitting-a-string-by-a-separator-not-prefixed-by-an-escape-string/259382
+func splitWithEscaping(s, separator, escape string) []string {
+	s = strings.ReplaceAll(s, escape+separator, "\x00")
+	tokens := strings.Split(s, separator)
+	for i, token := range tokens {
+		tokens[i] = strings.ReplaceAll(token, "\x00", separator)
+	}
+	return tokens
 }

--- a/core/config.go
+++ b/core/config.go
@@ -59,7 +59,7 @@ func loadFromEnv(configMap *koanf.Koanf) error {
 	e := env.ProviderWithValue(defaultEnvPrefix, defaultDelimiter, func(rawKey string, rawValue string) (string, interface{}) {
 		key := strings.Replace(strings.ToLower(strings.TrimPrefix(rawKey, defaultEnvPrefix)), defaultEnvDelimiter, defaultDelimiter, -1)
 
-		// Support multiple values separated by a comma
+		// Support multiple values separated by a comma, but let them be escaped with a backslash
 		values := splitWithEscaping(rawValue, configValueListSeparator, "\\")
 		for i, value := range values {
 			values[i] = strings.TrimSpace(value)

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -102,7 +102,7 @@ func Test_loadConfigIntoStruct(t *testing.T) {
 		assert.Equal(t, "nvironment", target.E)
 	})
 	t.Run("support for listed values from env and CLI", func(t *testing.T) {
-		os.Setenv("NUTS_LIST", "a, b, c,d")
+		os.Setenv("NUTS_LIST", ",a, b, c,d,value-\\,-with-escaped-comma,")
 		defer os.Unsetenv("NUTS_LIST")
 		flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
 		type Target struct {
@@ -114,7 +114,7 @@ func Test_loadConfigIntoStruct(t *testing.T) {
 		assert.NoError(t, loadFromEnv(configMap))
 		err := loadConfigIntoStruct(&target, configMap)
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"a", "b", "c", "d"}, target.List)
+		assert.Equal(t, []string{"", "a", "b", "c", "d", "value-,-with-escaped-comma", ""}, target.List)
 	})
 }
 

--- a/docs/pages/deployment/configuration.rst
+++ b/docs/pages/deployment/configuration.rst
@@ -31,6 +31,7 @@ is equal to ``$ nuts --engine.nested.parameter X`` is equal to ``$ NUTS_ENGINE_N
 
 While most options are a single value, some are represented as a list (indicated with the square brackets in the table below).
 To provide multiple values through flags or environment variables you can separate them with a comma (``var1,var2``).
+If you need to provide an actual value with a comma, you can escape it with a backslash (``\,``) to avoid it having split into multiple values.
 
 Ordering
 ********

--- a/docs/pages/deployment/storage-configuration.rst
+++ b/docs/pages/deployment/storage-configuration.rst
@@ -69,12 +69,6 @@ Since commas (``,``) are used to specify a list of values when configuring throu
 you need to escape them when you configure the Sentinel instances. You do so by escaping the comma with a backslash (``\,``).
 This does not apply to YAML configuration.
 
-.. code-block:: yaml
-
-    storage:
-      redis:
-        address: redis://instance1:1234,instance2:4321?sentinelMasterName=some-master-name
-
 Private Keys
 ************
 

--- a/docs/pages/deployment/storage-configuration.rst
+++ b/docs/pages/deployment/storage-configuration.rst
@@ -51,6 +51,30 @@ The server's certificate will be verified against the OS' CA bundle.
 
     Make sure to `configure persistence for your Redis server <https://redis.io/docs/manual/persistence/>`_.
 
+Redis Sentinel
+^^^^^^^^^^^^^^
+
+You can enable Redis Sentinel by providing ``sentinelMasterName`` as the connecting string parameter.
+Specify multiple Sentinel instance addresses separated by a comma.
+Other Sentinel-specific parameters that can be used in the connecting string are ``sentinelUsername`` and ``sentinelPassword``.
+Configuration and parameters not specific to Sentinel still apply.
+
+.. code-block:: yaml
+
+    storage:
+      redis:
+        address: redis://instance1:1234,instance2:4321?sentinelMasterName=some-master-name
+
+Since commas (``,``) are used to specify a list of values when configuring through environment variables or command line flags,
+you need to escape them when you configure the Sentinel instances. You do so by escaping the comma with a backslash (``\,``).
+This does not apply to YAML configuration.
+
+.. code-block:: yaml
+
+    storage:
+      redis:
+        address: redis://instance1:1234,instance2:4321?sentinelMasterName=some-master-name
+
 Private Keys
 ************
 

--- a/go.sum
+++ b/go.sum
@@ -594,6 +594,14 @@ github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b h1:80
 github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b/go.mod h1:6YUioYirD6/8IahZkoS4Ypc8xbeJW76Xdk1QKcziNTM=
 github.com/nuts-foundation/go-did v0.3.0 h1:uZoFnwiAlJgVWWsr8b7tJXSMUgW2bajaLANE0f43fu4=
 github.com/nuts-foundation/go-did v0.3.0/go.mod h1:MD2sE53BOvsQHZ9CmGI+EGXPUk1QiU9bUqB062y9+N8=
+github.com/nuts-foundation/go-leia/v3 v3.1.3 h1:Kfo0SOOEoKy4DJ0CkZMtGipc6JFqqaP4UTN4jKWlzGY=
+github.com/nuts-foundation/go-leia/v3 v3.1.3/go.mod h1:Md202F2wpwkXGtOUzyqs0p1Y96+wOY8lpmDT9nuaxE0=
+github.com/nuts-foundation/go-stoabs v1.0.0 h1:1T385ghGzM849VgXYrEIr2EABfIGtjNpRL9S7D/hgmg=
+github.com/nuts-foundation/go-stoabs v1.0.0/go.mod h1:FzYovtpUhAjYFaiVvgFfT06iF0+MRaTgcaqQ6MVIq7Y=
+github.com/nuts-foundation/go-stoabs v1.0.1-0.20220916100843-4ae7b4227d91 h1:N+CN9kt0S5qwd5u9dgCGfQt+JDjFKy/rmTIKXj2mxno=
+github.com/nuts-foundation/go-stoabs v1.0.1-0.20220916100843-4ae7b4227d91/go.mod h1:FzYovtpUhAjYFaiVvgFfT06iF0+MRaTgcaqQ6MVIq7Y=
+github.com/nuts-foundation/go-stoabs v1.0.1-0.20220916115949-8d4df96bbe0c h1:nn2znKB0RoURuonXMUydcPI1kLD/0bj7ks5iFC3rD7I=
+github.com/nuts-foundation/go-stoabs v1.0.1-0.20220916115949-8d4df96bbe0c/go.mod h1:FzYovtpUhAjYFaiVvgFfT06iF0+MRaTgcaqQ6MVIq7Y=
 github.com/nuts-foundation/go-leia/v3 v3.2.0 h1:Z2+QAcvM2A0wlfW0NYa7VcB+u9CE0MmoJm+TZZZqnVQ=
 github.com/nuts-foundation/go-leia/v3 v3.2.0/go.mod h1:Md202F2wpwkXGtOUzyqs0p1Y96+wOY8lpmDT9nuaxE0=
 github.com/nuts-foundation/go-stoabs v1.2.0 h1:HSFF71iQalZLRI41VkXSJHyP0gUIeAAY0Km2Gzb9cNA=

--- a/go.sum
+++ b/go.sum
@@ -596,12 +596,6 @@ github.com/nuts-foundation/go-did v0.3.0 h1:uZoFnwiAlJgVWWsr8b7tJXSMUgW2bajaLANE
 github.com/nuts-foundation/go-did v0.3.0/go.mod h1:MD2sE53BOvsQHZ9CmGI+EGXPUk1QiU9bUqB062y9+N8=
 github.com/nuts-foundation/go-leia/v3 v3.1.3 h1:Kfo0SOOEoKy4DJ0CkZMtGipc6JFqqaP4UTN4jKWlzGY=
 github.com/nuts-foundation/go-leia/v3 v3.1.3/go.mod h1:Md202F2wpwkXGtOUzyqs0p1Y96+wOY8lpmDT9nuaxE0=
-github.com/nuts-foundation/go-stoabs v1.0.0 h1:1T385ghGzM849VgXYrEIr2EABfIGtjNpRL9S7D/hgmg=
-github.com/nuts-foundation/go-stoabs v1.0.0/go.mod h1:FzYovtpUhAjYFaiVvgFfT06iF0+MRaTgcaqQ6MVIq7Y=
-github.com/nuts-foundation/go-stoabs v1.0.1-0.20220916100843-4ae7b4227d91 h1:N+CN9kt0S5qwd5u9dgCGfQt+JDjFKy/rmTIKXj2mxno=
-github.com/nuts-foundation/go-stoabs v1.0.1-0.20220916100843-4ae7b4227d91/go.mod h1:FzYovtpUhAjYFaiVvgFfT06iF0+MRaTgcaqQ6MVIq7Y=
-github.com/nuts-foundation/go-stoabs v1.0.1-0.20220916115949-8d4df96bbe0c h1:nn2znKB0RoURuonXMUydcPI1kLD/0bj7ks5iFC3rD7I=
-github.com/nuts-foundation/go-stoabs v1.0.1-0.20220916115949-8d4df96bbe0c/go.mod h1:FzYovtpUhAjYFaiVvgFfT06iF0+MRaTgcaqQ6MVIq7Y=
 github.com/nuts-foundation/go-leia/v3 v3.2.0 h1:Z2+QAcvM2A0wlfW0NYa7VcB+u9CE0MmoJm+TZZZqnVQ=
 github.com/nuts-foundation/go-leia/v3 v3.2.0/go.mod h1:Md202F2wpwkXGtOUzyqs0p1Y96+wOY8lpmDT9nuaxE0=
 github.com/nuts-foundation/go-stoabs v1.2.0 h1:HSFF71iQalZLRI41VkXSJHyP0gUIeAAY0Km2Gzb9cNA=

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/go-redis/redis/v9"
 	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/storage/log"
@@ -100,6 +101,7 @@ func (e *engine) Configure(config core.ServerConfig) error {
 		e.databases = append(e.databases, redisDB)
 		log.Logger().Info("Redis database support enabled.")
 		log.Logger().Warn("Redis database support is still experimental: do not use for production environments!")
+		redis.SetLogger(redisLogWriter{logger: log.Logger()})
 	}
 	bboltDB, err := createBBoltDatabase(config.Datadir, e.config.BBolt)
 	if err != nil {

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -27,17 +27,25 @@ import (
 	"github.com/nuts-foundation/go-stoabs/redis7"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/storage/log"
+	"net/url"
 	"path"
 	"strings"
 )
+
+const sentinelMasterNameParam = "sentinelMasterName"
+const sentinelUsernameParam = "sentinelUsername"
+const sentinelPasswordParam = "sentinelPassword"
+
+var sentinelParamKeys = []string{sentinelMasterNameParam, sentinelUsernameParam, sentinelPasswordParam}
 
 var redisTLSModifier = func(conf *tls.Config) {
 	// do nothing by default, used for testing
 }
 
 type redisDatabase struct {
-	databaseName string
-	options      *redis.Options
+	databaseName    string
+	options         *redis.Options
+	sentinelOptions *redis.FailoverOptions
 }
 
 // RedisConfig specifies config for Redis databases.
@@ -64,6 +72,95 @@ func createRedisDatabase(config RedisConfig) (*redisDatabase, error) {
 	if !isRedisURL(config.Address) {
 		config.Address = "redis://" + config.Address
 	}
+
+	// Redis Sentinel support: if sentinelMasterName is present in the connection URL, crete a Sentinel client.
+	sentinelOptions, err := parseRedisSentinelURL(config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to configure Redis Sentinel client: %w", err)
+	}
+	if sentinelOptions != nil {
+		return &redisDatabase{
+			sentinelOptions: sentinelOptions,
+			databaseName:    config.Database,
+		}, nil
+	}
+
+	// Regular Redis client
+	opts, err := parseRedisConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return &redisDatabase{
+		options:      opts,
+		databaseName: config.Database,
+	}, nil
+}
+
+// parseRedisSentinelURL parses connectionString as URL to see if Redis Sentinel support must be enabled.
+// If so, it returns true, the parsed URL without Sentinel options (because otherwise redis.ParseURL() would fail later on),
+// If the connectionString doesn't specify Redis Sentinel options, it returns false.
+func parseRedisSentinelURL(config RedisConfig) (*redis.FailoverOptions, error) {
+	//uriString := "redis://host1:1234,host2:4321?sentinelMasterName=bla"
+	// Errors return by url.Parse() are ignored, because they only happen in edge, extremely edge situations.
+	// We just return from the function, and the error occurs and gets captured again when using redis.ParseURL().
+	sentinelURI, _ := url.Parse(config.Address)
+	if sentinelURI == nil {
+		return nil, nil
+	}
+	masterName := sentinelURI.Query().Get(sentinelMasterNameParam)
+	if len(masterName) == 0 {
+		// Sentinel not enabled
+		return nil, nil
+	}
+
+	// Parse Redis options without Sentinel options, because they are unofficial
+	redisURI := *sentinelURI
+	newQuery := sentinelURI.Query()
+	for _, key := range sentinelParamKeys {
+		newQuery.Del(key)
+	}
+	redisURI.RawQuery = newQuery.Encode()
+	config.Address = redisURI.String()
+	opts, err := parseRedisConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse Sentinel addresses
+	sentinelAddrs := strings.Split(sentinelURI.Host, ",")
+
+	return &redis.FailoverOptions{
+		MasterName:       masterName,
+		SentinelAddrs:    sentinelAddrs,
+		SentinelUsername: sentinelURI.Query().Get(sentinelUsernameParam),
+		SentinelPassword: sentinelURI.Query().Get(sentinelPasswordParam),
+		Username:         opts.Username,
+		Password:         opts.Password,
+		DB:               opts.DB,
+		MaxRetries:       opts.MaxRetries,
+		MinRetryBackoff:  opts.MinRetryBackoff,
+		MaxRetryBackoff:  opts.MaxRetryBackoff,
+		DialTimeout:      opts.DialTimeout,
+		ReadTimeout:      opts.ReadTimeout,
+		WriteTimeout:     opts.WriteTimeout,
+		PoolFIFO:         opts.PoolFIFO,
+		PoolSize:         opts.PoolSize,
+		PoolTimeout:      opts.PoolTimeout,
+		MinIdleConns:     opts.MinIdleConns,
+		MaxIdleConns:     opts.MaxIdleConns,
+		ConnMaxIdleTime:  opts.ConnMaxIdleTime,
+		ConnMaxLifetime:  opts.ConnMaxLifetime,
+		TLSConfig:        opts.TLSConfig,
+	}, nil
+}
+
+func isRedisURL(address string) bool {
+	return strings.HasPrefix(address, "redis://") ||
+		strings.HasPrefix(address, "rediss://") ||
+		strings.HasPrefix(address, "unix://")
+}
+
+func parseRedisConfig(config RedisConfig) (*redis.Options, error) {
 	opts, err := redis.ParseURL(config.Address)
 	if err != nil {
 		return nil, err
@@ -89,17 +186,7 @@ func createRedisDatabase(config RedisConfig) (*redisDatabase, error) {
 		opts.TLSConfig.RootCAs = trustStore.CertPool
 	}
 	redisTLSModifier(opts.TLSConfig)
-
-	return &redisDatabase{
-		options:      opts,
-		databaseName: config.Database,
-	}, nil
-}
-
-func isRedisURL(address string) bool {
-	return strings.HasPrefix(address, "redis://") ||
-		strings.HasPrefix(address, "rediss://") ||
-		strings.HasPrefix(address, "unix://")
+	return opts, nil
 }
 
 func (b redisDatabase) createStore(moduleName string, storeName string) (stoabs.KVStore, error) {
@@ -113,7 +200,11 @@ func (b redisDatabase) createStore(moduleName string, storeName string) (stoabs.
 	prefixParts = append(prefixParts, moduleName)
 	prefixParts = append(prefixParts, storeName)
 	prefix := strings.ToLower(strings.Join(prefixParts, "_"))
-	return redis7.CreateRedisStore(prefix, b.options, stoabs.WithLockAcquireTimeout(lockAcquireTimeout))
+	opts := stoabs.WithLockAcquireTimeout(lockAcquireTimeout)
+	if b.sentinelOptions != nil {
+		return redis7.Wrap(prefix, redis.NewFailoverClient(b.sentinelOptions), opts)
+	}
+	return redis7.CreateRedisStore(prefix, b.options, opts)
 }
 
 func (b redisDatabase) getClass() Class {

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -19,6 +19,7 @@
 package storage
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -27,6 +28,7 @@ import (
 	"github.com/nuts-foundation/go-stoabs/redis7"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/storage/log"
+	"github.com/sirupsen/logrus"
 	"net/url"
 	"path"
 	"strings"
@@ -213,4 +215,16 @@ func (b redisDatabase) getClass() Class {
 
 func (b redisDatabase) close() {
 	// Nothing to do
+}
+
+// redisLogWriter is a wrapper to redirect redis log to our logger
+type redisLogWriter struct {
+	logger *logrus.Entry
+}
+
+// Printf expects entries in the form:
+// redis: sentinel.go:628: sentinel: new master="mymaster" addr="172.20.0.4:6379"
+// All logs are written as Warning
+func (t redisLogWriter) Printf(_ context.Context, format string, v ...interface{}) {
+	t.logger.Warnf(format, v...)
 }

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -131,6 +131,11 @@ func parseRedisSentinelURL(config RedisConfig) (*redis.FailoverOptions, error) {
 	// Parse Sentinel addresses
 	sentinelAddrs := strings.Split(sentinelURI.Host, ",")
 
+	// Make tls.Config.ServerName empty if set, since otherwise it will pin a single server name, but sentinel will connect to any/multiple.
+	if opts.TLSConfig != nil {
+		opts.TLSConfig.ServerName = ""
+	}
+
 	return &redis.FailoverOptions{
 		MasterName:       masterName,
 		SentinelAddrs:    sentinelAddrs,

--- a/storage/redis_test.go
+++ b/storage/redis_test.go
@@ -150,6 +150,7 @@ func Test_redisDatabase_createStore(t *testing.T) {
 		assert.Equal(t, "password", db.sentinelOptions.Password)
 		// Assert sentinel-specific options
 		assert.Equal(t, "master", db.sentinelOptions.MasterName)
+		assert.Empty(t, db.sentinelOptions.TLSConfig.ServerName)
 		assert.Equal(t, []string{"instance1:1234", "instance2:4321"}, db.sentinelOptions.SentinelAddrs)
 		assert.Equal(t, "sentinel-user", db.sentinelOptions.SentinelUsername)
 		assert.Equal(t, "sentinel-password", db.sentinelOptions.SentinelPassword)

--- a/storage/redis_test.go
+++ b/storage/redis_test.go
@@ -193,7 +193,7 @@ func Test_redisDatabase_createStore(t *testing.T) {
 		redis7.PingAttemptBackoff = 0
 		_, err = db.createStore("unit", "test")
 		// We don't have Sentinel support in Miniredis, but we can check that the client attempted to connect using Sentinel
-		assert.EqualError(t, err, "unable to connect to Redis database: redis: all sentinels specified in configuration are unreachable")
+		assert.EqualError(t, err, "unable to connect to Redis database: Database Error: redis: all sentinels specified in configuration are unreachable")
 	})
 }
 

--- a/storage/redis_test.go
+++ b/storage/redis_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"github.com/alicebob/miniredis/v2"
 	"github.com/nuts-foundation/go-stoabs"
+	"github.com/nuts-foundation/go-stoabs/redis7"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -128,6 +129,70 @@ func Test_redisDatabase_createStore(t *testing.T) {
 		})
 		assert.EqualError(t, err, "TLS configured but not connecting to a Redis TLS server")
 		assert.Nil(t, db)
+	})
+	t.Run("with Sentinel support", func(t *testing.T) {
+		db, err := createRedisDatabase(RedisConfig{
+			Address: "rediss://instance1:1234,instance2:4321?sentinelMasterName=master&sentinelUsername=sentinel-user&sentinelPassword=sentinel-password",
+			TLS: RedisTLSConfig{
+				TrustStoreFile: "test/truststore.pem",
+			},
+			Username: "username",
+			Password: "password",
+		})
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotNil(t, db.sentinelOptions)
+		// Assert non-sentinel-specific options are still parsed
+		assert.NotNil(t, db.sentinelOptions.TLSConfig)
+		assert.Equal(t, "username", db.sentinelOptions.Username)
+		assert.Equal(t, "password", db.sentinelOptions.Password)
+		// Assert sentinel-specific options
+		assert.Equal(t, "master", db.sentinelOptions.MasterName)
+		assert.Equal(t, []string{"instance1:1234", "instance2:4321"}, db.sentinelOptions.SentinelAddrs)
+		assert.Equal(t, "sentinel-user", db.sentinelOptions.SentinelUsername)
+		assert.Equal(t, "sentinel-password", db.sentinelOptions.SentinelPassword)
+	})
+	t.Run("with Sentinel support (connect)", func(t *testing.T) {
+		// Setup server-side TLS
+		cert, err := tls.LoadX509KeyPair("test/certificate.pem", "test/certificate.pem")
+		if !assert.NoError(t, err) {
+			return
+		}
+		redis, err := miniredis.RunTLS(&tls.Config{
+			Certificates: []tls.Certificate{cert},
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+		t.Cleanup(func() {
+			redis.Close()
+		})
+
+		// Setup client-side TLS config
+		redisTLSModifier = func(conf *tls.Config) {
+			conf.InsecureSkipVerify = true
+		}
+
+		db, err := createRedisDatabase(RedisConfig{
+			Address: "rediss://" + redis.Addr() + "?sentinelMasterName=master",
+			TLS: RedisTLSConfig{
+				TrustStoreFile: "test/truststore.pem",
+			},
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		oldPingAttemptBackoff := redis7.PingAttemptBackoff
+		defer func() {
+			redis7.PingAttemptBackoff = oldPingAttemptBackoff
+		}()
+		redis7.PingAttemptBackoff = 0
+		_, err = db.createStore("unit", "test")
+		// We don't have Sentinel support in Miniredis, but we can check that the client attempted to connect using Sentinel
+		assert.EqualError(t, err, "unable to connect to Redis database: redis: all sentinels specified in configuration are unreachable")
 	})
 }
 


### PR DESCRIPTION
This PR will add Redis Sentinel support.

Sentinel support is enabled when storage detects a Redis URL with sentinelMasterName as query parameter (see docs).
If Redis URL is configured through environment variables or commandline flags, commas separating sentinel hosts need to be escaped, otherwise the value is splitted into a []string. You can now prefix commas with a backslash to avoid splitting.

TODO:

- [x] Consider setting up an end-to-end test with Sentinel
- [x] Consider https://github.com/Bose/minisentinel to integration test (adds Sentinel support to miniredis, which we use for testing against in-memory/Golang Redis), but hasn't seen action in 3 years..
- [x] Make a 1.1.0 release of go-stoabs (introduced Wrap() function, but didn't release the library yet)

No additional tests will be performed for now, test manually and add a more elaborate setup in end-to-end tests later.

Fixes https://github.com/nuts-foundation/nuts-node/issues/1369