### PR TITLE
Crypto: do not overwrite private keys when generating new one

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -124,7 +124,7 @@ func (client *Crypto) New(namingFunc KIDNamingFunc) (Key, error) {
 	if err = validateKID(kid); err != nil {
 		return nil, err
 	}
-	if client.Exists(kid) {
+	if client.Storage.PrivateKeyExists(kid) {
 		return nil, errors.New("key with the given ID already exists")
 	}
 	if err = client.Storage.SavePrivateKey(kid, keyPair); err != nil {

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -114,9 +114,8 @@ func (client *Crypto) Configure(config core.ServerConfig) error {
 }
 
 // New generates a new key pair.
-// Stores the private key, returns the public key
-// If a key is overwritten is handled by the storage implementation.
-// (it's considered bad practise to reuse a kid for different keys)
+// Stores the private key, returns the public key.
+// It returns an error when a key with the resulting ID already exists.
 func (client *Crypto) New(namingFunc KIDNamingFunc) (Key, error) {
 	keyPair, kid, err := generateKeyPairAndKID(namingFunc)
 	if err != nil {
@@ -124,6 +123,9 @@ func (client *Crypto) New(namingFunc KIDNamingFunc) (Key, error) {
 	}
 	if err = validateKID(kid); err != nil {
 		return nil, err
+	}
+	if client.Exists(kid) {
+		return nil, errors.New("key with the given ID already exists")
 	}
 	if err = client.Storage.SavePrivateKey(kid, keyPair); err != nil {
 		return nil, fmt.Errorf("could not create new keypair: could not save private key: %w", err)

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -94,6 +94,18 @@ func TestCrypto_New(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, "could not create new keypair: could not save private key: foo", err.Error())
 	})
+
+	t.Run("error - ID already in use", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		storageMock := storage.NewMockStorage(ctrl)
+		storageMock.EXPECT().PrivateKeyExists("123").Return(true)
+
+		client := &Crypto{Storage: storageMock}
+		key, err := client.New(StringNamingFunc("123"))
+		assert.Nil(t, key)
+		assert.EqualError(t, err, "key with the given ID already exists", err)
+	})
 }
 
 func TestCrypto_Resolve(t *testing.T) {

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -86,6 +86,7 @@ func TestCrypto_New(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		storageMock := storage.NewMockStorage(ctrl)
+		storageMock.EXPECT().PrivateKeyExists("123").Return(false)
 		storageMock.EXPECT().SavePrivateKey(gomock.Any(), gomock.Any()).Return(errors.New("foo"))
 
 		client := &Crypto{Storage: storageMock}


### PR DESCRIPTION
Firstly, key IDs are unique in practice, since they are derived from the public key. Secondly, it's unsafe:

- An attacker who is allowed to (although currently not possible) specify his own key ID, could overwrite existing keys (potential data loss)
- It allows to accidentally overwrite a private key (potential data loss)
- Leaving it up to the storage implementation leads to unpredictable behavior