### PR TITLE
Docs: improve OpenAPI examples to reflect actual data

### DIFF
--- a/api/ssi_types.go
+++ b/api/ssi_types.go
@@ -142,7 +142,7 @@ type VerifiableCredential struct {
 	// ExpirationDate rfc3339 time string until when the credential is valid.
 	ExpirationDate *string `json:"expirationDate,omitempty"`
 
-	// Id Credential ID. An URI wich uniquely identifies the credential e.g. the issuers DID concatenated with an uuid.
+	// Id Credential ID. An URI which uniquely identifies the credential e.g. the issuers DID concatenated with an UUID.
 	Id *string `json:"id,omitempty"`
 
 	// IssuanceDate rfc3339 time string when the credential was issued.

--- a/api/ssi_types.go
+++ b/api/ssi_types.go
@@ -142,7 +142,7 @@ type VerifiableCredential struct {
 	// ExpirationDate rfc3339 time string until when the credential is valid.
 	ExpirationDate *string `json:"expirationDate,omitempty"`
 
-	// Id Credential ID. An URI which uniquely identifies the credential e.g. the issuers DID concatenated with an UUID.
+	// Id Credential ID. An URI which uniquely identifies the credential e.g. the issuers DID concatenated with a UUID.
 	Id *string `json:"id,omitempty"`
 
 	// IssuanceDate rfc3339 time string when the credential was issued.

--- a/docs/_static/auth/v1.yaml
+++ b/docs/_static/auth/v1.yaml
@@ -398,7 +398,7 @@ components:
     LegalEntity:
       type: string
       description: DID of the organization as registered in the Nuts registry.
-      example: "did:nuts:128903fjgfslcnmgpe84"
+      example: "did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic"
     Contract:
       required:
         - type
@@ -626,12 +626,12 @@ components:
           type: string
           description: |
             The subject (not a Nuts subject) contains the DID of the authorizer.
-          example: "did:nuts:128903fjgfslcnmgpe84"
+          example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
         sub:
           type: string
           description: |
             The subject is always the acting party, thus the care organization requesting access to data.
-          example: "did:nuts:128903fjgfslcnmgpe84"
+          example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
         aud:
           type: string
           description: |

--- a/docs/_static/common/ssi_types.yaml
+++ b/docs/_static/common/ssi_types.yaml
@@ -15,8 +15,8 @@ components:
         "@context":
           description: "List of URIs of JSON-LD contexts of the VC."
         id:
-          description: Credential ID. An URI wich uniquely identifies the credential e.g. the issuers DID concatenated with an uuid.
-          example: "did:nuts:123#B8PUHs2AUHbFF1xLLK4eZjgErEcMXHxs68FteY7NDtCY"
+          description: Credential ID. An URI which uniquely identifies the credential e.g. the issuers DID concatenated with an UUID.
+          example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic#b53bda82-712a-4d20-b673-e67efaf60acc
           type: string
         type:
           description: A single string or array of strings. The value(s) indicate the type of credential. It should contain `VerifiableCredential`. Each type should be defined in the @context.
@@ -99,7 +99,7 @@ components:
           type: string
           description: "URI of the entity that is generating the presentation."
           format: uri
-          example: "did:nuts:123"
+          example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
         proof:
           description: |
             Cryptographic proofs that can be used to detect tampering and verify the authorship of a
@@ -159,7 +159,7 @@ components:
             Specifies the public key that can be used to verify the digital signature.
             Dereferencing a public key URL reveals information about the controller of the key,
             which can be checked against the issuer of the credential.
-          example: did:nuts:123#key-5
+          example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic#zx1alkbvj2mqxi55WSVYWv_rek0uNO2iTZaqTTULpCE
         jws:
           type: string
           description: JSON Web Signature
@@ -264,7 +264,7 @@ components:
       properties:
         controller:
           description: The DID subject this key belongs to.
-          example: "did:nuts:1"
+          example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
           type: string
         id:
           description: The ID of the key, used as KID in various JWX technologies.

--- a/docs/_static/common/ssi_types.yaml
+++ b/docs/_static/common/ssi_types.yaml
@@ -15,7 +15,7 @@ components:
         "@context":
           description: "List of URIs of JSON-LD contexts of the VC."
         id:
-          description: Credential ID. An URI which uniquely identifies the credential e.g. the issuers DID concatenated with an UUID.
+          description: Credential ID. An URI which uniquely identifies the credential e.g. the issuers DID concatenated with a UUID.
           example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic#b53bda82-712a-4d20-b673-e67efaf60acc
           type: string
         type:

--- a/docs/_static/didman/v1.yaml
+++ b/docs/_static/didman/v1.yaml
@@ -330,7 +330,7 @@ components:
         serviceEndpoint:
           description: An endpoint URL or a reference to another service.
           type: string
-          example:
+          examples:
             - 'did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic/serviceEndpoint?type=eOverdracht-fhir'
             - 'http://example.com/some/service/endpoint'
     EndpointProperties:
@@ -346,7 +346,7 @@ components:
         endpoint:
           description: An endpoint URL or a reference to another service.
           type: string
-          example:
+          examples:
             - 'did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic/serviceEndpoint?type=eOverdracht-fhir'
             - 'http://example.com/some/service/endpoint'
     CompoundServiceProperties:

--- a/docs/_static/didman/v1.yaml
+++ b/docs/_static/didman/v1.yaml
@@ -14,7 +14,7 @@ paths:
         in: path
         description: URL encoded DID.
         required: true
-        example: "did:nuts:1234"
+        example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
         schema:
           type: string
     get:
@@ -61,7 +61,7 @@ paths:
         in: path
         description: URL encoded DID.
         required: true
-        example: "did:nuts:1234"
+        example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
         schema:
           type: string
     post:
@@ -103,14 +103,14 @@ paths:
         in: path
         description: URL encoded DID.
         required: true
-        example: "did:nuts:1234"
+        example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
         schema:
           type: string
       - name: type
         in: path
         description: Type of the service
         required: true
-        example: "eOverdracht"
+        example: oauth
         schema:
           type: string
     delete:
@@ -136,7 +136,7 @@ paths:
         in: path
         description: URL encoded DID.
         required: true
-        example: "did:nuts:1234"
+        example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
         schema:
           type: string
     get:
@@ -199,7 +199,7 @@ paths:
         in: path
         description: URL encoded DID.
         required: true
-        example: "did:nuts:1234"
+        example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
         schema:
           type: string
       - name: compoundServiceType
@@ -258,7 +258,7 @@ paths:
         in: path
         description: URL encoded service ID.
         required: true
-        example: "did:nuts:1234#service-x"
+        example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic#7zKW6JtrkWpvcxBisYAoqZw1eavRULtLa8asDc6KJ6yc
         schema:
           type: string
     delete:
@@ -330,7 +330,9 @@ components:
         serviceEndpoint:
           description: An endpoint URL or a reference to another service.
           type: string
-          example: 'did:nuts:123/serviceEndpoint?type=eOverdracht-fhir'
+          example:
+            - 'did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic/serviceEndpoint?type=eOverdracht-fhir'
+            - 'http://example.com/some/service/endpoint'
     EndpointProperties:
       type: object
       description: A combination of type and URL.
@@ -344,7 +346,9 @@ components:
         endpoint:
           description: An endpoint URL or a reference to another service.
           type: string
-          example: 'did:nuts:123/serviceEndpoint?type=eOverdracht-fhir'
+          example:
+            - 'did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic/serviceEndpoint?type=eOverdracht-fhir'
+            - 'http://example.com/some/service/endpoint'
     CompoundServiceProperties:
       type: object
       description: A creation request for a compound service that contains endpoints. The endpoints can be either absolute endpoints or references.
@@ -357,7 +361,7 @@ components:
           type: string
         serviceEndpoint:
           description: A map containing service references and/or endpoints.
-          example: { 'auth': 'did:nuts:1312321/serviceEndpoint?type=auth' }
+          example: { 'auth': 'did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic/serviceEndpoint?type=auth' }
           type: object
     CompoundService:
       type: object
@@ -374,7 +378,7 @@ components:
           type: string
         serviceEndpoint:
           description: A map containing service references and/or endpoints.
-          example: { 'auth': 'did:nuts:1312321/serviceEndpoint?type=auth' }
+          example: { 'auth': 'did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic/serviceEndpoint?type=auth' }
           type: object
     ContactInformation:
       type: object

--- a/docs/_static/didman/v1.yaml
+++ b/docs/_static/didman/v1.yaml
@@ -330,7 +330,7 @@ components:
         serviceEndpoint:
           description: An endpoint URL or a reference to another service.
           type: string
-          examples:
+          example:
             - 'did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic/serviceEndpoint?type=eOverdracht-fhir'
             - 'http://example.com/some/service/endpoint'
     EndpointProperties:
@@ -346,7 +346,7 @@ components:
         endpoint:
           description: An endpoint URL or a reference to another service.
           type: string
-          examples:
+          example:
             - 'did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic/serviceEndpoint?type=eOverdracht-fhir'
             - 'http://example.com/some/service/endpoint'
     CompoundServiceProperties:

--- a/docs/_static/didman/v1.yaml
+++ b/docs/_static/didman/v1.yaml
@@ -331,8 +331,8 @@ components:
           description: An endpoint URL or a reference to another service.
           type: string
           example:
-            - 'did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic/serviceEndpoint?type=eOverdracht-fhir'
-            - 'http://example.com/some/service/endpoint'
+            referenceExample: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic/serviceEndpoint?type=eOverdracht-fhir
+            urlExample: http://example.com/some/service/endpoint
     EndpointProperties:
       type: object
       description: A combination of type and URL.
@@ -347,8 +347,8 @@ components:
           description: An endpoint URL or a reference to another service.
           type: string
           example:
-            - 'did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic/serviceEndpoint?type=eOverdracht-fhir'
-            - 'http://example.com/some/service/endpoint'
+            referenceExample: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic/serviceEndpoint?type=eOverdracht-fhir
+            urlExample: http://example.com/some/service/endpoint
     CompoundServiceProperties:
       type: object
       description: A creation request for a compound service that contains endpoints. The endpoints can be either absolute endpoints or references.

--- a/docs/_static/vcr/v2.yaml
+++ b/docs/_static/vcr/v2.yaml
@@ -156,14 +156,14 @@ paths:
         - name: issuer
           in: query
           description: the DID of the issuer
-          example: did:nuts:123
+          example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
           required: true
           schema:
             type: string
         - name: subject
           in: query
           description: the URI which indicates the subject (usually a DID)
-          example: did:nuts:456
+          example: did:nuts:9z72Hjg5P567VkgFFvUNjSHtG6pYzqvcLA1KXnFq6VK7
           required: false
           schema:
             type: string
@@ -451,7 +451,7 @@ components:
           type: string
           example: "did:nuts:B8PUHs2AUHbFF1xLLK4eZjgErEcMXHxs68FteY7NDtCY"
         expirationDate:
-          description: rfc3339 time string until when the credential is valid.
+          description: RFC3339 time string until when the credential is valid.
           type: string
           example: "2012-01-02T12:00:00Z"
         publishToNetwork:

--- a/docs/_static/vdr/v1.yaml
+++ b/docs/_static/vdr/v1.yaml
@@ -43,7 +43,7 @@ paths:
         in: path
         description: URL encoded DID.
         required: true
-        example: "did:nuts:1234"
+        example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
         schema:
           type: string
     get:
@@ -167,7 +167,7 @@ paths:
         in: path
         description: URL encoded DID.
         required: true
-        example: "did:nuts:1234"
+        example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
         schema:
           type: string
     post:
@@ -205,14 +205,14 @@ paths:
         in: path
         description: URL encoded DID.
         required: true
-        example: "did:nuts:1234"
+        example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
         schema:
           type: string
       - name: kid
         in: path
         description: URL encoded DID identifying the verification method.
         required: true
-        example: "did:nuts:1234#abc"
+        example: "did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic#zx1alkbvj2mqxi55WSVYWv_rek0uNO2iTZaqTTULpCE"
         schema:
           type: string
     delete:
@@ -273,7 +273,7 @@ components:
           items:
             type: string
             description: DID according to Nuts specification
-            example: "did:nuts:128903fjgfslcnmgpe84"
+            example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
         assertionMethod:
           type: boolean
           description: indicates if the generated key pair can be used for assertions.

--- a/vcr/api/v2/generated.go
+++ b/vcr/api/v2/generated.go
@@ -70,7 +70,7 @@ type IssueVCRequest struct {
 	// CredentialSubject Subject of a Verifiable Credential identifying the holder and expressing claims.
 	CredentialSubject CredentialSubject `json:"credentialSubject"`
 
-	// ExpirationDate rfc3339 time string until when the credential is valid.
+	// ExpirationDate RFC3339 time string until when the credential is valid.
 	ExpirationDate *string `json:"expirationDate,omitempty"`
 
 	// Issuer DID according to Nuts specification.


### PR DESCRIPTION
During past hackatons people keep getting confused about incorrect examples. Mostly about service ID which appears to be the service type in some examples, but which is actually the hash of the service.

This PR fixes examples containing DIDs (DIDs, verification method IDs and service IDs).

Partially fixes https://github.com/nuts-foundation/nuts-node/issues/1196