### PR TITLE
VCR: Validate SearchVCs input

### DIFF
--- a/auth/services/contract/notary.go
+++ b/auth/services/contract/notary.go
@@ -305,7 +305,10 @@ func (n *notary) findVC(orgID did.DID) (string, string, error) {
 	}
 
 	// expand
-	reader := jsonld.Reader{DocumentLoader: n.jsonldManager.DocumentLoader()}
+	reader := jsonld.Reader{
+		DocumentLoader:           n.jsonldManager.DocumentLoader(),
+		AllowUndefinedProperties: true,
+	}
 	document, err := reader.Read(result[0])
 	if err != nil {
 		return "", "", fmt.Errorf("could not read VC: %w", err)

--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -309,7 +309,10 @@ func (s *service) validateIssuer(vContext *validationContext) error {
 		return errors.New("requester has no trusted organization VC")
 	}
 
-	reader := jsonld.Reader{DocumentLoader: s.jsonldManager.DocumentLoader()}
+	reader := jsonld.Reader{
+		DocumentLoader:           s.jsonldManager.DocumentLoader(),
+		AllowUndefinedProperties: true,
+	}
 	document, err := reader.Read(vcs[0])
 	if err != nil {
 		return fmt.Errorf("could not expand credential to JSON-LD: %w", err)

--- a/didman/didman.go
+++ b/didman/didman.go
@@ -396,7 +396,10 @@ func (d *didman) SearchOrganizations(ctx context.Context, query string, didServi
 	// Convert organization concepts and DID documents to search results
 	results := make([]OrganizationSearchResult, len(organizations))
 	for i := range organizations {
-		reader := jsonld.Reader{DocumentLoader: d.jsonldManager.DocumentLoader()}
+		reader := jsonld.Reader{
+			DocumentLoader:           d.jsonldManager.DocumentLoader(),
+			AllowUndefinedProperties: true,
+		}
 		document, err := reader.Read(organizations[i])
 		if err != nil {
 			return nil, fmt.Errorf("failed to expand credential to JSON-LD: %w", err)

--- a/jsonld/reader.go
+++ b/jsonld/reader.go
@@ -32,6 +32,8 @@ const JSONLdBase = ""
 type Reader struct {
 	// DocumentLoader the document loader that resolves JSON-LD context urls
 	DocumentLoader ld.DocumentLoader
+	// AllowUndefinedProperties specifies whether the reader should return an error when it occurs a property that is not defined in the JSON-LD context.
+	AllowUndefinedProperties bool
 }
 
 // Read transforms a struct to a Document (expanded JSON-LD)
@@ -53,6 +55,7 @@ func (r Reader) ReadBytes(asJSON []byte) (Document, error) {
 
 	processor := ld.NewJsonLdProcessor()
 	options := ld.NewJsonLdOptions(JSONLdBase)
+	options.SafeMode = !r.AllowUndefinedProperties
 	options.DocumentLoader = r.DocumentLoader
 
 	return processor.Expand(compact, options)

--- a/vcr/context_test.go
+++ b/vcr/context_test.go
@@ -55,7 +55,9 @@ func TestNutsV1Context(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("NutsAuthorizationCredential", func(t *testing.T) {
-		vcJSON, _ := credential.ValidNutsAuthorizationCredential().MarshalJSON()
+		subject := credential.ValidNutsAuthorizationCredential()
+		subject.Proof = nil
+		vcJSON, _ := subject.MarshalJSON()
 		documents, err := reader.ReadBytes(vcJSON)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Requires https://github.com/nuts-foundation/nuts-node/pull/1677, since otherwise any undefined property is imported into the Nuts context due to `@vocab`.