### PR TITLE
Disable codeclimate/golint since it breaks on generics

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -20,7 +20,8 @@ exclude_patterns:
 plugins:
   gofmt:
     enabled: true
+  # golint doesn't support Go 1.19, so it crashes on generics (2022-11-28)
   golint:
-    enabled: true
+    enabled: false
   govet:
     enabled: true


### PR DESCRIPTION
Codeclimate seems unmaintained (at least for Go): https://github.com/codeclimate/codeclimate-golint/issues/28

`golint` is also deprecated: https://github.com/golang/lint