### PR TITLE
Auth: clearly distinguish errors returned by remote nodes

### DIFF
--- a/auth/api/v1/api.go
+++ b/auth/api/v1/api.go
@@ -322,7 +322,7 @@ func (w Wrapper) RequestAccessToken(ctx echo.Context) error {
 	}
 	accessTokenResponse, err := authClient.CreateAccessToken(*authServerEndpoint, jwtGrantResponse.BearerToken)
 	if err != nil {
-		return core.Error(http.StatusBadGateway, "remote server/nuts node returned error creating access token: %w", err)
+		return core.Error(http.StatusServiceUnavailable, "remote server/nuts node returned error creating access token: %w", err)
 	}
 
 	return ctx.JSON(http.StatusOK, accessTokenResponse)

--- a/auth/api/v1/api.go
+++ b/auth/api/v1/api.go
@@ -322,11 +322,7 @@ func (w Wrapper) RequestAccessToken(ctx echo.Context) error {
 	}
 	accessTokenResponse, err := authClient.CreateAccessToken(*authServerEndpoint, jwtGrantResponse.BearerToken)
 	if err != nil {
-		if statusCodeErr, ok := err.(core.HTTPStatusCodeError); ok {
-			return core.Error(statusCodeErr.StatusCode(), "unable to create access token: %w", err)
-		}
-
-		return fmt.Errorf("unable to create access token: %w", err)
+		return core.Error(http.StatusBadGateway, "remote server/nuts node returned error creating access token: %w", err)
 	}
 
 	return ctx.JSON(http.StatusOK, accessTokenResponse)

--- a/auth/api/v1/api_test.go
+++ b/auth/api/v1/api_test.go
@@ -436,7 +436,7 @@ func TestWrapper_RequestAccessToken(t *testing.T) {
 		Service:    "test-service",
 	}
 
-	t.Run("returns_error_when_request_is_invalid", func(t *testing.T) {
+	t.Run("returns error when request is invalid", func(t *testing.T) {
 		ctx := createContext(t)
 
 		ctx.echoMock.EXPECT().
@@ -448,7 +448,7 @@ func TestWrapper_RequestAccessToken(t *testing.T) {
 		assert.EqualError(t, err, "random error")
 	})
 
-	t.Run("returns_error_when_creating_jwt_grant_fails", func(t *testing.T) {
+	t.Run("returns error when creating jwt grant fails", func(t *testing.T) {
 		ctx := createContext(t)
 
 		ctx.echoMock.EXPECT().
@@ -472,7 +472,7 @@ func TestWrapper_RequestAccessToken(t *testing.T) {
 		assert.EqualError(t, err, "random error")
 	})
 
-	t.Run("returns_error_when_http_create_access_token_fails", func(t *testing.T) {
+	t.Run("returns error when http create access token fails", func(t *testing.T) {
 		ctx := createContext(t)
 
 		ctx.echoMock.EXPECT().
@@ -483,7 +483,7 @@ func TestWrapper_RequestAccessToken(t *testing.T) {
 			})
 
 		server := httptest.NewServer(&http2.Handler{
-			StatusCode: http.StatusBadGateway,
+			StatusCode: http.StatusInternalServerError,
 		})
 
 		t.Cleanup(server.Close)
@@ -502,7 +502,7 @@ func TestWrapper_RequestAccessToken(t *testing.T) {
 
 		err := ctx.wrapper.RequestAccessToken(ctx.echoMock)
 
-		assert.EqualError(t, err, "unable to create access token: server returned HTTP 502 (expected: 200), response: null")
+		assert.EqualError(t, err, "remote server/nuts node returned error creating access token: server returned HTTP 500 (expected: 200), response: null")
 		require.Implements(t, new(core.HTTPStatusCodeError), err)
 		assert.Equal(t, http.StatusBadGateway, err.(core.HTTPStatusCodeError).StatusCode())
 	})

--- a/auth/api/v1/api_test.go
+++ b/auth/api/v1/api_test.go
@@ -504,7 +504,7 @@ func TestWrapper_RequestAccessToken(t *testing.T) {
 
 		assert.EqualError(t, err, "remote server/nuts node returned error creating access token: server returned HTTP 500 (expected: 200), response: null")
 		require.Implements(t, new(core.HTTPStatusCodeError), err)
-		assert.Equal(t, http.StatusBadGateway, err.(core.HTTPStatusCodeError).StatusCode())
+		assert.Equal(t, http.StatusServiceUnavailable, err.(core.HTTPStatusCodeError).StatusCode())
 	})
 
 	t.Run("happy_path", func(t *testing.T) {

--- a/docs/_static/auth/v1.yaml
+++ b/docs/_static/auth/v1.yaml
@@ -191,7 +191,7 @@ paths:
 
         error returns:
         * 400 - one of the parameters has the wrong format
-        * 502 - the authorizer could not be reached or returned an error
+        * 503 - the authorizer could not be reached or returned an error
       tags:
         - auth
       requestBody:

--- a/docs/_static/auth/v1.yaml
+++ b/docs/_static/auth/v1.yaml
@@ -191,6 +191,7 @@ paths:
 
         error returns:
         * 400 - one of the parameters has the wrong format
+        * 502 - the authorizer could not be reached or returned an error
       tags:
         - auth
       requestBody:


### PR DESCRIPTION
Partially fixes #1527 

- More clearly indicates that the error is returned by the remote Nuts node
- Stop returning the received response code as the local API call's response code, a downstream error should have a specific status code, not influenced by the downstream system being called. Otherwise, you never know which status code is going to be returned, which can even be a vulnerability.