### PR TITLE
self-authenticate on startup

### DIFF
--- a/network/transport/grpc/authenticator_mock.go
+++ b/network/transport/grpc/authenticator_mock.go
@@ -5,6 +5,7 @@
 package grpc
 
 import (
+	x509 "crypto/x509"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -49,4 +50,18 @@ func (m *MockAuthenticator) Authenticate(nodeDID did.DID, grpcPeer peer.Peer, pe
 func (mr *MockAuthenticatorMockRecorder) Authenticate(nodeDID, grpcPeer, peer interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Authenticate", reflect.TypeOf((*MockAuthenticator)(nil).Authenticate), nodeDID, grpcPeer, peer)
+}
+
+// AuthenticateNodeDID mocks base method.
+func (m *MockAuthenticator) AuthenticateNodeDID(nodeDID did.DID, certificate x509.Certificate) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthenticateNodeDID", nodeDID, certificate)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AuthenticateNodeDID indicates an expected call of AuthenticateNodeDID.
+func (mr *MockAuthenticatorMockRecorder) AuthenticateNodeDID(nodeDID, certificate interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticateNodeDID", reflect.TypeOf((*MockAuthenticator)(nil).AuthenticateNodeDID), nodeDID, certificate)
 }

--- a/network/transport/grpc/authenticator_test.go
+++ b/network/transport/grpc/authenticator_test.go
@@ -35,7 +35,7 @@ import (
 	"google.golang.org/grpc/peer"
 )
 
-func Test_tlsAuthenticator_Authenticate(t *testing.T) {
+func TestTlsAuthenticator_Authenticate(t *testing.T) {
 	certData, _ := os.ReadFile("test/nuts.nl.cer")
 	cert, _ := x509.ParseCertificate(certData)
 	wildcardCertData, _ := os.ReadFile("test/wildcard.nuts.nl.cer")
@@ -107,7 +107,7 @@ func Test_tlsAuthenticator_Authenticate(t *testing.T) {
 
 			authenticatedPeer, err := authenticator.Authenticate(nodeDID, grpcPeer, transportPeer)
 
-			assert.EqualError(t, err, "none of the DNS names in the peer's TLS certificate match the NutsComm endpoint (nodeDID=did:nuts:test)")
+			assert.EqualError(t, err, "none of the DNS names in the TLS certificate match the NutsComm endpoint (nodeDID=did:nuts:test)")
 			assert.Empty(t, authenticatedPeer)
 		})
 		t.Run("no TLS info", func(t *testing.T) {
@@ -182,5 +182,13 @@ func TestDummyAuthenticator_Authenticate(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, *nodeDID, peer.NodeDID)
+	})
+}
+
+func TestDummyAuthenticator_AuthenticateNodeDID(t *testing.T) {
+	t.Run("always ok", func(t *testing.T) {
+		authenticator := NewDummyAuthenticator(nil)
+
+		assert.Nil(t, authenticator.AuthenticateNodeDID(*nodeDID, x509.Certificate{}))
 	})
 }


### PR DESCRIPTION
Verifies that the configuration is valid for authenticated connections. This should simplify dealing with errors on the users side.

still needs:
- documentation
- double check on logged errors