### PR TITLE
OpenAPI: order response types to support OAPI Java Generator

### DIFF
--- a/docs/_static/didman/v1.yaml
+++ b/docs/_static/didman/v1.yaml
@@ -244,12 +244,12 @@ paths:
             The endpoint of the given type and compound service is returned.
             It returns JSON by default, text if requested through the accept header (text/plain)
           content:
-            text/plain:
-              schema:
-                type: string
             application/json:
               schema:
                 $ref: '#/components/schemas/EndpointResponse'
+            text/plain:
+              schema:
+                type: string
         default:
           $ref: '../common/error_response.yaml'
   /internal/didman/v1/service/{id}:

--- a/docs/_static/monitoring/v1.yaml
+++ b/docs/_static/monitoring/v1.yaml
@@ -52,13 +52,13 @@ paths:
         200:
           description: Basic nuts-node diagnostics
           content:
+            application/json:
+              schema:
+                type: object
             text/plain:
               schema:
                 type: string
             application/yaml:
-              schema:
-                type: object
-            application/json:
               schema:
                 type: object
   /metrics:


### PR DESCRIPTION
OpenAPI Generator Tools Java generates an API for the first content type it sees, but deserializes it as JSON. So if the first is `text/plain` it generates an API returning a String, but returns the JSON as-is when the returned content-type is `application/json`.

Putting JSON on top fixes this.