### PR TITLE
Increment client backoff when server returned unauthenticated

### DIFF
--- a/network/transport/grpc/connection.go
+++ b/network/transport/grpc/connection.go
@@ -365,9 +365,6 @@ func (mc *conn) IsProtocolConnected(protocol Protocol) bool {
 }
 
 func (mc *conn) CloseError() *status.Status {
-	mc.mux.RLock()
-	defer mc.mux.RUnlock()
-
 	return mc.status.Load()
 }
 

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -335,7 +335,7 @@ func (s *grpcConnectionManager) openOutboundStreams(connection Connection, grpcC
 	connection.waitUntilDisconnected()
 	_ = grpcConn.Close()
 
-	if st := connection.ErrorStatus(); st != nil && st.Code() == codes.Unauthenticated {
+	if st := connection.CloseError(); st != nil && st.Code() == codes.Unauthenticated {
 		// other side said unauthenticated, increase backoff
 		backoff.Backoff()
 		// return error so entire connection will be tried anew. Otherwise, backoff isn't honored

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -30,9 +30,11 @@ import (
 	"github.com/nuts-foundation/nuts-node/network/transport"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	grpcPeer "google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
 	"net"
 	"sync"
 )
@@ -44,7 +46,7 @@ const nodeDIDHeader = "nodeDID"
 
 // ErrNodeDIDAuthFailed is the error message returned to the peer when the node DID it sent could not be authenticated.
 // It is specified by RFC017.
-var ErrNodeDIDAuthFailed = errors.New("nodeDID authentication failed")
+var ErrNodeDIDAuthFailed = status.Error(codes.Unauthenticated, "nodeDID authentication failed")
 
 // ErrAlreadyConnected indicates the node is already connected to the peer.
 var ErrAlreadyConnected = errors.New("already connected")
@@ -233,7 +235,7 @@ func (s *grpcConnectionManager) Stop() {
 	}
 }
 
-func (s grpcConnectionManager) Connect(peerAddress string, options ...transport.ConnectionOption) {
+func (s *grpcConnectionManager) Connect(peerAddress string, options ...transport.ConnectionOption) {
 	peer := transport.Peer{Address: peerAddress}
 	for _, o := range options {
 		o(&peer)
@@ -276,7 +278,7 @@ func (s *grpcConnectionManager) Diagnostics() []core.DiagnosticResult {
 }
 
 // RegisterService implements grpc.ServiceRegistrar to register the gRPC services protocols expose.
-func (s grpcConnectionManager) RegisterService(desc *grpc.ServiceDesc, impl interface{}) {
+func (s *grpcConnectionManager) RegisterService(desc *grpc.ServiceDesc, impl interface{}) {
 	s.grpcServer.RegisterService(desc, impl)
 }
 
@@ -329,11 +331,20 @@ func (s *grpcConnectionManager) openOutboundStreams(connection Connection, grpcC
 	s.peersCounter.Inc()
 	defer s.peersCounter.Dec()
 
-	// Connection is OK, reset backoff it can immediately try reconnecting when it disconnects
-	backoff.Reset(0)
 	// Function must block until streams are closed or disconnect() is called.
 	connection.waitUntilDisconnected()
 	_ = grpcConn.Close()
+
+	if st := connection.ErrorStatus(); st != nil && st.Code() == codes.Unauthenticated {
+		// other side said unauthenticated, increase backoff
+		backoff.Backoff()
+		// return error so entire connection will be tried anew. Otherwise, backoff isn't honored
+		return st.Err()
+	}
+
+	// Connection is OK, reset backoff it can immediately try reconnecting when it disconnects
+	backoff.Reset(0)
+
 	return nil
 }
 
@@ -514,6 +525,7 @@ func (s *grpcConnectionManager) startTracking(address string, connection Connect
 		tls:               tlsConfig,
 		connectionTimeout: s.config.connectionTimeout,
 	}
+
 	connection.startConnecting(cfg, backoff, func(grpcConn *grpc.ClientConn) bool {
 		err := s.openOutboundStreams(connection, grpcConn, backoff)
 		if err != nil {

--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -516,7 +516,7 @@ func Test_grpcConnectionManager_openOutboundStreams(t *testing.T) {
 		clientCfg, _ := newBufconnConfig("client", withBufconnDialer(serverListener))
 		client := NewGRPCConnectionManager(clientCfg, nil, &transport.FixedNodeDIDResolver{}, nil, &TestProtocol{}).(*grpcConnectionManager)
 		c := createConnection(context.Background(), clientCfg.dialer, transport.Peer{}).(*conn)
-		c.errStatus = status.New(codes.Unauthenticated, "unauthenticated")
+		c.status.Store(status.New(codes.Unauthenticated, "unauthenticated"))
 		grpcConn, err := clientCfg.dialer(context.Background(), "server")
 		require.NoError(t, err)
 		connectedWG := sync.WaitGroup{}

--- a/network/transport/grpc/connection_mock.go
+++ b/network/transport/grpc/connection_mock.go
@@ -36,18 +36,18 @@ func (m *MockConnection) EXPECT() *MockConnectionMockRecorder {
 	return m.recorder
 }
 
-// ErrorStatus mocks base method.
-func (m *MockConnection) ErrorStatus() *status.Status {
+// CloseError mocks base method.
+func (m *MockConnection) CloseError() *status.Status {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ErrorStatus")
+	ret := m.ctrl.Call(m, "CloseError")
 	ret0, _ := ret[0].(*status.Status)
 	return ret0
 }
 
-// ErrorStatus indicates an expected call of ErrorStatus.
-func (mr *MockConnectionMockRecorder) ErrorStatus() *gomock.Call {
+// CloseError indicates an expected call of CloseError.
+func (mr *MockConnectionMockRecorder) CloseError() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ErrorStatus", reflect.TypeOf((*MockConnection)(nil).ErrorStatus))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseError", reflect.TypeOf((*MockConnection)(nil).CloseError))
 }
 
 // IsConnected mocks base method.
@@ -104,18 +104,6 @@ func (m *MockConnection) Send(protocol Protocol, envelope interface{}, ignoreSof
 func (mr *MockConnectionMockRecorder) Send(protocol, envelope, ignoreSoftLimit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockConnection)(nil).Send), protocol, envelope, ignoreSoftLimit)
-}
-
-// SetErrorStatus mocks base method.
-func (m *MockConnection) SetErrorStatus(status *status.Status) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetErrorStatus", status)
-}
-
-// SetErrorStatus indicates an expected call of SetErrorStatus.
-func (mr *MockConnectionMockRecorder) SetErrorStatus(status interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetErrorStatus", reflect.TypeOf((*MockConnection)(nil).SetErrorStatus), status)
 }
 
 // disconnect mocks base method.

--- a/network/transport/grpc/connection_mock.go
+++ b/network/transport/grpc/connection_mock.go
@@ -10,6 +10,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	transport "github.com/nuts-foundation/nuts-node/network/transport"
 	grpc "google.golang.org/grpc"
+	status "google.golang.org/grpc/status"
 )
 
 // MockConnection is a mock of Connection interface.
@@ -33,6 +34,20 @@ func NewMockConnection(ctrl *gomock.Controller) *MockConnection {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockConnection) EXPECT() *MockConnectionMockRecorder {
 	return m.recorder
+}
+
+// ErrorStatus mocks base method.
+func (m *MockConnection) ErrorStatus() *status.Status {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ErrorStatus")
+	ret0, _ := ret[0].(*status.Status)
+	return ret0
+}
+
+// ErrorStatus indicates an expected call of ErrorStatus.
+func (mr *MockConnectionMockRecorder) ErrorStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ErrorStatus", reflect.TypeOf((*MockConnection)(nil).ErrorStatus))
 }
 
 // IsConnected mocks base method.
@@ -89,6 +104,18 @@ func (m *MockConnection) Send(protocol Protocol, envelope interface{}, ignoreSof
 func (mr *MockConnectionMockRecorder) Send(protocol, envelope, ignoreSoftLimit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockConnection)(nil).Send), protocol, envelope, ignoreSoftLimit)
+}
+
+// SetErrorStatus mocks base method.
+func (m *MockConnection) SetErrorStatus(status *status.Status) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetErrorStatus", status)
+}
+
+// SetErrorStatus indicates an expected call of SetErrorStatus.
+func (mr *MockConnectionMockRecorder) SetErrorStatus(status interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetErrorStatus", reflect.TypeOf((*MockConnection)(nil).SetErrorStatus), status)
 }
 
 // disconnect mocks base method.

--- a/network/transport/grpc/connection_test.go
+++ b/network/transport/grpc/connection_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"github.com/nuts-foundation/nuts-node/test"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -137,6 +138,9 @@ func Test_conn_startSending(t *testing.T) {
 		test.WaitFor(t, func() (bool, error) {
 			return atomic.LoadInt32(&connection.activeGoroutines) == 0, nil
 		}, 5*time.Second, "waiting for all goroutines to exit")
+
+		// err status is set on connection. Due to EOF it's an unknown error
+		assert.Equal(t, codes.Unknown, connection.errStatus.Code())
 	})
 }
 

--- a/network/transport/grpc/connection_test.go
+++ b/network/transport/grpc/connection_test.go
@@ -140,7 +140,7 @@ func Test_conn_startSending(t *testing.T) {
 		}, 5*time.Second, "waiting for all goroutines to exit")
 
 		// err status is set on connection. Due to EOF it's an unknown error
-		assert.Equal(t, codes.Unknown, connection.errStatus.Code())
+		assert.Equal(t, codes.Unknown, connection.status.Load().Code())
 	})
 }
 

--- a/network/transport/grpc/test.go
+++ b/network/transport/grpc/test.go
@@ -167,7 +167,7 @@ func (s *StubConnection) IsProtocolConnected(_ Protocol) bool {
 	return s.Open
 }
 
-func (s *StubConnection) ErrorStatus() *status.Status {
+func (s *StubConnection) CloseError() *status.Status {
 	panic("implement me")
 }
 

--- a/network/transport/grpc/test.go
+++ b/network/transport/grpc/test.go
@@ -150,7 +150,7 @@ func (s *StubConnection) Send(_ Protocol, envelope interface{}, _ bool) error {
 }
 
 // Peer returns the peer information of the connection
-func (s StubConnection) Peer() transport.Peer {
+func (s *StubConnection) Peer() transport.Peer {
 	return transport.Peer{
 		ID:      s.PeerID,
 		NodeDID: s.NodeDID,
@@ -158,43 +158,51 @@ func (s StubConnection) Peer() transport.Peer {
 }
 
 // IsConnected returns true if the connection is connected
-func (s StubConnection) IsConnected() bool {
+func (s *StubConnection) IsConnected() bool {
 	return s.Open
 }
 
 // IsProtocolConnected returns true if the connection is connected for the given protocol
-func (s StubConnection) IsProtocolConnected(_ Protocol) bool {
+func (s *StubConnection) IsProtocolConnected(_ Protocol) bool {
 	return s.Open
 }
 
-func (s StubConnection) disconnect() {
+func (s *StubConnection) ErrorStatus() *status.Status {
 	panic("implement me")
 }
 
-func (s StubConnection) waitUntilDisconnected() {
+func (s *StubConnection) SetErrorStatus(_ *status.Status) {
 	panic("implement me")
 }
 
-func (s StubConnection) startConnecting(_ connectorConfig, _ Backoff, _ func(_ *grpc.ClientConn) bool) {
+func (s *StubConnection) disconnect() {
 	panic("implement me")
 }
 
-func (s StubConnection) stopConnecting() {
+func (s *StubConnection) waitUntilDisconnected() {
 	panic("implement me")
 }
 
-func (s StubConnection) registerStream(_ Protocol, _ Stream) bool {
+func (s *StubConnection) startConnecting(_ connectorConfig, _ Backoff, _ func(_ *grpc.ClientConn) bool) {
 	panic("implement me")
 }
 
-func (s StubConnection) verifyOrSetPeerID(_ transport.PeerID) bool {
+func (s *StubConnection) stopConnecting() {
 	panic("implement me")
 }
 
-func (s StubConnection) setPeer(_ transport.Peer) {
+func (s *StubConnection) registerStream(_ Protocol, _ Stream) bool {
 	panic("implement me")
 }
 
-func (s StubConnection) outboundConnector() *outboundConnector {
+func (s *StubConnection) verifyOrSetPeerID(_ transport.PeerID) bool {
+	panic("implement me")
+}
+
+func (s *StubConnection) setPeer(_ transport.Peer) {
+	panic("implement me")
+}
+
+func (s *StubConnection) outboundConnector() *outboundConnector {
 	panic("implement me")
 }


### PR DESCRIPTION
fixes #1265 

store grpc error before closing connection, can then be used to increment backoff
currently backoff only increased for Code==16 (Unauthenticated)