### PR TITLE
VCR: Fix Nuts v2 JSON-LD context, evidence missing @id

### DIFF
--- a/vcr/assets/assets/contexts/nuts-v2.ldjson
+++ b/vcr/assets/assets/contexts/nuts-v2.ldjson
@@ -82,6 +82,7 @@
             "@protected": true,
             "consentType": "nuts:consentType",
             "evidence": {
+              "@id":"nuts:evidence",
               "@context": {
                 "@version": 1.1,
                 "@protected": true,


### PR DESCRIPTION
Found while testing VC field validation (https://github.com/nuts-foundation/nuts-node/pull/1190)