### PR TITLE
VCR: Revoking unknown VC now returns HTTP 404

### DIFF
--- a/vcr/issuer/interface.go
+++ b/vcr/issuer/interface.go
@@ -19,7 +19,6 @@
 package issuer
 
 import (
-	"errors"
 	"github.com/nuts-foundation/nuts-node/core"
 	"io"
 
@@ -57,12 +56,6 @@ type Issuer interface {
 	Revoke(credentialID ssi.URI) (*credential.Revocation, error)
 	CredentialSearcher
 }
-
-// ErrNotFound is returned when a credential or revocation can not be found based on its ID.
-var ErrNotFound = errors.New("not found")
-
-// ErrMultipleFound is returned when multiple credentials or revocations are found for the same ID.
-var ErrMultipleFound = errors.New("multiple found")
 
 // Store defines the interface for an issuer store.
 // An implementation stores all the issued credentials and the revocations.

--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -245,9 +245,9 @@ func (i issuer) isRevoked(credentialID ssi.URI) (bool, error) {
 	switch err {
 	case nil: // revocation found
 		return true, nil
-	case ErrMultipleFound:
+	case vcr.ErrMultipleFound:
 		return true, nil
-	case ErrNotFound:
+	case vcr.ErrNotFound:
 		return false, nil
 	default:
 		return true, err

--- a/vcr/issuer/issuer_test.go
+++ b/vcr/issuer/issuer_test.go
@@ -389,7 +389,7 @@ func Test_issuer_Revoke(t *testing.T) {
 		storeWithActualCredential := func(c *gomock.Controller) *MockStore {
 			store := NewMockStore(c)
 			store.EXPECT().GetCredential(credentialURI).Return(credentialToRevoke(), nil)
-			store.EXPECT().GetRevocation(credentialURI).Return(nil, ErrNotFound)
+			store.EXPECT().GetRevocation(credentialURI).Return(nil, vcr.ErrNotFound)
 			return store
 		}
 
@@ -439,7 +439,7 @@ func Test_issuer_Revoke(t *testing.T) {
 			invalidCredential := vc.VerifiableCredential{}
 			store := NewMockStore(ctrl)
 			store.EXPECT().GetCredential(credentialURI).Return(&invalidCredential, nil)
-			store.EXPECT().GetRevocation(credentialURI).Return(nil, ErrNotFound)
+			store.EXPECT().GetRevocation(credentialURI).Return(nil, vcr.ErrNotFound)
 
 			sut := issuer{
 				store: store,
@@ -500,7 +500,7 @@ func Test_issuer_Revoke(t *testing.T) {
 	t.Run("for an unknown credential", func(t *testing.T) {
 		storeWithoutCredential := func(c *gomock.Controller) Store {
 			store := NewMockStore(c)
-			store.EXPECT().GetCredential(credentialURI).Return(nil, ErrNotFound)
+			store.EXPECT().GetCredential(credentialURI).Return(nil, vcr.ErrNotFound)
 			return store
 		}
 
@@ -513,7 +513,7 @@ func Test_issuer_Revoke(t *testing.T) {
 			}
 
 			revocation, err := sut.Revoke(credentialURI)
-			assert.EqualError(t, err, "could not revoke (id=did:nuts:123#abc): not found")
+			assert.EqualError(t, err, "could not revoke (id=did:nuts:123#abc): credential not found")
 			assert.Nil(t, revocation)
 		})
 	})
@@ -533,7 +533,7 @@ func TestIssuer_isRevoked(t *testing.T) {
 	}
 
 	t.Run("ok - no revocation", func(t *testing.T) {
-		store.EXPECT().GetRevocation(credentialURI).Return(nil, ErrNotFound)
+		store.EXPECT().GetRevocation(credentialURI).Return(nil, vcr.ErrNotFound)
 
 		isRevoked, err := sut.isRevoked(credentialURI)
 
@@ -549,7 +549,7 @@ func TestIssuer_isRevoked(t *testing.T) {
 		assert.True(t, isRevoked)
 	})
 	t.Run("ok - multiple revocations exists", func(t *testing.T) {
-		store.EXPECT().GetRevocation(credentialURI).Return(nil, ErrMultipleFound)
+		store.EXPECT().GetRevocation(credentialURI).Return(nil, vcr.ErrMultipleFound)
 
 		isRevoked, err := sut.isRevoked(credentialURI)
 

--- a/vcr/issuer/leia_store.go
+++ b/vcr/issuer/leia_store.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/vcr/log"
+	"github.com/nuts-foundation/nuts-node/vcr/types"
 
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
@@ -129,10 +130,10 @@ func (s leiaIssuerStore) GetCredential(id ssi.URI) (*vc.VerifiableCredential, er
 		return nil, fmt.Errorf("could not get credential by id: %w", err)
 	}
 	if len(results) == 0 {
-		return nil, ErrNotFound
+		return nil, types.ErrNotFound
 	}
 	if len(results) > 1 {
-		return nil, ErrMultipleFound
+		return nil, types.ErrMultipleFound
 	}
 	result := results[0]
 	credential := &vc.VerifiableCredential{}
@@ -165,10 +166,10 @@ func (s leiaIssuerStore) GetRevocation(subject ssi.URI) (*credential.Revocation,
 		return nil, fmt.Errorf("error while getting revocation by id: %w", err)
 	}
 	if len(results) == 0 {
-		return nil, ErrNotFound
+		return nil, types.ErrNotFound
 	}
 	if len(results) > 1 {
-		return nil, ErrMultipleFound
+		return nil, types.ErrMultipleFound
 	}
 	result := results[0]
 	revocation := &credential.Revocation{}

--- a/vcr/issuer/leia_store_test.go
+++ b/vcr/issuer/leia_store_test.go
@@ -166,7 +166,7 @@ func Test_leiaStore_GetCredential(t *testing.T) {
 	t.Run("no results", func(t *testing.T) {
 		store := newStore(t)
 		foundCredential, err := store.GetCredential(*vcToGet.ID)
-		assert.EqualError(t, err, types.ErrNotFound.Error())
+		assert.ErrorIs(t, err, types.ErrNotFound)
 		assert.Nil(t, foundCredential)
 	})
 

--- a/vcr/issuer/leia_store_test.go
+++ b/vcr/issuer/leia_store_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/go-stoabs/bbolt"
+	"github.com/nuts-foundation/nuts-node/vcr/types"
 	"github.com/stretchr/testify/require"
 	"path"
 	"testing"
@@ -165,7 +166,7 @@ func Test_leiaStore_GetCredential(t *testing.T) {
 	t.Run("no results", func(t *testing.T) {
 		store := newStore(t)
 		foundCredential, err := store.GetCredential(*vcToGet.ID)
-		assert.EqualError(t, err, ErrNotFound.Error())
+		assert.EqualError(t, err, types.ErrNotFound.Error())
 		assert.Nil(t, foundCredential)
 	})
 
@@ -183,7 +184,7 @@ func Test_leiaStore_GetCredential(t *testing.T) {
 
 		t.Run("it fails", func(t *testing.T) {
 			foundCredential, err := store.GetCredential(*vcToGet.ID)
-			assert.ErrorIs(t, err, ErrMultipleFound)
+			assert.ErrorIs(t, err, types.ErrMultipleFound)
 			assert.Nil(t, foundCredential)
 		})
 	})
@@ -223,7 +224,7 @@ func Test_leiaIssuerStore_GetRevocation(t *testing.T) {
 
 		result, err := store.GetRevocation(unknownSubjectID)
 
-		assert.ErrorIs(t, err, ErrNotFound)
+		assert.ErrorIs(t, err, types.ErrNotFound)
 		assert.Nil(t, result)
 	})
 
@@ -237,7 +238,7 @@ func Test_leiaIssuerStore_GetRevocation(t *testing.T) {
 
 		result, err := store.GetRevocation(duplicateSubjectID)
 
-		assert.ErrorIs(t, err, ErrMultipleFound)
+		assert.ErrorIs(t, err, types.ErrMultipleFound)
 		assert.Nil(t, result)
 	})
 }

--- a/vcr/types/constants.go
+++ b/vcr/types/constants.go
@@ -23,14 +23,11 @@ import (
 	"errors"
 )
 
-// ErrInvalidIssuer is returned when a credential is issued by a DID that is unknown or when the private key is missing.
-var ErrInvalidIssuer = errors.New("invalid credential issuer")
-
-// ErrInvalidSubject is returned when a credential is issued to a DID that is unknown or revoked.
-var ErrInvalidSubject = errors.New("invalid credential subject")
-
 // ErrNotFound is returned when a credential can not be found based on its ID.
 var ErrNotFound = errors.New("credential not found")
+
+// ErrMultipleFound is returned when multiple credentials or revocations are found for the same ID.
+var ErrMultipleFound = errors.New("multiple found")
 
 // ErrRevoked is returned when a credential has been revoked and the required action requires it to not be revoked.
 var ErrRevoked = errors.New("credential is revoked")


### PR DESCRIPTION
Returned HTTP 500 (unmapped error) because of ambiguous error types, issuer package just uses the commonly defined VCR errors (which are mapped in the API).

```shell
curl -X DELETE http://localhost:1323/internal/vcr/v2/issuer/vc/foo | jq
```

Now returns:

```json
{
  "detail": "could not revoke (id=foo): credential not found",
  "status": 404,
  "title": "RevokeVC failed"
}
```

Closes https://github.com/nuts-foundation/nuts-node/issues/1635