### PR TITLE
NutsComm: allow custom TLD

### DIFF
--- a/network/transport/types.go
+++ b/network/transport/types.go
@@ -121,31 +121,31 @@ func ParseNutsCommAddress(input string) (string, error) {
 // isReserved returns true if URL uses any of the reserved TLDs or addresses
 func isReserved(URL *url.URL) bool {
 	parts := strings.Split(strings.ToLower(URL.Hostname()), ".")
-	if len(parts) < 2 {
-		// valid address contains at least a 2nd level address + tld
-		return true
-	}
-
 	tld := parts[len(parts)-1]
 	if contains(reservedTLDs, tld) {
 		return true
 	}
 
-	l2address := strings.Join(parts[len(parts)-2:], ".")
-	return contains(reservedAddresses, l2address)
+	if len(parts) > 1 {
+		l2address := strings.Join(parts[len(parts)-2:], ".")
+		return contains(reservedAddresses, l2address)
+	}
+
+	return false
 }
 
 var reservedTLDs = []string{
-	"test",
+	"", // no domain specified
+	"corp",
 	"example",
-	"invalid",
-	"localhost",
-	"local",
-	"localdomain",
-	"lan",
 	"home",
 	"host",
-	"corp",
+	"invalid",
+	"lan",
+	"local",
+	"localdomain",
+	"localhost",
+	"test",
 }
 var reservedAddresses = []string{
 	"example.com",

--- a/network/transport/types_test.go
+++ b/network/transport/types_test.go
@@ -38,6 +38,7 @@ func Test_ParseAddress(t *testing.T) {
 	}{
 		{"grpc://foo.bar:5050", "foo.bar:5050", nil},
 		{"grpc://foo.BAR", "foo.BAR", nil},
+		{"grpc://fooBAR", "fooBAR", nil},
 		{"foo.bar", "", errScheme},
 		{"http://foo.bar", "", errScheme},
 		{"grpc://1.2.3.4:5555", "", errIsIp},
@@ -55,12 +56,12 @@ func Test_ParseAddress(t *testing.T) {
 		addr, err := ParseNutsCommAddress(tc.input)
 		if tc.err == nil {
 			// valid test cases
-			assert.Equal(t, tc.output, addr, "test case: %V", tc)
-			assert.NoError(t, err, "test case: %V", tc)
+			assert.Equal(t, tc.output, addr, "test case: %v", tc)
+			assert.NoError(t, err, "test case: %v", tc)
 		} else {
 			// invalid test cases
-			assert.Empty(t, addr, "test case: %V", tc)
-			assert.EqualError(t, err, tc.err.Error(), "test case: %V", tc)
+			assert.Empty(t, addr, "test case: %v", tc)
+			assert.EqualError(t, err, tc.err.Error(), "test case: %v", tc)
 		}
 	}
 }


### PR DESCRIPTION
The use of custom TLDs (`nodeA`) is not part of reserved addresses per https://www.ietf.org/archive/id/draft-chapin-rfc2606bis-00.html. This restriction complicates our testing strategy. 

Allowing non reserved TLDs does not pose a security risk since they probably do not resolve to anything, but if they do, authentication will fail on production networks since you cannot add these addresses to a PKIo certificate.