### PR TITLE
update to stoabs v1.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b
 	github.com/nuts-foundation/go-did v0.4.0
 	github.com/nuts-foundation/go-leia/v3 v3.3.0
-	github.com/nuts-foundation/go-stoabs v1.4.0
+	github.com/nuts-foundation/go-stoabs v1.5.1
 	github.com/piprate/json-gold v0.5.1-0.20221121142341-01873264bae4
 	github.com/privacybydesign/irmago v0.10.0
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -578,6 +578,10 @@ github.com/nuts-foundation/go-leia/v3 v3.3.0 h1:d0AIihk8nF6QCMpA9I01ZS+pp+GCgoJh
 github.com/nuts-foundation/go-leia/v3 v3.3.0/go.mod h1:Md202F2wpwkXGtOUzyqs0p1Y96+wOY8lpmDT9nuaxE0=
 github.com/nuts-foundation/go-stoabs v1.4.0 h1:y2wHibnQWyqX+oaO8Uhonon3K+gDIsvmqp8vZGGVLo0=
 github.com/nuts-foundation/go-stoabs v1.4.0/go.mod h1:cE/Msdaie74PeMCX38ixRy3M9hpdIO7rmSZMCKt7qKg=
+github.com/nuts-foundation/go-stoabs v1.5.0 h1:SBPWRVEvFWOvUHRdp+B/HwrImEzmkhP4T4zdJPU/Lvg=
+github.com/nuts-foundation/go-stoabs v1.5.0/go.mod h1:cE/Msdaie74PeMCX38ixRy3M9hpdIO7rmSZMCKt7qKg=
+github.com/nuts-foundation/go-stoabs v1.5.1 h1:xQZ3YxwgmALLSiABor1cQQtEDPeB8jVd8CjzRNFYpGk=
+github.com/nuts-foundation/go-stoabs v1.5.1/go.mod h1:cE/Msdaie74PeMCX38ixRy3M9hpdIO7rmSZMCKt7qKg=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/go.sum
+++ b/go.sum
@@ -576,10 +576,6 @@ github.com/nuts-foundation/go-did v0.4.0 h1:HyzyDOup3Mwt8t8PESQeipW3y8KHDf/XNlBb
 github.com/nuts-foundation/go-did v0.4.0/go.mod h1:FfY394+fFTGXQeYTzIFAHlzGZfPYpL0XygmtHb5Xjdg=
 github.com/nuts-foundation/go-leia/v3 v3.3.0 h1:d0AIihk8nF6QCMpA9I01ZS+pp+GCgoJhblTNkyIZz40=
 github.com/nuts-foundation/go-leia/v3 v3.3.0/go.mod h1:Md202F2wpwkXGtOUzyqs0p1Y96+wOY8lpmDT9nuaxE0=
-github.com/nuts-foundation/go-stoabs v1.4.0 h1:y2wHibnQWyqX+oaO8Uhonon3K+gDIsvmqp8vZGGVLo0=
-github.com/nuts-foundation/go-stoabs v1.4.0/go.mod h1:cE/Msdaie74PeMCX38ixRy3M9hpdIO7rmSZMCKt7qKg=
-github.com/nuts-foundation/go-stoabs v1.5.0 h1:SBPWRVEvFWOvUHRdp+B/HwrImEzmkhP4T4zdJPU/Lvg=
-github.com/nuts-foundation/go-stoabs v1.5.0/go.mod h1:cE/Msdaie74PeMCX38ixRy3M9hpdIO7rmSZMCKt7qKg=
 github.com/nuts-foundation/go-stoabs v1.5.1 h1:xQZ3YxwgmALLSiABor1cQQtEDPeB8jVd8CjzRNFYpGk=
 github.com/nuts-foundation/go-stoabs v1.5.1/go.mod h1:cE/Msdaie74PeMCX38ixRy3M9hpdIO7rmSZMCKt7qKg=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/network/dag/notifier.go
+++ b/network/dag/notifier.go
@@ -276,10 +276,7 @@ func (p *notifier) Save(tx stoabs.WriteTx, event Event) error {
 		return errors.New("trying to save Event on different DB")
 	}
 
-	writer, err := tx.GetShelfWriter(p.shelfName())
-	if err != nil {
-		return err
-	}
+	writer := tx.GetShelfWriter(p.shelfName())
 
 	// apply filters
 	for _, f := range p.filters {

--- a/network/dag/notifier_test.go
+++ b/network/dag/notifier_test.go
@@ -224,19 +224,6 @@ func TestNotifier_Save(t *testing.T) {
 		})
 	})
 
-	t.Run("error on ShelfWriter", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		kvMock := stoabs.NewMockKVStore(ctrl)
-		tx := stoabs.NewMockWriteTx(ctrl)
-		s := NewNotifier(t.Name(), dummyFunc, WithPersistency(kvMock)).(*notifier)
-		tx.EXPECT().Store().Return(kvMock)
-		tx.EXPECT().GetShelfWriter(s.shelfName()).Return(nil, errors.New("failure"))
-
-		err := s.Save(tx, Event{})
-
-		assert.EqualError(t, err, "failure")
-	})
-
 	t.Run("error on readEvent", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		kvMock := stoabs.NewMockKVStore(ctrl)
@@ -244,7 +231,7 @@ func TestNotifier_Save(t *testing.T) {
 		writer := stoabs.NewMockWriter(ctrl)
 		s := NewNotifier(t.Name(), dummyFunc, WithPersistency(kvMock)).(*notifier)
 		tx.EXPECT().Store().Return(kvMock)
-		tx.EXPECT().GetShelfWriter(s.shelfName()).Return(writer, nil)
+		tx.EXPECT().GetShelfWriter(s.shelfName()).Return(writer)
 		writer.EXPECT().Get(stoabs.BytesKey(hash.EmptyHash().Slice())).Return(nil, errors.New("failure"))
 
 		err := s.Save(tx, Event{Hash: hash.EmptyHash()})

--- a/network/dag/payloadstore.go
+++ b/network/dag/payloadstore.go
@@ -62,9 +62,6 @@ func (store payloadStore) readPayload(tx stoabs.ReadTx, payloadHash hash.SHA256H
 }
 
 func (store payloadStore) writePayload(tx stoabs.WriteTx, payloadHash hash.SHA256Hash, data []byte) error {
-	writer, err := tx.GetShelfWriter(payloadsShelf)
-	if err != nil {
-		return err
-	}
+	writer := tx.GetShelfWriter(payloadsShelf)
 	return writer.Put(stoabs.NewHashKey(payloadHash), data)
 }

--- a/network/dag/payloadstore_test.go
+++ b/network/dag/payloadstore_test.go
@@ -89,18 +89,9 @@ func TestPayloadStore_writePayload(t *testing.T) {
 	writer := stoabs.NewMockWriter(ctrl)
 	payloadStore := NewPayloadStore().(*payloadStore)
 
-	t.Run("error - db failure", func(t *testing.T) {
-		tx.EXPECT().GetShelfWriter(payloadsShelf).Return(writer, errors.New("custom"))
+	t.Run("error - write failure", func(t *testing.T) {
 		h := hash.FromSlice([]byte("test write"))
-
-		err := payloadStore.writePayload(tx, h, nil)
-
-		assert.EqualError(t, err, "custom")
-	})
-
-	t.Run("error - read failure", func(t *testing.T) {
-		h := hash.FromSlice([]byte("test write"))
-		tx.EXPECT().GetShelfWriter(payloadsShelf).Return(writer, nil)
+		tx.EXPECT().GetShelfWriter(payloadsShelf).Return(writer)
 		writer.EXPECT().Put(gomock.Any(), gomock.Any()).Return(errors.New("custom"))
 
 		err := payloadStore.writePayload(tx, h, nil)

--- a/network/dag/treestore.go
+++ b/network/dag/treestore.go
@@ -63,10 +63,7 @@ func (store *treeStore) write(tx stoabs.WriteTx, transaction Transaction) error 
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
 
-	writer, err := tx.GetShelfWriter(store.bucketName)
-	if err != nil {
-		return err
-	}
+	writer := tx.GetShelfWriter(store.bucketName)
 
 	store.tree.Insert(transaction.Ref(), transaction.Clock())
 	dirties, orphaned := store.tree.Updates()
@@ -74,7 +71,7 @@ func (store *treeStore) write(tx stoabs.WriteTx, transaction Transaction) error 
 
 	// delete orphaned leaves
 	for _, orphan := range orphaned { // always zero
-		err = writer.Delete(clockToKey(orphan))
+		err := writer.Delete(clockToKey(orphan))
 		if err != nil {
 			return err
 		}
@@ -82,7 +79,7 @@ func (store *treeStore) write(tx stoabs.WriteTx, transaction Transaction) error 
 
 	// write new/updated leaves
 	for dirty, data := range dirties { // contains exactly 1 dirty
-		err = writer.Put(clockToKey(dirty), data)
+		err := writer.Put(clockToKey(dirty), data)
 		if err != nil {
 			return err
 		}

--- a/vcr/issuer/leia_store.go
+++ b/vcr/issuer/leia_store.go
@@ -229,10 +229,7 @@ func (s leiaIssuerStore) handleRestore(collection leia.Collection, backupShelf s
 	var set []refDoc
 	writeDocuments := func(set []refDoc) error {
 		return s.backupStore.Write(context.Background(), func(tx stoabs.WriteTx) error {
-			writer, err := tx.GetShelfWriter(backupShelf)
-			if err != nil {
-				return err
-			}
+			writer := tx.GetShelfWriter(backupShelf)
 			for _, entry := range set {
 				if err := writer.Put(stoabs.BytesKey(entry.ref), entry.doc); err != nil {
 					return err

--- a/vdr/store/store.go
+++ b/vdr/store/store.go
@@ -91,10 +91,7 @@ func (mr metadataRecord) ref() []byte {
 
 func (s *store) Write(document did.Document, metadata vdr.DocumentMetadata) error {
 	return s.db.Write(context.Background(), func(tx stoabs.WriteTx) error {
-		latestWriter, err := tx.GetShelfWriter(latestShelf)
-		if err != nil {
-			return err
-		}
+		latestWriter := tx.GetShelfWriter(latestShelf)
 
 		didString := document.ID.String()
 
@@ -121,14 +118,8 @@ func (s *store) Write(document did.Document, metadata vdr.DocumentMetadata) erro
 
 func (s *store) Update(id did.DID, current hash.SHA256Hash, next did.Document, metadata *vdr.DocumentMetadata) error {
 	return s.db.Write(context.Background(), func(tx stoabs.WriteTx) error {
-		latestWriter, err := tx.GetShelfWriter(latestShelf)
-		if err != nil {
-			return err
-		}
-		metadataWriter, err := tx.GetShelfWriter(metadataShelf)
-		if err != nil {
-			return err
-		}
+		latestWriter := tx.GetShelfWriter(latestShelf)
+		metadataWriter := tx.GetShelfWriter(metadataShelf)
 		didString := id.String()
 
 		// first get latest
@@ -175,23 +166,11 @@ func (s *store) Update(id did.DID, current hash.SHA256Hash, next did.Document, m
 
 func (s *store) writeDocument(tx stoabs.WriteTx, document did.Document, metadataRecord metadataRecord) error {
 	// get shelf writers
-	latestWriter, err := tx.GetShelfWriter(latestShelf)
-	if err != nil {
-		return err
-	}
-	metadataWriter, err := tx.GetShelfWriter(metadataShelf)
-	if err != nil {
-		return err
-	}
-	transactionIndexWriter, err := tx.GetShelfWriter(transactionIndexShelf)
-	if err != nil {
-		return err
-	}
-	documentWriter, err := tx.GetShelfWriter(documentShelf)
-	if err != nil {
-		return err
-	}
-
+	latestWriter := tx.GetShelfWriter(latestShelf)
+	metadataWriter := tx.GetShelfWriter(metadataShelf)
+	transactionIndexWriter := tx.GetShelfWriter(transactionIndexShelf)
+	documentWriter := tx.GetShelfWriter(documentShelf)
+	
 	// store in metadataShelf
 	newRefBytes := metadataRecord.ref()
 	newRecordBytes, _ := json.Marshal(metadataRecord)


### PR DESCRIPTION
New version of stoabs no longer returns an error on GetShelfWriter. This eliminates a lot of error checks