### PR TITLE
Storage: support Redis Sentinel (v4)

### DIFF
--- a/core/config_test.go
+++ b/core/config_test.go
@@ -102,7 +102,7 @@ func Test_loadConfigIntoStruct(t *testing.T) {
 		assert.Equal(t, "nvironment", target.E)
 	})
 	t.Run("support for listed values from env and CLI", func(t *testing.T) {
-		os.Setenv("NUTS_LIST", "a, b, c,d")
+		os.Setenv("NUTS_LIST", ",a, b, c,d,value-\\,-with-escaped-comma,")
 		defer os.Unsetenv("NUTS_LIST")
 		flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
 		type Target struct {
@@ -114,7 +114,7 @@ func Test_loadConfigIntoStruct(t *testing.T) {
 		assert.NoError(t, loadFromEnv(configMap))
 		err := loadConfigIntoStruct(flagSet, &target, configMap)
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"a", "b", "c", "d"}, target.List)
+		assert.Equal(t, []string{"", "a", "b", "c", "d", "value-,-with-escaped-comma", ""}, target.List)
 	})
 }
 

--- a/docs/pages/deployment/database-configuration.rst
+++ b/docs/pages/deployment/database-configuration.rst
@@ -43,6 +43,30 @@ The server's certificate will be verified against the OS' CA bundle.
 
 Make sure to `configure persistence for your Redis server <https://redis.io/docs/manual/persistence/>`_.
 
+Redis Sentinel
+^^^^^^^^^^^^^^
+
+You can enable Redis Sentinel by providing ``sentinelMasterName`` as the connecting string parameter.
+Specify multiple Sentinel instance addresses separated by a comma.
+Other Sentinel-specific parameters that can be used in the connecting string are ``sentinelUsername`` and ``sentinelPassword``.
+Configuration and parameters not specific to Sentinel still apply.
+
+.. code-block:: yaml
+
+    storage:
+      redis:
+        address: redis://instance1:1234,instance2:4321?sentinelMasterName=some-master-name
+
+Since commas (``,``) are used to specify a list of values when configuring through environment variables or command line flags,
+you need to escape them when you configure the Sentinel instances. You do so by escaping the comma with a backslash (``\,``).
+This does not apply to YAML configuration.
+
+.. code-block:: yaml
+
+    storage:
+      redis:
+        address: redis://instance1:1234,instance2:4321?sentinelMasterName=some-master-name
+
 Private Keys
 ************
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b
 	github.com/nuts-foundation/go-did v0.3.0
 	github.com/nuts-foundation/go-leia/v3 v3.1.3
-	github.com/nuts-foundation/go-stoabs v1.0.0
+	github.com/nuts-foundation/go-stoabs v1.0.1-0.20220916115949-8d4df96bbe0c
 	github.com/piprate/json-gold v0.4.1
 	github.com/privacybydesign/irmago v0.10.0
 	github.com/prometheus/client_golang v1.12.2

--- a/go.sum
+++ b/go.sum
@@ -591,6 +591,10 @@ github.com/nuts-foundation/go-leia/v3 v3.1.3 h1:Kfo0SOOEoKy4DJ0CkZMtGipc6JFqqaP4
 github.com/nuts-foundation/go-leia/v3 v3.1.3/go.mod h1:Md202F2wpwkXGtOUzyqs0p1Y96+wOY8lpmDT9nuaxE0=
 github.com/nuts-foundation/go-stoabs v1.0.0 h1:1T385ghGzM849VgXYrEIr2EABfIGtjNpRL9S7D/hgmg=
 github.com/nuts-foundation/go-stoabs v1.0.0/go.mod h1:FzYovtpUhAjYFaiVvgFfT06iF0+MRaTgcaqQ6MVIq7Y=
+github.com/nuts-foundation/go-stoabs v1.0.1-0.20220916100843-4ae7b4227d91 h1:N+CN9kt0S5qwd5u9dgCGfQt+JDjFKy/rmTIKXj2mxno=
+github.com/nuts-foundation/go-stoabs v1.0.1-0.20220916100843-4ae7b4227d91/go.mod h1:FzYovtpUhAjYFaiVvgFfT06iF0+MRaTgcaqQ6MVIq7Y=
+github.com/nuts-foundation/go-stoabs v1.0.1-0.20220916115949-8d4df96bbe0c h1:nn2znKB0RoURuonXMUydcPI1kLD/0bj7ks5iFC3rD7I=
+github.com/nuts-foundation/go-stoabs v1.0.1-0.20220916115949-8d4df96bbe0c/go.mod h1:FzYovtpUhAjYFaiVvgFfT06iF0+MRaTgcaqQ6MVIq7Y=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -27,17 +27,25 @@ import (
 	"github.com/nuts-foundation/go-stoabs/redis7"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/storage/log"
+	"net/url"
 	"path"
 	"strings"
 )
+
+const sentinelMasterNameParam = "sentinelMasterName"
+const sentinelUsernameParam = "sentinelUsername"
+const sentinelPasswordParam = "sentinelPassword"
+
+var sentinelParamKeys = []string{sentinelMasterNameParam, sentinelUsernameParam, sentinelPasswordParam}
 
 var redisTLSModifier = func(conf *tls.Config) {
 	// do nothing by default, used for testing
 }
 
 type redisDatabase struct {
-	databaseName string
-	options      *redis.Options
+	databaseName    string
+	options         *redis.Options
+	sentinelOptions *redis.FailoverOptions
 }
 
 // RedisConfig specifies config for Redis databases.
@@ -64,6 +72,100 @@ func createRedisDatabase(config RedisConfig) (*redisDatabase, error) {
 	if !isRedisURL(config.Address) {
 		config.Address = "redis://" + config.Address
 	}
+
+	// Redis Sentinel support: if sentinelMasterName is present in the connection URL, crete a Sentinel client.
+	sentinelOptions, err := parseRedisSentinelURL(config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to configure Redis Sentinel client: %w", err)
+	}
+	if sentinelOptions != nil {
+		return &redisDatabase{
+			sentinelOptions: sentinelOptions,
+			databaseName:    config.Database,
+		}, nil
+	}
+
+	// Regular Redis client
+	opts, err := parseRedisConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return &redisDatabase{
+		options:      opts,
+		databaseName: config.Database,
+	}, nil
+}
+
+// parseRedisSentinelURL parses connectionString as URL to see if Redis Sentinel support must be enabled.
+// If so, it returns true, the parsed URL without Sentinel options (because otherwise redis.ParseURL() would fail later on),
+// If the connectionString doesn't specify Redis Sentinel options, it returns false.
+func parseRedisSentinelURL(config RedisConfig) (*redis.FailoverOptions, error) {
+	//uriString := "redis://host1:1234,host2:4321?sentinelMasterName=bla"
+	// Errors return by url.Parse() are ignored, because they only happen in edge, extremely edge situations.
+	// We just return from the function, and the error occurs and gets captured again when using redis.ParseURL().
+	sentinelURI, _ := url.Parse(config.Address)
+	if sentinelURI == nil {
+		return nil, nil
+	}
+	masterName := sentinelURI.Query().Get(sentinelMasterNameParam)
+	if len(masterName) == 0 {
+		// Sentinel not enabled
+		return nil, nil
+	}
+
+	// Parse Redis options without Sentinel options, because they are unofficial
+	redisURI := *sentinelURI
+	newQuery := sentinelURI.Query()
+	for _, key := range sentinelParamKeys {
+		newQuery.Del(key)
+	}
+	redisURI.RawQuery = newQuery.Encode()
+	config.Address = redisURI.String()
+	opts, err := parseRedisConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse Sentinel addresses
+	sentinelAddrs := strings.Split(sentinelURI.Host, ",")
+
+	// Make tls.Config.ServerName empty if set, since otherwise it will pin a single server name, but sentinel will connect to any/multiple.
+	if opts.TLSConfig != nil {
+		opts.TLSConfig.ServerName = ""
+	}
+
+	return &redis.FailoverOptions{
+		MasterName:       masterName,
+		SentinelAddrs:    sentinelAddrs,
+		SentinelUsername: sentinelURI.Query().Get(sentinelUsernameParam),
+		SentinelPassword: sentinelURI.Query().Get(sentinelPasswordParam),
+		Username:         opts.Username,
+		Password:         opts.Password,
+		DB:               opts.DB,
+		MaxRetries:       opts.MaxRetries,
+		MinRetryBackoff:  opts.MinRetryBackoff,
+		MaxRetryBackoff:  opts.MaxRetryBackoff,
+		DialTimeout:      opts.DialTimeout,
+		ReadTimeout:      opts.ReadTimeout,
+		WriteTimeout:     opts.WriteTimeout,
+		PoolFIFO:         opts.PoolFIFO,
+		PoolSize:         opts.PoolSize,
+		PoolTimeout:      opts.PoolTimeout,
+		MinIdleConns:     opts.MinIdleConns,
+		MaxIdleConns:     opts.MaxIdleConns,
+		ConnMaxIdleTime:  opts.ConnMaxIdleTime,
+		ConnMaxLifetime:  opts.ConnMaxLifetime,
+		TLSConfig:        opts.TLSConfig,
+	}, nil
+}
+
+func isRedisURL(address string) bool {
+	return strings.HasPrefix(address, "redis://") ||
+		strings.HasPrefix(address, "rediss://") ||
+		strings.HasPrefix(address, "unix://")
+}
+
+func parseRedisConfig(config RedisConfig) (*redis.Options, error) {
 	opts, err := redis.ParseURL(config.Address)
 	if err != nil {
 		return nil, err
@@ -89,17 +191,7 @@ func createRedisDatabase(config RedisConfig) (*redisDatabase, error) {
 		opts.TLSConfig.RootCAs = trustStore.CertPool
 	}
 	redisTLSModifier(opts.TLSConfig)
-
-	return &redisDatabase{
-		options:      opts,
-		databaseName: config.Database,
-	}, nil
-}
-
-func isRedisURL(address string) bool {
-	return strings.HasPrefix(address, "redis://") ||
-		strings.HasPrefix(address, "rediss://") ||
-		strings.HasPrefix(address, "unix://")
+	return opts, nil
 }
 
 func (b redisDatabase) createStore(moduleName string, storeName string) (stoabs.KVStore, error) {
@@ -113,7 +205,11 @@ func (b redisDatabase) createStore(moduleName string, storeName string) (stoabs.
 	prefixParts = append(prefixParts, moduleName)
 	prefixParts = append(prefixParts, storeName)
 	prefix := strings.ToLower(strings.Join(prefixParts, "_"))
-	return redis7.CreateRedisStore(prefix, b.options, stoabs.WithLockAcquireTimeout(lockAcquireTimeout))
+	opts := stoabs.WithLockAcquireTimeout(lockAcquireTimeout)
+	if b.sentinelOptions != nil {
+		return redis7.Wrap(prefix, redis.NewFailoverClient(b.sentinelOptions), opts)
+	}
+	return redis7.CreateRedisStore(prefix, b.options, opts)
 }
 
 func (b redisDatabase) getClass() Class {

--- a/storage/redis_test.go
+++ b/storage/redis_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"github.com/alicebob/miniredis/v2"
 	"github.com/nuts-foundation/go-stoabs"
+	"github.com/nuts-foundation/go-stoabs/redis7"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -128,6 +129,71 @@ func Test_redisDatabase_createStore(t *testing.T) {
 		})
 		assert.EqualError(t, err, "TLS configured but not connecting to a Redis TLS server")
 		assert.Nil(t, db)
+	})
+	t.Run("with sentinel support", func(t *testing.T) {
+		db, err := createRedisDatabase(RedisConfig{
+			Address: "rediss://instance1:1234,instance2:4321?sentinelMasterName=master&sentinelUsername=sentinel-user&sentinelPassword=sentinel-password",
+			TLS: RedisTLSConfig{
+				TrustStoreFile: "test/truststore.pem",
+			},
+			Username: "username",
+			Password: "password",
+		})
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotNil(t, db.sentinelOptions)
+		// Assert non-sentinel-specific options are still parsed
+		assert.NotNil(t, db.sentinelOptions.TLSConfig)
+		assert.Equal(t, "username", db.sentinelOptions.Username)
+		assert.Equal(t, "password", db.sentinelOptions.Password)
+		// Assert sentinel-specific options
+		assert.Equal(t, "master", db.sentinelOptions.MasterName)
+		assert.Empty(t, db.sentinelOptions.TLSConfig.ServerName)
+		assert.Equal(t, []string{"instance1:1234", "instance2:4321"}, db.sentinelOptions.SentinelAddrs)
+		assert.Equal(t, "sentinel-user", db.sentinelOptions.SentinelUsername)
+		assert.Equal(t, "sentinel-password", db.sentinelOptions.SentinelPassword)
+	})
+	t.Run("with Sentinel support (connect)", func(t *testing.T) {
+		// Setup server-side TLS
+		cert, err := tls.LoadX509KeyPair("test/certificate.pem", "test/certificate.pem")
+		if !assert.NoError(t, err) {
+			return
+		}
+		redis, err := miniredis.RunTLS(&tls.Config{
+			Certificates: []tls.Certificate{cert},
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+		t.Cleanup(func() {
+			redis.Close()
+		})
+
+		// Setup client-side TLS config
+		redisTLSModifier = func(conf *tls.Config) {
+			conf.InsecureSkipVerify = true
+		}
+
+		db, err := createRedisDatabase(RedisConfig{
+			Address: "rediss://" + redis.Addr() + "?sentinelMasterName=master",
+			TLS: RedisTLSConfig{
+				TrustStoreFile: "test/truststore.pem",
+			},
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		oldPingAttemptBackoff := redis7.PingAttemptBackoff
+		defer func() {
+			redis7.PingAttemptBackoff = oldPingAttemptBackoff
+		}()
+		redis7.PingAttemptBackoff = 0
+		_, err = db.createStore("unit", "test")
+		// We don't have Sentinel support in Miniredis, but we can check that the client attempted to connect using Sentinel
+		assert.EqualError(t, err, "unable to connect to Redis database: redis: all sentinels specified in configuration are unreachable")
 	})
 }
 


### PR DESCRIPTION
This PR will add Redis Sentinel support to v4. After merging, it will have to be applied to master as well!

Sentinel support is enabled when storage detects a Redis URL with `sentinelMasterName` as query parameter (see docs).

Changes:

- [ ] Requires config with commas, but these were splitted into a `[]string`. You can now prefix commas with a backslash to avoid splitting.

TODO:

- [ ] Test it with Sentinel (@jelmerterwal reported `redis: <date> pubsub.go:159: redis: discarding bad PubSub connection: read tcp <masked>:<masked>-><masked>:<masked>: i/o timeout`)
- [x] Make a 1.1.0 release of `go-stoabs` (introduced `Wrap()` function, but didn't release the library yet)
- [ ] Consider https://github.com/Bose/minisentinel to integration test (adds Sentinel support to miniredis, which we use for testing against in-memory/Golang Redis), but hasn't seen action in 3 years..

Fixes https://github.com/nuts-foundation/nuts-node/issues/1369