### PR TITLE
VCR: Add debug log of expanded json-ld VCR search query

### DIFF
--- a/vcr/api/v2/registry.go
+++ b/vcr/api/v2/registry.go
@@ -21,6 +21,7 @@ package v2
 import (
 	"encoding/json"
 	"github.com/nuts-foundation/nuts-node/vcr/log"
+	"github.com/sirupsen/logrus"
 	"net/http"
 	"sort"
 	"strings"
@@ -77,8 +78,10 @@ func (w *Wrapper) SearchVCs(ctx echo.Context) error {
 		return core.InvalidInputError("failed to convert query to JSON-LD expanded form: %w", err)
 	}
 
-	documentAsJson, _ := json.MarshalIndent(document, "", " ")
-	log.Logger().Debug(string(documentAsJson))
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		documentAsJson, _ := json.MarshalIndent(document, "", " ")
+		log.Logger().Debug(string(documentAsJson))
+	}
 
 	searchTerms := flatten(document, nil)
 

--- a/vcr/api/v2/registry.go
+++ b/vcr/api/v2/registry.go
@@ -80,7 +80,7 @@ func (w *Wrapper) SearchVCs(ctx echo.Context) error {
 
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		documentAsJson, _ := json.MarshalIndent(document, "", " ")
-		log.Logger().Debug(string(documentAsJson))
+		log.Logger().Debugf("Expanded JSON-LD search query:\n%s", string(documentAsJson))
 	}
 
 	searchTerms := flatten(document, nil)

--- a/vcr/api/v2/registry.go
+++ b/vcr/api/v2/registry.go
@@ -19,6 +19,8 @@
 package v2
 
 import (
+	"encoding/json"
+	"github.com/nuts-foundation/nuts-node/vcr/log"
 	"net/http"
 	"sort"
 	"strings"
@@ -74,6 +76,10 @@ func (w *Wrapper) SearchVCs(ctx echo.Context) error {
 	if err != nil {
 		return core.InvalidInputError("failed to convert query to JSON-LD expanded form: %w", err)
 	}
+
+	documentAsJson, _ := json.MarshalIndent(document, "", " ")
+	log.Logger().Debug(string(documentAsJson))
+
 	searchTerms := flatten(document, nil)
 
 	// sort terms to aid testing


### PR DESCRIPTION
Replaces #1230 

The following query:

```
{
  "query": {
    "@context": [
      "https://www.w3.org/2018/credentials/v1",
      "https://nuts.nl/credentials/v1"
    ],
    "type": [
      "VerifiableCredential",
      "NutsOrganizationCredential"
    ],
    "credentialSubject": {
      "organization": {
        "name": "Zorggroep de Nootjes",
        "city": "Amandelmere"
      }
    }
  }
}
```

Log the following output:

```
DEBU[0003] [
 {
  "@type": [
   "https://www.w3.org/2018/credentials#VerifiableCredential",
   "https://nuts.nl/credentials/v1#NutsOrganizationCredential"
  ],
  "https://www.w3.org/2018/credentials#credentialSubject": [
   {
    "http://schema.org/organization": [
     {
      "http://schema.org/city": [
       {
        "@value": "Amandelmere"
       }
      ],
      "http://schema.org/legalname": [
       {
        "@value": "Zorggroep de Nootjes"
       }
      ]
     }
    ]
   }
  ]
 }
]  module=VCR
INFO[0003] HTTP request                                  method=POST module=http remote_ip=127.0.0.1 status=200 uri=/internal/vcr/v2/search
```
