### PR TITLE
Set IRMA to production-mode on strict-mode installs (#1491)

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -129,6 +129,7 @@ func (auth *Auth) Configure(config core.ServerConfig) error {
 		AutoUpdateIrmaSchemas: auth.config.IrmaAutoUpdateSchemas,
 		ContractValidators:    auth.config.ContractValidators,
 		ContractValidity:      contractValidity,
+		StrictMode:            config.Strictmode,
 	}, auth.vcr, doc.KeyResolver{Store: auth.registry}, auth.keyStore, auth.jsonldManager)
 
 	if config.Strictmode && !auth.config.tlsEnabled() {

--- a/auth/services/contract/notary.go
+++ b/auth/services/contract/notary.go
@@ -241,6 +241,8 @@ func (n *notary) configureIrma(config Config) (irmaServer *irmaserver.Server, ir
 		IrmaConfigPath:        config.IrmaConfigPath,
 		IrmaSchemeManager:     config.IrmaSchemeManager,
 		AutoUpdateIrmaSchemas: config.AutoUpdateIrmaSchemas,
+		// Deduce IRMA production mode from the nuts strict-mode
+		Production: config.StrictMode,
 	}
 	if irmaConfig, err = irma.GetIrmaConfig(n.irmaServiceConfig); err != nil {
 		return

--- a/auth/services/irma/irmaconfig.go
+++ b/auth/services/irma/irmaconfig.go
@@ -73,6 +73,7 @@ func GetIrmaServer(validatorConfig ValidatorConfig, irmaConfig *irma.Configurati
 		Verbose:              irmaLogLevel(&logger),
 		SchemesPath:          validatorConfig.IrmaConfigPath,
 		DisableSchemesUpdate: !validatorConfig.AutoUpdateIrmaSchemas,
+		Production:           validatorConfig.Production,
 	}
 
 	log.Logger().Debugf("Initializing IRMA library (baseURL=%s)...", config.URL)

--- a/auth/services/irma/validator.go
+++ b/auth/services/irma/validator.go
@@ -70,6 +70,9 @@ type ValidatorConfig struct {
 	IrmaSchemeManager string
 	// Auto update the schemas every x minutes or not?
 	AutoUpdateIrmaSchemas bool
+	// Use the IRMA server in production mode. Without this the IRMA app needs to be in "developer mode"
+	// https://irma.app/docs/irma-app/#developer-mode
+	Production bool
 }
 
 // VPProof is a specific IrmaProof for the specific VerifiablePresentation


### PR DESCRIPTION
Add `production` var to IRMA config and let it follow the strict-mode setting.