### PR TITLE
Fix vault memory error

### DIFF
--- a/crypto/storage/vault.go
+++ b/crypto/storage/vault.go
@@ -155,12 +155,8 @@ func (v vaultKVStorage) storeValue(path, key string, value string) error {
 
 func (v vaultKVStorage) PrivateKeyExists(kid string) bool {
 	path := privateKeyPath(v.config.PathPrefix, kid)
-	result, err := v.client.Read(path)
-	if err != nil {
-		return false
-	}
-	_, ok := result.Data[keyName]
-	return ok
+	_, err := v.getValue(path, keyName)
+	return err == nil
 }
 
 func (v vaultKVStorage) ListPrivateKeys() []string {

--- a/crypto/storage/vault_test.go
+++ b/crypto/storage/vault_test.go
@@ -41,8 +41,12 @@ func (m mockVaultClient) Read(path string) (*vault.Secret, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
+	data, ok := m.store[path]
+	if !ok {
+		return nil, nil
+	}
 	return &vault.Secret{
-		Data: m.store[path],
+		Data: data,
 	}, nil
 }
 
@@ -105,6 +109,9 @@ func TestVaultKVStorage(t *testing.T) {
 		_, err := vaultStorage.GetPrivateKey(kid)
 		assert.Error(t, err, "expected error on unknown kid")
 		assert.EqualError(t, err, "key not found")
+
+		exists := vaultStorage.PrivateKeyExists(kid)
+		assert.False(t, exists)
 	})
 
 	t.Run("error - key not found (key not present in data field)", func(t *testing.T) {
@@ -115,6 +122,9 @@ func TestVaultKVStorage(t *testing.T) {
 		_, err := vaultStorage.GetPrivateKey(kid)
 		assert.Error(t, err, "expected error on unknown kid")
 		assert.EqualError(t, err, "key not found")
+
+		exists := vaultStorage.PrivateKeyExists(kid)
+		assert.False(t, exists)
 	})
 
 	t.Run("error - encoding issues", func(t *testing.T) {


### PR DESCRIPTION
Reuse the getValue logic which handles errors correct. Fix mock to mimic vault implementation behaviour.