### PR TITLE
Network: add highest LC to cached state

### DIFF
--- a/network/dag/interface.go
+++ b/network/dag/interface.go
@@ -79,13 +79,13 @@ type State interface {
 	//	- upper-limit of the page that contains the requested clock
 	//	- highest lamport clock in the DAG
 	// A requested clock of math.MaxUint32 will return the xor of the entire DAG
-	XOR(ctx context.Context, reqClock uint32) (hash.SHA256Hash, uint32)
+	XOR(reqClock uint32) (hash.SHA256Hash, uint32)
 	// IBLT returns the iblt of all transaction references between the DAG root and the clock closest to the requested clock value.
 	// This closest clock value is also returned, and is defined as the lowest of:
 	//	- upper-limit of the page that contains the requested clock
 	//	- highest lamport clock in the DAG
 	// A requested clock of math.MaxUint32 will return the iblt of the entire DAG
-	IBLT(ctx context.Context, reqClock uint32) (tree.Iblt, uint32)
+	IBLT(reqClock uint32) (tree.Iblt, uint32)
 }
 
 // Statistics holds data about the current state of the DAG.

--- a/network/dag/mock.go
+++ b/network/dag/mock.go
@@ -112,18 +112,18 @@ func (mr *MockStateMockRecorder) Head(ctx interface{}) *gomock.Call {
 }
 
 // IBLT mocks base method.
-func (m *MockState) IBLT(ctx context.Context, reqClock uint32) (tree.Iblt, uint32) {
+func (m *MockState) IBLT(reqClock uint32) (tree.Iblt, uint32) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IBLT", ctx, reqClock)
+	ret := m.ctrl.Call(m, "IBLT", reqClock)
 	ret0, _ := ret[0].(tree.Iblt)
 	ret1, _ := ret[1].(uint32)
 	return ret0, ret1
 }
 
 // IBLT indicates an expected call of IBLT.
-func (mr *MockStateMockRecorder) IBLT(ctx, reqClock interface{}) *gomock.Call {
+func (mr *MockStateMockRecorder) IBLT(reqClock interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IBLT", reflect.TypeOf((*MockState)(nil).IBLT), ctx, reqClock)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IBLT", reflect.TypeOf((*MockState)(nil).IBLT), reqClock)
 }
 
 // IsPayloadPresent mocks base method.
@@ -276,18 +276,18 @@ func (mr *MockStateMockRecorder) WritePayload(ctx, transaction, payloadHash, dat
 }
 
 // XOR mocks base method.
-func (m *MockState) XOR(ctx context.Context, reqClock uint32) (hash.SHA256Hash, uint32) {
+func (m *MockState) XOR(reqClock uint32) (hash.SHA256Hash, uint32) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "XOR", ctx, reqClock)
+	ret := m.ctrl.Call(m, "XOR", reqClock)
 	ret0, _ := ret[0].(hash.SHA256Hash)
 	ret1, _ := ret[1].(uint32)
 	return ret0, ret1
 }
 
 // XOR indicates an expected call of XOR.
-func (mr *MockStateMockRecorder) XOR(ctx, reqClock interface{}) *gomock.Call {
+func (mr *MockStateMockRecorder) XOR(reqClock interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "XOR", reflect.TypeOf((*MockState)(nil).XOR), ctx, reqClock)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "XOR", reflect.TypeOf((*MockState)(nil).XOR), reqClock)
 }
 
 // MockPayloadStore is a mock of PayloadStore interface.

--- a/network/dag/state.go
+++ b/network/dag/state.go
@@ -51,6 +51,7 @@ type state struct {
 	notifiers           map[string]Notifier
 	xorTree             *treeStore
 	ibltTree            *treeStore
+	highestLC           highestLC
 	transactionCount    prometheus.Counter
 	eventsNotifyCount   prometheus.Counter
 	eventsFinishedCount prometheus.Counter
@@ -75,6 +76,10 @@ func NewState(db stoabs.KVStore, verifiers ...Verifier) (State, error) {
 		xorTree:      newTreeStore(xorShelf, tree.New(tree.NewXor(), PageSize)),
 		ibltTree:     newTreeStore(ibltShelf, tree.New(tree.NewIblt(IbltNumBuckets), PageSize)),
 		notifiersMux: &sync.RWMutex{},
+		highestLC: highestLC{
+			mux:   sync.RWMutex{},
+			value: 0,
+		},
 	}
 	err := newState.initPrometheusCounters()
 	if err != nil && err.Error() != (prometheus.AlreadyRegisteredError{}).Error() { // No unwrap on prometheus.AlreadyRegisteredError
@@ -199,10 +204,10 @@ func (s *state) Add(ctx context.Context, transaction Transaction, payload []byte
 		}
 
 		// update XOR and IBLT
-		return s.updateTrees(tx, transaction)
+		return s.updateState(tx, transaction)
 	}, stoabs.OnRollback(func() {
 		log.Logger().Warn("Reloading the XOR and IBLT trees due to a DB transaction Rollback")
-		s.loadTrees(ctx)
+		s.loadState(ctx)
 	}), stoabs.AfterCommit(func() {
 		if txAdded {
 			s.notify(txEvent)
@@ -217,15 +222,19 @@ func (s *state) Add(ctx context.Context, transaction Transaction, payload []byte
 	}), stoabs.WithWriteLock())
 }
 
-func (s *state) updateTrees(tx stoabs.WriteTx, transaction Transaction) error {
+func (s *state) updateState(tx stoabs.WriteTx, transaction Transaction) error {
+	if s.highestLC.get() < transaction.Clock() {
+		s.highestLC.set(transaction.Clock())
+	}
 	if err := s.ibltTree.write(tx, transaction); err != nil {
 		return err
 	}
 	return s.xorTree.write(tx, transaction)
 }
 
-func (s *state) loadTrees(ctx context.Context) {
+func (s *state) loadState(ctx context.Context) {
 	if err := s.db.Read(ctx, func(tx stoabs.ReadTx) error {
+		s.highestLC.set(s.graph.getHighestClockValue(tx))
 		if err := s.xorTree.read(tx); err != nil {
 			return fmt.Errorf("failed to read xorTree: %w", err)
 		}
@@ -344,10 +353,10 @@ func (s *state) Notifiers() []Notifier {
 	return notifiers
 }
 
-func (s *state) XOR(ctx context.Context, reqClock uint32) (hash.SHA256Hash, uint32) {
+func (s *state) XOR(reqClock uint32) (hash.SHA256Hash, uint32) {
 	var data tree.Data
 
-	currentClock := s.lamportClock(ctx)
+	currentClock := s.highestLC.get()
 	dataClock := currentClock
 	if reqClock < currentClock {
 		var pageClock uint32
@@ -362,10 +371,10 @@ func (s *state) XOR(ctx context.Context, reqClock uint32) (hash.SHA256Hash, uint
 	return data.(*tree.Xor).Hash(), dataClock
 }
 
-func (s *state) IBLT(ctx context.Context, reqClock uint32) (tree.Iblt, uint32) {
+func (s *state) IBLT(reqClock uint32) (tree.Iblt, uint32) {
 	var data tree.Data
 
-	currentClock := s.lamportClock(ctx)
+	currentClock := s.highestLC.get()
 	dataClock := currentClock
 	if reqClock < currentClock {
 		var pageClock uint32
@@ -380,17 +389,6 @@ func (s *state) IBLT(ctx context.Context, reqClock uint32) (tree.Iblt, uint32) {
 	return *data.(*tree.Iblt), dataClock
 }
 
-// lamportClock returns the highest clock value in the DAG.
-func (s *state) lamportClock(ctx context.Context) uint32 {
-	lc := uint32(0)
-	// errors are logged at the lower level
-	_ = s.db.Read(ctx, func(tx stoabs.ReadTx) error {
-		lc = s.graph.getHighestClockValue(tx)
-		return nil
-	})
-	return lc
-}
-
 func (s *state) Shutdown() error {
 	if s.transactionCount != nil {
 		prometheus.Unregister(s.transactionCount)
@@ -399,7 +397,7 @@ func (s *state) Shutdown() error {
 }
 
 func (s *state) Start() error {
-	s.loadTrees(context.Background())
+	s.loadState(context.Background())
 
 	err := s.db.Read(context.Background(), func(tx stoabs.ReadTx) error {
 		currentTXCount := s.graph.getNumberOfTransactions(tx)
@@ -482,4 +480,22 @@ func (s *state) Diagnostics() []core.DiagnosticResult {
 	diag = append(diag, &core.GenericDiagnosticResult{Title: "dag_xor", Outcome: s.xorTree.getRoot().(*tree.Xor).Hash()})
 	diag = append(diag, &core.GenericDiagnosticResult{Title: "failed_events", Outcome: len(s.getFailedEvents())})
 	return diag
+}
+
+type highestLC struct {
+	mux   sync.RWMutex
+	value uint32
+}
+
+func (h *highestLC) get() uint32 {
+	h.mux.RLock()
+	defer h.mux.RUnlock()
+	lc := h.value
+	return lc
+}
+
+func (h *highestLC) set(lc uint32) {
+	h.mux.Lock()
+	defer h.mux.Unlock()
+	h.value = lc
 }

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -341,19 +341,19 @@ func TestState_XOR(t *testing.T) {
 	}
 
 	t.Run("requested clock larger than dag", func(t *testing.T) {
-		xor, actualClock := txState.XOR(ctx, MaxLamportClock)
+		xor, actualClock := txState.XOR(MaxLamportClock)
 
 		assert.Equal(t, dagClock, actualClock)
 		assert.Equal(t, tx.Ref(), xor)
 	})
 	t.Run("requested clock before last page", func(t *testing.T) {
-		xor, actualClock := txState.XOR(ctx, uint32(1))
+		xor, actualClock := txState.XOR(uint32(1))
 
 		assert.Equal(t, PageSize-1, actualClock)
 		assert.Equal(t, hash.EmptyHash(), xor)
 	})
 	t.Run("requested clock on last page, lower than dag", func(t *testing.T) {
-		xor, actualClock := txState.XOR(ctx, PageSize+1)
+		xor, actualClock := txState.XOR(PageSize + 1)
 
 		assert.Equal(t, dagClock, actualClock)
 		assert.Equal(t, tx.Ref(), xor)
@@ -380,20 +380,20 @@ func TestState_IBLT(t *testing.T) {
 	}
 
 	t.Run("requested clock larger than dag", func(t *testing.T) {
-		iblt, actualClock := txState.IBLT(ctx, MaxLamportClock)
+		iblt, actualClock := txState.IBLT(MaxLamportClock)
 		_ = iblt.Subtract(dagIBLT)
 
 		assert.Equal(t, dagClock, actualClock)
 		assert.True(t, iblt.IsEmpty(), iblt)
 	})
 	t.Run("requested clock before last page", func(t *testing.T) {
-		iblt, actualClock := txState.IBLT(ctx, uint32(1))
+		iblt, actualClock := txState.IBLT(uint32(1))
 
 		assert.Equal(t, PageSize-1, actualClock)
 		assert.True(t, iblt.IsEmpty(), iblt)
 	})
 	t.Run("requested clock on last page, lower than dag", func(t *testing.T) {
-		iblt, actualClock := txState.IBLT(ctx, PageSize+1)
+		iblt, actualClock := txState.IBLT(PageSize + 1)
 		_ = iblt.Subtract(dagIBLT)
 
 		assert.Equal(t, dagClock, actualClock)
@@ -446,7 +446,7 @@ func TestState_updateTrees(t *testing.T) {
 			return
 		}
 
-		xor, _ := txState.XOR(ctx, 1)
+		xor, _ := txState.XOR(1)
 		assert.False(t, hash.EmptyHash().Equals(xor))
 	})
 }

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -425,7 +425,7 @@ func TestState_InitialTransactionCountMetric(t *testing.T) {
 	})
 }
 
-func TestState_updateTrees(t *testing.T) {
+func TestState_updateState(t *testing.T) {
 	setup := func(t *testing.T) State {
 		txState := createState(t)
 		err := txState.Start()
@@ -453,6 +453,27 @@ func TestState_updateTrees(t *testing.T) {
 
 func Test_createStore(t *testing.T) {
 	assert.NotNil(t, createState(t))
+}
+
+func Test_highestLC(t *testing.T) {
+	t.Run("get()", func(t *testing.T) {
+		assert.Equal(t, uint32(0), (&highestLC{}).get())
+		assert.Equal(t, uint32(5), (&highestLC{value: 5}).get())
+	})
+	t.Run("set()", func(t *testing.T) {
+		lc := highestLC{value: 5}
+		lc.set(6)
+		assert.Equal(t, uint32(6), lc.value)
+		lc.set(4)
+		assert.Equal(t, uint32(4), lc.value)
+	})
+	t.Run("setIfBigger()", func(t *testing.T) {
+		lc := highestLC{value: 5}
+		lc.setIfBigger(6)
+		assert.Equal(t, uint32(6), lc.value)
+		lc.setIfBigger(4)
+		assert.Equal(t, uint32(6), lc.value)
+	})
 }
 
 func createState(t *testing.T, verifier ...Verifier) State {

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -298,9 +298,9 @@ func TestNetworkIntegration_Messages(t *testing.T) {
 		node3.network.connectionManager.Connect(nameToAddress(t, "integration_node2"))
 		waitForTransactions("node 3", node3.network.state, expectedDocLogSize)
 
-		xor1, _ := node1.network.state.XOR(context.Background(), dag.MaxLamportClock)
-		xor2, _ := node2.network.state.XOR(context.Background(), dag.MaxLamportClock)
-		xor3, _ := node3.network.state.XOR(context.Background(), dag.MaxLamportClock)
+		xor1, _ := node1.network.state.XOR(dag.MaxLamportClock)
+		xor2, _ := node2.network.state.XOR(dag.MaxLamportClock)
+		xor3, _ := node3.network.state.XOR(dag.MaxLamportClock)
 		assert.True(t, xor1.Equals(xor3))
 		assert.True(t, xor2.Equals(xor3))
 	})
@@ -481,8 +481,8 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 		waitForTransaction(t, tx, "node2")
 
 		// assert not only TX is transfered, but state is updates as well
-		xor1, _ := node1.network.state.XOR(context.Background(), dag.MaxLamportClock)
-		xor2, _ := node2.network.state.XOR(context.Background(), dag.MaxLamportClock)
+		xor1, _ := node1.network.state.XOR(dag.MaxLamportClock)
+		xor2, _ := node2.network.state.XOR(dag.MaxLamportClock)
 		assert.Equal(t, xor1.String(), xor2.String())
 	})
 
@@ -669,8 +669,8 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 		}, defaultTimeout, "time-out while waiting for node1 to connect to node2")
 
 		test.WaitFor(t, func() (bool, error) {
-			xor1, _ := node1.network.state.XOR(context.Background(), 10)
-			xor2, _ := node2.network.state.XOR(context.Background(), 10)
+			xor1, _ := node1.network.state.XOR(10)
+			xor2, _ := node2.network.state.XOR(10)
 			return xor1.Equals(xor2), nil
 		}, 10*time.Second, "%s: time-out while waiting for transactions", node2.network.Name())
 	})

--- a/network/transport/v2/handlers_test.go
+++ b/network/transport/v2/handlers_test.go
@@ -244,7 +244,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 
 	t.Run("ok - xors match", func(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
-		mocks.State.EXPECT().XOR(gomock.Any(), uint32(dag.MaxLamportClock)).Return(xorPeer, clockPeer)
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorPeer, clockPeer)
 
 		err := p.handleGossip(peer, envelope)
 
@@ -257,7 +257,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 		envelope := &Envelope{Message: &Envelope_Gossip{&Gossip{XOR: xorPeer.Slice(), LC: clockPeer, Transactions: [][]byte{xorPeer.Slice()}}}}
 
 		p, mocks := newTestProtocol(t, nil)
-		mocks.State.EXPECT().XOR(gomock.Any(), uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
 		mocks.State.EXPECT().IsPresent(gomock.Any(), xorPeer).Return(false, nil)
 		mocks.Gossip.EXPECT().GossipReceived(peer.ID, xorPeer)
 		mocks.Sender.EXPECT().sendTransactionListQuery(peer.ID, []hash.SHA256Hash{xorPeer}).Return(nil)
@@ -269,7 +269,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 
 	t.Run("ok - new transaction ref, xors still unequal but peers is behind", func(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
-		mocks.State.EXPECT().XOR(gomock.Any(), uint32(dag.MaxLamportClock)).Return(xorLocal, clockPeer+1)
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockPeer+1)
 		mocks.State.EXPECT().IsPresent(gomock.Any(), xorPeer).Return(false, nil)
 		mocks.Gossip.EXPECT().GossipReceived(peer.ID, xorPeer)
 		mocks.Sender.EXPECT().sendTransactionListQuery(peer.ID, []hash.SHA256Hash{xorPeer}).Return(nil)
@@ -283,7 +283,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 
 	t.Run("ok - xors don't match, peer is behind", func(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
-		mocks.State.EXPECT().XOR(gomock.Any(), uint32(dag.MaxLamportClock)).Return(xorLocal, clockPeer+1)
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockPeer+1)
 		mocks.State.EXPECT().IsPresent(gomock.Any(), xorPeer).Return(true, nil)
 		mocks.Gossip.EXPECT().GossipReceived(peer.ID, xorPeer)
 		mocks.Sender.EXPECT().sendState(peer.ID, xorLocal, clockPeer+1)
@@ -296,7 +296,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 	t.Run("ok - new transaction ref, xors still unequal", func(t *testing.T) {
 		xorLocal := hash.FromSlice([]byte("completely different"))
 		p, mocks := newTestProtocol(t, nil)
-		mocks.State.EXPECT().XOR(gomock.Any(), uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
 		mocks.State.EXPECT().IsPresent(gomock.Any(), xorPeer).Return(false, nil)
 		mocks.Gossip.EXPECT().GossipReceived(peer.ID, xorPeer)
 		mocks.Sender.EXPECT().sendState(peer.ID, xorLocal, clockLocal).Return(nil)
@@ -310,7 +310,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 		envelope := &Envelope{Message: &Envelope_Gossip{&Gossip{XOR: xorPeer.Slice(), LC: clockLocal}}}
 
 		p, mocks := newTestProtocol(t, nil)
-		mocks.State.EXPECT().XOR(gomock.Any(), uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
 		mocks.Sender.EXPECT().sendState(peer.ID, xorLocal, clockLocal).Return(nil)
 
 		err := p.handleGossip(peer, envelope)
@@ -322,7 +322,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 		envelope := &Envelope{Message: &Envelope_Gossip{&Gossip{XOR: xorPeer.Slice(), LC: clockLocal, Transactions: [][]byte{xorLocal.Slice()}}}}
 
 		p, mocks := newTestProtocol(t, nil)
-		mocks.State.EXPECT().XOR(gomock.Any(), uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
 		mocks.State.EXPECT().IsPresent(gomock.Any(), xorLocal).Return(true, nil)
 		mocks.Gossip.EXPECT().GossipReceived(peer.ID, xorLocal)
 		mocks.Sender.EXPECT().sendState(peer.ID, xorLocal, clockLocal).Return(nil)
@@ -338,7 +338,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 		envelope := &Envelope{Message: &Envelope_Gossip{&Gossip{XOR: xorPeer.Slice(), LC: clockLocal - 1, Transactions: [][]byte{xorPeer.Slice()}}}}
 
 		p, mocks := newTestProtocol(t, nil)
-		mocks.State.EXPECT().XOR(gomock.Any(), uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
 		mocks.State.EXPECT().IsPresent(gomock.Any(), xorPeer).Return(false, nil)
 		mocks.Gossip.EXPECT().GossipReceived(peer.ID, xorPeer)
 
@@ -351,7 +351,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
-		mocks.State.EXPECT().XOR(gomock.Any(), uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
 		mocks.State.EXPECT().IsPresent(gomock.Any(), xorPeer).Return(false, errors.New("custom"))
 		mocks.Gossip.EXPECT().GossipReceived(peer.ID, xorPeer)
 
@@ -529,7 +529,7 @@ func TestProtocol_handleState(t *testing.T) {
 	t.Run("ok - xors are the same", func(t *testing.T) {
 		msg := &Envelope_State{State: &State{LC: peerClock, XOR: peerXor.Slice()}}
 		p, mocks := newTestProtocol(t, nil)
-		mocks.State.EXPECT().XOR(context.Background(), uint32(dag.MaxLamportClock)).Return(peerXor, localClock)
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(peerXor, localClock)
 
 		err := p.handleState(peer, &Envelope{Message: msg})
 
@@ -541,8 +541,8 @@ func TestProtocol_handleState(t *testing.T) {
 		iblt := *tree.NewIblt(10)
 		p, mocks := newTestProtocol(t, nil)
 		conversation := p.cMan.startConversation(msg, "peerID")
-		mocks.State.EXPECT().XOR(context.Background(), uint32(dag.MaxLamportClock)).Return(localXor, localClock)
-		mocks.State.EXPECT().IBLT(context.Background(), peerClock).Return(iblt, uint32(0))
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(localXor, localClock)
+		mocks.State.EXPECT().IBLT(peerClock).Return(iblt, uint32(0))
 		mocks.Sender.EXPECT().sendTransactionSet(peer.ID, conversation.conversationID, peerClock, localClock, iblt)
 
 		err := p.handleState(peer, &Envelope{Message: msg})
@@ -569,8 +569,8 @@ func TestProtocol_handleTransactionSet(t *testing.T) {
 		localLC := requestLC
 		p, mocks := newTestProtocol(t, nil)
 		conversation := p.cMan.startConversation(request, peerID)
-		mocks.State.EXPECT().IBLT(context.Background(), peerLC).Return(*oneHashIblt.Clone().(*tree.Iblt), dag.PageSize-1)
-		mocks.State.EXPECT().XOR(context.Background(), uint32(dag.MaxLamportClock)).Return(hash.FromSlice([]byte("ignored")), localLC)
+		mocks.State.EXPECT().IBLT(peerLC).Return(*oneHashIblt.Clone().(*tree.Iblt), dag.PageSize-1)
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(hash.FromSlice([]byte("ignored")), localLC)
 
 		err := p.handleTransactionSet(peer, &Envelope{Message: &Envelope_TransactionSet{
 			TransactionSet: &TransactionSet{ConversationID: conversation.conversationID.slice(), LCReq: requestLC, LC: peerLC, IBLT: emptyIbltBytes},
@@ -584,7 +584,7 @@ func TestProtocol_handleTransactionSet(t *testing.T) {
 		peerLC := requestLC - 1
 		p, mocks := newTestProtocol(t, nil)
 		conversation := p.cMan.startConversation(request, peerID)
-		mocks.State.EXPECT().IBLT(context.Background(), peerLC).Return(*emptyIblt.Clone().(*tree.Iblt), dag.PageSize-1)
+		mocks.State.EXPECT().IBLT(peerLC).Return(*emptyIblt.Clone().(*tree.Iblt), dag.PageSize-1)
 		mocks.Sender.EXPECT().sendTransactionListQuery(peer.ID, []hash.SHA256Hash{hash1.Ref()}).Return(nil)
 
 		err := p.handleTransactionSet(peer, &Envelope{Message: &Envelope_TransactionSet{
@@ -600,8 +600,8 @@ func TestProtocol_handleTransactionSet(t *testing.T) {
 		peerLC := requestLC + dag.PageSize*3
 		p, mocks := newTestProtocol(t, nil)
 		conversation := p.cMan.startConversation(request, peerID)
-		mocks.State.EXPECT().IBLT(context.Background(), requestLC).Return(*oneHashIblt.Clone().(*tree.Iblt), dag.PageSize-1)
-		mocks.State.EXPECT().XOR(context.Background(), uint32(dag.MaxLamportClock)).Return(hash.FromSlice([]byte("ignored")), localLC)
+		mocks.State.EXPECT().IBLT(requestLC).Return(*oneHashIblt.Clone().(*tree.Iblt), dag.PageSize-1)
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(hash.FromSlice([]byte("ignored")), localLC)
 		mocks.Sender.EXPECT().sendTransactionRangeQuery(peer.ID, dag.PageSize, 2*dag.PageSize).Return(nil)
 
 		err := p.handleTransactionSet(peer, &Envelope{Message: &Envelope_TransactionSet{
@@ -616,8 +616,8 @@ func TestProtocol_handleTransactionSet(t *testing.T) {
 		peerLC := requestLC + dag.PageSize
 		p, mocks := newTestProtocol(t, nil)
 		conversation := p.cMan.startConversation(request, peerID)
-		mocks.State.EXPECT().IBLT(context.Background(), requestLC).Return(*oneHashIblt.Clone().(*tree.Iblt), dag.PageSize-1)
-		mocks.State.EXPECT().XOR(context.Background(), uint32(dag.MaxLamportClock)).Return(hash.FromSlice([]byte("ignored")), requestLC)
+		mocks.State.EXPECT().IBLT(requestLC).Return(*oneHashIblt.Clone().(*tree.Iblt), dag.PageSize-1)
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(hash.FromSlice([]byte("ignored")), requestLC)
 		mocks.Sender.EXPECT().sendTransactionRangeQuery(peer.ID, dag.PageSize, uint32(dag.MaxLamportClock)).Return(nil)
 
 		err := p.handleTransactionSet(peer, &Envelope{Message: &Envelope_TransactionSet{
@@ -637,8 +637,8 @@ func TestProtocol_handleTransactionSet(t *testing.T) {
 		conflictingIblt.Insert(hash1.Ref())
 		p, mocks := newTestProtocol(t, nil)
 		conversation := p.cMan.startConversation(request, peerID)
-		mocks.State.EXPECT().IBLT(context.Background(), page1RequestLC).Return(*conflictingIblt, dag.PageSize-1)
-		mocks.State.EXPECT().XOR(context.Background(), uint32(dag.MaxLamportClock)).Return(localXor, uint32(0))
+		mocks.State.EXPECT().IBLT(page1RequestLC).Return(*conflictingIblt, dag.PageSize-1)
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(localXor, uint32(0))
 		mocks.Sender.EXPECT().sendState(peer.ID, localXor, dag.PageSize-1).Return(nil)
 
 		err := p.handleTransactionSet(peer, &Envelope{Message: &Envelope_TransactionSet{
@@ -655,7 +655,7 @@ func TestProtocol_handleTransactionSet(t *testing.T) {
 		conflictingIblt.Insert(hash1.Ref())
 		p, mocks := newTestProtocol(t, nil)
 		conversation := p.cMan.startConversation(request, peerID)
-		mocks.State.EXPECT().IBLT(context.Background(), requestLC).Return(*conflictingIblt, dag.PageSize-1)
+		mocks.State.EXPECT().IBLT(requestLC).Return(*conflictingIblt, dag.PageSize-1)
 		mocks.Sender.EXPECT().sendTransactionRangeQuery(peer.ID, uint32(0), dag.PageSize).Return(nil)
 
 		err := p.handleTransactionSet(peer, &Envelope{Message: &Envelope_TransactionSet{
@@ -682,7 +682,7 @@ func TestProtocol_handleTransactionSet(t *testing.T) {
 	t.Run("error - iblt subtract fails", func(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
 		conversation := p.cMan.startConversation(request, peerID)
-		mocks.State.EXPECT().IBLT(context.Background(), requestLC).Return(*tree.NewIblt(20), dag.PageSize-1)
+		mocks.State.EXPECT().IBLT(requestLC).Return(*tree.NewIblt(20), dag.PageSize-1)
 
 		emptyIbltBytes, _ := emptyIblt.MarshalBinary()
 

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -202,7 +202,7 @@ func (p *protocol) connectionStateCallback(peer transport.Peer, state transport.
 	if protocol.Version() == p.Version() {
 		switch state {
 		case transport.StateConnected:
-			xor, clock := p.state.XOR(context.Background(), dag.MaxLamportClock)
+			xor, clock := p.state.XOR(dag.MaxLamportClock)
 			p.gManager.PeerConnected(peer, xor, clock)
 			p.diagnosticsMan.add(peer.ID)
 		case transport.StateDisconnected:
@@ -214,10 +214,9 @@ func (p *protocol) connectionStateCallback(peer transport.Peer, state transport.
 
 // gossipTransaction is called when a transaction is added to the DAG
 func (p *protocol) gossipTransaction(event dag.Event) (bool, error) {
-	ctx := context.Background()
 	// race conditions may occur since the XOR may have been updated in parallel.
 	// If this is the case, nodes will fall back to using the IBLT.
-	xor, clock := p.state.XOR(ctx, dag.MaxLamportClock)
+	xor, clock := p.state.XOR(dag.MaxLamportClock)
 	p.gManager.TransactionRegistered(event.Hash, xor, clock)
 
 	return true, nil

--- a/network/transport/v2/protocol_test.go
+++ b/network/transport/v2/protocol_test.go
@@ -230,7 +230,7 @@ func TestProtocol_Start(t *testing.T) {
 func TestProtocol_connectionStateCallback(t *testing.T) {
 	t.Run("ok - connected", func(t *testing.T) {
 		proto, mocks := newTestProtocol(t, nil)
-		mocks.State.EXPECT().XOR(gomock.Any(), uint32(dag.MaxLamportClock)).Return(hash.EmptyHash(), uint32(5))
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(hash.EmptyHash(), uint32(5))
 		mocks.Gossip.EXPECT().PeerConnected(peer, hash.EmptyHash(), uint32(5))
 
 		proto.connectionStateCallback(peer, transport.StateConnected, proto)
@@ -257,7 +257,7 @@ func TestProtocol_gossipTransaction(t *testing.T) {
 	t.Run("ok - to gossipManager", func(t *testing.T) {
 		proto, mocks := newTestProtocol(t, nil)
 		tx, _, _ := dag.CreateTestTransaction(0)
-		mocks.State.EXPECT().XOR(gomock.Any(), uint32(dag.MaxLamportClock))
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock))
 		mocks.Gossip.EXPECT().TransactionRegistered(tx.Ref(), hash.EmptyHash(), uint32(0))
 		event := dag.Event{
 			Type:        dag.TransactionEventType,

--- a/network/transport/v2/transactionlist_handler.go
+++ b/network/transport/v2/transactionlist_handler.go
@@ -111,7 +111,7 @@ func (p *protocol) handleTransactionList(peer transport.Peer, envelope *Envelope
 					WithField(core.LogFieldConversationID, cid).
 					WithField(core.LogFieldTransactionRef, tx.Ref()).
 					Warn("Ignoring remainder of TransactionList due to missing prevs")
-				xor, clock := p.state.XOR(ctx, dag.MaxLamportClock)
+				xor, clock := p.state.XOR(dag.MaxLamportClock)
 				return p.sender.sendState(peer.ID, xor, clock)
 			}
 			return fmt.Errorf("unable to add received transaction to DAG (tx=%s): %w", tx.Ref(), err)

--- a/network/transport/v2/transactionlist_handler_test.go
+++ b/network/transport/v2/transactionlist_handler_test.go
@@ -103,7 +103,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 		conversation := p.cMan.startConversation(request, peerID)
 		envelope := envelopeWithConversation(conversation)
 		mocks.State.EXPECT().Add(context.Background(), tx, payload).Return(dag.ErrPreviousTransactionMissing)
-		mocks.State.EXPECT().XOR(context.Background(), uint32(dag.MaxLamportClock)).Return(hash.FromSlice([]byte("stateXor")), uint32(7))
+		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(hash.FromSlice([]byte("stateXor")), uint32(7))
 		mocks.Sender.EXPECT().sendState(peer.ID, hash.FromSlice([]byte("stateXor")), uint32(7))
 
 		err := p.handleTransactionList(peer, envelope)


### PR DESCRIPTION
XOR and IBLT are cached in memory, but every request for an IBLT/XOR still required an DB call for the highest LC.