### PR TITLE
fix panic when VCs do not have a custom type

### DIFF
--- a/vcr/store.go
+++ b/vcr/store.go
@@ -65,8 +65,11 @@ func (c *vcr) StoreCredential(credential vc.VerifiableCredential, validAt *time.
 }
 
 func (c *vcr) writeCredential(subject vc.VerifiableCredential) error {
-	// validation has made sure there's exactly one!
-	vcType := credential.ExtractTypes(subject)[0]
+	vcType := "VerifiableCredential"
+	customTypes := credential.ExtractTypes(subject)
+	if len(customTypes) > 0 {
+		vcType = customTypes[0]
+	}
 
 	log.Logger().
 		WithField(core.LogFieldCredentialID, subject.ID).

--- a/vcr/store_test.go
+++ b/vcr/store_test.go
@@ -131,4 +131,20 @@ func TestStore_writeCredential(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, doc)
 	})
+
+	t.Run("ok - accepts credentials without custom type", func(t *testing.T) {
+		ctx := newMockContext(t)
+		vc := vc.VerifiableCredential{}
+		vcBytes, _ := json.Marshal(vc)
+		ref := sha1.Sum(vcBytes)
+
+		err := ctx.vcr.writeCredential(vc)
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		doc, err := ctx.vcr.credentialCollection().Get(ref[:])
+		assert.NoError(t, err)
+		assert.NotNil(t, doc)
+	})
 }


### PR DESCRIPTION
fixes #1512

less strict validation on VC type introduced a panic. Extra painful is that it was only used for logging.