### PR TITLE
VCR: Tolerate undefined fields for v1 NutsAuthCred

### DIFF
--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -28,8 +28,9 @@ Breaking changes
 
 While Nuts RFC014 (Authorization Credential) required ``legalBase`` to be present in all ``NutsAuthorizationCredential``s,
 this property was missing in the Nuts v1 JSON-LD context. When issuing Verifiable Credentials, now all fields must be defined in its context(s).
-This means, starting this version, the ``legalBase`` property can't used in new v1 ``NutsAuthorizationCredential``s.
-Until the next major version (v6.0.0) it should be removed.
+This means, starting this version, the ``legalBase`` property shouldn't used in new v1 ``NutsAuthorizationCredential``s.
+But, to maintain backwards compatibility, especially in mixed networks (nodes running v4, others running v5), it only generates a warning.
+Still, until the next major version (v6.0.0) the ``legalBase`` should be removed.
 Then when v6.0.0 is released, upgrade to the v2 JSON-LD context version and re-add the ``legalBase``.
 
 Redis Sentinel was configured through a Redis connection URL by passing Sentinel-specific query parameters,

--- a/vcr/credential/validator_test.go
+++ b/vcr/credential/validator_test.go
@@ -184,6 +184,25 @@ func TestNutsAuthorizationCredentialValidator_Validate(t *testing.T) {
 
 			assert.NoError(t, err)
 		})
+		t.Run("ok - backwards compatibility for LegalBase", func(t *testing.T) {
+			// Tests with a credential with LegalBase which was required up to v4,
+			// but disallowed starting v5 since it isn't defined in the JSON-LD context.
+			// But to maintain backwards compatibility, it's allowed and logged as a warning.
+			v := validV1NutsAuthorizationCredential()
+			v.CredentialSubject = []interface{}{
+				NutsAuthorizationCredentialSubject{
+					ID:           vdr.TestDIDB.String(),
+					PurposeOfUse: "eTransfer",
+					LegalBase: &LegalBase{
+						ConsentType: "implied",
+					},
+				},
+			}
+
+			err := validator.Validate(*v)
+
+			assert.NoError(t, err)
+		})
 	})
 	t.Run("v2", func(t *testing.T) {
 		t.Run("ok - implied", func(t *testing.T) {


### PR DESCRIPTION
To maintain backwards compatibility with v4. Remove for v6.

Backport to v5