### PR TITLE
Core: remove server response body HTTP client errors

### DIFF
--- a/auth/api/v1/api_test.go
+++ b/auth/api/v1/api_test.go
@@ -523,7 +523,7 @@ func TestWrapper_RequestAccessToken(t *testing.T) {
 
 		err := ctx.wrapper.RequestAccessToken(ctx.echoMock)
 
-		assert.EqualError(t, err, "remote server/nuts node returned error creating access token: server returned HTTP 500 (expected: 200), response: null")
+		assert.EqualError(t, err, "remote server/nuts node returned error creating access token: server returned HTTP 502 (expected: 200)")
 		require.Implements(t, new(core.HTTPStatusCodeError), err)
 		assert.Equal(t, http.StatusServiceUnavailable, err.(core.HTTPStatusCodeError).StatusCode())
 	})

--- a/auth/api/v1/api_test.go
+++ b/auth/api/v1/api_test.go
@@ -504,7 +504,7 @@ func TestWrapper_RequestAccessToken(t *testing.T) {
 			})
 
 		server := httptest.NewServer(&http2.Handler{
-			StatusCode: http.StatusInternalServerError,
+			StatusCode: http.StatusBadGateway,
 		})
 
 		t.Cleanup(server.Close)

--- a/auth/api/v1/client.go
+++ b/auth/api/v1/client.go
@@ -20,13 +20,13 @@ package v1
 
 import (
 	"context"
-	"github.com/nuts-foundation/nuts-node/auth/log"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
 	"github.com/nuts-foundation/nuts-node/auth"
+	"github.com/nuts-foundation/nuts-node/auth/log"
 	"github.com/nuts-foundation/nuts-node/core"
 )
 
@@ -78,7 +78,7 @@ func (h HTTPClient) CreateAccessToken(endpointURL url.URL, bearerToken string) (
 	}
 
 	if err := core.TestResponseCode(http.StatusOK, response); err != nil {
-		rse := err.(core.RemoteServerError)
+		rse := err.(core.HttpError)
 		log.Logger().WithError(err).Debugf("Erroneous CreateAccessToken response: %s", string(rse.ResponseBody))
 		return nil, &oauthAPIError{err: err, statusCode: response.StatusCode}
 	}

--- a/auth/api/v1/client.go
+++ b/auth/api/v1/client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"context"
+	"github.com/nuts-foundation/nuts-node/auth/log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -77,6 +78,8 @@ func (h HTTPClient) CreateAccessToken(endpointURL url.URL, bearerToken string) (
 	}
 
 	if err := core.TestResponseCode(http.StatusOK, response); err != nil {
+		rse := err.(core.RemoteServerError)
+		log.Logger().WithError(err).Debugf("Erroneous CreateAccessToken response: %s", string(rse.ResponseBody))
 		return nil, &oauthAPIError{err: err, statusCode: response.StatusCode}
 	}
 

--- a/auth/api/v1/client_test.go
+++ b/auth/api/v1/client_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestHTTPClient_CreateAccessToken(t *testing.T) {
-	t.Run("happy_path", func(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
 		server := httptest.NewServer(&http2.Handler{StatusCode: http.StatusOK})
 		serverURL, _ := url.Parse(server.URL)
 
@@ -45,8 +45,8 @@ func TestHTTPClient_CreateAccessToken(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("error_internal_server_error", func(t *testing.T) {
-		server := httptest.NewServer(&http2.Handler{StatusCode: http.StatusInternalServerError})
+	t.Run("error - non-OK HTTP status code", func(t *testing.T) {
+		server := httptest.NewServer(&http2.Handler{StatusCode: http.StatusInternalServerError, ResponseData: "Hello, World!"})
 		serverURL, _ := url.Parse(server.URL)
 
 		client, _ := NewHTTPClient("", time.Second)
@@ -59,7 +59,7 @@ func TestHTTPClient_CreateAccessToken(t *testing.T) {
 		assert.Equal(t, http.StatusInternalServerError, err.(core.HTTPStatusCodeError).StatusCode())
 	})
 
-	t.Run("error_invalid_endpoint", func(t *testing.T) {
+	t.Run("error - invalid endpoint", func(t *testing.T) {
 		client, _ := NewHTTPClient("", time.Second)
 
 		response, err := client.CreateAccessToken(url.URL{}, "bearer_token")

--- a/auth/api/v1/client_test.go
+++ b/auth/api/v1/client_test.go
@@ -54,7 +54,7 @@ func TestHTTPClient_CreateAccessToken(t *testing.T) {
 		response, err := client.CreateAccessToken(*serverURL, "bearer_token")
 
 		assert.Nil(t, response)
-		assert.EqualError(t, err, "server returned HTTP 500 (expected: 200), response: null")
+		assert.EqualError(t, err, "server returned HTTP 500 (expected: 200)")
 		require.Implements(t, new(core.HTTPStatusCodeError), err)
 		assert.Equal(t, http.StatusInternalServerError, err.(core.HTTPStatusCodeError).StatusCode())
 	})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -290,7 +290,7 @@ func clientErrorHandler(command CobraRunE) CobraRunE {
 	return func(cmd *cobra.Command, args []string) error {
 		err := command(cmd, args)
 		if err != nil {
-			var serverError core.RemoteServerError
+			var serverError core.HttpError
 			if errors.As(err, &serverError) && len(serverError.ResponseBody) > 0 {
 				cmd.PrintErrln("Server returned:")
 				cmd.PrintErrln(string(serverError.ResponseBody))

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/spf13/cobra"
 	"os"
 	"path"
 	"testing"
@@ -166,4 +167,54 @@ func Test_CreateSystem(t *testing.T) {
 		numEngines++
 	})
 	assert.Equal(t, 13, numEngines)
+}
+
+func Test_ClientCommand_ErrorHandlers(t *testing.T) {
+	t.Run("RunE is not used", func(t *testing.T) {
+		cmd := &cobra.Command{Run: func(cmd *cobra.Command, args []string) {
+			// noop
+		}}
+
+		registerClientErrorHandler(cmd)
+
+		assert.Nil(t, cmd.RunE)
+	})
+	t.Run("no error", func(t *testing.T) {
+		cmd := &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		}}
+
+		registerClientErrorHandler(cmd)
+
+		err := cmd.RunE(cmd, nil)
+		assert.NoError(t, err)
+	})
+	t.Run("server error", func(t *testing.T) {
+		rootCmd := &cobra.Command{}
+		responseBody := "Hello, World!"
+		buf := new(bytes.Buffer)
+		cmd := &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error {
+			return core.RemoteServerError{
+				ResponseBody: []byte(responseBody),
+			}
+		}}
+		cmd.SetErr(buf)
+		rootCmd.AddCommand(cmd)
+
+		registerClientErrorHandler(rootCmd)
+
+		err := cmd.RunE(cmd, nil)
+		assert.Error(t, err)
+		assert.Contains(t, buf.String(), responseBody)
+	})
+	t.Run("other error", func(t *testing.T) {
+		cmd := &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("failed")
+		}}
+
+		registerClientErrorHandler(cmd)
+
+		err := cmd.RunE(cmd, nil)
+		assert.Error(t, err)
+	})
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -194,7 +194,7 @@ func Test_ClientCommand_ErrorHandlers(t *testing.T) {
 		responseBody := "Hello, World!"
 		buf := new(bytes.Buffer)
 		cmd := &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error {
-			return core.RemoteServerError{
+			return core.HttpError{
 				ResponseBody: []byte(responseBody),
 			}
 		}}

--- a/core/http_client.go
+++ b/core/http_client.go
@@ -26,11 +26,23 @@ import (
 	"net/http"
 )
 
+// RemoteServerError describes an error returned when invoking a remote server.
+type RemoteServerError struct {
+	error
+	StatusCode   int
+	ResponseBody []byte
+}
+
+// TestResponseCode checks whether the returned HTTP status response code matches the expected code.
+// If it doesn't match it returns an error, containing the received and expected status code, and the response body.
 func TestResponseCode(expectedStatusCode int, response *http.Response) error {
 	if response.StatusCode != expectedStatusCode {
 		responseData, _ := io.ReadAll(response.Body)
-		return fmt.Errorf("server returned HTTP %d (expected: %d), response: %s",
-			response.StatusCode, expectedStatusCode, string(responseData))
+		return RemoteServerError{
+			error:        fmt.Errorf("server returned HTTP %d (expected: %d)", response.StatusCode, expectedStatusCode),
+			StatusCode:   response.StatusCode,
+			ResponseBody: responseData,
+		}
 	}
 	return nil
 }

--- a/core/http_client.go
+++ b/core/http_client.go
@@ -26,8 +26,8 @@ import (
 	"net/http"
 )
 
-// RemoteServerError describes an error returned when invoking a remote server.
-type RemoteServerError struct {
+// HttpError describes an error returned when invoking a remote server.
+type HttpError struct {
 	error
 	StatusCode   int
 	ResponseBody []byte
@@ -38,7 +38,7 @@ type RemoteServerError struct {
 func TestResponseCode(expectedStatusCode int, response *http.Response) error {
 	if response.StatusCode != expectedStatusCode {
 		responseData, _ := io.ReadAll(response.Body)
-		return RemoteServerError{
+		return HttpError{
 			error:        fmt.Errorf("server returned HTTP %d (expected: %d)", response.StatusCode, expectedStatusCode),
 			StatusCode:   response.StatusCode,
 			ResponseBody: responseData,

--- a/core/http_client_test.go
+++ b/core/http_client_test.go
@@ -97,9 +97,9 @@ func TestTestResponseCode(t *testing.T) {
 		err := TestResponseCode(stdHttp.StatusOK, &stdHttp.Response{StatusCode: status, Body: readCloser(data)})
 
 		assert.Error(t, err)
-		require.ErrorAs(t, err, new(RemoteServerError))
-		assert.Equal(t, data, err.(RemoteServerError).ResponseBody)
-		assert.Equal(t, status, err.(RemoteServerError).StatusCode)
+		require.ErrorAs(t, err, new(HttpError))
+		assert.Equal(t, data, err.(HttpError).ResponseBody)
+		assert.Equal(t, status, err.(HttpError).StatusCode)
 	})
 }
 

--- a/didman/api/v1/client_test.go
+++ b/didman/api/v1/client_test.go
@@ -106,7 +106,7 @@ func TestHTTPClient_AddEndpoint(t *testing.T) {
 		s := httptest.NewServer(&http2.Handler{StatusCode: http.StatusInternalServerError, ResponseData: ""})
 		c := getClient(s)
 		endpoint, err := c.AddEndpoint("abc", "type", "some-url")
-		assert.EqualError(t, err, "server returned HTTP 500 (expected: 200), response: ")
+		assert.EqualError(t, err, "server returned HTTP 500 (expected: 200)")
 		assert.Nil(t, endpoint)
 	})
 	t.Run("error - wrong address", func(t *testing.T) {
@@ -131,7 +131,7 @@ func TestHTTPClient_DeleteEndpointsByType(t *testing.T) {
 		s := httptest.NewServer(&http2.Handler{StatusCode: http.StatusInternalServerError})
 		c := getClient(s)
 		err := c.DeleteEndpointsByType("did:nuts:123", "eOverdracht")
-		assert.EqualError(t, err, "server returned HTTP 500 (expected: 204), response: null")
+		assert.EqualError(t, err, "server returned HTTP 500 (expected: 204)")
 	})
 	t.Run("error - wrong address", func(t *testing.T) {
 		c := HTTPClient{
@@ -219,7 +219,7 @@ func TestHTTPClient_GetCompoundServices(t *testing.T) {
 		c := getClient(s)
 		res, err := c.GetCompoundServices("did:nuts:123")
 		assert.Error(t, err)
-		assert.EqualError(t, err, "server returned HTTP 500 (expected: 200), response: null")
+		assert.EqualError(t, err, "server returned HTTP 500 (expected: 200)")
 		assert.Nil(t, res)
 	})
 	t.Run("error - wrong address", func(t *testing.T) {

--- a/vdr/api/v1/client_test.go
+++ b/vdr/api/v1/client_test.go
@@ -208,7 +208,7 @@ func TestHTTPClient_AddNewVerificationMethod(t *testing.T) {
 		c := getClient(s.URL)
 		_, err := c.AddNewVerificationMethod(vdr.TestDIDA.String())
 		assert.Error(t, err)
-		assert.EqualError(t, err, "server returned HTTP 403 (expected: 200), response: null")
+		assert.EqualError(t, err, "server returned HTTP 403 (expected: 200)")
 	})
 
 	t.Run("error - server problems", func(t *testing.T) {
@@ -231,7 +231,7 @@ func TestHTTPClient_DeleteVerificationMethod(t *testing.T) {
 		c := getClient(s.URL)
 		err := c.DeleteVerificationMethod(vdr.TestDIDA.String(), vdr.TestMethodDIDA.String())
 		assert.Error(t, err)
-		assert.EqualError(t, err, "server returned HTTP 403 (expected: 204), response: null")
+		assert.EqualError(t, err, "server returned HTTP 403 (expected: 204)")
 	})
 
 	t.Run("error - server problems", func(t *testing.T) {

--- a/vdr/cmd/cmd_test.go
+++ b/vdr/cmd/cmd_test.go
@@ -110,7 +110,6 @@ func TestEngine_Command(t *testing.T) {
 
 			assert.Error(t, err)
 			assert.Contains(t, errBuf.String(), "unable to create new DID")
-			assert.Contains(t, errBuf.String(), "b00m!")
 		})
 	})
 
@@ -161,7 +160,6 @@ func TestEngine_Command(t *testing.T) {
 
 			assert.Error(t, err)
 			assert.Contains(t, errBuf.String(), "failed to resolve DID document")
-			assert.Contains(t, errBuf.String(), "not found")
 		})
 	})
 
@@ -236,7 +234,6 @@ func TestEngine_Command(t *testing.T) {
 
 			assert.Error(t, err)
 			assert.Contains(t, errBuf.String(), "failed to update DID document")
-			assert.Contains(t, errBuf.String(), "invalid")
 		})
 	})
 
@@ -313,7 +310,7 @@ func TestEngine_Command(t *testing.T) {
 
 			err := cmd.Execute()
 			require.Error(t, err)
-			assert.Contains(t, errBuf.String(), "failed to add a new verification method to DID document: server returned HTTP 404 (expected: 200), response: null")
+			assert.Contains(t, errBuf.String(), "failed to add a new verification method to DID document: server returned HTTP 404 (expected: 200)")
 		})
 	})
 
@@ -335,7 +332,7 @@ func TestEngine_Command(t *testing.T) {
 			cmd.PersistentFlags().AddFlagSet(core.ClientConfigFlags())
 			err := cmd.Execute()
 			require.Error(t, err)
-			assert.Contains(t, errBuf.String(), "failed to delete the verification method from DID document: server returned HTTP 404 (expected: 204), response: null")
+			assert.Contains(t, errBuf.String(), "failed to delete the verification method from DID document: server returned HTTP 404 (expected: 204)")
 		})
 	})
 


### PR DESCRIPTION
Since the server may return anything (e.g., binary response, or a very large blob), it's unsafe to include it in the error message: it gets logged and sometimes returned to the client.

Better to record it in the error struct, but not to include it in the error message.

Since it's still useful to print when a CLI command fails (due to non-OK server response), introduced a wrapper for all client commands.