### PR TITLE
Network: Add Rebuild

### DIFF
--- a/crypto/hash/sha256.go
+++ b/crypto/hash/sha256.go
@@ -74,7 +74,7 @@ func (h SHA256Hash) Slice() []byte {
 
 // Equals determines whether the given Hash is exactly the same (bytes match).
 func (h SHA256Hash) Equals(other SHA256Hash) bool {
-	return h.Compare(other) == 0
+	return bytes.Equal(h[:], other[:])
 }
 
 // Compare compares this Hash to another Hash using bytes.Compare.

--- a/network/dag/interface.go
+++ b/network/dag/interface.go
@@ -79,6 +79,8 @@ type State interface {
 	Shutdown() error
 	// Start the publisher and verifier
 	Start() error
+	// Rebuild walks the DAG one page at a time and fixes the in-memory state where needed.
+	Rebuild(ctx context.Context) error
 	// Verify checks the integrity of the DAG. Should be called when it's loaded, e.g. from disk.
 	Verify(ctx context.Context) error
 	// XOR returns the xor of all transaction references between the DAG root and the clock closest to the requested clock value.

--- a/network/dag/mock.go
+++ b/network/dag/mock.go
@@ -219,6 +219,20 @@ func (mr *MockStateMockRecorder) ReadPayload(ctx, payloadHash interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPayload", reflect.TypeOf((*MockState)(nil).ReadPayload), ctx, payloadHash)
 }
 
+// Rebuild mocks base method.
+func (m *MockState) Rebuild(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Rebuild", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Rebuild indicates an expected call of Rebuild.
+func (mr *MockStateMockRecorder) Rebuild(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rebuild", reflect.TypeOf((*MockState)(nil).Rebuild), ctx)
+}
+
 // Shutdown mocks base method.
 func (m *MockState) Shutdown() error {
 	m.ctrl.T.Helper()

--- a/network/dag/tree/tree_test.go
+++ b/network/dag/tree/tree_test.go
@@ -40,6 +40,16 @@ func TestNew(t *testing.T) {
 	assert.True(t, emptyTree.root.isLeaf())
 }
 
+func TestTree_Prototype(t *testing.T) {
+	t.Run("correct prototype", func(t *testing.T) {
+		assert.Equal(t, NewXor(), (&tree{prototype: NewXor()}).Prototype())
+		assert.Equal(t, NewIblt(numTestBuckets), (&tree{prototype: NewIblt(numTestBuckets)}).Prototype())
+	})
+	t.Run("prototype not set", func(t *testing.T) {
+		assert.Nil(t, (&tree{}).Prototype())
+	})
+}
+
 func TestTree_Insert(t *testing.T) {
 	t.Run("insert single Tx", func(t *testing.T) {
 		ref := hash.FromSlice([]byte{123})
@@ -199,7 +209,7 @@ func TestTree_reRoot(t *testing.T) {
 	})
 }
 
-func TestTree_GetUpdate(t *testing.T) {
+func TestTree_GetUpdates(t *testing.T) {
 	t.Run("dirty leaves after insert", func(t *testing.T) {
 		tr := newTestTree(NewXor(), testLeafSize)
 		h := hash.FromSlice([]byte{1})
@@ -246,12 +256,12 @@ func TestTree_GetUpdate(t *testing.T) {
 	})
 }
 
-func TestTree_ResetUpdate(t *testing.T) {
+func TestTree_ResetUpdates(t *testing.T) {
 	tr, _ := filledTestTree(NewXor(), testLeafSize)
 	tr.DropLeaves()
 
 	dirty, orphaned := tr.GetUpdates()
-	tr.ResetUpdate()
+	tr.ResetUpdates()
 	dirtyReset, orphanedReset := tr.GetUpdates()
 
 	assert.Equal(t, 3, len(orphaned))

--- a/network/interface.go
+++ b/network/interface.go
@@ -51,6 +51,9 @@ type Transactions interface {
 	// Reprocess walks the DAG and publishes all transactions matching the contentType via Nats
 	// This is an async process and will not return any feedback
 	Reprocess(contentType string)
+	// Rebuild walks the DAG, verifies all derived data in the Network engine, and fixes any inconsistencies.
+	// This is a resource intensive operation. Duration of the process depends on the number of corrections made.
+	Rebuild()
 	// WithPersistency returns a SubscriberOption for persistency. It allows the DAG KVStore to be used as persistent store for notifications.
 	// The notifications will then have ACID properties
 	WithPersistency() SubscriberOption

--- a/network/mock.go
+++ b/network/mock.go
@@ -110,6 +110,18 @@ func (mr *MockTransactionsMockRecorder) PeerDiagnostics() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PeerDiagnostics", reflect.TypeOf((*MockTransactions)(nil).PeerDiagnostics))
 }
 
+// Rebuild mocks base method.
+func (m *MockTransactions) Rebuild() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Rebuild")
+}
+
+// Rebuild indicates an expected call of Rebuild.
+func (mr *MockTransactionsMockRecorder) Rebuild() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rebuild", reflect.TypeOf((*MockTransactions)(nil).Rebuild))
+}
+
 // Reprocess mocks base method.
 func (m *MockTransactions) Reprocess(contentType string) {
 	m.ctrl.T.Helper()

--- a/network/network.go
+++ b/network/network.go
@@ -677,6 +677,17 @@ func (n *Network) Reprocess(contentType string) {
 	}()
 }
 
+func (n *Network) Rebuild() {
+	log.Logger().Warn("Rebuilding Network...") // TODO: log level?
+	if err := n.state.Rebuild(context.Background()); err != nil {
+		log.Logger().
+			WithError(err).
+			Error("Rebuild failed")
+		return
+	}
+	log.Logger().Warn("Rebuild complete") // TODO: log level?
+}
+
 func (n *Network) collectDiagnosticsForPeers() transport.Diagnostics {
 	stateDiagnostics := n.state.Diagnostics()
 	transactionCount := uint(0)

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -843,6 +843,41 @@ func TestNetworkIntegration_TLSOffloading(t *testing.T) {
 	})
 }
 
+func TestNetworkIntegration_Rebuild(t *testing.T) {
+	testDirectory := io.TestDirectory(t)
+	resetIntegrationTest()
+	key := nutsCrypto.NewTestKey("key")
+	expectedDocLogSize := 0
+
+	// single node
+	bootstrap := startNode(t, "bootstrap", testDirectory)
+
+	// Add transaction on 3 pages
+	for i := uint32(0); i <= dag.PageSize*100; i++ { // 51200 transactions ->
+		if !addTransactionAndWaitForItToArrive(t, fmt.Sprintf("doc%d", i), key, bootstrap, "bootstrap") {
+			return
+		}
+		expectedDocLogSize++
+	}
+
+	// Now assert that all nodes have received all transactions
+	waitForTransactions := func(node string, state dag.State) bool {
+		return test.WaitFor(t, func() (bool, error) {
+			var (
+				docs []dag.Transaction
+				err  error
+			)
+			if docs, err = state.FindBetweenLC(context.Background(), 0, dag.MaxLamportClock); err != nil {
+				return false, err
+			}
+			return len(docs) == expectedDocLogSize, nil
+		}, defaultTimeout, "%s: time-out while waiting for %d transactions", node, expectedDocLogSize)
+	}
+	waitForTransactions("bootstrap", bootstrap.network.state)
+
+	bootstrap.network.Rebuild()
+}
+
 func resetIntegrationTest() {
 	// in an integration test we want everything to work as intended, disable test speedup and re-enable file sync for bbolt
 	defaultBBoltOptions.NoSync = false


### PR DESCRIPTION
Proposal for Rebuild state from DAG, code is untested.

`data.db` has a bunch of shelves. The `transactionsShelf` contains the actual data and should be considered correct/leading. We can add another command to verify the data in here (`state.Verify` still exists), but that is a different feature.

All other shelfs are derived from the `transactionsShelf` and may need fixing/rebuilding. The main difficulty in doing this on a running node is dealing with new transactions (both network and api) while rebuilding. The following shelfs are derived from the `transactionsShelf` (and updated transactionally): 
- `clockShelf`: maps lamport clock to tx references
- `metadataShelf`: head, highest LC, # tx on dag
- `ibltShelf` & `xorShelf`: state trees
- `payload`: not considered (yet) as its behavior is a bit different

The `clockShelf` is the only one that must be rebuild from the `transactionsShelf`, the rest can be rebuild from either of the two. The only strategy I could come up with to rebuild the `clockShelf` is locking the entire `data.db` and iterating over the entire thing. This locks the DB for a very long time (all other requests for write locks are guaranteed to expire), parses all transactions (resource heavy), and keeps track of a potentially very large map between clock values and transaction references.

All other shelfs (with the exception of the `numberOfTransactions` value on the `metadataShelf`) can be rebuild in batches where the DB is locked while a small range of LC values is evaluated. However, this actually rebuilds all other shelfs to match the data on the `clockShelf` and is thus possible IFF the `clockShelf` is correct.

Questions/Options:
- Benchmark takes 4s to complete for a single `state.Rebuild` (for ~50k txs on DAG) when there is nothing to fix. The write/reloads when there actually is an inconsistency will add a significant amount of time to this. Should this be done on a live node in the first place?
- Just rebuilding state in batches seems possible. Should we provide 2 commands. One to rebuild `clockShelf` and one to rebuild the rest? (not entirely sure where the `metadataShelf` belongs) 
- If processing in batches, how should a write lock request timeout be dealt with?
- There is a good chance the logs will provide a hint to what LC value/range might have issues. Adding a range to the Rebuild command could make the procedure more manageable.