### PR TITLE
Dockerfile: update musl-dev=1.2.3-r2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ LABEL maintainer="wout.slakhorst@nuts.nl"
 RUN apk update \
  && apk add --no-cache \
             gcc=11.2.1_git20220219-r2 \
-            musl-dev=1.2.3-r1 \
+            musl-dev=1.2.3-r2 \
  && update-ca-certificates
 
 ENV GO111MODULE on


### PR DESCRIPTION
tests currently fail due to failing builds