### PR TITLE
Tree and Iblt optimizations

### DIFF
--- a/crypto/hash/sha256.go
+++ b/crypto/hash/sha256.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 )
 
 // SHA256HashSize holds the size of a sha256 hash in bytes.
@@ -59,14 +58,6 @@ func (h SHA256Hash) Empty() bool {
 		}
 	}
 	return true
-}
-
-// RandomHash returns a Hash that is initialized with math/rand.
-// So NOT a cryptographic secure random Hash, but does generate reproducible results in tests.
-func RandomHash() SHA256Hash {
-	h := EmptyHash()
-	_, _ = rand.Read(h[:])
-	return h
 }
 
 // Clone returns a copy of the Hash.

--- a/crypto/hash/sha256.go
+++ b/crypto/hash/sha256.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 )
 
 // SHA256HashSize holds the size of a sha256 hash in bytes.
@@ -52,12 +53,20 @@ func EmptyHash() SHA256Hash {
 
 // Empty tests whether the Hash is empty (all zeros).
 func (h SHA256Hash) Empty() bool {
-	for _, b := range h {
-		if b != 0 {
+	for i := range h {
+		if h[i] != 0 {
 			return false
 		}
 	}
 	return true
+}
+
+// RandomHash returns a Hash that is initialized with math/rand.
+// So NOT a cryptographic secure random Hash, but does generate reproducible results in tests.
+func RandomHash() SHA256Hash {
+	h := EmptyHash()
+	_, _ = rand.Read(h[:])
+	return h
 }
 
 // Clone returns a copy of the Hash.
@@ -74,7 +83,7 @@ func (h SHA256Hash) Slice() []byte {
 
 // Equals determines whether the given Hash is exactly the same (bytes match).
 func (h SHA256Hash) Equals(other SHA256Hash) bool {
-	return h.Compare(other) == 0
+	return bytes.Equal(h[:], other[:])
 }
 
 // Compare compares this Hash to another Hash using bytes.Compare.
@@ -84,9 +93,9 @@ func (h SHA256Hash) Compare(other SHA256Hash) int {
 
 // Xor returns the xor of this Hash and all others. It does not change this Hash.
 func (h SHA256Hash) Xor(others ...SHA256Hash) SHA256Hash {
-	for _, o := range others {
-		for i := range o {
-			h[i] ^= o[i]
+	for n := range others {
+		for i := range others[n] {
+			h[i] ^= others[n][i]
 		}
 	}
 	return h

--- a/crypto/hash/sha256_test.go
+++ b/crypto/hash/sha256_test.go
@@ -182,3 +182,12 @@ func TestHash_Xor(t *testing.T) {
 	assert.Equal(t, EmptyHash(), h0, "original Hash should not change")
 	assert.Equal(t, expected, actual)
 }
+
+func TestHash_RandomHash(t *testing.T) {
+	h1 := RandomHash()
+	h2 := RandomHash()
+
+	assert.False(t, h1.Equals(h2))
+	assert.False(t, h1.Empty())
+	assert.False(t, h2.Empty())
+}

--- a/crypto/hash/test.go
+++ b/crypto/hash/test.go
@@ -18,7 +18,10 @@
 
 package hash
 
-import "github.com/golang/mock/gomock"
+import (
+	"github.com/golang/mock/gomock"
+	"math/rand"
+)
 
 func EqHash(hash SHA256Hash) gomock.Matcher {
 	return &hashMatcher{expected: hash}
@@ -38,4 +41,12 @@ func (h hashMatcher) Matches(x interface{}) bool {
 
 func (h hashMatcher) String() string {
 	return "Hash matches: " + h.expected.String()
+}
+
+// RandomHash returns a Hash that is initialized with math/rand.
+// So NOT a cryptographic secure random Hash, but does generate reproducible results in tests.
+func RandomHash() SHA256Hash {
+	h := EmptyHash()
+	_, _ = rand.Read(h[:])
+	return h
 }

--- a/docs/generate_docs_test.go
+++ b/docs/generate_docs_test.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package main
 
 import (

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -376,7 +376,7 @@ func TestState_IBLT(t *testing.T) {
 	// expected iblt
 	dagIBLT := tree.NewIblt(IbltNumBuckets)
 	dagIBLT.Insert(tx.Ref())
-	if !assert.False(t, dagIBLT.IsEmpty()) {
+	if !assert.False(t, dagIBLT.Empty()) {
 		return
 	}
 
@@ -385,20 +385,20 @@ func TestState_IBLT(t *testing.T) {
 		_ = iblt.Subtract(dagIBLT)
 
 		assert.Equal(t, dagClock, actualClock)
-		assert.True(t, iblt.IsEmpty(), iblt)
+		assert.True(t, iblt.Empty(), iblt)
 	})
 	t.Run("requested clock before last page", func(t *testing.T) {
 		iblt, actualClock := txState.IBLT(uint32(1))
 
 		assert.Equal(t, PageSize-1, actualClock)
-		assert.True(t, iblt.IsEmpty(), iblt)
+		assert.True(t, iblt.Empty(), iblt)
 	})
 	t.Run("requested clock on last page, lower than dag", func(t *testing.T) {
 		iblt, actualClock := txState.IBLT(PageSize + 1)
 		_ = iblt.Subtract(dagIBLT)
 
 		assert.Equal(t, dagClock, actualClock)
-		assert.True(t, iblt.IsEmpty(), iblt)
+		assert.True(t, iblt.Empty(), iblt)
 	})
 }
 

--- a/network/dag/state_test.go
+++ b/network/dag/state_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/test"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"go.uber.org/atomic"
+	"math"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -479,4 +480,33 @@ func assertCountMetric(t testing.TB, state *state, count float64) {
 	metric := &io_prometheus_client.Metric{}
 	state.transactionCount.Write(metric)
 	assert.Equal(t, count, *metric.Counter.Value)
+}
+
+func BenchmarkState_loadTrees(b *testing.B) {
+	state := createState(b).(*state)
+	ctx := context.Background()
+
+	// add a bunch of transactions
+	maxDepth := 16
+	nextLeaf := uint32(0)
+	var current Transaction
+	next, _, _ := CreateTestTransaction(0)
+	for depth := 0; depth < maxDepth; depth++ {
+		numLeaves := uint32(math.Pow(2, float64(depth)))
+		for l := nextLeaf; l < numLeaves; l++ {
+			current = next
+			current.(*transaction).lamportClock = l * PageSize
+			_ = state.Add(ctx, current, nil)
+			next, _, _ = CreateTestTransaction(l, current)
+			nextLeaf++
+		}
+
+		// benchmark reload state
+		b.Run(fmt.Sprintf("Depth=%d Transactions=%d", depth, current.(*transaction).lamportClock+PageSize), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				state.loadState(ctx)
+			}
+		})
+	}
 }

--- a/network/dag/tree/benchmark_test.go
+++ b/network/dag/tree/benchmark_test.go
@@ -36,7 +36,7 @@ func BenchTree_Load(b *testing.B, proto Data) {
 			tree.Insert(hash.RandomHash(), i*leafSize)
 			nextLeaf++
 		}
-		dirties, _ = tree.GetUpdates() // tree.ResetUpdate() is never called, so dirties contains all leaves.
+		dirties, _ = tree.Updates() // tree.ResetUpdates() is never called, so dirties contains all leaves.
 
 		b.Run(fmt.Sprintf("Depth=%d Transactions=%d", d, numLeaves*leafSize), func(b *testing.B) {
 			b.ResetTimer()
@@ -102,19 +102,19 @@ func BenchData(b *testing.B, proto Data) {
 		}
 	})
 
-	b.Run("IsEmpty()", func(b *testing.B) {
+	b.Run("Empty()", func(b *testing.B) {
 		b.Run("true", func(b *testing.B) {
 			data := proto.New()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = data.IsEmpty()
+				_ = data.Empty()
 			}
 		})
 		b.Run("false", func(b *testing.B) {
 			data, _ := dataWithRandomHashes(proto, 128)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = data.IsEmpty()
+				_ = data.Empty()
 			}
 		})
 	})

--- a/network/dag/tree/benchmark_test.go
+++ b/network/dag/tree/benchmark_test.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package tree
 
 import (

--- a/network/dag/tree/benchmark_test.go
+++ b/network/dag/tree/benchmark_test.go
@@ -1,0 +1,150 @@
+package tree
+
+import (
+	"fmt"
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	"math"
+	"testing"
+)
+
+func BenchmarkTree(b *testing.B) {
+	b.Run("IBLT", func(b *testing.B) {
+		BenchProto(b, NewIblt(numTestBuckets))
+	})
+
+	b.Run("Xor", func(b *testing.B) {
+		BenchProto(b, NewXor())
+	})
+}
+
+func BenchProto(b *testing.B, proto Data) {
+	b.Run("tree.Load()", func(b *testing.B) { BenchTree_Load(b, proto) })
+	b.Run("Data", func(b *testing.B) { BenchData(b, proto) })
+}
+
+func BenchTree_Load(b *testing.B, proto Data) {
+	leafSize := uint32(512)
+	maxDepth := 16
+	tree := New(proto, leafSize)
+	benchTree := New(proto, leafSize)
+	nextLeaf := uint32(0)
+
+	for d := 0; d < maxDepth; d++ {
+		numLeaves := uint32(math.Pow(2, float64(d)))
+		dirties := map[uint32][]byte{}
+		for i := nextLeaf; i < numLeaves; i++ {
+			tree.Insert(hash.RandomHash(), i*leafSize)
+			nextLeaf++
+		}
+		dirties, _ = tree.GetUpdates() // tree.ResetUpdate() is never called, so dirties contains all leaves.
+
+		b.Run(fmt.Sprintf("Depth=%d Transactions=%d", d, numLeaves*leafSize), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = benchTree.Load(dirties)
+			}
+		})
+	}
+}
+
+func BenchData(b *testing.B, proto Data) {
+
+	b.Run("New()", func(b *testing.B) {
+		var data Data
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			data = proto.New()
+		}
+		_ = data
+	})
+
+	b.Run("Clone()", func(b *testing.B) {
+		data, _ := dataWithRandomHashes(proto, 128)
+		var clone Data
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			clone = data.Clone()
+		}
+		_ = clone
+	})
+
+	b.Run("Insert()", func(b *testing.B) {
+		data, _ := dataWithRandomHashes(proto, 128)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			data.Insert(hash.RandomHash())
+		}
+	})
+
+	b.Run("Delete()", func(b *testing.B) {
+		data, _ := dataWithRandomHashes(proto, 128)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			data.Delete(hash.RandomHash())
+		}
+	})
+
+	b.Run("Add()", func(b *testing.B) {
+		data1, _ := dataWithRandomHashes(proto, 128)
+		data2, _ := dataWithRandomHashes(proto, 128)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = data1.Add(data2)
+		}
+	})
+
+	b.Run("Subtract()", func(b *testing.B) {
+		data1, _ := dataWithRandomHashes(proto, 128)
+		data2, _ := dataWithRandomHashes(proto, 128)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = data1.Subtract(data2)
+		}
+	})
+
+	b.Run("IsEmpty()", func(b *testing.B) {
+		b.Run("true", func(b *testing.B) {
+			data := proto.New()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = data.IsEmpty()
+			}
+		})
+		b.Run("false", func(b *testing.B) {
+			data, _ := dataWithRandomHashes(proto, 128)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = data.IsEmpty()
+			}
+		})
+	})
+
+	b.Run("MarshalBinary()", func(b *testing.B) {
+		data, _ := dataWithRandomHashes(proto, 128)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = data.MarshalBinary()
+		}
+	})
+
+	b.Run("UnmarshalBinary()", func(b *testing.B) {
+		data, _ := dataWithRandomHashes(proto, 128)
+		bytes, _ := data.MarshalBinary()
+		data = data.New()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = data.UnmarshalBinary(bytes)
+		}
+	})
+}
+
+func dataWithRandomHashes(proto Data, numHashes int) (Data, map[hash.SHA256Hash]struct{}) {
+	data := proto.New()
+	hashes := make(map[hash.SHA256Hash]struct{}, numHashes)
+	for i := 0; i < numHashes; i++ {
+		ref := hash.RandomHash()
+		data.Insert(ref)
+		hashes[ref] = struct{}{}
+	}
+	return data, hashes
+}

--- a/network/dag/tree/iblt.go
+++ b/network/dag/tree/iblt.go
@@ -179,7 +179,7 @@ func (i *Iblt) Decode() (remaining []hash.SHA256Hash, missing []hash.SHA256Hash,
 
 		// if no pures exist, the iblt is empty or cannot be decoded
 		if !updated {
-			if !i.IsEmpty() {
+			if !i.Empty() {
 				err = ErrDecodeNotPossible
 			}
 			break
@@ -189,7 +189,7 @@ func (i *Iblt) Decode() (remaining []hash.SHA256Hash, missing []hash.SHA256Hash,
 	return remaining, missing, err
 }
 
-func (i *Iblt) IsEmpty() bool {
+func (i *Iblt) Empty() bool {
 	for idx := range i.buckets {
 		if !i.buckets[idx].isEmpty() {
 			return false

--- a/network/dag/tree/iblt.go
+++ b/network/dag/tree/iblt.go
@@ -43,14 +43,14 @@ var (
 /*
 Iblt implements an Invertible Bloom Filter, which is the special case of an IBLT where the key-value pair consist of a key-hash(key) pair.
 The hash(key) value ensures correct decoding after subtraction of two IBLTs. Iblt is not thread-safe.
-	- Goodrich, Michael T., and Michael Mitzenmacher. "Invertible bloom lookup tables." http://arxiv.org/pdf/1101.2245
-	- Eppstein, David, et al. "What's the difference?: efficient set reconciliation without prior context." http://conferences.sigcomm.org/sigcomm/2011/papers/sigcomm/p218.pdf
+  - Goodrich, Michael T., and Michael Mitzenmacher. "Invertible bloom lookup tables." http://arxiv.org/pdf/1101.2245
+  - Eppstein, David, et al. "What's the difference?: efficient set reconciliation without prior context." http://conferences.sigcomm.org/sigcomm/2011/papers/sigcomm/p218.pdf
 */
 type Iblt struct {
 	hc      uint64
 	hk      uint32
 	k       uint8
-	buckets []*bucket
+	buckets []bucket
 }
 
 // NewIblt returns an *Iblt with default settings and specified number of buckets. numBuckets must be >= Iblt.k
@@ -59,24 +59,28 @@ func NewIblt(numBuckets int) *Iblt {
 		numBuckets = int(ibltK)
 	}
 	return &Iblt{
-		buckets: makeBuckets(numBuckets),
+		buckets: make([]bucket, numBuckets),
 		hc:      ibltHc,
 		hk:      ibltHk,
 		k:       ibltK,
 	}
 }
 
-func (i Iblt) New() Data {
+func (i *Iblt) New() Data {
 	return NewIblt(i.numBuckets())
 }
 
-func (i Iblt) Clone() Data {
-	tmpBuckets := makeBuckets(i.numBuckets())
-	for idx, b := range i.buckets {
-		tmpBuckets[idx] = b.clone()
+func (i *Iblt) Clone() Data {
+	clone := &Iblt{
+		hc:      i.hc,
+		hk:      i.hk,
+		k:       i.k,
+		buckets: make([]bucket, i.numBuckets()),
 	}
-	i.buckets = tmpBuckets
-	return &i
+	for idx := range i.buckets {
+		clone.buckets[idx] = i.buckets[idx]
+	}
+	return clone
 }
 
 func (i *Iblt) Insert(ref hash.SHA256Hash) {
@@ -86,7 +90,6 @@ func (i *Iblt) Insert(ref hash.SHA256Hash) {
 	}
 }
 
-// Delete subtracts the key from the iblt and is the inverse of Insert.
 func (i *Iblt) Delete(key hash.SHA256Hash) {
 	keyHash := i.hashKey(key)
 	for _, h := range i.bucketIndices(keyHash) {
@@ -99,8 +102,8 @@ func (i *Iblt) Add(other Data) error {
 	if err != nil {
 		return err
 	}
-	for idx, b := range i.buckets {
-		b.add(o.buckets[idx])
+	for idx := range i.buckets {
+		i.buckets[idx].add(&o.buckets[idx])
 	}
 	return nil
 }
@@ -110,18 +113,18 @@ func (i *Iblt) Subtract(other Data) error {
 	if err != nil {
 		return err
 	}
-	for idx, b := range i.buckets {
-		b.subtract(o.buckets[idx])
+	for idx := range i.buckets {
+		i.buckets[idx].subtract(&o.buckets[idx])
 	}
 	return nil
 }
 
-// validate returns other as an *iblt if it is compatible with self, or an error if not.
-func (i Iblt) validate(other Data) (*Iblt, error) {
+// validate returns other as an *Iblt if it is compatible with self, or an error if not.
+func (i *Iblt) validate(other Data) (*Iblt, error) {
 	// validate datatype
 	o, ok := other.(*Iblt)
 	if !ok {
-		return nil, fmt.Errorf("other invalid - expected type %T, got %T", &i, other)
+		return nil, fmt.Errorf("other invalid - expected type %T, got %T", i, other)
 	}
 
 	// validate format
@@ -152,9 +155,9 @@ func (i *Iblt) Decode() (remaining []hash.SHA256Hash, missing []hash.SHA256Hash,
 		updated := false
 
 		// peel off pures (count == ±1)
-		for _, b := range i.buckets {
-			if (b.count == 1 || b.count == -1) && i.hashKey(b.keySum) == b.hashSum {
-				txRef := b.keySum
+		for idx := range i.buckets {
+			if (i.buckets[idx].count == 1 || i.buckets[idx].count == -1) && i.hashKey(i.buckets[idx].keySum) == i.buckets[idx].hashSum {
+				txRef := i.buckets[idx].keySum
 				if pures[txRef] {
 					// Decode gets stuck in a loop when the b.keySum is not exactly ±1 times in all buckets with indices i.bucketIndices(b.hashSum)
 					// this can occur when two Iblt are subtracted that use different methods for assigning buckets
@@ -163,7 +166,7 @@ func (i *Iblt) Decode() (remaining []hash.SHA256Hash, missing []hash.SHA256Hash,
 				}
 				pures[txRef] = true
 
-				if b.count == 1 {
+				if i.buckets[idx].count == 1 {
 					remaining = append(remaining, txRef)
 					i.Delete(txRef)
 				} else { // b.count == -1
@@ -186,32 +189,24 @@ func (i *Iblt) Decode() (remaining []hash.SHA256Hash, missing []hash.SHA256Hash,
 	return remaining, missing, err
 }
 
-func (i Iblt) IsEmpty() bool {
-	for _, b := range i.buckets {
-		if !b.isEmpty() {
+func (i *Iblt) IsEmpty() bool {
+	for idx := range i.buckets {
+		if !i.buckets[idx].isEmpty() {
 			return false
 		}
 	}
 	return true
 }
 
-func (i Iblt) numBuckets() int {
+func (i *Iblt) numBuckets() int {
 	return len(i.buckets)
 }
 
-func makeBuckets(numBuckets int) []*bucket {
-	buckets := make([]*bucket, numBuckets)
-	for i := 0; i < numBuckets; i++ {
-		buckets[i] = new(bucket)
-	}
-	return buckets
-}
-
-func (i Iblt) bucketIndices(hash uint64) []uint32 {
+func (i *Iblt) bucketIndices(hash uint64) []uint32 {
 	bucketUsed := make(map[uint32]bool, i.k)
-	var indices []uint32
+	indices := make([]uint32, 0, i.hk)
 	hashKeyBytes, nextBytes := make([]byte, 8), make([]byte, 4)
-	byteOrder().PutUint64(hashKeyBytes, hash)
+	byteOrder.PutUint64(hashKeyBytes, hash)
 	next := murmur3.SeedSum32(i.hk, hashKeyBytes)
 	for len(indices) < int(i.k) {
 		bucketID := next % uint32(i.numBuckets())
@@ -219,20 +214,20 @@ func (i Iblt) bucketIndices(hash uint64) []uint32 {
 			indices = append(indices, bucketID)
 			bucketUsed[bucketID] = true
 		}
-		byteOrder().PutUint32(nextBytes, next)
+		byteOrder.PutUint32(nextBytes, next)
 		next = murmur3.SeedSum32(i.hk, nextBytes)
 	}
 	return indices
 }
 
-func (i Iblt) hashKey(key hash.SHA256Hash) uint64 {
+func (i *Iblt) hashKey(key hash.SHA256Hash) uint64 {
 	return murmur3.SeedSum64(i.hc, key.Slice())
 }
 
-func (i Iblt) MarshalBinary() ([]byte, error) {
+func (i *Iblt) MarshalBinary() ([]byte, error) {
 	data := make([]byte, i.numBuckets()*bucketBytes)
-	for idx, b := range i.buckets {
-		bs, err := b.MarshalBinary()
+	for idx := range i.buckets {
+		bs, err := i.buckets[idx].MarshalBinary()
 		if err != nil {
 			return nil, err
 		}
@@ -250,7 +245,7 @@ func (i *Iblt) UnmarshalBinary(data []byte) error {
 	i.hc = ibltHc
 	i.hk = ibltHk
 	i.k = ibltK
-	i.buckets = makeBuckets(numBuckets)
+	i.buckets = make([]bucket, numBuckets)
 	for j := 0; j < i.numBuckets(); j++ {
 		err := i.buckets[j].UnmarshalBinary(buf.Next(bucketBytes))
 		if err != nil {
@@ -293,43 +288,38 @@ func (b *bucket) update(key hash.SHA256Hash, hash uint64) {
 	b.hashSum ^= hash
 }
 
-func (b bucket) clone() *bucket {
-	return &b
+func (b *bucket) isEmpty() bool {
+	return b.equals(new(bucket))
 }
 
-func (b bucket) isEmpty() bool {
-	return b.equals(*new(bucket))
+func (b *bucket) equals(o *bucket) bool {
+	return *b == *o
 }
 
-func (b bucket) equals(o bucket) bool {
-	return b == o
-}
-
-func (b bucket) String() string {
+func (b *bucket) String() string {
 	return fmt.Sprintf("{count:%d keySum:%s hashSum:%d}", b.count, b.keySum, b.hashSum)
 }
 
-func (b bucket) MarshalBinary() ([]byte, error) {
-	bs := make([]byte, bucketBytes)
-	byteOrder().PutUint32(bs, uint32(b.count)) // #1
-	byteOrder().PutUint64(bs[4:], b.hashSum)   // #2
-	copy(bs[12:], b.keySum.Clone().Slice())    // #3
-	return bs, nil
+func (b *bucket) MarshalBinary() ([]byte, error) {
+	bs := [bucketBytes]byte{}
+	byteOrder.PutUint32(bs[0:], uint32(b.count)) // #1
+	byteOrder.PutUint64(bs[4:], b.hashSum)       // #2
+	copy(bs[12:], b.keySum.Clone().Slice())      // #3
+	return bs[:], nil
 }
 
 func (b *bucket) UnmarshalBinary(data []byte) error {
 	if len(data) != bucketBytes {
 		return errors.New("invalid data length")
 	}
-	buf := bytes.NewBuffer(data)
-	b.count = int32(byteOrder().Uint32(buf.Next(4)))         // #1
-	b.hashSum = byteOrder().Uint64(buf.Next(8))              // #2
-	b.keySum = hash.FromSlice(buf.Next(hash.SHA256HashSize)) // #3
+	d := (*[bucketBytes]byte)(data)
+	b.count = int32(byteOrder.Uint32(d[:4])) // #1
+	b.hashSum = byteOrder.Uint64(d[4:12])    // #2
+	keySum := (*hash.SHA256Hash)(d[12:])
+	b.keySum = *keySum // #3
 	return nil
 }
 
 // byteOrder returns the binary.ByteOrder described in the specs.
 // This guarantees Iblt generation is platform independent and allows decentralized comparison.
-func byteOrder() binary.ByteOrder {
-	return binary.LittleEndian
-}
+var byteOrder = binary.LittleEndian

--- a/network/dag/tree/iblt_test.go
+++ b/network/dag/tree/iblt_test.go
@@ -360,7 +360,7 @@ func TestIblt_IsEmpty(t *testing.T) {
 	t.Run("true - new iblt", func(t *testing.T) {
 		iblt := NewIblt(numTestBuckets)
 
-		assert.True(t, iblt.IsEmpty())
+		assert.True(t, iblt.Empty())
 	})
 
 	t.Run("false - insert", func(t *testing.T) {
@@ -369,7 +369,7 @@ func TestIblt_IsEmpty(t *testing.T) {
 
 		iblt.Insert(h)
 
-		assert.False(t, iblt.IsEmpty())
+		assert.False(t, iblt.Empty())
 	})
 
 	t.Run("true - insert and delete same hash", func(t *testing.T) {
@@ -379,7 +379,7 @@ func TestIblt_IsEmpty(t *testing.T) {
 		iblt.Insert(h)
 		iblt.Delete(h)
 
-		assert.True(t, iblt.IsEmpty())
+		assert.True(t, iblt.Empty())
 	})
 }
 

--- a/network/dag/tree/iblt_test.go
+++ b/network/dag/tree/iblt_test.go
@@ -69,10 +69,10 @@ func getEmptyTestIblt(numBuckets int) *Iblt {
 		hc:      ibltHc,
 		hk:      ibltHk,
 		k:       ibltK,
-		buckets: make([]*bucket, numBuckets),
+		buckets: make([]bucket, numBuckets),
 	}
 	for i := range iblt.buckets {
-		iblt.buckets[i] = new(bucket)
+		iblt.buckets[i] = *new(bucket)
 	}
 	return iblt
 }
@@ -98,7 +98,7 @@ func equals(iblt1, iblt2 *Iblt) bool {
 		return false
 	}
 	for i := range iblt1.buckets {
-		if !iblt1.buckets[i].equals(*iblt2.buckets[i]) {
+		if !iblt1.buckets[i].equals(&iblt2.buckets[i]) {
 			return false
 		}
 	}
@@ -148,7 +148,7 @@ func TestIblt_Insert(t *testing.T) {
 
 	numMatches := 0
 	for _, b := range iblt.buckets {
-		if b.equals(bExp) {
+		if b.equals(&bExp) {
 			numMatches++
 		}
 	}
@@ -168,7 +168,7 @@ func TestIblt_Delete(t *testing.T) {
 	iblt.Delete(h)
 
 	for i, b := range iblt.buckets {
-		assert.Truef(t, b.equals(bExp), "bucket %d did not match", i)
+		assert.Truef(t, b.equals(&bExp), "bucket %d did not match", i)
 	}
 }
 
@@ -404,7 +404,7 @@ func TestIblt_UnmarshalBinary(t *testing.T) {
 	var data []byte
 	for i := 0; i < int(ibltK); i++ {
 		data = append(data, hash1BucketBytes...)
-		ibltExpected.buckets[i] = hash1Bucket.clone()
+		ibltExpected.buckets[i] = hash1Bucket
 	}
 
 	err := iblt.UnmarshalBinary(data)
@@ -430,7 +430,7 @@ func TestBucket_UnmarshalBinary(t *testing.T) {
 		err := b.UnmarshalBinary(hash1BucketBytes)
 
 		assert.NoError(t, err)
-		assert.True(t, b.equals(*hash1Bucket))
+		assert.True(t, b.equals(&hash1Bucket))
 	})
 
 	t.Run("fail - invalid data length", func(t *testing.T) {
@@ -444,9 +444,9 @@ func TestBucket_UnmarshalBinary(t *testing.T) {
 }
 
 // creates a bucket containing hash.FromSlice([]byte{1})
-func marshalBucketWithHash1() (hash.SHA256Hash, *bucket, []byte) {
+func marshalBucketWithHash1() (hash.SHA256Hash, bucket, []byte) {
 	hash1 := hash.FromSlice([]byte{1})
-	hash1Bucket := &bucket{
+	hash1Bucket := bucket{
 		count:   1,
 		hashSum: uint64(6332109210212100501),
 		keySum:  hash1,

--- a/network/dag/tree/tree_test.go
+++ b/network/dag/tree/tree_test.go
@@ -87,7 +87,7 @@ func TestTree_GetRoot(t *testing.T) {
 	t.Run("root Data is zero", func(t *testing.T) {
 		tr := newTestTree(NewXor(), testLeafSize)
 
-		assert.Equal(t, hash.EmptyHash(), tr.GetRoot().(*Xor).Hash())
+		assert.Equal(t, hash.EmptyHash(), tr.Root().(*Xor).Hash())
 	})
 
 	t.Run("root after re-rooting", func(t *testing.T) {
@@ -96,7 +96,7 @@ func TestTree_GetRoot(t *testing.T) {
 
 		tr.Insert(ref, testLeafSize)
 
-		assert.Equal(t, ref, tr.GetRoot().(*Xor).Hash())
+		assert.Equal(t, ref, tr.Root().(*Xor).Hash())
 	})
 
 	t.Run("root of many Tx", func(t *testing.T) {
@@ -111,17 +111,17 @@ func TestTree_GetRoot(t *testing.T) {
 			tr.Insert(ref, N-i)
 		}
 
-		assert.Equal(t, allRefs, tr.GetRoot().(*Xor).Hash())
+		assert.Equal(t, allRefs, tr.Root().(*Xor).Hash())
 	})
 }
 
 func TestTree_GetZeroTo(t *testing.T) {
 	tr, td := filledTestTree(NewXor(), testLeafSize)
 
-	c0t, lc0 := tr.GetZeroTo(0 * testLeafSize)
-	p0t, lc1 := tr.GetZeroTo(1 * testLeafSize)
-	r0t, lc2 := tr.GetZeroTo(2 * testLeafSize)
-	root, lcMax := tr.GetZeroTo(2 * tr.treeSize)
+	c0t, lc0 := tr.ZeroTo(0 * testLeafSize)
+	p0t, lc1 := tr.ZeroTo(1 * testLeafSize)
+	r0t, lc2 := tr.ZeroTo(2 * testLeafSize)
+	root, lcMax := tr.ZeroTo(2 * tr.treeSize)
 
 	assert.Equal(t, td.c0, c0t)
 	assert.Equal(t, testLeafSize-1, lc0)
@@ -204,7 +204,7 @@ func TestTree_GetUpdate(t *testing.T) {
 		h := hash.FromSlice([]byte{1})
 		tr.Insert(h, 2*testLeafSize)
 
-		dirty, orphaned := tr.GetUpdates()
+		dirty, orphaned := tr.Updates()
 
 		assert.Equal(t, 0, len(orphaned))
 		assert.Equal(t, 2, len(dirty))
@@ -214,13 +214,13 @@ func TestTree_GetUpdate(t *testing.T) {
 		assert.True(t, ok)
 	})
 
-	t.Run("GetUpdates does not reset update tracking", func(t *testing.T) {
+	t.Run("Updates does not reset update tracking", func(t *testing.T) {
 		tr := newTestTree(NewXor(), testLeafSize)
 		h := hash.FromSlice([]byte{1})
 		tr.Insert(h, 2*testLeafSize)
 
-		_, _ = tr.GetUpdates()
-		dirty, orphaned := tr.GetUpdates()
+		_, _ = tr.Updates()
+		dirty, orphaned := tr.Updates()
 
 		assert.Equal(t, 0, len(orphaned))
 		assert.Equal(t, 2, len(dirty))
@@ -234,7 +234,7 @@ func TestTree_GetUpdate(t *testing.T) {
 		tr, _ := filledTestTree(NewXor(), testLeafSize)
 		tr.DropLeaves()
 
-		dirty, orphaned := tr.GetUpdates()
+		dirty, orphaned := tr.Updates()
 
 		assert.Equal(t, 3, len(orphaned))
 		assert.Equal(t, 2, len(dirty))
@@ -249,9 +249,9 @@ func TestTree_ResetUpdate(t *testing.T) {
 	tr, _ := filledTestTree(NewXor(), testLeafSize)
 	tr.DropLeaves()
 
-	dirty, orphaned := tr.GetUpdates()
-	tr.ResetUpdate()
-	dirtyReset, orphanedReset := tr.GetUpdates()
+	dirty, orphaned := tr.Updates()
+	tr.ResetUpdates()
+	dirtyReset, orphanedReset := tr.Updates()
 
 	assert.Equal(t, 3, len(orphaned))
 	assert.Equal(t, 0, len(orphanedReset))
@@ -262,7 +262,7 @@ func TestTree_ResetUpdate(t *testing.T) {
 func TestTree_Load(t *testing.T) {
 	t.Run("ok - tree reconstructed from bytes", func(t *testing.T) {
 		tr, _ := filledTestTree(NewXor(), testLeafSize)
-		dirty, _ := tr.GetUpdates()
+		dirty, _ := tr.Updates()
 		loadedTree := New(NewXor(), 0).(*tree)
 
 		err := loadedTree.Load(dirty)
@@ -273,8 +273,8 @@ func TestTree_Load(t *testing.T) {
 		assert.Equal(t, tr.root, loadedTree.root)
 
 		for lc := testLeafSize - 1; lc < loadedTree.treeSize; lc += testLeafSize {
-			expData, expLc := tr.GetZeroTo(lc)
-			actualData, actualLc := loadedTree.GetZeroTo(lc)
+			expData, expLc := tr.ZeroTo(lc)
+			actualData, actualLc := loadedTree.ZeroTo(lc)
 			assert.Equal(t, expData, actualData)
 			assert.Equal(t, expLc, actualLc)
 		}
@@ -293,7 +293,7 @@ func TestTree_Load(t *testing.T) {
 
 	t.Run("fail - incorrect data prototype", func(t *testing.T) {
 		tr, _ := filledTestTree(NewXor(), testLeafSize)
-		dirty, _ := tr.GetUpdates()
+		dirty, _ := tr.Updates()
 		loadedTree := New(NewIblt(1024), 0)
 
 		err := loadedTree.Load(dirty)

--- a/network/dag/tree/tree_test.go
+++ b/network/dag/tree/tree_test.go
@@ -19,7 +19,6 @@
 package tree
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -107,7 +106,7 @@ func TestTree_GetRoot(t *testing.T) {
 		var ref hash.SHA256Hash
 
 		for i := uint32(0); i < N; i++ {
-			rand.Read(ref[:])
+			ref = hash.RandomHash()
 			allRefs = allRefs.Xor(ref)
 			tr.Insert(ref, N-i)
 		}

--- a/network/dag/tree/xor.go
+++ b/network/dag/tree/xor.go
@@ -69,7 +69,7 @@ func (x *Xor) Subtract(data Data) error {
 	}
 }
 
-func (x *Xor) IsEmpty() bool {
+func (x *Xor) Empty() bool {
 	return *x == Xor{}
 }
 

--- a/network/dag/tree/xor.go
+++ b/network/dag/tree/xor.go
@@ -33,11 +33,11 @@ func NewXor() *Xor {
 }
 
 // Hash returns a copy as a hash.SHA256Hash
-func (x Xor) Hash() hash.SHA256Hash {
-	return hash.SHA256Hash(x)
+func (x *Xor) Hash() hash.SHA256Hash {
+	return hash.SHA256Hash(*x).Clone()
 }
 
-func (x Xor) New() Data {
+func (x *Xor) New() Data {
 	return new(Xor)
 }
 
@@ -69,11 +69,11 @@ func (x *Xor) Subtract(data Data) error {
 	}
 }
 
-func (x Xor) IsEmpty() bool {
-	return x == Xor{}
+func (x *Xor) IsEmpty() bool {
+	return *x == Xor{}
 }
 
-func (x Xor) MarshalBinary() ([]byte, error) {
+func (x *Xor) MarshalBinary() ([]byte, error) {
 	return x.Clone().(*Xor)[:], nil
 }
 

--- a/network/dag/tree/xor_test.go
+++ b/network/dag/tree/xor_test.go
@@ -165,12 +165,12 @@ func TestXor_Subtract(t *testing.T) {
 func TestXor_IsEmpty(t *testing.T) {
 	t.Run("is empty", func(t *testing.T) {
 		x := NewXor()
-		assert.True(t, x.IsEmpty())
+		assert.True(t, x.Empty())
 	})
 
 	t.Run("is not empty", func(t *testing.T) {
 		x := Xor(hash.FromSlice([]byte("not empty")))
-		assert.False(t, x.IsEmpty())
+		assert.False(t, x.Empty())
 	})
 }
 

--- a/network/dag/treestore.go
+++ b/network/dag/treestore.go
@@ -45,7 +45,7 @@ func (store *treeStore) getRoot() tree.Data {
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
 
-	return store.tree.GetRoot()
+	return store.tree.Root()
 }
 
 // getZeroTo returns the tree.Data sum of all tree pages/leaves upto and including the one containing the requested Lamport Clock value.
@@ -54,7 +54,7 @@ func (store *treeStore) getZeroTo(clock uint32) (tree.Data, uint32) {
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
 
-	return store.tree.GetZeroTo(clock)
+	return store.tree.ZeroTo(clock)
 }
 
 // write inserts a transaction reference to the in-memory tree and to persistent storage.
@@ -69,8 +69,8 @@ func (store *treeStore) write(tx stoabs.WriteTx, transaction Transaction) error 
 	}
 
 	store.tree.Insert(transaction.Ref(), transaction.Clock())
-	dirties, orphaned := store.tree.GetUpdates()
-	store.tree.ResetUpdate() // failure after this point results in rollback anyway
+	dirties, orphaned := store.tree.Updates()
+	store.tree.ResetUpdates() // failure after this point results in rollback anyway
 
 	// delete orphaned leaves
 	for _, orphan := range orphaned { // always zero


### PR DESCRIPTION
lessons learned from profiling in #1509

`Iblt.Unmarshal` can be made twice as fast by replacing the buckets slice with a bucket array of fixed length if needed. (useful if trees are reloaded from disk often)