### PR TITLE
Network/Auth: send custom UserAgent on HTTP calls

### DIFF
--- a/core/build_vars.go
+++ b/core/build_vars.go
@@ -64,3 +64,9 @@ func BuildInfo() string {
 
 	return b.String()
 }
+
+// UserAgent returns a string that can be used as HTTP user agent, containing the version of the node (e.g. nuts-node-refimpl/5.0.0)
+func UserAgent() string {
+	// Remove leading "v" from version to keep it standard for user agent strings.
+	return "nuts-node-refimpl/" + strings.TrimPrefix(Version(), "v")
+}

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -52,6 +52,9 @@ var ErrAlreadyConnected = errors.New("already connected")
 // MaxMessageSizeInBytes defines the maximum size of an in- or outbound gRPC/Protobuf message
 var MaxMessageSizeInBytes = defaultMaxMessageSizeInBytes
 
+// defaultInterceptors aids testing
+var defaultInterceptors []grpc.StreamServerInterceptor
+
 type fatalError struct {
 	error
 }
@@ -136,7 +139,8 @@ func (s *grpcConnectionManager) Start() error {
 		return err
 	}
 
-	serverInterceptors := []grpc.StreamServerInterceptor{}
+	var serverInterceptors []grpc.StreamServerInterceptor
+	serverInterceptors = append(serverInterceptors, defaultInterceptors...)
 	// Configure TLS if enabled
 	var tlsConfig *tls.Config
 	if s.config.tlsEnabled() {

--- a/network/transport/grpc/outbound_connector.go
+++ b/network/transport/grpc/outbound_connector.go
@@ -146,6 +146,7 @@ func (c *outboundConnector) tryConnect() (*grpcLib.ClientConn, error) {
 			grpcLib.MaxCallRecvMsgSize(MaxMessageSizeInBytes),
 			grpcLib.MaxCallSendMsgSize(MaxMessageSizeInBytes),
 		),
+		grpcLib.WithUserAgent(core.UserAgent()),
 	}
 	if c.tlsConfig != nil {
 		dialOptions = append(dialOptions, grpcLib.WithTransportCredentials(credentials.NewTLS(c.tlsConfig))) // TLS authentication

--- a/network/transport/grpc/outbound_connector_test.go
+++ b/network/transport/grpc/outbound_connector_test.go
@@ -24,7 +24,9 @@ import (
 	"github.com/nuts-foundation/nuts-node/test"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -36,23 +38,43 @@ var testConnectorConfig = connectorConfig{
 }
 
 func Test_connector_tryConnect(t *testing.T) {
+	// Set up gRPC stream interceptor to capture headers sent by client
+	actualUserAgent := atomic.Value{}
+	defaultInterceptors = append(defaultInterceptors, func(_ interface{}, stream grpc.ServerStream, _ *grpc.StreamServerInfo, h grpc.StreamHandler) error {
+		m, _ := metadata.FromIncomingContext(stream.Context())
+		actualUserAgent.Store(m.Get("User-Agent")[0])
+		return nil
+	})
+
+	// Setup server
 	serverConfig := NewConfig(fmt.Sprintf("localhost:%d", test.FreeTCPPort()), "server")
-	cm := NewGRPCConnectionManager(serverConfig, createKVStore(t), &TestNodeDIDResolver{}, nil)
+	cm := NewGRPCConnectionManager(serverConfig, createKVStore(t), &TestNodeDIDResolver{}, nil, &TestProtocol{})
 	if !assert.NoError(t, cm.Start()) {
 		return
 	}
 	defer cm.Stop()
 
+	// Setup connector to test
 	bo := &trackingBackoff{}
 	cfg := testConnectorConfig
 	cfg.address = serverConfig.listenAddress
 	connector := createOutboundConnector(cfg, grpc.DialContext, func() bool {
 		return false
 	}, nil, bo)
+
+	// Connect and call protocol function to set up streams, required to assert headers.
+	// Then wait for stream to be set up
 	grpcConn, err := connector.tryConnect()
-	assert.NoError(t, err)
-	assert.NotNil(t, grpcConn)
+	if !assert.NoError(t, err) || !assert.NotNil(t, grpcConn) {
+		return
+	}
+	_, _ = (&TestProtocol{}).CreateClientStream(context.Background(), grpcConn)
+	test.WaitFor(t, func() (bool, error) {
+		return actualUserAgent.Load() != nil, nil
+	}, time.Second, "time-out while waiting for connection to be set up")
+
 	assert.Equal(t, uint32(1), connector.stats().Attempts)
+	assert.Contains(t, actualUserAgent.Load().(string), "nuts-node-refimpl/development")
 }
 
 func Test_connector_stats(t *testing.T) {


### PR DESCRIPTION
HTTP header for gRPC calls:

```
nuts-node-refimpl/v4.3.0 grpc-go/1.50.1
```
(`grpc-go` user agent is always added by the library)