### PR TITLE
refactor types.ErrInvalidServiceQuery to doc.DIDServiceQueryError

### DIFF
--- a/didman/api/v1/api_test.go
+++ b/didman/api/v1/api_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/didman"
 	"github.com/nuts-foundation/nuts-node/mock"
+	"github.com/nuts-foundation/nuts-node/vdr/doc"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -468,7 +469,7 @@ func TestWrapper_GetCompoundServiceEndpoint(t *testing.T) {
 	t.Run("error mapping", func(t *testing.T) {
 		ctx := newMockContext(t)
 		assert.Equal(t, http.StatusNotFound, ctx.wrapper.ResolveStatusCode(types.ErrServiceNotFound))
-		assert.Equal(t, http.StatusBadRequest, ctx.wrapper.ResolveStatusCode(types.ErrInvalidServiceQuery{}))
+		assert.Equal(t, http.StatusBadRequest, ctx.wrapper.ResolveStatusCode(doc.DIDServiceQueryError{errors.New("arbitrary")}))
 		assert.Equal(t, http.StatusNotAcceptable, ctx.wrapper.ResolveStatusCode(types.ErrServiceReferenceToDeep))
 		assert.Equal(t, http.StatusNotAcceptable, ctx.wrapper.ResolveStatusCode(didman.ErrReferencedServiceNotAnEndpoint{}))
 		assert.Equal(t, http.StatusNotFound, ctx.wrapper.ResolveStatusCode(types.ErrNotFound))

--- a/didman/types.go
+++ b/didman/types.go
@@ -53,7 +53,7 @@ type Didman interface {
 
 	// AddCompoundService adds a compound endpoint to a DID Document.
 	// It returns ErrDuplicateService if a service with the given type already exists.
-	// It returns ErrInvalidServiceQuery if one of the service references is invalid.
+	// It returns doc.DIDServiceQueryError if one of the service references is invalid.
 	// It returns ErrReferencedServiceNotAnEndpoint if one of the references does not resolve to a single endpoint URL.
 	// It can also return various errors from DocResolver.Resolve and VDR.Update
 	AddCompoundService(id did.DID, serviceType string, endpoints map[string]ssi.URI) (*did.Service, error)
@@ -80,7 +80,7 @@ type CompoundServiceResolver interface {
 	// It returns the serviceEndpoint of the specified service (which must be an absolute URL endpoint).
 	// If resolveReferences is true and the specified endpointType contains a reference, it is resolved and the referenced endpoint is returned instead.
 	// It returns ErrServiceNotFound if the specified compound service or endpoint can't be found in the DID Document.
-	// It returns ErrInvalidServiceQuery if the endpoint doesn't contain a (valid) reference and resolveReferences = true.
+	// It returns doc.DIDServiceQueryError if the endpoint doesn't contain a (valid) reference and resolveReferences = true.
 	// It returns ErrServiceReferenceToDeep if the endpoint reference is nested too deep.
 	GetCompoundServiceEndpoint(id did.DID, compoundServiceType string, endpointType string, resolveReferences bool) (string, error)
 

--- a/vdr/doc/resolvers_test.go
+++ b/vdr/doc/resolvers_test.go
@@ -534,7 +534,7 @@ func TestServiceResolver_Resolve(t *testing.T) {
 
 		actual, err := NewServiceResolver(docResolver).Resolve(MakeServiceReference(*didB, "invalid-ref"), DefaultMaxServiceReferenceDepth)
 
-		assert.EqualError(t, err, "service query is invalid: URL path must be '/serviceEndpoint'")
+		assert.EqualError(t, err, "DID service query invalid: endpoint URI path must be /serviceEndpoint")
 		assert.Empty(t, actual)
 	})
 	t.Run("error - service not found", func(t *testing.T) {

--- a/vdr/doc/util.go
+++ b/vdr/doc/util.go
@@ -79,8 +79,9 @@ func ValidateServiceReference(endpointURI ssi.URI) error {
 		return DIDServiceQueryError{errors.New("endpoint URI with multiple " + serviceTypeQueryParameter + " query parameters")}
 	}
 
+	// “Other query parameters, paths or fragments SHALL NOT be used.”
+	// — RFC006, subsection 4.2
 	if len(q) > 1 {
-		// weird requirement; needs explaination why
 		return DIDServiceQueryError{errors.New("endpoint URI with query parameter other than " + serviceTypeQueryParameter)}
 	}
 

--- a/vdr/doc/util.go
+++ b/vdr/doc/util.go
@@ -19,20 +19,20 @@
 package doc
 
 import (
+	"errors"
 	"fmt"
 	"github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
-	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"strings"
 )
 
 const serviceTypeQueryParameter = "type"
-const serviceEndpointPath = "serviceEndpoint"
+const serviceEndpointPath = "/serviceEndpoint"
 
 // MakeServiceReference creates a service reference, which can be used as query when looking up services.
 func MakeServiceReference(subjectDID did.DID, serviceType string) ssi.URI {
 	ref := subjectDID.URI()
-	ref.Opaque += "/" + serviceEndpointPath
+	ref.Opaque += serviceEndpointPath
 	ref.Fragment = ""
 	ref.RawQuery = fmt.Sprintf("%s=%s", serviceTypeQueryParameter, serviceType)
 	return ref
@@ -43,31 +43,46 @@ func IsServiceReference(endpoint string) bool {
 	return strings.HasPrefix(endpoint, "did:")
 }
 
+// DIDServiceQueryError denies the query based on validation constraints.
+type DIDServiceQueryError struct {
+	Err error // cause
+}
+
+// Error implements the error interface.
+func (e DIDServiceQueryError) Error() string {
+	return "DID service query invalid: " + e.Err.Error()
+}
+
+// Unwrap implements the errors.Unwrap convention.
+func (e DIDServiceQueryError) Unwrap() error { return e.Err }
+
 // ValidateServiceReference checks whether the given URI matches the format for a service reference.
 func ValidateServiceReference(endpointURI ssi.URI) error {
 	// Parse it as DID URL since DID URLs are rootless and thus opaque (RFC 3986), meaning the path will be part of the URI body, rather than the URI path.
 	// For DID URLs the path is parsed properly.
 	didEndpointURL, err := did.ParseDIDURL(endpointURI.String())
 	if err != nil {
-		return types.ErrInvalidServiceQuery{Cause: err}
+		return DIDServiceQueryError{err}
 	}
-	if didEndpointURL.Path != serviceEndpointPath {
-		// Service reference doesn't refer to `/serviceEndpoint`
-		return types.ErrInvalidServiceQuery{Cause: fmt.Errorf("URL path must be '/%s'", serviceEndpointPath)}
+
+	if "/"+didEndpointURL.Path != serviceEndpointPath {
+		return DIDServiceQueryError{errors.New("endpoint URI path must be " + serviceEndpointPath)}
 	}
-	queriedServiceType := endpointURI.Query().Get(serviceTypeQueryParameter)
-	typeQueryParameterError := types.ErrInvalidServiceQuery{Cause: fmt.Errorf("URL must contain exactly one '%s' query parameter, with exactly one value", serviceTypeQueryParameter)}
-	if len(queriedServiceType) == 0 {
-		// Service reference doesn't contain `type` query parameter
-		return typeQueryParameterError
+
+	q := endpointURI.Query()
+	switch len(q[serviceTypeQueryParameter]) {
+	case 1:
+		break // good
+	case 0:
+		return DIDServiceQueryError{errors.New("endpoint URI without " + serviceTypeQueryParameter + " query parameter")}
+	default:
+		return DIDServiceQueryError{errors.New("endpoint URI with multiple " + serviceTypeQueryParameter + " query parameters")}
 	}
-	if len(endpointURI.Query()[serviceTypeQueryParameter]) > 1 {
-		// Service reference contains more than 1 `type` query parameter
-		return typeQueryParameterError
+
+	if len(q) > 1 {
+		// weird requirement; needs explaination why
+		return DIDServiceQueryError{errors.New("endpoint URI with query parameter other than " + serviceTypeQueryParameter)}
 	}
-	if len(endpointURI.Query()) > 1 {
-		// Service reference contains more than just `type` query parameter
-		return typeQueryParameterError
-	}
+
 	return nil
 }

--- a/vdr/doc/util_test.go
+++ b/vdr/doc/util_test.go
@@ -21,7 +21,6 @@ package doc
 import (
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
-	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -45,25 +44,29 @@ func Test_ValidateServiceReference(t *testing.T) {
 	t.Run("error - invalid path", func(t *testing.T) {
 		ref := ssi.MustParseURI("did:nuts:abc/serviceEndpointWithInvalidPostfix?type=sajdklsad")
 		err := ValidateServiceReference(ref)
-		assert.ErrorIs(t, err, types.ErrInvalidServiceQuery{})
-		assert.ErrorContains(t, err, "URL path must be '/serviceEndpoint'")
+		assert.ErrorAs(t, err, new(DIDServiceQueryError))
+		assert.ErrorContains(t, err, "DID service query invalid")
+		assert.ErrorContains(t, err, "endpoint URI path must be /serviceEndpoint")
 	})
 	t.Run("error - too many type params", func(t *testing.T) {
 		ref := ssi.MustParseURI("did:nuts:abc/serviceEndpoint?type=t1&type=t2")
 		err := ValidateServiceReference(ref)
-		assert.ErrorIs(t, err, types.ErrInvalidServiceQuery{})
-		assert.ErrorContains(t, err, "URL must contain exactly one 'type' query parameter, with exactly one value")
+		assert.ErrorAs(t, err, new(DIDServiceQueryError))
+		assert.ErrorContains(t, err, "DID service query invalid")
+		assert.ErrorContains(t, err, "endpoint URI with multiple type query parameters")
 	})
 	t.Run("error - no type params", func(t *testing.T) {
 		ref := ssi.MustParseURI("did:nuts:abc/serviceEndpoint")
 		err := ValidateServiceReference(ref)
-		assert.ErrorIs(t, err, types.ErrInvalidServiceQuery{})
-		assert.ErrorContains(t, err, "URL must contain exactly one 'type' query parameter, with exactly one value")
+		assert.ErrorAs(t, err, new(DIDServiceQueryError))
+		assert.ErrorContains(t, err, "DID service query invalid")
+		assert.ErrorContains(t, err, "endpoint URI without type query parameter")
 	})
 	t.Run("error - invalid params", func(t *testing.T) {
 		ref := ssi.MustParseURI("did:nuts:abc/serviceEndpoint?type=t1&someOther=not-allowed")
 		err := ValidateServiceReference(ref)
-		assert.ErrorIs(t, err, types.ErrInvalidServiceQuery{})
-		assert.ErrorContains(t, err, "URL must contain exactly one 'type' query parameter, with exactly one value")
+		assert.ErrorAs(t, err, new(DIDServiceQueryError))
+		assert.ErrorContains(t, err, "DID service query invalid")
+		assert.ErrorContains(t, err, "endpoint URI with query parameter other than type")
 	})
 }

--- a/vdr/types/common.go
+++ b/vdr/types/common.go
@@ -20,7 +20,6 @@ package types
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/nuts-foundation/go-did/did"
@@ -56,21 +55,6 @@ var ErrServiceNotFound = errors.New("service not found in DID Document")
 
 // ErrServiceReferenceToDeep is returned when a service reference is chain is nested too deeply.
 var ErrServiceReferenceToDeep = errors.New("service references are nested to deeply before resolving to a non-reference")
-
-// ErrInvalidServiceQuery is returned when a compound service contains an invalid service reference.
-type ErrInvalidServiceQuery struct {
-	Cause error
-}
-
-// Error returns the error message.
-func (e ErrInvalidServiceQuery) Error() string {
-	return fmt.Sprintf("service query is invalid: %s", e.Cause)
-}
-
-// Is checks whether the other error is also a ErrInvalidServiceQuery
-func (e ErrInvalidServiceQuery) Is(other error) bool {
-	return fmt.Sprintf("%T", e) == fmt.Sprintf("%T", other)
-}
 
 type deactivatedError struct {
 	msg string

--- a/vdr/types/common_test.go
+++ b/vdr/types/common_test.go
@@ -88,12 +88,3 @@ func Test_deactivatedError_Is(t *testing.T) {
 	assert.ErrorIs(t, ErrNoActiveController, ErrDeactivated)
 	assert.NotErrorIs(t, io.EOF, ErrDeactivated)
 }
-
-func Test_ErrInvalidServiceQuery_Is(t *testing.T) {
-	assert.ErrorIs(t, ErrInvalidServiceQuery{}, ErrInvalidServiceQuery{})
-	assert.NotErrorIs(t, ErrInvalidServiceQuery{}, io.EOF)
-}
-
-func Test_ErrInvalidServiceQuery_Error(t *testing.T) {
-	assert.EqualError(t, ErrInvalidServiceQuery{Cause: io.EOF}, "service query is invalid: EOF")
-}


### PR DESCRIPTION
Error type names should end with Error. The error strings each should classify the full context of what is already explicit in code. In this case, describe the error is about "DID Subjects" and "endpoint URIs".

Errors should live together with the code that encounters any of the respective cases. The package name becomes a descriptive part of the scenario. Package names like `types` or `core` must be killed with fire.

https://go.dev/doc/effective_go#names

Do not introduce functions for cases handled well in plain code, especially if such function has an odd structure like core.ResolveStatusCode does. The new `switch` is more readable, it requires no knowledge of the Nuts packages, and it provides a sane default [HTTP 500].