### PR TITLE
implement ranged ListTransactions (?start=N&end=M)

### DIFF
--- a/crypto/storage/vault_test.go
+++ b/crypto/storage/vault_test.go
@@ -225,6 +225,7 @@ func TestNewVaultKVStorage(t *testing.T) {
 		storage, err := NewVaultKVStorage(VaultConfig{Address: "http://non-existing"})
 		assert.Error(t, err)
 		assert.Regexp(t, `no such host|Temporary failure in name resolution`, err.Error())
+		require.Error(t, err)
 		assert.Nil(t, storage)
 	})
 }

--- a/crypto/storage/vault_test.go
+++ b/crypto/storage/vault_test.go
@@ -224,7 +224,7 @@ func TestNewVaultKVStorage(t *testing.T) {
 	t.Run("error - wrong URL", func(t *testing.T) {
 		storage, err := NewVaultKVStorage(VaultConfig{Address: "http://non-existing"})
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "no such host")
+		assert.Regexp(t, `no such host|Temporary failure in name resolution`, err.Error())
 		assert.Nil(t, storage)
 	})
 }

--- a/crypto/storage/vault_test.go
+++ b/crypto/storage/vault_test.go
@@ -223,9 +223,8 @@ func TestNewVaultKVStorage(t *testing.T) {
 
 	t.Run("error - wrong URL", func(t *testing.T) {
 		storage, err := NewVaultKVStorage(VaultConfig{Address: "http://non-existing"})
-		assert.Error(t, err)
-		assert.Regexp(t, `no such host|Temporary failure in name resolution`, err.Error())
 		require.Error(t, err)
+		assert.Regexp(t, `no such host|Temporary failure in name resolution`, err.Error())
 		assert.Nil(t, storage)
 	})
 }

--- a/didman/api/v1/client_test.go
+++ b/didman/api/v1/client_test.go
@@ -115,7 +115,7 @@ func TestHTTPClient_AddEndpoint(t *testing.T) {
 				Address: "not_an_address", Timeout: time.Second},
 		}
 		endpoint, err := c.AddEndpoint("abc", "type", "some-url")
-		assert.ErrorContains(t, err, "no such host")
+		assert.Regexp(t, `no such host|Temporary failure in name resolution`, err.Error())
 		assert.Nil(t, endpoint)
 	})
 }
@@ -139,7 +139,7 @@ func TestHTTPClient_DeleteEndpointsByType(t *testing.T) {
 				Address: "not_an_address", Timeout: time.Second},
 		}
 		err := c.DeleteEndpointsByType("did:nuts:123", "eOverdracht")
-		assert.ErrorContains(t, err, "no such host")
+		assert.Regexp(t, `no such host|Temporary failure in name resolution`, err.Error())
 	})
 }
 
@@ -228,7 +228,7 @@ func TestHTTPClient_GetCompoundServices(t *testing.T) {
 				Address: "not_an_address", Timeout: time.Second},
 		}
 		res, err := c.GetCompoundServices("did:nuts:123")
-		assert.ErrorContains(t, err, "no such host")
+		assert.Regexp(t, `no such host|Temporary failure in name resolution`, err.Error())
 		assert.Nil(t, res)
 	})
 

--- a/docs/_static/network/v1.yaml
+++ b/docs/_static/network/v1.yaml
@@ -30,7 +30,6 @@ paths:
       summary: "Lists transactions on the DAG"
       description: >
         Lists transactions on the DAG. Since this call returns all transactions on the DAG, care should be taken when there are many of them. A range (start,end) are recommended at all times to avoid overloading the endpoint.
-        TODO: We may need a more elaborate querying interface (pagination, filtering, etc).
 
         error returns:
         * 500 - internal server error

--- a/docs/_static/network/v1.yaml
+++ b/docs/_static/network/v1.yaml
@@ -9,6 +9,23 @@ servers:
   - url: http://localhost:1323
 paths:
   /internal/network/v1/transaction:
+    parameters:
+      - name: start
+        description: "Inclusive start of range (in lamport clock)"
+        example: 1
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+      - name: end
+        description: "Exclusive stop of range (in lamport clock)"
+        example: 1000
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
     get:
       summary: "Lists the transactions on the DAG"
       description: >

--- a/docs/_static/network/v1.yaml
+++ b/docs/_static/network/v1.yaml
@@ -11,7 +11,7 @@ paths:
   /internal/network/v1/transaction:
     parameters:
       - name: start
-        description: "Inclusive start of range (in lamport clock)"
+        description: "Inclusive start of range (in lamport clock); default=0"
         example: 1
         in: query
         required: false
@@ -19,7 +19,7 @@ paths:
           type: integer
           minimum: 0
       - name: end
-        description: "Exclusive stop of range (in lamport clock)"
+        description: "Exclusive stop of range (in lamport clock); default=∞"
         example: 1000
         in: query
         required: false
@@ -27,11 +27,10 @@ paths:
           type: integer
           minimum: 0
     get:
-      summary: "Lists the transactions on the DAG"
+      summary: "Lists transactions on the DAG"
       description: >
-        Lists all transactions on the DAG. Since this call returns all transactions on the DAG, care should be taken when there
-        are many of them.
-        TODO: By then we'd need a more elaborate querying interface (ranging over timestamps/hashes, pagination, filtering, etc).
+        Lists transactions on the DAG. Since this call returns all transactions on the DAG, care should be taken when there are many of them. A range (start,end) are recommended at all times to avoid overloading the endpoint.
+        TODO: We may need a more elaborate querying interface (pagination, filtering, etc).
 
         error returns:
         * 500 - internal server error

--- a/docs/pages/deployment/cli-reference.rst
+++ b/docs/pages/deployment/cli-reference.rst
@@ -37,7 +37,7 @@ The following options apply to the server commands below:
       --http.default.log string                       What to log about HTTP requests. Options are 'nothing', 'metadata' (log request method, URI, IP and response code), and 'metadata-and-body' (log the request and response body, in addition to the metadata). (default "metadata")
       --http.default.tls string                       Whether to enable TLS for the default interface, options are 'disabled', 'server', 'server-client'. Leaving it empty is synonymous to 'disabled',
       --internalratelimiter                           When set, expensive internal calls are rate-limited to protect the network. Always enabled in strict mode. (default true)
-      --jsonld.contexts.localmapping stringToString   This setting allows mapping external URLs to local files for e.g. preventing external dependencies. These mappings have precedence over those in remoteallowlist. (default [https://www.w3.org/2018/credentials/v1=assets/contexts/w3c-credentials-v1.ldjson,https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json=assets/contexts/lds-jws2020-v1.ldjson,https://schema.org=assets/contexts/schema-org-v13.ldjson,https://nuts.nl/credentials/v1=assets/contexts/nuts.ldjson])
+      --jsonld.contexts.localmapping stringToString   This setting allows mapping external URLs to local files for e.g. preventing external dependencies. These mappings have precedence over those in remoteallowlist. (default [https://nuts.nl/credentials/v1=assets/contexts/nuts.ldjson,https://www.w3.org/2018/credentials/v1=assets/contexts/w3c-credentials-v1.ldjson,https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json=assets/contexts/lds-jws2020-v1.ldjson,https://schema.org=assets/contexts/schema-org-v13.ldjson])
       --jsonld.contexts.remoteallowlist strings       In strict mode, fetching external JSON-LD contexts is not allowed except for context-URLs listed here. (default [https://schema.org,https://www.w3.org/2018/credentials/v1,https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json])
       --loggerformat string                           Log format (text, json) (default "text")
       --network.bootstrapnodes strings                List of bootstrap nodes ('<host>:<port>') which the node initially connect to.
@@ -173,8 +173,10 @@ Lists the transactions on the network
   nuts network list [flags]
 
       --address string      Address of the node. Must contain at least host and port, URL scheme may be omitted. In that case it 'http://' is prepended. (default "localhost:1323")
+      --end string          exclusive end of lamport clock range
   -h, --help                help for list
       --sort string         sort the results on either time or type (default "time")
+      --start string        inclusive start of lamport clock range
       --timeout duration    Client time-out when performing remote operations, such as '500ms' or '10s'. Refer to Golang's 'time.Duration' syntax for a more elaborate description of the syntax. (default 10s)
       --token string        Token to be used for authenticating on the remote node. Takes precedence over 'token-file'.
       --token-file string   File from which the authentication token will be read. If not specified it will try to read the token from the '.nuts-client.cfg' file in the user's home dir.

--- a/network/api/v1/api.go
+++ b/network/api/v1/api.go
@@ -46,11 +46,21 @@ func (a *Wrapper) Routes(router core.EchoRouter) {
 }
 
 // ListTransactions lists all transactions
-func (a Wrapper) ListTransactions(ctx echo.Context) error {
-	transactions, err := a.Service.ListTransactionsInRange(0, dag.MaxLamportClock)
+func (a Wrapper) ListTransactions(ctx echo.Context, params ListTransactionsParams) error {
+	// Parse the start/end params, which have default values
+	start := toInt(params.Start, 0)
+	end := toInt(params.End, dag.MaxLamportClock)
+	if start < 0 || end < 1 || start >= end {
+		return core.InvalidInputError("invalid range")
+	}
+
+	// List the specified transaction range (if it exists)
+	transactions, err := a.Service.ListTransactionsInRange(uint32(start), uint32(end))
 	if err != nil {
 		return err
 	}
+
+	// The results are returned as a JSON encoded array of strings
 	results := make([]string, len(transactions))
 	for i, transaction := range transactions {
 		results[i] = string(transaction.Data())

--- a/network/api/v1/api_test.go
+++ b/network/api/v1/api_test.go
@@ -148,7 +148,7 @@ func TestApiWrapper_RenderGraph(t *testing.T) {
 	t.Run("ok - no query params", func(t *testing.T) {
 		var networkClient = network.NewMockTransactions(mockCtrl)
 		e, wrapper := initMockEcho(networkClient)
-		networkClient.EXPECT().ListTransactionsInRange(gomock.Any(), gomock.Any())
+		networkClient.EXPECT().ListTransactionsInRange(uint32(0), uint32(dag.MaxLamportClock))
 
 		req := httptest.NewRequest(echo.GET, "/", nil)
 		rec := httptest.NewRecorder()
@@ -164,10 +164,10 @@ func TestApiWrapper_RenderGraph(t *testing.T) {
 	t.Run("ok - with query params", func(t *testing.T) {
 		var networkClient = network.NewMockTransactions(mockCtrl)
 		e, wrapper := initMockEcho(networkClient)
-		networkClient.EXPECT().ListTransactionsInRange(gomock.Any(), gomock.Any())
+		networkClient.EXPECT().ListTransactionsInRange(uint32(1), uint32(4))
 		q := make(url.Values)
-		q.Set("start", "0")
-		q.Set("end", "5")
+		q.Set("start", "1")
+		q.Set("end", "4")
 
 		req := httptest.NewRequest(echo.GET, "/?"+q.Encode(), nil)
 		rec := httptest.NewRecorder()
@@ -274,12 +274,31 @@ func TestApiWrapper_ListTransactions(t *testing.T) {
 	defer mockCtrl.Finish()
 	transaction := dag.CreateTestTransactionWithJWK(1)
 
-	t.Run("200", func(t *testing.T) {
+	t.Run("200 - no query params", func(t *testing.T) {
 		var networkClient = network.NewMockTransactions(mockCtrl)
 		e, wrapper := initMockEcho(networkClient)
 		networkClient.EXPECT().ListTransactionsInRange(uint32(0), uint32(dag.MaxLamportClock)).Return([]dag.Transaction{transaction}, nil)
 
 		req := httptest.NewRequest(echo.GET, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/transaction")
+
+		err := wrapper.ListTransactions(c)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, `["`+string(transaction.Data())+`"]`, strings.TrimSpace(rec.Body.String()))
+	})
+	t.Run("200 - query params", func(t *testing.T) {
+		var networkClient = network.NewMockTransactions(mockCtrl)
+		e, wrapper := initMockEcho(networkClient)
+		networkClient.EXPECT().ListTransactionsInRange(uint32(1), uint32(4)).Return([]dag.Transaction{transaction}, nil)
+		q := make(url.Values)
+		q.Set("start", "1")
+		q.Set("end", "4")
+
+		req := httptest.NewRequest(echo.GET, "/?"+q.Encode(), nil)
+
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 		c.SetPath("/transaction")

--- a/network/api/v1/client.go
+++ b/network/api/v1/client.go
@@ -64,15 +64,10 @@ func (hb HTTPClient) GetTransaction(transactionRef hash.SHA256Hash) (dag.Transac
 }
 
 // ListTransactions returns all transactions known to this network instance.
-func (hb HTTPClient) ListTransactions() ([]dag.Transaction, error) {
-	return hb.ListTransactionsInRange(0, dag.MaxLamportClock)
-}
-
-// ListTransactions returns all transactions known to this network instance.
-func (hb HTTPClient) ListTransactionsInRange(startInclusive int, endExclusive int) ([]dag.Transaction, error) {
+// TODO: This is potentially an expensive operation without pagination
+func (hb HTTPClient) ListTransactions(params *ListTransactionsParams) ([]dag.Transaction, error) {
 	ctx := context.Background()
 
-	params := &ListTransactionsParams{Start: &startInclusive, End: &endExclusive}
 	res, err := hb.client().ListTransactions(ctx, params)
 	if err != nil {
 		return nil, err

--- a/network/api/v1/client.go
+++ b/network/api/v1/client.go
@@ -65,8 +65,15 @@ func (hb HTTPClient) GetTransaction(transactionRef hash.SHA256Hash) (dag.Transac
 
 // ListTransactions returns all transactions known to this network instance.
 func (hb HTTPClient) ListTransactions() ([]dag.Transaction, error) {
+	return hb.ListTransactionsInRange(0, dag.MaxLamportClock)
+}
+
+// ListTransactions returns all transactions known to this network instance.
+func (hb HTTPClient) ListTransactionsInRange(startInclusive int, endExclusive int) ([]dag.Transaction, error) {
 	ctx := context.Background()
-	res, err := hb.client().ListTransactions(ctx)
+
+	params := &ListTransactionsParams{Start: &startInclusive, End: &endExclusive}
+	res, err := hb.client().ListTransactions(ctx, params)
 	if err != nil {
 		return nil, err
 	}

--- a/network/api/v1/client_test.go
+++ b/network/api/v1/client_test.go
@@ -49,7 +49,7 @@ func TestHttpClient_ListTransactions(t *testing.T) {
 		expected := dag.CreateTestTransactionWithJWK(1)
 		data, _ := json.Marshal([]string{string(expected.Data())})
 		s := httptest.NewServer(handler{statusCode: http.StatusOK, responseData: data})
-		actual, err := getClient(s).ListTransactions()
+		actual, err := getClient(s).ListTransactions(&ListTransactionsParams{})
 		require.NoError(t, err)
 		require.Len(t, actual, 1)
 		assert.Equal(t, expected, actual[0])

--- a/network/api/v1/generated.go
+++ b/network/api/v1/generated.go
@@ -63,10 +63,10 @@ type ReprocessParams struct {
 
 // ListTransactionsParams defines parameters for ListTransactions.
 type ListTransactionsParams struct {
-	// Start Inclusive start of range (in lamport clock)
+	// Start Inclusive start of range (in lamport clock); default=0
 	Start *int `form:"start,omitempty" json:"start,omitempty"`
 
-	// End Exclusive stop of range (in lamport clock)
+	// End Exclusive stop of range (in lamport clock); default=∞
 	End *int `form:"end,omitempty" json:"end,omitempty"`
 }
 
@@ -1143,7 +1143,7 @@ type ServerInterface interface {
 	// Reprocess all transactions of the given type, verify and process
 	// (POST /internal/network/v1/reprocess)
 	Reprocess(ctx echo.Context, params ReprocessParams) error
-	// Lists the transactions on the DAG
+	// Lists transactions on the DAG
 	// (GET /internal/network/v1/transaction)
 	ListTransactions(ctx echo.Context, params ListTransactionsParams) error
 	// Retrieves a transaction

--- a/network/cmd/cmd.go
+++ b/network/cmd/cmd.go
@@ -20,6 +20,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -132,28 +133,31 @@ func getCommand() *cobra.Command {
 const sortFlagTime = "time"
 const sortFlagType = "type"
 
+// convertRange is a utility function for converting optional string args to *int
+func convertRange(s string) *int {
+	// Empty strings are converted to nil
+	if s == "" {
+		return nil
+	}
+
+	// Non-empty strings are converted (if possible) to int pointers
+	if n, err := strconv.ParseUint(s, 10, 32); err == nil {
+		// Upon successful integer parsing return a pointer to the value
+		nInt := int(n)
+		return &nInt
+	}
+
+	// Panic if parsing fails
+	log.Panicf("cannot parse argument: %v", s)
+
+	// Never reached...but needed for the compiler
+	return nil
+}
+
 func listCommand() *cobra.Command {
 	var sortFlag string
 	var rangeStart string
 	var rangeEnd string
-
-	// convertRange is a utility function for converting optional string args to *int
-	convertRange := func(s string) *int {
-		// Empty strings are converted to nil
-		if s == "" {
-			return nil
-		}
-
-		// Non-empty strings are converted (if possible) to int pointers
-		if n, err := strconv.ParseUint(s, 10, 32); err != nil {
-			// Return nil of the integer parsing fails
-			return nil
-		} else {
-			// Upon successful integer parsing return a pointer to the value
-			nInt := int(n)
-			return &nInt
-		}
-	}
 
 	cmd := &cobra.Command{
 		Use:   "list",

--- a/network/cmd/cmd.go
+++ b/network/cmd/cmd.go
@@ -21,6 +21,7 @@ package cmd
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/nuts-foundation/nuts-node/network"

--- a/network/cmd/cmd.go
+++ b/network/cmd/cmd.go
@@ -143,7 +143,7 @@ func listCommand() *cobra.Command {
 		if s == "" {
 			return nil
 		}
-	
+
 		// Non-empty strings are converted (if possible) to int pointers
 		if n, err := strconv.ParseUint(s, 10, 32); err != nil {
 			// Return nil of the integer parsing fails
@@ -163,7 +163,7 @@ func listCommand() *cobra.Command {
 
 			params := &v1.ListTransactionsParams{
 				Start: convertRange(rangeStart),
-				End: convertRange(rangeEnd),
+				End:   convertRange(rangeEnd),
 			}
 
 			transactions, err := httpClient(clientConfig).ListTransactions(params)

--- a/network/cmd/cmd_test.go
+++ b/network/cmd/cmd_test.go
@@ -48,6 +48,22 @@ func TestFlagSet(t *testing.T) {
 	})
 }
 
+func TestConvertRange(t *testing.T) {
+	t.Run("it ignores empty ranges", func(t *testing.T) {
+		assert.Nil(t, convertRange(""))
+	})
+
+	t.Run("it converts positive ints", func(t *testing.T) {
+		i := convertRange("5")
+		assert.NotNil(t, i)
+		assert.Equal(t, *i, 5)
+	})
+
+	t.Run("it ignores negative ints", func(t *testing.T) {
+		assert.Panics(t, func() {convertRange("-5")})
+	})
+}
+
 // Test the 'nuts network list' command.
 func TestCmd_List(t *testing.T) {
 	// Create 3 transactions


### PR DESCRIPTION
A ranged operation for ListTransactions was always intended and is implemented via this PR. The query string now accepts an optional ?start=N&end=M pattern. Following convention of the surrounding code the start parameter is inclusive and the end parameter is exclusive. These parameters restrict the lamport clock values of the returned transactions. This feature is needed to implement a scalable data viewer client.