### PR TITLE
Build: migrate to GitHub Docker Actions

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -11,7 +11,6 @@ on:
     branches:
       - master
 
-
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -35,12 +34,12 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v4.1.1
+        uses: docker/metadata-action@v4
         with:
           images: nutsfoundation/nuts-node
-          tag-semver: |
-            {{version}}
-            {{major}}.{{minor}}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -39,7 +39,7 @@ jobs:
           images: nutsfoundation/nuts-node
           tags: |
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -40,6 +40,9 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern=v{{major}}
+          flavor: |
+            latest=auto
+            prefix=v,onlatest=false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           images: nutsfoundation/nuts-node
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}
           flavor: |
             latest=auto


### PR DESCRIPTION
Fixes https://github.com/nuts-foundation/nuts-node/issues/1733

See https://github.com/marketplace/actions/docker-metadata-action

`latest` tag should be handled correctly by default (semver): https://github.com/marketplace/actions/docker-metadata-action#latest-tag

Not sure how to test this without creating a release...?