### PR TITLE
Fix vcr api example requests

### DIFF
--- a/docs/_static/vcr/v2.yaml
+++ b/docs/_static/vcr/v2.yaml
@@ -63,7 +63,7 @@ paths:
               $ref: '#/components/schemas/SearchVCRequest'
             examples:
               NutsOrganizationCredential:
-                value: >
+                value:
                   {
                     "query": {
                       "@context": ["https://www.w3.org/2018/credentials/v1","https://nuts.nl/credentials/v1"],
@@ -77,7 +77,7 @@ paths:
                     }
                   }
               NutsAuthorizationCredential:
-                value: >
+                value:
                   {
                     "query": {
                       "@context": ["https://www.w3.org/2018/credentials/v1","https://nuts.nl/credentials/v1"],


### PR DESCRIPTION
removes the `>` character. With this character the example is text, now it is JSON.