### PR TITLE
Hide usage information on server error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,10 +96,10 @@ func createServerCommand(system *core.System) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			// Load all config and add generic options
 			if err := system.Load(cmd.Flags()); err != nil {
-				logrus.WithError(err).Fatal("could not start the server")
+				logrus.WithError(err).Fatal("Could not start the server")
 			}
 			if err := startServer(cmd.Context(), system); err != nil {
-				logrus.WithError(err).Fatal("could not start the server")
+				logrus.WithError(err).Fatal("Could not start the server")
 			}
 		},
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,7 +101,6 @@ func createServerCommand(system *core.System) *cobra.Command {
 			}
 			if err := startServer(cmd.Context(), system); err != nil {
 				logrus.WithError(err).Error("could not start the server")
-				return
 			}
 		},
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,15 +93,16 @@ func createServerCommand(system *core.System) *cobra.Command {
 	return &cobra.Command{
 		Use:   "server",
 		Short: "Starts the Nuts server",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			// Load all config and add generic options
 			if err := system.Load(cmd.Flags()); err != nil {
-				return err
+				logrus.WithError(err).Error("could not start the server")
+				return
 			}
 			if err := startServer(cmd.Context(), system); err != nil {
-				return err
+				logrus.WithError(err).Error("could not start the server")
+				return
 			}
-			return nil
 		},
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,11 +96,10 @@ func createServerCommand(system *core.System) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			// Load all config and add generic options
 			if err := system.Load(cmd.Flags()); err != nil {
-				logrus.WithError(err).Error("could not start the server")
-				return
+				logrus.WithError(err).Fatal("could not start the server")
 			}
 			if err := startServer(cmd.Context(), system); err != nil {
-				logrus.WithError(err).Error("could not start the server")
+				logrus.WithError(err).Fatal("could not start the server")
 			}
 		},
 	}


### PR DESCRIPTION
This PR cleans up the output during startup when an error is encountered.
If the error is unrelated to the command options, the "usage" is not printed.

Reasoning:
* Finding the actual error is harder.
* Printing the usage info is confusing and condescending because it suggests the user made a mistake in the command.

Old output:

```
WARN[0000] Deprecated: use `tls.certkeyfile` instead of `network.certkeyfile` 
WARN[0000] Deprecated: use `tls.truststorefile` instead of `network.truststorefile` 
Error: no scheme file found
Usage:
  nuts server [flags]

Flags:
      --auth.clockskew int                            Allowed JWT Clock skew in milliseconds (default 5000)
      --auth.contractvalidators strings               sets the different contract validators to use (default [irma,uzi,dummy])
      --auth.http.timeout int                         HTTP timeout (in seconds) used by the Auth API HTTP client (default 30)
      --auth.irma.autoupdateschemas                   set if you want automatically update the IRMA schemas every 60 minutes. (default true)
      --auth.irma.schememanager string                IRMA schemeManager to use for attributes. Can be either 'pbdf' or 'irma-demo'. (default "pbdf")
      --auth.publicurl string                         public URL which can be reached by a users IRMA client, this should include the scheme and domain: https://example.com. Additional paths should only be added if some sort of url-rewriting is done in a reverse-proxy.
      --configfile string                             Nuts config file (default "nuts.yaml")
      --cpuprofile string                             When set, a CPU profile is written to the given path. Ignored when strictmode is set.
      --crypto.storage string                         Storage to use, 'fs' for file system, vaultkv for Vault KV store, default: fs. (default "fs")
      --crypto.vault.address string                   The Vault address. If set it overwrites the VAULT_ADDR env var.
      --crypto.vault.pathprefix string                The Vault path prefix. default: kv. (default "kv")
      --crypto.vault.timeout duration                 Timeout of client calls to Vault, in Golang time.Duration string format (e.g. 5s). (default 5s)
      --crypto.vault.token string                     The Vault token. If set it overwrites the VAULT_TOKEN env var.
      --datadir string                                Directory where the node stores its files. (default "./data")
      --events.nats.hostname string                   Hostname for the NATS server (default "localhost")
      --events.nats.port int                          Port where the NATS server listens on (default 4222)
      --events.nats.storagedir string                 Directory where file-backed streams are stored in the NATS server
      --events.nats.timeout int                       Timeout for NATS server operations (default 30)
  -h, --help                                          help for server
      --http.default.address string                   Address and port the server will be listening to (default ":1323")
      --http.default.auth.type string                 Whether to enable authentication for the default interface, specify 'token' for bearer token authentication.
      --http.default.cors.origin strings              When set, enables CORS from the specified origins on the default HTTP interface.
      --http.default.log string                       What to log about HTTP requests. Options are 'nothing', 'metadata' (log request method, URI, IP and response code), and 'metadata-and-body' (log the request and response body, in addition to the metadata). (default "metadata")
      --http.default.tls string                       Whether to enable TLS for the default interface, options are 'disabled', 'server', 'server-client'. Leaving it empty is synonymous to 'disabled',
      --internalratelimiter                           When set, expensive internal calls are rate-limited to protect the network. Always enabled in strict mode. (default true)
      --jsonld.contexts.localmapping stringToString   This setting allows mapping external URLs to local files for e.g. preventing external dependencies. These mappings have precedence over those in remoteallowlist. (default [https://nuts.nl/credentials/v1=assets/contexts/nuts.ldjson,https://www.w3.org/2018/credentials/v1=assets/contexts/w3c-credentials-v1.ldjson,https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json=assets/contexts/lds-jws2020-v1.ldjson,https://schema.org=assets/contexts/schema-org-v13.ldjson])
      --jsonld.contexts.remoteallowlist strings       In strict mode, fetching external JSON-LD contexts is not allowed except for context-URLs listed here. (default [https://schema.org,https://www.w3.org/2018/credentials/v1,https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json])
      --loggerformat string                           Log format (text, json) (default "text")
      --network.bootstrapnodes strings                List of bootstrap nodes ('<host>:<port>') which the node initially connect to.
      --network.connectiontimeout int                 Timeout before an outbound connection attempt times out (in milliseconds). (default 5000)
      --network.disablenodeauthentication             Disable node DID authentication using client certificate, causing all node DIDs to be accepted. Unsafe option, only intended for workshops/demo purposes so it's not allowed in strict-mode. Automatically enabled when TLS is disabled.
      --network.enablediscovery                       Whether to enable automatic connecting to other nodes. (default true)
      --network.enabletls                             Whether to enable TLS for gRPC connections, which can be disabled for demo/development purposes. It is NOT meant for TLS offloading (see 'tls.offload'). Disabling TLS is not allowed in strict-mode. (default true)
      --network.grpcaddr string                       Local address for gRPC to listen on. If empty the gRPC server won't be started and other nodes will not be able to connect to this node (outbound connections can still be made). (default ":5555")
      --network.maxbackoff duration                   Maximum between outbound connections attempts to unresponsive nodes (in Golang duration format, e.g. '1h', '30m'). (default 24h0m0s)
      --network.nodedid string                        Specifies the DID of the organization that operates this node, typically a vendor for EPD software. It is used to identify the node on the network. If the DID document does not exist of is deactivated, the node will not start.
      --network.protocols ints                        Specifies the list of network protocols to enable on the server. They are specified by version (1, 2). If not set, all protocols are enabled.
      --network.v2.diagnosticsinterval int            Interval (in milliseconds) that specifies how often the node should broadcast its diagnostic information to other nodes (specify 0 to disable). (default 5000)
      --network.v2.gossipinterval int                 Interval (in milliseconds) that specifies how often the node should gossip its new hashes to other nodes. (default 5000)
      --storage.bbolt.backup.directory string         Target directory for BBolt database backups.
      --storage.bbolt.backup.interval duration        Interval, formatted as Golang duration (e.g. 10m, 1h) at which BBolt database backups will be performed.
      --storage.redis.address string                  Redis database server address. This can be a simple 'host:port' or a Redis connection URL with scheme, auth and other options.
      --storage.redis.database string                 Redis database name, which is used as prefix every key. Can be used to have multiple instances use the same Redis instance.
      --storage.redis.password string                 Redis database password. If set, it overrides the username in the connection URL.
      --storage.redis.sentinel.master string          Name of the Redis Sentinel master. Setting this property enables Redis Sentinel.
      --storage.redis.sentinel.nodes strings          Addresses of the Redis Sentinels to connect to initially. Setting this property enables Redis Sentinel.
      --storage.redis.sentinel.password string        Password for authenticating to Redis Sentinels.
      --storage.redis.sentinel.username string        Username for authenticating to Redis Sentinels.
      --storage.redis.tls.truststorefile string       PEM file containing the trusted CA certificate(s) for authenticating remote Redis servers. Can only be used when connecting over TLS (use 'rediss://' as scheme in address).
      --storage.redis.username string                 Redis database username. If set, it overrides the username in the connection URL.
      --strictmode                                    When set, insecure settings are forbidden.
      --tls.certfile string                           PEM file containing the certificate for the server (also used as client certificate).
      --tls.certheader string                         Name of the HTTP header that will contain the client certificate when TLS is offloaded.
      --tls.certkeyfile string                        PEM file containing the private key of the server certificate.
      --tls.crl.maxvaliditydays int                   The number of days a CRL can be outdated, after that it will hard-fail.
      --tls.offload string                            Whether to enable TLS offloading for incoming connections. Enable by setting it to 'incoming'. If enabled 'tls.certheader' must be configured as well.
      --tls.truststorefile string                     PEM file containing the trusted CA certificates for authenticating remote servers. (default "truststore.pem")
      --verbosity string                              Log level (trace, debug, info, warn, error) (default "info")

ERRO[0000] no scheme file found                         

Process finished with the exit code 0
```

New output:

```
WARN[0000] Deprecated: use `tls.certkeyfile` instead of `network.certkeyfile` 
WARN[0000] Deprecated: use `tls.truststorefile` instead of `network.truststorefile` 
ERRO[0000] could not parse the IRMA schemas, try emptying the irma directory and restart the node.  error="no scheme file found" module=Auth
ERRO[0000] could not start the server                    error="no scheme file found"

Process finished with the exit code 0
```