### PR TITLE
Speedup integration tests

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -107,12 +107,10 @@ func NewNetworkInstance(
 	}
 }
 
-var dagStorageClass storage.Class = storage.PersistentStorageClass
-
 // Configure configures the Network subsystem
 func (n *Network) Configure(config core.ServerConfig) error {
 	var err error
-	dagStore, err := n.storeProvider.GetKVStore("data", dagStorageClass)
+	dagStore, err := n.storeProvider.GetKVStore("data", storage.PersistentStorageClass)
 	if err != nil {
 		return fmt.Errorf("unable to create database: %w", err)
 	}

--- a/network/network.go
+++ b/network/network.go
@@ -107,10 +107,12 @@ func NewNetworkInstance(
 	}
 }
 
+var dagStorageClass storage.Class = storage.PersistentStorageClass
+
 // Configure configures the Network subsystem
 func (n *Network) Configure(config core.ServerConfig) error {
 	var err error
-	dagStore, err := n.storeProvider.GetKVStore("data", storage.PersistentStorageClass)
+	dagStore, err := n.storeProvider.GetKVStore("data", dagStorageClass)
 	if err != nil {
 		return fmt.Errorf("unable to create database: %w", err)
 	}

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -938,14 +938,9 @@ func startNode(t *testing.T, name string, testDirectory string, opts ...func(ser
 		t.Fatal(err)
 	}
 
-	memstore, err := storage.CreateTestBBoltStore(serverConfig.Datadir + "/test.db")
-	if err != nil {
-		panic(err)
+	storeProvider := storage.StaticKVStoreProvider{
+		Store: storage.CreateTestBBoltStore(t, serverConfig.Datadir+"/test.db"),
 	}
-	t.Cleanup(func() {
-		_ = memstore.Close(context.Background())
-	})
-	storeProvider := storage.StaticKVStoreProvider{memstore}
 
 	instance := &Network{
 		config:              config,

--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -865,10 +865,5 @@ func (s stubNodeDIDReader) Resolve() (did.DID, error) {
 }
 
 func createKVStore(t *testing.T) stoabs.KVStore {
-	testDirectory := io2.TestDirectory(t)
-	db, err := storage.CreateTestBBoltStore(filepath.Join(testDirectory, "grpc.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	return db
+	return storage.CreateTestBBoltStore(t, filepath.Join(io2.TestDirectory(t), "grpc.db"))
 }

--- a/storage/test.go
+++ b/storage/test.go
@@ -19,10 +19,12 @@
 package storage
 
 import (
+	"context"
 	"errors"
 	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/go-stoabs/bbolt"
 	"github.com/nuts-foundation/nuts-node/core"
+	"testing"
 )
 
 func NewTestStorageEngine(testDirectory string) Engine {
@@ -31,8 +33,16 @@ func NewTestStorageEngine(testDirectory string) Engine {
 	return result
 }
 
-func CreateTestBBoltStore(filePath string) (stoabs.KVStore, error) {
-	return bbolt.CreateBBoltStore(filePath, stoabs.WithNoSync())
+// CreateTestBBoltStore creates an in-memory bbolt store
+func CreateTestBBoltStore(tb testing.TB, filePath string) stoabs.KVStore {
+	db, err := bbolt.CreateBBoltStore(filePath, stoabs.WithNoSync())
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() {
+		db.Close(context.Background())
+	})
+	return db
 }
 
 // StaticKVStoreProvider contains a single store.

--- a/storage/test.go
+++ b/storage/test.go
@@ -35,10 +35,12 @@ func CreateTestBBoltStore(filePath string) (stoabs.KVStore, error) {
 	return bbolt.CreateBBoltStore(filePath, stoabs.WithNoSync())
 }
 
+// StaticKVStoreProvider contains a single store.
 type StaticKVStoreProvider struct {
 	Store stoabs.KVStore
 }
 
+// GetKVStore ignores the inputs and returns the Store, or an error when Store == nil.
 func (p *StaticKVStoreProvider) GetKVStore(_ string, _ Class) (stoabs.KVStore, error) {
 	if p.Store == nil {
 		return nil, errors.New("no store available")

--- a/storage/test.go
+++ b/storage/test.go
@@ -19,6 +19,7 @@
 package storage
 
 import (
+	"errors"
 	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/go-stoabs/bbolt"
 	"github.com/nuts-foundation/nuts-node/core"
@@ -32,4 +33,15 @@ func NewTestStorageEngine(testDirectory string) Engine {
 
 func CreateTestBBoltStore(filePath string) (stoabs.KVStore, error) {
 	return bbolt.CreateBBoltStore(filePath, stoabs.WithNoSync())
+}
+
+type StaticKVStoreProvider struct {
+	Store stoabs.KVStore
+}
+
+func (p *StaticKVStoreProvider) GetKVStore(_ string, _ Class) (stoabs.KVStore, error) {
+	if p.Store == nil {
+		return nil, errors.New("no store available")
+	}
+	return p.Store, nil
 }

--- a/vdr/integration_test.go
+++ b/vdr/integration_test.go
@@ -22,8 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/nuts-foundation/go-stoabs"
-
 	"net/url"
 	"sync"
 	"testing"
@@ -283,14 +281,9 @@ func setup(t *testing.T) testContext {
 	cryptoInstance.Configure(nutsConfig)
 
 	// Storage
-	var memstore stoabs.KVStore
-	if memstore, err = storage.CreateTestBBoltStore(testDir + "/test.db"); err != nil {
-		t.Fatal(err)
+	storageProvider := storage.StaticKVStoreProvider{
+		Store: storage.CreateTestBBoltStore(t, testDir+"/test.db"),
 	}
-	storageProvider := storage.StaticKVStoreProvider{memstore}
-	t.Cleanup(func() {
-		memstore.Close(context.Background())
-	})
 
 	// DID Store
 	didStore := store.NewMemoryStore()

--- a/vdr/store/store_test.go
+++ b/vdr/store/store_test.go
@@ -38,16 +38,12 @@ const moduleName = "VDR"
 func newTestStore(t *testing.T) types.Store {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	mockProvider := storage.NewMockProvider(ctrl)
-	store := NewStore(mockProvider)
-
-	bboltStore, err := storage.CreateTestBBoltStore(path.Join(io.TestDirectory(t), moduleName, "didstore.db"))
-	if !assert.NoError(t, err) {
-		t.Fatal(err)
+	storeProvider := storage.StaticKVStoreProvider{
+		Store: storage.CreateTestBBoltStore(t, path.Join(io.TestDirectory(t), moduleName, "didstore.db")),
 	}
-	mockProvider.EXPECT().GetKVStore(gomock.Any(), gomock.Any()).Return(bboltStore, nil)
+	store := NewStore(&storeProvider)
 
-	err = store.(core.Configurable).Configure(*core.NewServerConfig())
+	err := store.(core.Configurable).Configure(*core.NewServerConfig())
 	if !assert.NoError(t, err) {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
closes #1219 

network/vdr integration test use bbolt store without syncing

test speedup:
network 26s -> 9s
vdr 5s -> 0.7s