### PR TITLE
State: saveEvent should fail when Notifier.Save fails

### DIFF
--- a/network/dag/state.go
+++ b/network/dag/state.go
@@ -431,7 +431,7 @@ func (s *state) Verify(ctx context.Context) error {
 func (s *state) saveEvent(tx stoabs.WriteTx, event Event) error {
 	var err error
 	s.notifiers.Range(func(_, value any) bool {
-		err := value.(Notifier).Save(tx, event)
+		err = value.(Notifier).Save(tx, event)
 		return err == nil
 	})
 	return err


### PR DESCRIPTION
state.Add should fail when the event cannot be saved to guarantee notification of network subscribers