### PR TITLE
Docs: minor correction to issuing Auth credential

### DIFF
--- a/docs/pages/getting-started/6-adding-authorizations.rst
+++ b/docs/pages/getting-started/6-adding-authorizations.rst
@@ -77,7 +77,7 @@ The DID typically comes from your own administration, see also :ref:`Getting Sta
 
 type
 ====
-The ``type`` must equal to ``["NutsAuthorizationCredential"]``, no exceptions.
+The ``type`` must equal to ``"NutsAuthorizationCredential"``, no exceptions.
 
 visibility
 ==========


### PR DESCRIPTION
type is specced as string, not an array.