### PR TITLE
Fix crl validator tests

### DIFF
--- a/crl/validator.go
+++ b/crl/validator.go
@@ -39,6 +39,8 @@ import (
 // Should be set to a number where the possibility for hash collisions is low
 const defaultBitSetSize = 500
 
+var nowFunc = time.Now
+
 func hash(issuer string, serialNumber *big.Int) int64 {
 	data := append([]byte(issuer), serialNumber.Bytes()...)
 	sum := int64(murmur3.Sum64(data))
@@ -192,7 +194,7 @@ func (v *validator) IsSynced(maxOffsetDays int) bool {
 	}
 
 	// Verify that none of the CRLs are outdated
-	now := time.Now().Add(time.Duration(-maxOffsetDays) * (time.Hour * 24))
+	now := nowFunc().Add(time.Duration(-maxOffsetDays) * (time.Hour * 24))
 
 	for _, list := range v.lists {
 		if list.HasExpired(now) {

--- a/crl/validator_test.go
+++ b/crl/validator_test.go
@@ -124,9 +124,6 @@ func TestValidator_IsRevoked(t *testing.T) {
 	nowFunc = func() time.Time {
 		return time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
 	}
-	t.Cleanup(func() {
-		nowFunc = time.Now
-	})
 
 	data, err := os.ReadFile(pkiOverheidCRL)
 	if !assert.NoError(t, err) {
@@ -135,8 +132,6 @@ func TestValidator_IsRevoked(t *testing.T) {
 	httpClient := &http.Client{Transport: &fakeTransport{responseData: data}}
 
 	t.Run("should return true if the certificate was revoked", func(t *testing.T) {
-		t.Parallel()
-
 		store, err := core.LoadTrustStore(pkiOverheidRootCA)
 		assert.NoError(t, err)
 
@@ -151,9 +146,24 @@ func TestValidator_IsRevoked(t *testing.T) {
 		assert.True(t, crlValidator.IsSynced(0))
 	})
 
-	t.Run("should return false if the certificate was not revoked even though the bit was set", func(t *testing.T) {
-		t.Parallel()
+	t.Run("should return false if the crl is expired", func(t *testing.T) {
+		oldNowFunc := nowFunc
+		nowFunc = func() time.Time {
+			return time.Date(2022, 12, 1, 0, 0, 0, 0, time.UTC)
+		}
 
+		store, err := core.LoadTrustStore(pkiOverheidRootCA)
+		assert.NoError(t, err)
+
+		crlValidator := NewValidatorWithHTTPClient(store.Certificates(), httpClient)
+		crlValidator.Sync()
+
+		assert.False(t, crlValidator.IsSynced(0))
+
+		nowFunc = oldNowFunc
+	})
+
+	t.Run("should return false if the certificate was not revoked even though the bit was set", func(t *testing.T) {
 		store, err := core.LoadTrustStore(pkiOverheidRootCA)
 		assert.NoError(t, err)
 
@@ -172,8 +182,6 @@ func TestValidator_IsRevoked(t *testing.T) {
 	})
 
 	t.Run("should return false when the bit was not set and shouldn't check the actual certificate", func(t *testing.T) {
-		t.Parallel()
-
 		store, err := core.LoadTrustStore(pkiOverheidRootCA)
 		assert.NoError(t, err)
 

--- a/crl/validator_test.go
+++ b/crl/validator_test.go
@@ -31,6 +31,7 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/nuts-foundation/nuts-node/core"
 
@@ -118,6 +119,14 @@ func TestValidator_IsRevoked(t *testing.T) {
 	if _, ok := sn.SetString(revokedSerialNumber, 10); !ok {
 		t.FailNow()
 	}
+
+	// overwrite the nowFunc so the CRL is valid
+	nowFunc = func() time.Time {
+		return time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
+	}
+	t.Cleanup(func() {
+		nowFunc = time.Now
+	})
 
 	data, err := os.ReadFile(pkiOverheidCRL)
 	if !assert.NoError(t, err) {


### PR DESCRIPTION
The CRL testdata expired on 15 november 2022.
This PR adds
* a `nowFunc` to `crl/validator` which can be overridden during testing to set it to a valid date.
* an extra test to check if a failing crl is actually resulting in an error.