### PR TITLE
replace not found data nil with an ErrNotFound

### DIFF
--- a/network/api/v1/api.go
+++ b/network/api/v1/api.go
@@ -19,6 +19,7 @@
 package v1
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -65,10 +66,10 @@ func (a Wrapper) GetTransaction(ctx echo.Context, hashAsString string) error {
 	}
 	transaction, err := a.Service.GetTransaction(hash)
 	if err != nil {
+		if errors.Is(err, dag.ErrTransactionNotFound) {
+			return core.NotFoundError("transaction not found")
+		}
 		return err
-	}
-	if transaction == nil {
-		return core.NotFoundError("transaction not found")
 	}
 	ctx.Response().Header().Set(echo.HeaderContentType, "application/jose")
 	ctx.Response().WriteHeader(http.StatusOK)
@@ -84,10 +85,10 @@ func (a Wrapper) GetTransactionPayload(ctx echo.Context, hashAsString string) er
 	}
 	data, err := a.Service.GetTransactionPayload(hash)
 	if err != nil {
+		if errors.Is(err, dag.ErrPayloadNotFound) {
+			return core.NotFoundError("transaction or contents not found")
+		}
 		return err
-	}
-	if data == nil {
-		return core.NotFoundError("transaction or contents not found")
 	}
 	ctx.Response().Header().Set(echo.HeaderContentType, "application/octet-stream")
 	ctx.Response().WriteHeader(http.StatusOK)

--- a/network/api/v1/api_test.go
+++ b/network/api/v1/api_test.go
@@ -115,7 +115,7 @@ func TestApiWrapper_GetTransaction(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		var networkClient = network.NewMockTransactions(mockCtrl)
 		e, wrapper := initMockEcho(networkClient)
-		networkClient.EXPECT().GetTransaction(gomock.Any()).Return(nil, nil)
+		networkClient.EXPECT().GetTransaction(gomock.Any()).Return(nil, dag.ErrTransactionNotFound)
 
 		req := httptest.NewRequest(echo.GET, "/", nil)
 		rec := httptest.NewRecorder()
@@ -254,7 +254,7 @@ func TestApiWrapper_GetTransactionPayload(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		var networkClient = network.NewMockTransactions(mockCtrl)
 		e, wrapper := initMockEcho(networkClient)
-		networkClient.EXPECT().GetTransactionPayload(gomock.Any()).Return(nil, nil)
+		networkClient.EXPECT().GetTransactionPayload(gomock.Any()).Return(nil, dag.ErrPayloadNotFound)
 
 		req := httptest.NewRequest(echo.GET, "/", nil)
 		rec := httptest.NewRecorder()

--- a/network/dag/dag.go
+++ b/network/dag/dag.go
@@ -21,6 +21,7 @@ package dag
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -146,7 +147,13 @@ func (d *dag) Migrate() error {
 				for _, ref := range heads {
 					transaction, err := getTransaction(ref, tx)
 					if err != nil {
+						if errors.Is(err, ErrTransactionNotFound) {
+							return fmt.Errorf("database migration failed: head not found (%s=%s)", core.LogFieldTransactionRef, ref)
+						}
 						return err
+					}
+					if transaction == nil {
+
 					}
 					if transaction.Clock() >= latestLC {
 						latestHead = ref
@@ -444,12 +451,16 @@ func getRoots(lcBucket stoabs.Reader) []hash.SHA256Hash {
 	return parseHashList(roots) // no need to copy, calls FromSlice() (which copies)
 }
 
+// getTransaction returns the transaction, or an error. returns ErrTransactionNotFound if the transaction cannot be found.
 func getTransaction(hash hash.SHA256Hash, tx stoabs.ReadTx) (Transaction, error) {
 	transactions := tx.GetShelfReader(transactionsShelf)
 
 	transactionBytes, err := transactions.Get(stoabs.NewHashKey(hash))
-	if err != nil || transactionBytes == nil {
+	if err != nil {
 		return nil, err
+	}
+	if transactionBytes == nil {
+		return nil, ErrTransactionNotFound
 	}
 	parsedTx, err := ParseTransaction(transactionBytes)
 	if err != nil {

--- a/network/dag/dag.go
+++ b/network/dag/dag.go
@@ -148,12 +148,9 @@ func (d *dag) Migrate() error {
 					transaction, err := getTransaction(ref, tx)
 					if err != nil {
 						if errors.Is(err, ErrTransactionNotFound) {
-							return fmt.Errorf("database migration failed: head not found (%s=%s)", core.LogFieldTransactionRef, ref)
+							return fmt.Errorf("database migration failed: %w (%s=%s)", err, core.LogFieldTransactionRef, ref)
 						}
 						return err
-					}
-					if transaction == nil {
-
 					}
 					if transaction.Clock() >= latestLC {
 						latestHead = ref

--- a/network/dag/dag_test.go
+++ b/network/dag/dag_test.go
@@ -103,7 +103,7 @@ func TestDAG_Get(t *testing.T) {
 		graph := CreateDAG(t)
 		_ = graph.db.Write(ctx, func(tx stoabs.WriteTx) error {
 			actual, err := getTransaction(hash.SHA256Sum([]byte{1, 2, 3}), tx)
-			assert.NoError(t, err)
+			assert.ErrorIs(t, err, ErrTransactionNotFound)
 			assert.Nil(t, actual)
 			return nil
 		})

--- a/network/dag/payloadstore.go
+++ b/network/dag/payloadstore.go
@@ -52,6 +52,9 @@ func (store payloadStore) readPayload(tx stoabs.ReadTx, payloadHash hash.SHA256H
 	if err != nil {
 		return nil, fmt.Errorf("failed to read payload (hash=%s): %w", payloadHash, err)
 	}
+	if data == nil {
+		return nil, ErrPayloadNotFound
+	}
 	return data, nil
 }
 

--- a/network/dag/payloadstore.go
+++ b/network/dag/payloadstore.go
@@ -19,6 +19,7 @@
 package dag
 
 import (
+	"errors"
 	"fmt"
 	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
@@ -38,9 +39,11 @@ type payloadStore struct{}
 func (store payloadStore) isPayloadPresent(tx stoabs.ReadTx, payloadHash hash.SHA256Hash) bool {
 	data, err := store.readPayload(tx, payloadHash)
 	if err != nil {
-		log.Logger().
-			WithError(err).
-			Error("Failed to verify payload existence")
+		if !errors.Is(err, ErrPayloadNotFound) {
+			log.Logger().
+				WithError(err).
+				Error("Failed to verify payload existence")
+		}
 		return false
 	}
 	return len(data) > 0

--- a/network/dag/state.go
+++ b/network/dag/state.go
@@ -307,7 +307,7 @@ func (s *state) WritePayload(ctx context.Context, transaction Transaction, paylo
 }
 
 func (s *state) ReadPayload(ctx context.Context, hash hash.SHA256Hash) (payload []byte, err error) {
-	_ = s.db.Read(ctx, func(tx stoabs.ReadTx) error {
+	err = s.db.Read(ctx, func(tx stoabs.ReadTx) error {
 		payload, err = s.payloadStore.readPayload(tx, hash)
 		return err
 	})

--- a/network/dag/verifier.go
+++ b/network/dag/verifier.go
@@ -70,10 +70,10 @@ func NewPrevTransactionsVerifier() Verifier {
 		for _, prev := range transaction.Previous() {
 			previousTransaction, err := getTransaction(prev, tx)
 			if err != nil {
+				if errors.Is(err, ErrTransactionNotFound) {
+					return ErrPreviousTransactionMissing
+				}
 				return err
-			}
-			if previousTransaction == nil {
-				return ErrPreviousTransactionMissing
 			}
 			if int(previousTransaction.Clock()) >= highestLamportClock {
 				highestLamportClock = int(previousTransaction.Clock())

--- a/network/interface.go
+++ b/network/interface.go
@@ -35,10 +35,11 @@ type Transactions interface {
 	Subscribe(name string, receiver dag.ReceiverFn, filters ...SubscriberOption) error
 	// Subscribers returns the list of notifiers on the DAG that emit events to subscribers.
 	Subscribers() []dag.Notifier
-	// GetTransactionPayload retrieves the transaction Payload for the given transaction. If the transaction or Payload is not found
-	// nil is returned.
+	// GetTransactionPayload retrieves the transaction Payload for the given transaction.
+	// If the transaction or Payload is not found, dag.ErrPayloadNotFound is returned.
 	GetTransactionPayload(transactionRef hash.SHA256Hash) ([]byte, error)
-	// GetTransaction retrieves the transaction for the given reference. If the transaction is not known, an error is returned.
+	// GetTransaction retrieves the transaction for the given reference.
+	// If the transaction is not found, a dag.ErrTransactionNotFound is returned.
 	GetTransaction(transactionRef hash.SHA256Hash) (dag.Transaction, error)
 	// CreateTransaction creates a new transaction according to the given spec.
 	CreateTransaction(spec Template) (dag.Transaction, error)

--- a/network/network.go
+++ b/network/network.go
@@ -424,10 +424,10 @@ func (n *Network) GetTransaction(transactionRef hash.SHA256Hash) (dag.Transactio
 func (n *Network) GetTransactionPayload(transactionRef hash.SHA256Hash) ([]byte, error) {
 	transaction, err := n.state.GetTransaction(context.Background(), transactionRef)
 	if err != nil {
+		if errors.Is(err, dag.ErrTransactionNotFound) {
+			return nil, dag.ErrPayloadNotFound
+		}
 		return nil, err
-	}
-	if transaction == nil {
-		return nil, nil
 	}
 	return n.state.ReadPayload(context.Background(), transaction.PayloadHash())
 }
@@ -479,6 +479,8 @@ func (n *Network) CreateTransaction(template Template) (dag.Transaction, error) 
 	}
 	if !head.Equals(hash.EmptyHash()) {
 		prevs = append(prevs, head)
+	} else if len(template.AdditionalPrevs) != 0 {
+		return nil, fmt.Errorf("cannot have previous transactions on root transaction")
 	}
 	// and additional prevs
 	prevs = append(prevs, template.AdditionalPrevs...)
@@ -698,10 +700,10 @@ func (n *Network) collectDiagnosticsForPeers() transport.Diagnostics {
 func (n *Network) isPayloadPresent(ctx context.Context, txRef hash.SHA256Hash) (bool, error) {
 	tx, err := n.state.GetTransaction(ctx, txRef)
 	if err != nil {
+		if errors.Is(err, dag.ErrTransactionNotFound) {
+			return false, nil
+		}
 		return false, err
-	}
-	if tx == nil {
-		return false, nil
 	}
 	return n.state.IsPayloadPresent(ctx, tx.PayloadHash())
 }

--- a/network/network.go
+++ b/network/network.go
@@ -425,6 +425,7 @@ func (n *Network) GetTransactionPayload(transactionRef hash.SHA256Hash) ([]byte,
 	transaction, err := n.state.GetTransaction(context.Background(), transactionRef)
 	if err != nil {
 		if errors.Is(err, dag.ErrTransactionNotFound) {
+			// convert ErrPayloadNotFound for simpler error handling
 			return nil, dag.ErrPayloadNotFound
 		}
 		return nil, err

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -912,9 +912,9 @@ func startNode(t *testing.T, name string, testDirectory string, opts ...func(ser
 	_ = serverConfig.Load(core.FlagSet())
 	serverConfig.Datadir = path.Join(testDirectory, name)
 	serverConfig.LegacyTLS.Enabled = true
-	serverConfig.LegacyTLS.CertFile = "test/certificate-and-key.pem"
-	serverConfig.LegacyTLS.CertKeyFile = "test/certificate-and-key.pem"
-	serverConfig.LegacyTLS.TrustStoreFile = "test/truststore.pem"
+	serverConfig.TLS.CertFile = "test/certificate-and-key.pem"
+	serverConfig.TLS.CertKeyFile = "test/certificate-and-key.pem"
+	serverConfig.TLS.TrustStoreFile = "test/truststore.pem"
 
 	// Create Network instance
 	config := Config{

--- a/network/transport/v2/handlers_test.go
+++ b/network/transport/v2/handlers_test.go
@@ -102,7 +102,7 @@ func TestProtocol_handleTransactionPayload(t *testing.T) {
 
 	t.Run("error - tx not present", func(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
-		mocks.State.EXPECT().GetTransaction(gomock.Any(), tx.Ref()).Return(nil, nil)
+		mocks.State.EXPECT().GetTransaction(gomock.Any(), tx.Ref()).Return(nil, dag.ErrTransactionNotFound)
 
 		err := p.handleTransactionPayload(peer, &Envelope{Message: &Envelope_TransactionPayload{&TransactionPayload{TransactionRef: tx.Ref().Slice(), Data: payload}}})
 
@@ -135,7 +135,7 @@ func TestProtocol_handleTransactionPayloadQuery(t *testing.T) {
 
 		t.Run("transaction not found", func(t *testing.T) {
 			p, mocks := newTestProtocol(t, nil)
-			mocks.State.EXPECT().GetTransaction(gomock.Any(), tx.Ref()).Return(nil, nil)
+			mocks.State.EXPECT().GetTransaction(gomock.Any(), tx.Ref()).Return(nil, dag.ErrTransactionNotFound)
 
 			conns := &grpc.StubConnectionList{
 				Conn: &grpc.StubConnection{PeerID: peer.ID},
@@ -399,8 +399,8 @@ func TestProtocol_handleTransactionListQuery(t *testing.T) {
 
 	t.Run("ok - tx not present", func(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
-		mocks.State.EXPECT().GetTransaction(context.Background(), h1).Return(nil, nil)
-		mocks.State.EXPECT().GetTransaction(context.Background(), h2).Return(nil, nil)
+		mocks.State.EXPECT().GetTransaction(context.Background(), h1).Return(nil, dag.ErrTransactionNotFound)
+		mocks.State.EXPECT().GetTransaction(context.Background(), h2).Return(nil, dag.ErrTransactionNotFound)
 
 		mocks.Sender.EXPECT().sendTransactionList(peer.ID, conversationID, gomock.Any())
 
@@ -447,7 +447,7 @@ func TestProtocol_handleTransactionListQuery(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
 		mocks.State.EXPECT().GetTransaction(context.Background(), h1).Return(dagT1, nil)
 		mocks.State.EXPECT().GetTransaction(context.Background(), h2).Return(dagT2, nil)
-		mocks.State.EXPECT().ReadPayload(context.Background(), dagT1.PayloadHash()).Return(nil, nil)
+		mocks.State.EXPECT().ReadPayload(context.Background(), dagT1.PayloadHash()).Return(nil, dag.ErrPayloadNotFound)
 
 		err := p.handleTransactionListQuery(peer, &Envelope{
 			Message: &Envelope_TransactionListQuery{&TransactionListQuery{

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -246,6 +246,7 @@ func (p *protocol) handlePrivateTxRetry(event dag.Event) (bool, error) {
 	}
 
 	if isPresent {
+		// stop retrying
 		log.Logger().
 			WithField(core.LogFieldTransactionRef, event.Hash.String()).
 			Debug("Transaction payload already present, not querying")

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -237,7 +237,7 @@ func (p *protocol) sendGossip(id transport.PeerID, refs []hash.SHA256Hash, xor h
 
 func (p *protocol) handlePrivateTxRetry(event dag.Event) (bool, error) {
 	// Sanity check: if we have the payload, mark this job as finished
-	payload, err := p.state.ReadPayload(context.Background(), event.Transaction.PayloadHash())
+	isPresent, err := p.state.IsPayloadPresent(context.Background(), event.Transaction.PayloadHash())
 	if err != nil {
 		if !errors.As(err, new(stoabs.ErrDatabase)) {
 			err = dag.EventFatal{err}
@@ -245,8 +245,7 @@ func (p *protocol) handlePrivateTxRetry(event dag.Event) (bool, error) {
 		return false, fmt.Errorf("unable to read payload (tx=%s): %w", event.Hash, err)
 	}
 
-	if payload != nil {
-		// stop retrying
+	if isPresent {
 		log.Logger().
 			WithField(core.LogFieldTransactionRef, event.Hash.String()).
 			Debug("Transaction payload already present, not querying")

--- a/network/transport/v2/protocol_test.go
+++ b/network/transport/v2/protocol_test.go
@@ -286,7 +286,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 	t.Run("errors when reading payload errors", func(t *testing.T) {
 		proto, mocks := newTestProtocol(t, nil)
 
-		mocks.State.EXPECT().ReadPayload(gomock.Any(), txOk.PayloadHash()).Return(nil, stoabs.DatabaseError(errors.New("random error")))
+		mocks.State.EXPECT().IsPayloadPresent(gomock.Any(), txOk.PayloadHash()).Return(false, stoabs.DatabaseError(errors.New("random error")))
 
 		finished, err := proto.handlePrivateTxRetry(event)
 
@@ -298,7 +298,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 	t.Run("Finishes job when payload is already there", func(t *testing.T) {
 		proto, mocks := newTestProtocol(t, nil)
 
-		mocks.State.EXPECT().ReadPayload(gomock.Any(), txOk.PayloadHash()).Return([]byte{0}, nil)
+		mocks.State.EXPECT().IsPayloadPresent(gomock.Any(), txOk.PayloadHash()).Return(true, nil)
 
 		finished, err := proto.handlePrivateTxRetry(event)
 
@@ -308,7 +308,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 
 	t.Run("removes scheduled job when payload is present", func(t *testing.T) {
 		proto, mocks := newTestProtocol(t, nil)
-		mocks.State.EXPECT().ReadPayload(context.Background(), txOk.PayloadHash()).Return([]byte{}, nil)
+		mocks.State.EXPECT().IsPayloadPresent(context.Background(), txOk.PayloadHash()).Return(true, nil)
 
 		finished, err := proto.handlePrivateTxRetry(event)
 
@@ -318,7 +318,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 
 	t.Run("errors when node DID is not set", func(t *testing.T) {
 		proto, mocks := newTestProtocol(t, nil)
-		mocks.State.EXPECT().ReadPayload(context.Background(), txOk.PayloadHash()).Return(nil, nil)
+		mocks.State.EXPECT().IsPayloadPresent(context.Background(), txOk.PayloadHash()).Return(false, nil)
 
 		finished, err := proto.handlePrivateTxRetry(event)
 
@@ -329,7 +329,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 
 	t.Run("errors when resolving the node DID document fails", func(t *testing.T) {
 		proto, mocks := newTestProtocol(t, testDID)
-		mocks.State.EXPECT().ReadPayload(context.Background(), txOk.PayloadHash()).Return(nil, nil)
+		mocks.State.EXPECT().IsPayloadPresent(context.Background(), txOk.PayloadHash()).Return(false, nil)
 		mocks.DocResolver.EXPECT().Resolve(*testDID, nil).Return(nil, nil, stoabs.DatabaseError(errors.New("random error")))
 
 		finished, err := proto.handlePrivateTxRetry(event)
@@ -342,7 +342,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 	t.Run("errors when decryption fails because the key-agreement key could not be found", func(t *testing.T) {
 		proto, mocks := newTestProtocol(t, testDID)
 
-		mocks.State.EXPECT().ReadPayload(context.Background(), txOk.PayloadHash()).Return(nil, nil)
+		mocks.State.EXPECT().IsPayloadPresent(context.Background(), txOk.PayloadHash()).Return(false, nil)
 		mocks.DocResolver.EXPECT().Resolve(*testDID, nil).Return(&did.Document{
 			KeyAgreement: []did.VerificationRelationship{
 				{VerificationMethod: &did.VerificationMethod{ID: *keyDID}},
@@ -359,7 +359,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 
 	t.Run("valid transaction fails when there is no connection available to the node", func(t *testing.T) {
 		proto, mocks := newTestProtocol(t, testDID)
-		mocks.State.EXPECT().ReadPayload(context.Background(), txOk.PayloadHash()).Return(nil, nil)
+		mocks.State.EXPECT().IsPayloadPresent(context.Background(), txOk.PayloadHash()).Return(false, nil)
 		mocks.DocResolver.EXPECT().Resolve(*testDID, nil).Return(&did.Document{
 			KeyAgreement: []did.VerificationRelationship{
 				{VerificationMethod: &did.VerificationMethod{ID: *keyDID}},
@@ -379,7 +379,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 
 	t.Run("valid transaction fails when sending the payload query errors", func(t *testing.T) {
 		proto, mocks := newTestProtocol(t, testDID)
-		mocks.State.EXPECT().ReadPayload(context.Background(), txOk.PayloadHash()).Return(nil, nil)
+		mocks.State.EXPECT().IsPayloadPresent(context.Background(), txOk.PayloadHash()).Return(false, nil)
 		mocks.DocResolver.EXPECT().Resolve(*testDID, nil).Return(&did.Document{
 			KeyAgreement: []did.VerificationRelationship{
 				{VerificationMethod: &did.VerificationMethod{ID: *keyDID}},
@@ -406,7 +406,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 
 	t.Run("valid transaction is handled successfully", func(t *testing.T) {
 		proto, mocks := newTestProtocol(t, testDID)
-		mocks.State.EXPECT().ReadPayload(context.Background(), txOk.PayloadHash()).Return(nil, nil)
+		mocks.State.EXPECT().IsPayloadPresent(context.Background(), txOk.PayloadHash()).Return(false, nil)
 		mocks.DocResolver.EXPECT().Resolve(*testDID, nil).Return(&did.Document{
 			KeyAgreement: []did.VerificationRelationship{
 				{VerificationMethod: &did.VerificationMethod{ID: *keyDID}},
@@ -440,7 +440,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 
 		proto, mocks := newTestProtocol(t, testDID)
 
-		mocks.State.EXPECT().ReadPayload(gomock.Any(), tx.PayloadHash()).Return(nil, nil)
+		mocks.State.EXPECT().IsPayloadPresent(gomock.Any(), tx.PayloadHash()).Return(false, nil)
 		mocks.DocResolver.EXPECT().Resolve(*testDID, nil).Return(&did.Document{
 			KeyAgreement: []did.VerificationRelationship{
 				{VerificationMethod: &did.VerificationMethod{ID: *keyDID}},


### PR DESCRIPTION
closes #1543

`dag.getTransaction` and `dag.readPayload` now return `dag.ErrTransactionNotFound` and `dag.ErrPayloadNotFound` when the data is not found.