### PR TITLE
Feature/1530 did context

### DIFF
--- a/vdr/assets/assets.go
+++ b/vdr/assets/assets.go
@@ -1,0 +1,26 @@
+/*
+ * Nuts node
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package assets
+
+import "embed"
+
+// Contexts contains the context files needed for DID documents.
+//
+//go:embed contexts/*
+var Contexts embed.FS

--- a/vdr/assets/contexts/nuts-did-v1.ldjson
+++ b/vdr/assets/contexts/nuts-did-v1.ldjson
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "@base": "https://nuts.nl/did/v1",
+    "@vocab": "#",
+    "id": "@id",
+    "type": "@type",
+    "schema": "http://schema.org/",
+    "nuts": "https://nuts.nl/did/v1",
+    "node-contact-info": {
+      "@id": "nuts:NodeContactInfo",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@propagate": true,
+        "id": "@id",
+        "type": "@type",
+        "name": "schema:legalname",
+        "phone": "schema:telephone",
+        "website": "schema:url",
+        "email": "schema:email"
+      }
+    }
+  }
+}

--- a/vdr/doc/creator.go
+++ b/vdr/doc/creator.go
@@ -54,7 +54,7 @@ func JWS2020ContextV1URI() ssi.URI {
 // CreateDocument creates an empty DID document with baseline properties set.
 func CreateDocument() did.Document {
 	return did.Document{
-		Context: []ssi.URI{did.DIDContextV1URI(), JWS2020ContextV1URI(), NutsDIDContextV1URI()},
+		Context: []ssi.URI{NutsDIDContextV1URI(), JWS2020ContextV1URI(), did.DIDContextV1URI()},
 	}
 }
 

--- a/vdr/doc/creator.go
+++ b/vdr/doc/creator.go
@@ -35,9 +35,27 @@ import (
 // NutsDIDMethodName is the DID method name used by Nuts
 const NutsDIDMethodName = "nuts"
 
+// NutsDIDContextV1 contains the Nuts specific JSON-LD context for a DID Document
+const NutsDIDContextV1 = "https://nuts.nl/did/v1"
+
+// JWS2020ContextV1 contains the JSON-LD context for JWS and JWK
+const JWS2020ContextV1 = "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json"
+
+// NutsDIDContextV1URI returns NutsDIDContextV1 as a URI
+func NutsDIDContextV1URI() ssi.URI {
+	return ssi.MustParseURI(NutsDIDContextV1)
+}
+
+// JWS2020ContextV1URI returns JWS2020ContextV1 as a URI
+func JWS2020ContextV1URI() ssi.URI {
+	return ssi.MustParseURI(JWS2020ContextV1)
+}
+
 // CreateDocument creates an empty DID document with baseline properties set.
 func CreateDocument() did.Document {
-	return did.Document{Context: []ssi.URI{did.DIDContextV1URI()}}
+	return did.Document{
+		Context: []ssi.URI{did.DIDContextV1URI(), JWS2020ContextV1URI(), NutsDIDContextV1URI()},
+	}
 }
 
 // Creator implements the DocCreator interface and can create Nuts DID Documents.

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -388,3 +388,14 @@ func TestVDR_resolveControllerKey(t *testing.T) {
 		assert.Equal(t, types.ErrDIDNotManagedByThisNode, err)
 	})
 }
+
+func TestPatchContext(t *testing.T) {
+	id, _ := did.ParseDID("did:nuts:123")
+	document := did.Document{ID: *id}
+
+	patched := patchContext(document)
+
+	assert.Len(t, patched.Context, 2)
+	assert.Equal(t, doc.NutsDIDContextV1URI(), patched.Context[0])
+	assert.Equal(t, doc.JWS2020ContextV1URI(), patched.Context[1])
+}

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -389,13 +389,21 @@ func TestVDR_resolveControllerKey(t *testing.T) {
 	})
 }
 
-func TestPatchContext(t *testing.T) {
+func TestWithJSONLDContext(t *testing.T) {
 	id, _ := did.ParseDID("did:nuts:123")
-	document := did.Document{ID: *id}
+	expected := did.Document{ID: *id, Context: []ssi.URI{doc.NutsDIDContextV1URI()}}
 
-	patched := patchContext(document)
+	t.Run("added if not present", func(t *testing.T) {
+		document := did.Document{ID: *id}
 
-	assert.Len(t, patched.Context, 2)
-	assert.Equal(t, doc.NutsDIDContextV1URI(), patched.Context[0])
-	assert.Equal(t, doc.JWS2020ContextV1URI(), patched.Context[1])
+		patched := withJSONLDContext(document, doc.NutsDIDContextV1URI())
+
+		assert.EqualValues(t, expected.Context, patched.Context)
+	})
+
+	t.Run("no changes if existing", func(t *testing.T) {
+		patched := withJSONLDContext(expected, doc.NutsDIDContextV1URI())
+
+		assert.EqualValues(t, expected.Context, patched.Context)
+	})
 }


### PR DESCRIPTION
closes #1530 

it adds the nuts and JWS context URLS to did Docs when updating and creating. A nuts context is available in the assets.
No checking or JSON-LD magic is currently applied to did docs.