### PR TITLE
JSON web messages part 1

### DIFF
--- a/crypto/api/v1/api.go
+++ b/crypto/api/v1/api.go
@@ -69,9 +69,11 @@ func (signRequest SignJwsRequest) validate() error {
 	if len(signRequest.Kid) == 0 {
 		return errors.New("missing kid")
 	}
-
-	if len(signRequest.Claims) == 0 {
-		return errors.New("missing claims")
+	if signRequest.Headers == nil {
+		return errors.New("missing headers")
+	}
+	if signRequest.Payload == nil {
+		return errors.New("missing payload")
 	}
 
 	return nil
@@ -115,7 +117,8 @@ func (w *Wrapper) SignJws(ctx echo.Context) error {
 	if signRequest.Detached != nil {
 		detached = *signRequest.Detached
 	}
-	sig, err := w.C.SignJWS(signRequest.Headers, signRequest.Claims, signRequest.Kid, detached)
+
+	sig, err := w.C.SignJWS(signRequest.Headers, signRequest.Payload, signRequest.Kid, detached)
 	if err != nil {
 		return err
 	}

--- a/crypto/api/v1/api.go
+++ b/crypto/api/v1/api.go
@@ -118,7 +118,7 @@ func (w *Wrapper) SignJws(ctx echo.Context) error {
 		detached = *signRequest.Detached
 	}
 
-	sig, err := w.C.SignJWS(signRequest.Headers, signRequest.Payload, signRequest.Kid, detached)
+	sig, err := w.C.SignJWS(signRequest.Payload, signRequest.Headers, signRequest.Kid, detached)
 	if err != nil {
 		return err
 	}

--- a/crypto/api/v1/api.go
+++ b/crypto/api/v1/api.go
@@ -103,6 +103,7 @@ func (w *Wrapper) SignJwt(ctx echo.Context) error {
 	return ctx.String(http.StatusOK, sig)
 }
 
+// SignJws handles api calls for signing a JWS
 func (w *Wrapper) SignJws(ctx echo.Context) error {
 	var signRequest = &SignJwsRequest{}
 	err := ctx.Bind(signRequest)

--- a/crypto/api/v1/api_test.go
+++ b/crypto/api/v1/api_test.go
@@ -141,10 +141,12 @@ func TestWrapper_SignJwt(t *testing.T) {
 }
 
 func TestWrapper_SignJws(t *testing.T) {
+	payload, _ := json.Marshal(map[string]interface{}{"iss": "nuts"})
+	headers := map[string]interface{}{"typ": "JWM"}
+
 	t.Run("Missing kid returns 400", func(t *testing.T) {
 		ctx := newMockContext(t)
 		defer ctx.ctrl.Finish()
-		payload, _ := json.Marshal(map[string]interface{}{"iss": "nuts"})
 		jsonRequest := SignJwsRequest{
 			Payload: payload,
 		}
@@ -162,11 +164,10 @@ func TestWrapper_SignJws(t *testing.T) {
 	t.Run("error - SignJWS fails", func(t *testing.T) {
 		ctx := newMockContext(t)
 		defer ctx.ctrl.Finish()
-		payload, _ := json.Marshal(map[string]interface{}{"iss": "nuts"})
 		jsonRequest := SignJwsRequest{
 			Kid:     "kid",
 			Payload: payload,
-			Headers: map[string]interface{}{"typ": "JWM"},
+			Headers: headers,
 		}
 		jsonData, _ := json.Marshal(jsonRequest)
 
@@ -183,10 +184,9 @@ func TestWrapper_SignJws(t *testing.T) {
 	t.Run("All OK returns 200, with payload", func(t *testing.T) {
 		ctx := newMockContext(t)
 		defer ctx.ctrl.Finish()
-		payload, _ := json.Marshal(map[string]interface{}{"iss": "nuts"})
 		jsonRequest := SignJwsRequest{
 			Kid:     "kid",
-			Headers: map[string]interface{}{"typ": "JWM"},
+			Headers: headers,
 			Payload: payload,
 		}
 
@@ -206,11 +206,10 @@ func TestWrapper_SignJws(t *testing.T) {
 	t.Run("All OK returns 200, with payload, detached", func(t *testing.T) {
 		ctx := newMockContext(t)
 		defer ctx.ctrl.Finish()
-		payload, _ := json.Marshal(map[string]interface{}{"iss": "nuts"})
 		detached := true
 		jsonRequest := SignJwsRequest{
 			Kid:      "kid",
-			Headers:  map[string]interface{}{"typ": "JWM"},
+			Headers:  headers,
 			Payload:  payload,
 			Detached: &detached,
 		}

--- a/crypto/api/v1/api_test.go
+++ b/crypto/api/v1/api_test.go
@@ -141,25 +141,6 @@ func TestWrapper_SignJwt(t *testing.T) {
 }
 
 func TestWrapper_SignJws(t *testing.T) {
-	t.Run("error - no payload", func(t *testing.T) {
-		ctx := newMockContext(t)
-		defer ctx.ctrl.Finish()
-
-		jsonRequest := SignJwsRequest{
-			Kid:     "kid",
-			Headers: map[string]interface{}{"typ": "JWM"},
-		}
-		jsonData, _ := json.Marshal(jsonRequest)
-
-		ctx.echo.EXPECT().Bind(gomock.Any()).Do(func(f interface{}) {
-			_ = json.Unmarshal(jsonData, f)
-		})
-
-		err := ctx.client.SignJws(ctx.echo)
-
-		assert.EqualError(t, err, "invalid sign request: missing payload")
-	})
-
 	t.Run("Missing kid returns 400", func(t *testing.T) {
 		ctx := newMockContext(t)
 		defer ctx.ctrl.Finish()
@@ -197,26 +178,6 @@ func TestWrapper_SignJws(t *testing.T) {
 		err := ctx.client.SignJws(ctx.echo)
 
 		assert.EqualError(t, err, "b00m!")
-	})
-
-	t.Run("error - no headers", func(t *testing.T) {
-		ctx := newMockContext(t)
-		defer ctx.ctrl.Finish()
-		payload, _ := json.Marshal(map[string]interface{}{"iss": "nuts"})
-		jsonRequest := SignJwsRequest{
-			Kid:     "kid",
-			Payload: payload,
-		}
-
-		jsonData, _ := json.Marshal(jsonRequest)
-
-		ctx.echo.EXPECT().Bind(gomock.Any()).Do(func(f interface{}) {
-			_ = json.Unmarshal(jsonData, f)
-		})
-
-		err := ctx.client.SignJws(ctx.echo)
-
-		assert.EqualError(t, err, "invalid sign request: missing headers")
 	})
 
 	t.Run("All OK returns 200, with payload", func(t *testing.T) {

--- a/crypto/api/v1/generated.go
+++ b/crypto/api/v1/generated.go
@@ -21,14 +21,28 @@ const (
 	JwtBearerAuthScopes = "jwtBearerAuth.Scopes"
 )
 
+// SignJwsRequest defines model for SignJwsRequest.
+type SignJwsRequest struct {
+	Claims   map[string]interface{} `json:"claims"`
+	Detached *bool                  `json:"detached,omitempty"`
+	Headers  map[string]interface{} `json:"headers"`
+	Kid      string                 `json:"kid"`
+}
+
 // SignJwtRequest defines model for SignJwtRequest.
 type SignJwtRequest struct {
 	Claims map[string]interface{} `json:"claims"`
 	Kid    string                 `json:"kid"`
 }
 
+// SignJwsJSONBody defines parameters for SignJws.
+type SignJwsJSONBody = SignJwsRequest
+
 // SignJwtJSONBody defines parameters for SignJwt.
 type SignJwtJSONBody = SignJwtRequest
+
+// SignJwsJSONRequestBody defines body for SignJws for application/json ContentType.
+type SignJwsJSONRequestBody = SignJwsJSONBody
 
 // SignJwtJSONRequestBody defines body for SignJwt for application/json ContentType.
 type SignJwtJSONRequestBody = SignJwtJSONBody
@@ -106,10 +120,39 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 
 // The interface specification for the client above.
 type ClientInterface interface {
+	// SignJws request with any body
+	SignJwsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SignJws(ctx context.Context, body SignJwsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// SignJwt request with any body
 	SignJwtWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	SignJwt(ctx context.Context, body SignJwtJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+}
+
+func (c *Client) SignJwsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSignJwsRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SignJws(ctx context.Context, body SignJwsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSignJwsRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 }
 
 func (c *Client) SignJwtWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -134,6 +177,46 @@ func (c *Client) SignJwt(ctx context.Context, body SignJwtJSONRequestBody, reqEd
 		return nil, err
 	}
 	return c.Client.Do(req)
+}
+
+// NewSignJwsRequest calls the generic SignJws builder with application/json body
+func NewSignJwsRequest(server string, body SignJwsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSignJwsRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewSignJwsRequestWithBody generates requests for SignJws with any type of body
+func NewSignJwsRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/internal/crypto/v1/sign_jws")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
 }
 
 // NewSignJwtRequest calls the generic SignJwt builder with application/json body
@@ -219,10 +302,36 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
+	// SignJws request with any body
+	SignJwsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SignJwsResponse, error)
+
+	SignJwsWithResponse(ctx context.Context, body SignJwsJSONRequestBody, reqEditors ...RequestEditorFn) (*SignJwsResponse, error)
+
 	// SignJwt request with any body
 	SignJwtWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SignJwtResponse, error)
 
 	SignJwtWithResponse(ctx context.Context, body SignJwtJSONRequestBody, reqEditors ...RequestEditorFn) (*SignJwtResponse, error)
+}
+
+type SignJwsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r SignJwsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SignJwsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
 }
 
 type SignJwtResponse struct {
@@ -246,6 +355,23 @@ func (r SignJwtResponse) StatusCode() int {
 	return 0
 }
 
+// SignJwsWithBodyWithResponse request with arbitrary body returning *SignJwsResponse
+func (c *ClientWithResponses) SignJwsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SignJwsResponse, error) {
+	rsp, err := c.SignJwsWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSignJwsResponse(rsp)
+}
+
+func (c *ClientWithResponses) SignJwsWithResponse(ctx context.Context, body SignJwsJSONRequestBody, reqEditors ...RequestEditorFn) (*SignJwsResponse, error) {
+	rsp, err := c.SignJws(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSignJwsResponse(rsp)
+}
+
 // SignJwtWithBodyWithResponse request with arbitrary body returning *SignJwtResponse
 func (c *ClientWithResponses) SignJwtWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SignJwtResponse, error) {
 	rsp, err := c.SignJwtWithBody(ctx, contentType, body, reqEditors...)
@@ -261,6 +387,22 @@ func (c *ClientWithResponses) SignJwtWithResponse(ctx context.Context, body Sign
 		return nil, err
 	}
 	return ParseSignJwtResponse(rsp)
+}
+
+// ParseSignJwsResponse parses an HTTP response from a SignJwsWithResponse call
+func ParseSignJwsResponse(rsp *http.Response) (*SignJwsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SignJwsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
 }
 
 // ParseSignJwtResponse parses an HTTP response from a SignJwtWithResponse call
@@ -281,6 +423,9 @@ func ParseSignJwtResponse(rsp *http.Response) (*SignJwtResponse, error) {
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// sign a payload and headers with the private key of the given kid into a JWS object
+	// (POST /internal/crypto/v1/sign_jws)
+	SignJws(ctx echo.Context) error
 	// sign a JWT payload with the private key of the given kid
 	// (POST /internal/crypto/v1/sign_jwt)
 	SignJwt(ctx echo.Context) error
@@ -289,6 +434,17 @@ type ServerInterface interface {
 // ServerInterfaceWrapper converts echo contexts to parameters.
 type ServerInterfaceWrapper struct {
 	Handler ServerInterface
+}
+
+// SignJws converts echo context to params.
+func (w *ServerInterfaceWrapper) SignJws(ctx echo.Context) error {
+	var err error
+
+	ctx.Set(JwtBearerAuthScopes, []string{""})
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.SignJws(ctx)
+	return err
 }
 
 // SignJwt converts echo context to params.
@@ -342,6 +498,10 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 
 	// PATCH: This alteration wraps the call to the implementation in a function that sets the "OperationId" context parameter,
 	// so it can be used in error reporting middleware.
+	router.POST(baseURL+"/internal/crypto/v1/sign_jws", func(context echo.Context) error {
+		si.(Preprocessor).Preprocess("SignJws", context)
+		return wrapper.SignJws(context)
+	})
 	router.POST(baseURL+"/internal/crypto/v1/sign_jwt", func(context echo.Context) error {
 		si.(Preprocessor).Preprocess("SignJwt", context)
 		return wrapper.SignJwt(context)

--- a/crypto/api/v1/generated.go
+++ b/crypto/api/v1/generated.go
@@ -23,7 +23,7 @@ const (
 
 // SignJwsRequest defines model for SignJwsRequest.
 type SignJwsRequest struct {
-	// In detached mode the payload is signed but NOT included in the retured JWS object. Instead, the space between the first and second dot is empty, for example: <header>..<signature> Defaults to false.
+	// In detached mode the payload is signed but NOT included in the returned JWS object. Instead, the space between the first and second dot is empty, like this: "<header>..<signature>". Defaults to false.
 	Detached *bool `json:"detached,omitempty"`
 
 	// The map of protected headers
@@ -32,7 +32,7 @@ type SignJwsRequest struct {
 	// Reference to the key ID used for signing the JWS.
 	Kid string `json:"kid"`
 
-	// The object to be signed as bytes. The bytes encoded as base64 characters.
+	// The payload to be signed as bytes. The bytes must be encoded with base64 encoding.
 	Payload []byte `json:"payload"`
 }
 

--- a/crypto/api/v1/generated.go
+++ b/crypto/api/v1/generated.go
@@ -23,10 +23,17 @@ const (
 
 // SignJwsRequest defines model for SignJwsRequest.
 type SignJwsRequest struct {
-	Claims   map[string]interface{} `json:"claims"`
-	Detached *bool                  `json:"detached,omitempty"`
-	Headers  map[string]interface{} `json:"headers"`
-	Kid      string                 `json:"kid"`
+	// In detached mode the payload is signed but NOT included in the retured JWS object. Instead, the space between the first and second dot is empty, for example: <header>..<signature> Defaults to false.
+	Detached *bool `json:"detached,omitempty"`
+
+	// The map of protected headers
+	Headers map[string]interface{} `json:"headers"`
+
+	// Reference to the key ID used for signing the JWS.
+	Kid string `json:"kid"`
+
+	// The object to be signed as bytes. The bytes encoded as base64 characters.
+	Payload []byte `json:"payload"`
 }
 
 // SignJwtRequest defines model for SignJwtRequest.

--- a/crypto/api/v1/generated_test.go
+++ b/crypto/api/v1/generated_test.go
@@ -42,6 +42,10 @@ func (t *testServerInterface) SignJwt(_ echo.Context) error {
 	return t.err
 }
 
+func (t *testServerInterface) SignJws(_ echo.Context) error {
+	return t.err
+}
+
 var siws = []*ServerInterfaceWrapper{
 	serverInterfaceWrapper(nil), serverInterfaceWrapper(errors.New("Server error")),
 }
@@ -67,6 +71,7 @@ func TestRegisterHandlers(t *testing.T) {
 		echo := core.NewMockEchoRouter(ctrl)
 
 		echo.EXPECT().POST("/internal/crypto/v1/sign_jwt", gomock.Any())
+		echo.EXPECT().POST("/internal/crypto/v1/sign_jws", gomock.Any())
 
 		RegisterHandlers(echo, &testServerInterface{})
 	})

--- a/crypto/interface.go
+++ b/crypto/interface.go
@@ -66,6 +66,9 @@ type JWTSigner interface {
 	// SignJWT creates a signed JWT using the indicated key and map of claims.
 	// Returns ErrPrivateKeyNotFound when indicated private key is not present.
 	SignJWT(claims map[string]interface{}, kid string) (string, error)
+	// SignJWS creates a signed JWS using the indicated key and map of headers and map of claims.
+	// Returns ErrPrivateKeyNotFound when indicated private key is not present.
+	SignJWS(headers, claims map[string]interface{}, kid string, detached bool) (string, error)
 }
 
 // Key is a helper interface which holds a crypto.Signer, KID and public key for a key.

--- a/crypto/interface.go
+++ b/crypto/interface.go
@@ -68,7 +68,7 @@ type JWTSigner interface {
 	SignJWT(claims map[string]interface{}, kid string) (string, error)
 	// SignJWS creates a signed JWS using the indicated key and map of headers and map of claims.
 	// Returns ErrPrivateKeyNotFound when indicated private key is not present.
-	SignJWS(headers, claims map[string]interface{}, kid string, detached bool) (string, error)
+	SignJWS(headers map[string]interface{}, payload []byte, kid string, detached bool) (string, error)
 }
 
 // Key is a helper interface which holds a crypto.Signer, KID and public key for a key.

--- a/crypto/interface.go
+++ b/crypto/interface.go
@@ -66,9 +66,10 @@ type JWTSigner interface {
 	// SignJWT creates a signed JWT using the indicated key and map of claims.
 	// Returns ErrPrivateKeyNotFound when indicated private key is not present.
 	SignJWT(claims map[string]interface{}, kid string) (string, error)
-	// SignJWS creates a signed JWS using the indicated key and map of headers and map of claims.
+	// SignJWS creates a signed JWS using the indicated key and map of headers and payload as bytes.
+	// The detached boolean indicates if the body needs to be excluded from the response (detached mode).
 	// Returns ErrPrivateKeyNotFound when indicated private key is not present.
-	SignJWS(headers map[string]interface{}, payload []byte, kid string, detached bool) (string, error)
+	SignJWS(payload []byte, headers map[string]interface{}, kid string, detached bool) (string, error)
 }
 
 // Key is a helper interface which holds a crypto.Signer, KID and public key for a key.

--- a/crypto/jwx.go
+++ b/crypto/jwx.go
@@ -74,7 +74,7 @@ func (client *Crypto) SignJWT(claims map[string]interface{}, kid string) (token 
 }
 
 // SignJWS creates a signed JWS given a kid, map of headers and map of claims
-func (client *Crypto) SignJWS(headers, claims map[string]interface{}, kid string, detached bool) (token string, err error) {
+func (client *Crypto) SignJWS(headers map[string]interface{}, payload []byte, kid string, detached bool) (token string, err error) {
 	if err = validateKID(kid); err != nil {
 		return "", err
 	}
@@ -94,14 +94,9 @@ func (client *Crypto) SignJWS(headers, claims map[string]interface{}, kid string
 		return "", err
 	}
 
-	body, err := json.Marshal(claims)
-	if err != nil {
-		return "", err
-	}
-
 	headers[jws.KeyIDKey] = key.KeyID()
 
-	token, err = signJWS(body, headers, privateKey, detached)
+	token, err = signJWS(payload, headers, privateKey, detached)
 	return token, err
 }
 

--- a/crypto/jwx.go
+++ b/crypto/jwx.go
@@ -73,8 +73,8 @@ func (client *Crypto) SignJWT(claims map[string]interface{}, kid string) (token 
 	return
 }
 
-// SignJWS creates a signed JWS given a kid, map of headers and map of claims
-func (client *Crypto) SignJWS(headers map[string]interface{}, payload []byte, kid string, detached bool) (token string, err error) {
+// SignJWS creates a signed JWS using the indicated key and map of headers and payload as bytes.
+func (client *Crypto) SignJWS(payload []byte, headers map[string]interface{}, kid string, detached bool) (token string, err error) {
 	if err = validateKID(kid); err != nil {
 		return "", err
 	}

--- a/crypto/jwx.go
+++ b/crypto/jwx.go
@@ -23,7 +23,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/lestrrat-go/jwx/jwa"
@@ -180,14 +179,14 @@ func ParseJWT(tokenString string, f PublicKeyFunc, options ...jwt.ParseOption) (
 }
 
 // ParseJWS parses a JWS byte array object, validates and verifies it.
-// This method returns the value of the payload as map, or an error if
+// This method returns the value of the payload as byte array, or an error if
 // the parsing fails at any level.
-func ParseJWS(payload []byte, f PublicKeyFunc) (map[string]interface{}, error) {
-	message, err := jws.Parse(payload)
+func ParseJWS(token []byte, f PublicKeyFunc) (payload []byte, err error) {
+	message, err := jws.Parse(token)
 	if err != nil {
 		return nil, err
 	}
-	headers, body, _, err := jws.SplitCompact(payload)
+	headers, body, _, err := jws.SplitCompact(token)
 	if err != nil {
 		return nil, err
 	}
@@ -222,12 +221,8 @@ func ParseJWS(payload []byte, f PublicKeyFunc) (map[string]interface{}, error) {
 		}
 	}
 
-	var rv = make(map[string]interface{})
-	if err = json.Unmarshal(message.Payload(), &rv); err != nil {
-		return nil, err
-	}
-
-	return rv, nil
+	body = message.Payload()
+	return body, nil
 }
 
 // SignJWS signs the payload using the JWS format with the provided signer.

--- a/crypto/jwx.go
+++ b/crypto/jwx.go
@@ -179,7 +179,9 @@ func ParseJWT(tokenString string, f PublicKeyFunc, options ...jwt.ParseOption) (
 	return jwt.ParseString(tokenString, options...)
 }
 
-// ParseJWS parses JWS a object, validates and verifies it.
+// ParseJWS parses a JWS byte array object, validates and verifies it.
+// This method returns the value of the payload as map, or an error if
+// the parsing fails at any level.
 func ParseJWS(payload []byte, f PublicKeyFunc) (map[string]interface{}, error) {
 	message, err := jws.Parse(payload)
 	if err != nil {

--- a/crypto/jwx.go
+++ b/crypto/jwx.go
@@ -209,7 +209,11 @@ func ParseJWS(payload []byte, f PublicKeyFunc) (map[string]interface{}, error) {
 			return nil, err
 		}
 		// This seems an awkward way of appending 3 arrays.
-		payload := append(append(headers, "."...), body...)
+		var payload []byte
+		parts := [][]byte{headers, []byte("."), body}
+		for _, part := range parts {
+			payload = append(payload, part...)
+		}
 		err = verifier.Verify(payload, signature.Signature(), key)
 		if err != nil {
 			return nil, err

--- a/crypto/jwx_test.go
+++ b/crypto/jwx_test.go
@@ -199,12 +199,18 @@ func TestCrypto_SignJWS(t *testing.T) {
 		token, err := ParseJWS([]byte(tokenString), func(kid string) (crypto.PublicKey, error) {
 			return key.Public(), nil
 		})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		var body = make(map[string]interface{})
+		err = json.Unmarshal(token, &body)
 
 		if !assert.NoError(t, err) {
 			return
 		}
 
-		assert.Equal(t, "nuts", token["iss"])
+		assert.Equal(t, "nuts", body["iss"])
 	})
 
 	t.Run("returns error for not found", func(t *testing.T) {

--- a/crypto/jwx_test.go
+++ b/crypto/jwx_test.go
@@ -25,6 +25,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -188,7 +189,8 @@ func TestCrypto_SignJWS(t *testing.T) {
 	key, _ := client.New(StringNamingFunc(kid))
 
 	t.Run("creates valid JWS", func(t *testing.T) {
-		tokenString, err := client.SignJWS(map[string]interface{}{"typ": "JWT"}, map[string]interface{}{"iss": "nuts"}, kid, false)
+		payload, err := json.Marshal(map[string]interface{}{"iss": "nuts"})
+		tokenString, err := client.SignJWS(map[string]interface{}{"typ": "JWT"}, payload, kid, false)
 
 		if !assert.NoError(t, err) {
 			return
@@ -206,13 +208,15 @@ func TestCrypto_SignJWS(t *testing.T) {
 	})
 
 	t.Run("returns error for not found", func(t *testing.T) {
-		_, err := client.SignJWS(map[string]interface{}{"typ": "JWT"}, map[string]interface{}{"iss": "nuts"}, "unknown", false)
+		payload, _ := json.Marshal(map[string]interface{}{"iss": "nuts"})
+		_, err := client.SignJWS(map[string]interface{}{"typ": "JWT"}, payload, "unknown", false)
 
 		assert.True(t, errors.Is(err, ErrPrivateKeyNotFound))
 	})
 
 	t.Run("returns error for invalid KID", func(t *testing.T) {
-		_, err := client.SignJWS(map[string]interface{}{"typ": "JWT"}, map[string]interface{}{"iss": "nuts"}, "../certificate", false)
+		payload, _ := json.Marshal(map[string]interface{}{"iss": "nuts"})
+		_, err := client.SignJWS(map[string]interface{}{"typ": "JWT"}, payload, "../certificate", false)
 
 		assert.ErrorContains(t, err, "invalid key ID")
 	})

--- a/crypto/jwx_test.go
+++ b/crypto/jwx_test.go
@@ -196,7 +196,7 @@ func TestCrypto_SignJWS(t *testing.T) {
 			return
 		}
 
-		token, err := ParseJWS(tokenString, func(kid string) (crypto.PublicKey, error) {
+		token, err := ParseJWS([]byte(tokenString), func(kid string) (crypto.PublicKey, error) {
 			return key.Public(), nil
 		})
 

--- a/crypto/jwx_test.go
+++ b/crypto/jwx_test.go
@@ -190,7 +190,7 @@ func TestCrypto_SignJWS(t *testing.T) {
 
 	t.Run("creates valid JWS", func(t *testing.T) {
 		payload, err := json.Marshal(map[string]interface{}{"iss": "nuts"})
-		tokenString, err := client.SignJWS(map[string]interface{}{"typ": "JWT"}, payload, kid, false)
+		tokenString, err := client.SignJWS(payload, map[string]interface{}{"typ": "JWT"}, kid, false)
 
 		if !assert.NoError(t, err) {
 			return
@@ -209,14 +209,14 @@ func TestCrypto_SignJWS(t *testing.T) {
 
 	t.Run("returns error for not found", func(t *testing.T) {
 		payload, _ := json.Marshal(map[string]interface{}{"iss": "nuts"})
-		_, err := client.SignJWS(map[string]interface{}{"typ": "JWT"}, payload, "unknown", false)
+		_, err := client.SignJWS(payload, map[string]interface{}{"typ": "JWT"}, "unknown", false)
 
 		assert.True(t, errors.Is(err, ErrPrivateKeyNotFound))
 	})
 
 	t.Run("returns error for invalid KID", func(t *testing.T) {
 		payload, _ := json.Marshal(map[string]interface{}{"iss": "nuts"})
-		_, err := client.SignJWS(map[string]interface{}{"typ": "JWT"}, payload, "../certificate", false)
+		_, err := client.SignJWS(payload, map[string]interface{}{"typ": "JWT"}, "../certificate", false)
 
 		assert.ErrorContains(t, err, "invalid key ID")
 	})

--- a/crypto/mock.go
+++ b/crypto/mock.go
@@ -211,6 +211,21 @@ func (mr *MockKeyStoreMockRecorder) Resolve(kid interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockKeyStore)(nil).Resolve), kid)
 }
 
+// SignJWS mocks base method.
+func (m *MockKeyStore) SignJWS(headers, claims map[string]interface{}, kid string, detached bool) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SignJWS", headers, claims, kid, detached)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SignJWS indicates an expected call of SignJWS.
+func (mr *MockKeyStoreMockRecorder) SignJWS(headers, claims, kid, detached interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWS", reflect.TypeOf((*MockKeyStore)(nil).SignJWS), headers, claims, kid, detached)
+}
+
 // SignJWT mocks base method.
 func (m *MockKeyStore) SignJWT(claims map[string]interface{}, kid string) (string, error) {
 	m.ctrl.T.Helper()
@@ -285,6 +300,21 @@ func NewMockJWTSigner(ctrl *gomock.Controller) *MockJWTSigner {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockJWTSigner) EXPECT() *MockJWTSignerMockRecorder {
 	return m.recorder
+}
+
+// SignJWS mocks base method.
+func (m *MockJWTSigner) SignJWS(headers, claims map[string]interface{}, kid string, detached bool) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SignJWS", headers, claims, kid, detached)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SignJWS indicates an expected call of SignJWS.
+func (mr *MockJWTSignerMockRecorder) SignJWS(headers, claims, kid, detached interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWS", reflect.TypeOf((*MockJWTSigner)(nil).SignJWS), headers, claims, kid, detached)
 }
 
 // SignJWT mocks base method.

--- a/crypto/mock.go
+++ b/crypto/mock.go
@@ -212,18 +212,18 @@ func (mr *MockKeyStoreMockRecorder) Resolve(kid interface{}) *gomock.Call {
 }
 
 // SignJWS mocks base method.
-func (m *MockKeyStore) SignJWS(headers, claims map[string]interface{}, kid string, detached bool) (string, error) {
+func (m *MockKeyStore) SignJWS(headers map[string]interface{}, payload []byte, kid string, detached bool) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SignJWS", headers, claims, kid, detached)
+	ret := m.ctrl.Call(m, "SignJWS", headers, payload, kid, detached)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SignJWS indicates an expected call of SignJWS.
-func (mr *MockKeyStoreMockRecorder) SignJWS(headers, claims, kid, detached interface{}) *gomock.Call {
+func (mr *MockKeyStoreMockRecorder) SignJWS(headers, payload, kid, detached interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWS", reflect.TypeOf((*MockKeyStore)(nil).SignJWS), headers, claims, kid, detached)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWS", reflect.TypeOf((*MockKeyStore)(nil).SignJWS), headers, payload, kid, detached)
 }
 
 // SignJWT mocks base method.
@@ -303,18 +303,18 @@ func (m *MockJWTSigner) EXPECT() *MockJWTSignerMockRecorder {
 }
 
 // SignJWS mocks base method.
-func (m *MockJWTSigner) SignJWS(headers, claims map[string]interface{}, kid string, detached bool) (string, error) {
+func (m *MockJWTSigner) SignJWS(headers map[string]interface{}, payload []byte, kid string, detached bool) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SignJWS", headers, claims, kid, detached)
+	ret := m.ctrl.Call(m, "SignJWS", headers, payload, kid, detached)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SignJWS indicates an expected call of SignJWS.
-func (mr *MockJWTSignerMockRecorder) SignJWS(headers, claims, kid, detached interface{}) *gomock.Call {
+func (mr *MockJWTSignerMockRecorder) SignJWS(headers, payload, kid, detached interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWS", reflect.TypeOf((*MockJWTSigner)(nil).SignJWS), headers, claims, kid, detached)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWS", reflect.TypeOf((*MockJWTSigner)(nil).SignJWS), headers, payload, kid, detached)
 }
 
 // SignJWT mocks base method.

--- a/crypto/mock.go
+++ b/crypto/mock.go
@@ -212,18 +212,18 @@ func (mr *MockKeyStoreMockRecorder) Resolve(kid interface{}) *gomock.Call {
 }
 
 // SignJWS mocks base method.
-func (m *MockKeyStore) SignJWS(headers map[string]interface{}, payload []byte, kid string, detached bool) (string, error) {
+func (m *MockKeyStore) SignJWS(payload []byte, headers map[string]interface{}, kid string, detached bool) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SignJWS", headers, payload, kid, detached)
+	ret := m.ctrl.Call(m, "SignJWS", payload, headers, kid, detached)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SignJWS indicates an expected call of SignJWS.
-func (mr *MockKeyStoreMockRecorder) SignJWS(headers, payload, kid, detached interface{}) *gomock.Call {
+func (mr *MockKeyStoreMockRecorder) SignJWS(payload, headers, kid, detached interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWS", reflect.TypeOf((*MockKeyStore)(nil).SignJWS), headers, payload, kid, detached)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWS", reflect.TypeOf((*MockKeyStore)(nil).SignJWS), payload, headers, kid, detached)
 }
 
 // SignJWT mocks base method.
@@ -303,18 +303,18 @@ func (m *MockJWTSigner) EXPECT() *MockJWTSignerMockRecorder {
 }
 
 // SignJWS mocks base method.
-func (m *MockJWTSigner) SignJWS(headers map[string]interface{}, payload []byte, kid string, detached bool) (string, error) {
+func (m *MockJWTSigner) SignJWS(payload []byte, headers map[string]interface{}, kid string, detached bool) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SignJWS", headers, payload, kid, detached)
+	ret := m.ctrl.Call(m, "SignJWS", payload, headers, kid, detached)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SignJWS indicates an expected call of SignJWS.
-func (mr *MockJWTSignerMockRecorder) SignJWS(headers, payload, kid, detached interface{}) *gomock.Call {
+func (mr *MockJWTSignerMockRecorder) SignJWS(payload, headers, kid, detached interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWS", reflect.TypeOf((*MockJWTSigner)(nil).SignJWS), headers, payload, kid, detached)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWS", reflect.TypeOf((*MockJWTSigner)(nil).SignJWS), payload, headers, kid, detached)
 }
 
 // SignJWT mocks base method.

--- a/docs/_static/crypto/v1.yaml
+++ b/docs/_static/crypto/v1.yaml
@@ -75,18 +75,25 @@ components:
     SignJwsRequest:
       required:
         - headers
-        - claims
+        - payload
         - kid
       properties:
+        kid:
+          type: string
+          description: "Reference to the key ID used for signing the JWS."
+        headers:
+          type: object
+          description: "The map of protected headers"
+        payload:
+          type: string
+          format: byte
+          description: "The payload to be signed as bytes. The bytes must be encoded with base64 encoding."
         detached:
           type: boolean
           default: false
-        kid:
-          type: string
-        claims:
-          type: object
-        headers:
-          type: object
+          description: "In detached mode the payload is signed but NOT included in the returned JWS object. 
+          Instead, the space between the first and second dot is empty, like this: \"<header>..<signature>\".
+          Defaults to false."
   securitySchemes:
     jwtBearerAuth:
       type: http

--- a/docs/_static/crypto/v1.yaml
+++ b/docs/_static/crypto/v1.yaml
@@ -34,6 +34,32 @@ paths:
                 example: "aa==.bb==.cc=="
         default:
           $ref: '../common/error_response.yaml'
+  /internal/crypto/v1/sign_jws:
+    post:
+      summary: "sign a payload and headers with the private key of the given kid into a JWS object"
+      description: |
+        Sign a payload and headers with the private key of the given kid into a JWS object
+
+        error returns:
+        * 400 - incorrect input
+      operationId: signJws
+      tags:
+        - crypto
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SignJwsRequest'
+      responses:
+        '200':
+          description: "OK response, body holds JWS"
+          content:
+            text/plain:
+              schema:
+                example: "aa==.bb==.cc=="
+        default:
+          $ref: '../common/error_response.yaml'
 
 components:
   schemas:
@@ -45,6 +71,21 @@ components:
         kid:
           type: string
         claims:
+          type: object
+    SignJwsRequest:
+      required:
+        - headers
+        - claims
+        - kid
+      properties:
+        detached:
+          type: boolean
+          default: false
+        kid:
+          type: string
+        claims:
+          type: object
+        headers:
           type: object
   securitySchemes:
     jwtBearerAuth:


### PR DESCRIPTION
In KIK-V (and maybe HTI) we use  JSON web messages (JWM) messages to exchange information between services. Plain JWM messages can be  wrapped in JWS and JWE envelopes to ensure their origin with a signature (JWS) and be confidential by encrypting the message (JWE). 

<img width="603" alt="Screenshot 2022-09-22 at 16 14 29" src="https://user-images.githubusercontent.com/1409882/191771058-75428454-0b71-44d1-b851-f1152f6d7ff6.png">

In order to support JWM messages we need to encrypt(sign(plain)) these messages with NUTS. To our view, the JWE can be realized fairly easy by align to the sign_jwt method with a similar sign_jws method, with the following differences:

- The payload is not a set of claims, but a byte array, as the payload can be anything.
- The detached boolean is added to allow for detached JWS objects, that are objects _about_ a payload, which do not include the body. A use case can be a signed http request. 

Special attention needs to go to the OpenAPI footprint of the payload:
```
        payload:
          type: string
          format: byte
          description: "The payload to be signed as bytes. The bytes must be encoded with base64 encoding."
```
It works fine like this, but might not align to the API design.

I did not bump the API version (v1.yaml > v2.yaml) as I don't know the API versioning strategy. 

This PR only contains thee sign_jws method. As discussed on Slack with @woutslakhorst, it makes sense to split up the sign_jws and encrypt_jwe methods. Furthermore, I'm a novice to golang, so it makes sense to get some feedback at this point, and before progressing to the more complicated encrypt_jwe. 