### PR TITLE
VCR: Only check VC fields on issuance

### DIFF
--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -428,7 +428,7 @@ func (s *service) CreateJwtGrant(request services.CreateJwtGrantRequest) (*servi
 	}
 
 	for _, verifiableCredential := range request.Credentials {
-		validator := credential.FindValidator(verifiableCredential, s.jsonldManager.DocumentLoader())
+		validator := credential.FindValidator(verifiableCredential)
 		if err := validator.Validate(verifiableCredential); err != nil {
 			return nil, fmt.Errorf("invalid VerifiableCredential: %w", err)
 		}

--- a/vcr/credential/resolver.go
+++ b/vcr/credential/resolver.go
@@ -21,23 +21,22 @@ package credential
 
 import (
 	"github.com/nuts-foundation/go-did/vc"
-	"github.com/piprate/json-gold/ld"
 )
 
 // FindValidator finds the Validator the provided credential based on its Type
 // When no additional type is provided, it returns the default validator
-func FindValidator(credential vc.VerifiableCredential, documentLoader ld.DocumentLoader) Validator {
+func FindValidator(credential vc.VerifiableCredential) Validator {
 	if vcTypes := ExtractTypes(credential); len(vcTypes) > 0 {
 		for _, t := range vcTypes {
 			switch t {
 			case NutsOrganizationCredentialType:
-				return nutsOrganizationCredentialValidator{documentLoader: documentLoader}
+				return nutsOrganizationCredentialValidator{}
 			case NutsAuthorizationCredentialType:
-				return nutsAuthorizationCredentialValidator{documentLoader: documentLoader}
+				return nutsAuthorizationCredentialValidator{}
 			}
 		}
 	}
-	return defaultCredentialValidator{documentLoader: documentLoader}
+	return defaultCredentialValidator{}
 }
 
 // ExtractTypes extract additional VC types from the VC as strings

--- a/vcr/credential/resolver_test.go
+++ b/vcr/credential/resolver_test.go
@@ -29,21 +29,21 @@ import (
 
 func TestFindValidator(t *testing.T) {
 	t.Run("an unknown type returns the default validator", func(t *testing.T) {
-		v := FindValidator(vc.VerifiableCredential{}, nil)
+		v := FindValidator(vc.VerifiableCredential{})
 
 		assert.NotNil(t, t, v)
 	})
 
 	t.Run("validator and builder found for NutsOrganizationCredential", func(t *testing.T) {
 		vc := validNutsOrganizationCredential()
-		v := FindValidator(*vc, nil)
+		v := FindValidator(*vc)
 
 		assert.NotNil(t, v)
 	})
 
 	t.Run("validator and builder found for NutsAuthorizationCredential", func(t *testing.T) {
 		vc := ValidNutsAuthorizationCredential()
-		v := FindValidator(*vc, nil)
+		v := FindValidator(*vc)
 
 		assert.NotNil(t, v)
 	})

--- a/vcr/credential/validator.go
+++ b/vcr/credential/validator.go
@@ -61,10 +61,12 @@ func failure(err string, args ...interface{}) error {
 	return &validationError{errStr}
 }
 
+// AllFieldsDefinedValidator is a Validator that tests whether all fields are defined in the JSON-LD context.
 type AllFieldsDefinedValidator struct {
 	DocumentLoader ld.DocumentLoader
 }
 
+// Validate implements Validator.Validate.
 func (d AllFieldsDefinedValidator) Validate(input vc.VerifiableCredential) error {
 	// First expand, then compact and marshal to JSON, then compare
 	inputAsJSON, _ := input.MarshalJSON()

--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -68,7 +68,7 @@ func (i issuer) Issue(credentialOptions vc.VerifiableCredential, publish, public
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Sanity check: all provided fields must be defined by the context: otherwise they're not protected by the signature
 	err = credential.AllFieldsDefinedValidator{
 		DocumentLoader: i.jsonldManager.DocumentLoader(),

--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -68,8 +68,17 @@ func (i issuer) Issue(credentialOptions vc.VerifiableCredential, publish, public
 	if err != nil {
 		return nil, err
 	}
+	
+	// Sanity check: all provided fields must be defined by the context: otherwise they're not protected by the signature
+	err = credential.AllFieldsDefinedValidator{
+		DocumentLoader: i.jsonldManager.DocumentLoader(),
+	}.Validate(*createdVC)
+	if err != nil {
+		return nil, err
+	}
 
-	validator := credential.FindValidator(*createdVC, i.jsonldManager.DocumentLoader())
+	// Validate the VC using the type-specific validator
+	validator := credential.FindValidator(*createdVC)
 	if err := validator.Validate(*createdVC); err != nil {
 		return nil, err
 	}

--- a/vcr/verifier/verifier.go
+++ b/vcr/verifier/verifier.go
@@ -145,7 +145,7 @@ func (v *verifier) Validate(credentialToVerify vc.VerifiableCredential, at *time
 // It currently checks if the credential has the required fields and values, if it is valid at the given time and optional the signature.
 func (v verifier) Verify(credentialToVerify vc.VerifiableCredential, allowUntrusted bool, checkSignature bool, validAt *time.Time) error {
 	// it must have valid content
-	validator := credential.FindValidator(credentialToVerify, v.jsonldManager.DocumentLoader())
+	validator := credential.FindValidator(credentialToVerify)
 	if err := validator.Validate(credentialToVerify); err != nil {
 		return err
 	}


### PR DESCRIPTION
Checking whether all fields in a VC are defined in the given JSON-LD contexts should only happen when issuing a VC: protection against undefined fields (from VCs created by third parties) should be achieved by compacting it before returning it to the application/user.

TODO:

- [x] Fix tests
- [x] Review design (is it really an implementation of `credential.Validator`?)

Part of https://github.com/nuts-foundation/nuts-node/issues/1564
