### PR TITLE
Mark ssi_types.yaml as OpenAPI file

### DIFF
--- a/docs/_static/common/ssi_types.yaml
+++ b/docs/_static/common/ssi_types.yaml
@@ -1,3 +1,4 @@
+openapi: "3.0.0"
 components:
   schemas:
 # VC


### PR DESCRIPTION
Without it, OpenAPI Generator Tools for Java doesn't recognize it as a YAML OpenAPI file.