### PR TITLE
VCR: SearchVCs now logs invalid VCs on debug to avoid log clutter

### DIFF
--- a/vcr/search.go
+++ b/vcr/search.go
@@ -92,7 +92,7 @@ func (c *vcr) Search(ctx context.Context, searchTerms []SearchTerm, allowUntrust
 			log.Logger().
 				WithError(err).
 				WithField(core.LogFieldCredentialID, foundCredential.ID).
-				Info("Encountered invalid VC, omitting from search results.")
+				Debug("Encountered invalid VC, omitting from search results.")
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/nuts-foundation/nuts-node/issues/1628