### PR TITLE
VDR: Add ManagedDocumentValidator and managedServiceValidator

### DIFF
--- a/didman/didman_test.go
+++ b/didman/didman_test.go
@@ -184,7 +184,8 @@ func TestDidman_AddCompoundService(t *testing.T) {
 			func(_ interface{}, _ interface{}, doc interface{}, _ interface{}) error {
 				newDoc = doc.(did.Document)
 				// trigger validation to check if the added contact information isn't wrong
-				return vdr.NetworkDocumentValidator().Validate(newDoc)
+				ctx.serviceResolver.EXPECT().ResolveEx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
+				return vdr.ManagedDocumentValidator(ctx.serviceResolver).Validate(newDoc)
 			})
 
 		_, err := ctx.instance.AddCompoundService(*vdr.TestDIDA, "helloworld", references)
@@ -307,7 +308,7 @@ func TestDidman_UpdateContactInformation(t *testing.T) {
 		ctx.vdr.EXPECT().Update(*id, meta.Hash, gomock.Any(), nil).DoAndReturn(func(_ did.DID, _ hash.SHA256Hash, doc did.Document, _ *types.DocumentMetadata) error {
 			actualDocument = doc
 			// trigger validation to check if the added contact information isn't wrong
-			return vdr.NetworkDocumentValidator().Validate(doc)
+			return vdr.ManagedDocumentValidator(ctx.serviceResolver).Validate(doc)
 		})
 		actual, err := ctx.instance.UpdateContactInformation(*id, expected)
 		require.NoError(t, err)
@@ -784,12 +785,13 @@ func TestReferencesService(t *testing.T) {
 }
 
 type mockContext struct {
-	ctrl        *gomock.Controller
-	docResolver *types.MockDocResolver
-	store       *types.MockStore
-	vdr         *types.MockVDR
-	vcr         *vcr.MockFinder
-	instance    Didman
+	ctrl            *gomock.Controller
+	docResolver     *types.MockDocResolver
+	serviceResolver *didservice.MockServiceResolver
+	store           *types.MockStore
+	vdr             *types.MockVDR
+	vcr             *vcr.MockFinder
+	instance        Didman
 }
 
 func newMockContext(t *testing.T) mockContext {
@@ -801,11 +803,12 @@ func newMockContext(t *testing.T) mockContext {
 	instance := NewDidmanInstance(docResolver, store, mockVDR, mockVCR, jsonld.NewTestJSONLDManager(t))
 
 	return mockContext{
-		ctrl:        ctrl,
-		docResolver: docResolver,
-		store:       store,
-		vdr:         mockVDR,
-		vcr:         mockVCR,
-		instance:    instance,
+		ctrl:            ctrl,
+		docResolver:     docResolver,
+		serviceResolver: didservice.NewMockServiceResolver(ctrl),
+		store:           store,
+		vdr:             mockVDR,
+		vcr:             mockVCR,
+		instance:        instance,
 	}
 }

--- a/didman/didman_test.go
+++ b/didman/didman_test.go
@@ -184,7 +184,7 @@ func TestDidman_AddCompoundService(t *testing.T) {
 			func(_ interface{}, _ interface{}, doc interface{}, _ interface{}) error {
 				newDoc = doc.(did.Document)
 				// trigger validation to check if the added contact information isn't wrong
-				return vdr.CreateDocumentValidator().Validate(newDoc)
+				return vdr.NetworkDocumentValidator().Validate(newDoc)
 			})
 
 		_, err := ctx.instance.AddCompoundService(*vdr.TestDIDA, "helloworld", references)
@@ -307,7 +307,7 @@ func TestDidman_UpdateContactInformation(t *testing.T) {
 		ctx.vdr.EXPECT().Update(*id, meta.Hash, gomock.Any(), nil).DoAndReturn(func(_ did.DID, _ hash.SHA256Hash, doc did.Document, _ *types.DocumentMetadata) error {
 			actualDocument = doc
 			// trigger validation to check if the added contact information isn't wrong
-			return vdr.CreateDocumentValidator().Validate(doc)
+			return vdr.NetworkDocumentValidator().Validate(doc)
 		})
 		actual, err := ctx.instance.UpdateContactInformation(*id, expected)
 		require.NoError(t, err)

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -177,7 +177,7 @@ func (n *ambassador) callback(tx dag.Transaction, payload []byte) error {
 		return fmt.Errorf("unable to unmarshal DID document from network payload: %w", err)
 	}
 
-	if err := CreateDocumentValidator().Validate(nextDIDDocument); err != nil {
+	if err := NetworkDocumentValidator().Validate(nextDIDDocument); err != nil {
 		return fmt.Errorf("callback could not process new DID Document, DID Document integrity check failed: %w", err)
 	}
 

--- a/vdr/didservice/resolvers.go
+++ b/vdr/didservice/resolvers.go
@@ -306,6 +306,9 @@ func (s serviceResolver) ResolveEx(endpoint ssi.URI, depth int, maxDepth int, do
 	var service *did.Service
 	for _, curr := range document.Service {
 		if curr.Type == endpoint.Query().Get(serviceTypeQueryParameter) {
+			// If there are multiple services with the same type the document is conflicted.
+			// This can happen temporarily during a service update (delete old, add new).
+			// Both endpoints are likely to be active in the timeframe that the conflict exists, so picking the first entry is preferred for availability over an error.
 			service = &curr
 			break
 		}

--- a/vdr/validators.go
+++ b/vdr/validators.go
@@ -26,7 +26,6 @@ import (
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/vdr/didservice"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
-	"net/mail"
 	"net/url"
 )
 
@@ -217,44 +216,12 @@ func validateNutsCommEndpoint(endpoint any) error {
 
 func validateNodeContactInfo(endpoint any) error {
 	// RFC006 §4.2 Contact information
-	// check format
 	endpointMapAny, ok := endpoint.(map[string]any)
 	if !ok {
 		return errors.New("not a map")
 	}
-	endpointMap := make(map[string]string)
-	for k, v := range endpointMapAny {
-		if vString, ok := v.(string); ok {
-			endpointMap[k] = vString
-		} else {
-			return errors.New(k + " must be a string")
-		}
-	}
-
-	// check content
-	numKeys := 0
-	if _, ok = endpointMap["name"]; ok {
-		numKeys++
-	}
-	if email, ok := endpointMap["email"]; ok {
-		numKeys++
-		if _, err := mail.ParseAddress(email); err != nil {
-			return errors.New("invalid email")
-		}
-	} else {
+	if _, ok = endpointMapAny["email"]; !ok {
 		return errors.New("missing email")
-	}
-	if _, ok = endpointMap["telephone"]; ok {
-		numKeys++
-	}
-	if website, ok := endpointMap["website"]; ok {
-		numKeys++
-		if _, err := url.ParseRequestURI(website); err != nil {
-			return errors.New("invalid website")
-		}
-	}
-	if len(endpointMap) != numKeys {
-		return errors.New("must only contain 'name', 'email', 'telephone', and 'website'")
 	}
 	return nil
 }

--- a/vdr/validators_test.go
+++ b/vdr/validators_test.go
@@ -155,6 +155,11 @@ func Test_managedServiceValidator(t *testing.T) {
 			didDoc.Service[0].ServiceEndpoint = []string{serviceRef.String()}
 			return didDoc
 		}, errors.New("invalid service: invalid service format")},
+		{"nok - invalid reference", func() did.Document {
+			didDoc, _, _ := newDidDoc()
+			didDoc.Service[0].ServiceEndpoint = "did:invalid:reference"
+			return didDoc
+		}, errors.New("invalid service: DID service query invalid: endpoint URI path must be /serviceEndpoint")},
 	}
 	tableDrivenValidation(t, table, managedServiceValidator{serviceResolver})
 
@@ -226,32 +231,12 @@ func Test_managedServiceValidator(t *testing.T) {
 				didDoc.Service[0].ServiceEndpoint = map[string]string{}
 				return didDoc
 			}, errors.New("invalid service: node-contact-info: missing email")},
-			{"nok - invalid email", func() did.Document {
+			{"nok - not a map", func() did.Document {
 				didDoc, _, _ := newDidDoc()
 				didDoc.Service[0].Type = "node-contact-info"
-				didDoc.Service[0].ServiceEndpoint = map[string]string{
-					"email": "not a valid email",
-				}
+				didDoc.Service[0].ServiceEndpoint = "valid@email.address"
 				return didDoc
-			}, errors.New("invalid service: node-contact-info: invalid email")},
-			{"nok - invalid website", func() did.Document {
-				didDoc, _, _ := newDidDoc()
-				didDoc.Service[0].Type = "node-contact-info"
-				didDoc.Service[0].ServiceEndpoint = map[string]string{
-					"email":   "valid@email.address",
-					"website": "nuts.nl",
-				}
-				return didDoc
-			}, errors.New("invalid service: node-contact-info: invalid website")},
-			{"nok - contains unknown fields", func() did.Document {
-				didDoc, _, _ := newDidDoc()
-				didDoc.Service[0].Type = "node-contact-info"
-				didDoc.Service[0].ServiceEndpoint = map[string]string{
-					"email":      "valid@email.address",
-					"whose this": "I don't know",
-				}
-				return didDoc
-			}, errors.New("invalid service: node-contact-info: must only contain 'name', 'email', 'telephone', and 'website'")},
+			}, errors.New("invalid service: node-contact-info: not a map")},
 		}
 		tableDrivenValidation(t, table, managedServiceValidator{serviceResolver})
 	})

--- a/vdr/validators_test.go
+++ b/vdr/validators_test.go
@@ -23,133 +23,254 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/golang/mock/gomock"
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func Test_verificationMethodValidator(t *testing.T) {
-	type args struct {
-		doc did.Document
-	}
-	tests := []struct {
-		name      string
-		beforeFn  func(t *testing.T, a *args)
-		wantedErr error
-	}{
-		{"ok - valid document", func(t *testing.T, a *args) {
+	table := []validatorTest{
+		{"ok - valid document", func() did.Document {
 			didDoc, _, _ := newDidDoc()
-			a.doc = didDoc
+			return didDoc
 		}, nil},
-		{"nok - verificationMethod ID has no fragment", func(t *testing.T, a *args) {
+		{"nok - verificationMethod ID has no fragment", func() did.Document {
 			didDoc, _, _ := newDidDoc()
 			didDoc.VerificationMethod[0].ID.Fragment = ""
-			a.doc = didDoc
+			return didDoc
 		}, errors.New("invalid verificationMethod: ID must have a fragment")},
-		{"nok - verificationMethod ID has wrong prefix", func(t *testing.T, a *args) {
+		{"nok - verificationMethod ID has wrong prefix", func() did.Document {
 			didDoc, _, _ := newDidDoc()
 			didDoc.VerificationMethod[0].ID.ID = "foo:123"
-			a.doc = didDoc
+			return didDoc
 		}, errors.New("invalid verificationMethod: ID must have document prefix")},
-		{"nok - verificationMethod with duplicate id", func(t *testing.T, a *args) {
+		{"nok - verificationMethod with duplicate id", func() did.Document {
 			didDoc, _, _ := newDidDoc()
 			method := didDoc.VerificationMethod[0]
 			didDoc.VerificationMethod = append(didDoc.VerificationMethod, method)
-			a.doc = didDoc
+			return didDoc
 		}, errors.New("invalid verificationMethod: ID must be unique")},
-		{"nok - verificationMethod with invalid thumbprint", func(t *testing.T, a *args) {
+		{"nok - verificationMethod with invalid thumbprint", func() did.Document {
 			didDoc, _, _ := newDidDoc()
 			keyID := didDoc.VerificationMethod[0].ID
 			keyID.Fragment = "foobar"
 			pk, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 			vm, _ := did.NewVerificationMethod(keyID, didDoc.VerificationMethod[0].Type, didDoc.VerificationMethod[0].Controller, pk.Public())
 			didDoc.VerificationMethod = append(didDoc.VerificationMethod, vm)
-			a.doc = didDoc
+			return didDoc
 		}, errors.New("invalid verificationMethod: key thumbprint does not match ID")},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			a := args{}
-			tt.beforeFn(t, &a)
-			if err := (verificationMethodValidator{}).Validate(a.doc); err != nil || tt.wantedErr != nil {
-				if err == nil {
-					if tt.wantedErr != nil {
-						t.Error("expected an error, got nothing")
-
-					}
-				} else {
-					if tt.wantedErr == nil {
-
-						t.Errorf("unexpected error: %v", err)
-					} else {
-						if tt.wantedErr.Error() != err.Error() {
-							t.Errorf("wrong error\ngot:  %v\nwant: %v", err, tt.wantedErr)
-						}
-					}
-				}
-			}
-		})
-	}
+	tableDrivenValidation(t, table, verificationMethodValidator{})
 }
 
-func Test_serviceValidator(t *testing.T) {
-	type args struct {
-		doc did.Document
-	}
-	tests := []struct {
-		name      string
-		beforeFn  func(t *testing.T, a *args)
-		wantedErr error
-	}{
-		{"ok - valid document", func(t *testing.T, a *args) {
+func Test_basicServiceValidator(t *testing.T) {
+	table := []validatorTest{
+		{"ok - valid document", func() did.Document {
 			didDoc, _, _ := newDidDoc()
-			a.doc = didDoc
+			return didDoc
 		}, nil},
-		{"nok - service with duplicate id", func(t *testing.T, a *args) {
+		{"ok - service endpoint is not validated", func() did.Document {
+			// service endpoint is validated in managedServiceValidator
+			didDoc, _, _ := newDidDoc()
+			didDoc.Service[0].ServiceEndpoint = "did:foo:123/serviceEndpoint?type=NutsComm"
+			return didDoc
+		}, nil},
+		{"nok - service with duplicate id", func() did.Document {
 			didDoc, _, _ := newDidDoc()
 			svc := didDoc.Service[0]
 			didDoc.Service = append(didDoc.Service, svc)
-			a.doc = didDoc
+			return didDoc
 		}, errors.New("invalid service: ID must be unique")},
-		{"nok - service ID has no fragment", func(t *testing.T, a *args) {
+		{"nok - service ID has no fragment", func() did.Document {
 			didDoc, _, _ := newDidDoc()
 			didDoc.Service[0].ID.Fragment = ""
-			a.doc = didDoc
+			return didDoc
 		}, errors.New("invalid service: ID must have a fragment")},
-		{"nok - service ID has wrong prefix", func(t *testing.T, a *args) {
+		{"nok - service ID has wrong prefix", func() did.Document {
 			didDoc, _, _ := newDidDoc()
 			uri := ssi.MustParseURI("did:foo:123#foobar")
 			didDoc.Service[0].ID = uri
-			a.doc = didDoc
+			return didDoc
 		}, errors.New("invalid service: ID must have document prefix")},
-		{"nok - service with duplicate type", func(t *testing.T, a *args) {
+		{"nok - service with duplicate type", func() did.Document {
 			didDoc, _, _ := newDidDoc()
 			svc := didDoc.Service[0]
 			svc.ID.Fragment = "foobar"
 			didDoc.Service = append(didDoc.Service, svc)
-			a.doc = didDoc
+			return didDoc
 		}, errors.New("invalid service: service type is duplicate")},
 	}
+	tableDrivenValidation(t, table, basicServiceValidator{})
+}
+
+func Test_managedServiceValidator(t *testing.T) {
+	serviceResolver := didservice.NewMockServiceResolver(gomock.NewController(t))
+	service := did.Service{Type: "referenced_service", ServiceEndpoint: "https://nuts.nl"}
+	serviceRef := ssi.MustParseURI("did:nuts:123/serviceEndpoint?type=referenced_service")
+	//TODO: what if Type contains a space? ref should be URL encoded, but what about dereferencing?
+
+	table := []validatorTest{
+		{"ok - valid document", func() did.Document {
+			didDoc, _, _ := newDidDoc()
+			return didDoc
+		}, nil},
+		{"ok - doesn't panic", func() did.Document {
+			didDoc, _, _ := newDidDoc()
+			didDoc.Service = nil
+			return didDoc
+		}, nil},
+		{"ok - resolves string", func() did.Document {
+			didDoc, _, _ := newDidDoc()
+			didDoc.Service[0].ServiceEndpoint = serviceRef.String()
+
+			serviceResolver.EXPECT().ResolveEx(ssi.MustParseURI(didDoc.Service[0].ServiceEndpoint.(string)), 0, 5, gomock.Any()).Return(service, nil)
+
+			return didDoc
+		}, nil},
+		{"ok - resolves map", func() did.Document {
+			didDoc, _, _ := newDidDoc()
+			didDoc.Service[0].ServiceEndpoint = map[string]string{
+				"reference":      serviceRef.String(),
+				"url":            "super invalid but isn't validated",
+				"otherReference": serviceRef.String(),
+			}
+
+			serviceResolver.EXPECT().ResolveEx(serviceRef, 0, 5, gomock.Any()).Return(service, nil).Times(2) // 2 of 3 entries need to be resolved
+
+			return didDoc
+		}, nil},
+		{"nok - resolve fails", func() did.Document {
+			didDoc, _, _ := newDidDoc()
+			didDoc.Service[0].ServiceEndpoint = serviceRef.String()
+
+			serviceResolver.EXPECT().ResolveEx(serviceRef, 0, 5, gomock.Any()).Return(service, errors.New("resolve failed"))
+
+			return didDoc
+		}, errors.New("invalid service: resolve failed")},
+		{"nok - invalid format", func() did.Document {
+			didDoc, _, _ := newDidDoc()
+			didDoc.Service[0].ServiceEndpoint = []string{serviceRef.String()}
+			return didDoc
+		}, errors.New("invalid service: invalid service format")},
+	}
+	tableDrivenValidation(t, table, managedServiceValidator{serviceResolver})
+
+	t.Run("NutsComm", func(t *testing.T) {
+		table = []validatorTest{
+			{"ok", func() did.Document {
+				didDoc, _, _ := newDidDoc()
+				didDoc.Service[0].Type = "NutsComm"
+				didDoc.Service[0].ServiceEndpoint = "grpc://nuts.nl:5555"
+				return didDoc
+			}, nil},
+			{"nok - invalid scheme", func() did.Document {
+				didDoc, _, _ := newDidDoc()
+				didDoc.Service[0].Type = "NutsComm"
+				return didDoc
+			}, errors.New("invalid service: NutsComm: scheme must be grpc")},
+			{"nok - validates after resolving", func() did.Document {
+				didDoc, _, _ := newDidDoc()
+				didDoc.Service[0].Type = "NutsComm"
+				didDoc.Service[0].ServiceEndpoint = didDoc.ID.String() + "/serviceEndpoint?type=notNutsComm"
+
+				service := did.Service{Type: "notNutsComm", ServiceEndpoint: "https://nuts.nl"}
+				serviceResolver.EXPECT().ResolveEx(ssi.MustParseURI(didDoc.Service[0].ServiceEndpoint.(string)), 0, 5, gomock.Any()).Return(service, nil)
+				return didDoc
+			}, errors.New("invalid service: NutsComm: scheme must be grpc")},
+			{"nok - invalid format", func() did.Document {
+				didDoc, _, _ := newDidDoc()
+				didDoc.Service[0].Type = "NutsComm"
+				didDoc.Service[0].ServiceEndpoint = map[string]string{"NutsComm": "grpc://nuts.nl:5555"}
+				return didDoc
+			}, errors.New("invalid service: NutsComm: endpoint not a string")},
+		}
+		tableDrivenValidation(t, table, managedServiceValidator{serviceResolver})
+	})
+
+	t.Run("node-contact-info", func(t *testing.T) {
+		table = []validatorTest{
+			{"ok - node-contact-info all valid", func() did.Document {
+				didDoc, _, _ := newDidDoc()
+				didDoc.Service[0].Type = "node-contact-info"
+				didDoc.Service[0].ServiceEndpoint = map[string]string{
+					"name":      "name",
+					"email":     "valid@email.address",
+					"telephone": "is a string",
+					"website":   "https://nuts.nl",
+				}
+				return didDoc
+			}, nil},
+			{"ok - minimal info", func() did.Document {
+				didDoc, _, _ := newDidDoc()
+				didDoc.Service[0].Type = "node-contact-info"
+				didDoc.Service[0].ServiceEndpoint = map[string]string{
+					"email": "valid@email.address",
+				}
+				return didDoc
+			}, nil},
+			{"ok - validates after resolving", func() did.Document {
+				didDoc, _, _ := newDidDoc()
+				didDoc.Service[0].Type = "node-contact-info"
+				didDoc.Service[0].ServiceEndpoint = didDoc.ID.String() + "/serviceEndpoint?type=otherService"
+
+				service := did.Service{Type: "otherService", ServiceEndpoint: map[string]any{"email": "valid@email.address"}}
+				serviceResolver.EXPECT().ResolveEx(ssi.MustParseURI(didDoc.Service[0].ServiceEndpoint.(string)), 0, 5, gomock.Any()).Return(service, nil)
+				return didDoc
+			}, nil},
+			{"nok - missing email", func() did.Document {
+				didDoc, _, _ := newDidDoc()
+				didDoc.Service[0].Type = "node-contact-info"
+				didDoc.Service[0].ServiceEndpoint = map[string]string{}
+				return didDoc
+			}, errors.New("invalid service: node-contact-info: missing email")},
+			{"nok - invalid email", func() did.Document {
+				didDoc, _, _ := newDidDoc()
+				didDoc.Service[0].Type = "node-contact-info"
+				didDoc.Service[0].ServiceEndpoint = map[string]string{
+					"email": "not a valid email",
+				}
+				return didDoc
+			}, errors.New("invalid service: node-contact-info: invalid email")},
+			{"nok - invalid website", func() did.Document {
+				didDoc, _, _ := newDidDoc()
+				didDoc.Service[0].Type = "node-contact-info"
+				didDoc.Service[0].ServiceEndpoint = map[string]string{
+					"email":   "valid@email.address",
+					"website": "nuts.nl",
+				}
+				return didDoc
+			}, errors.New("invalid service: node-contact-info: invalid website")},
+			{"nok - contains unknown fields", func() did.Document {
+				didDoc, _, _ := newDidDoc()
+				didDoc.Service[0].Type = "node-contact-info"
+				didDoc.Service[0].ServiceEndpoint = map[string]string{
+					"email":      "valid@email.address",
+					"whose this": "I don't know",
+				}
+				return didDoc
+			}, errors.New("invalid service: node-contact-info: must only contain 'name', 'email', 'telephone', and 'website'")},
+		}
+		tableDrivenValidation(t, table, managedServiceValidator{serviceResolver})
+	})
+}
+
+type validatorTest struct {
+	name        string
+	buildDoc    func() did.Document
+	expectedErr error
+}
+
+func tableDrivenValidation(t *testing.T, tests []validatorTest, validator did.Validator) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := args{}
-			tt.beforeFn(t, &a)
-			if err := (serviceValidator{}).Validate(a.doc); err != nil || tt.wantedErr != nil {
-				if err == nil {
-					if tt.wantedErr != nil {
-						t.Error("expected an error, got nothing")
-
-					}
-				} else {
-					if tt.wantedErr == nil {
-
-						t.Errorf("unexpected error: %v", err)
-					} else {
-						if tt.wantedErr.Error() != err.Error() {
-							t.Errorf("wrong error\ngot:  %v\nwant: %v", err, tt.wantedErr)
-						}
-					}
-				}
+			err := validator.Validate(tt.buildDoc())
+			if tt.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.expectedErr.Error())
 			}
 		})
 	}

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -172,7 +172,7 @@ func (r VDR) Update(id did.DID, current hash.SHA256Hash, next did.Document, _ *t
 		return types.ErrDeactivated
 	}
 
-	if err = CreateDocumentValidator().Validate(next); err != nil {
+	if err = NetworkDocumentValidator().Validate(next); err != nil {
 		return err
 	}
 

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -172,13 +172,14 @@ func (r VDR) Update(id did.DID, current hash.SHA256Hash, next did.Document, _ *t
 		return types.ErrDeactivated
 	}
 
-	if err = NetworkDocumentValidator().Validate(next); err != nil {
-		return err
-	}
-
 	// #1530: add nuts and JWS context if not present
 	next = withJSONLDContext(next, didservice.NutsDIDContextV1URI())
 	next = withJSONLDContext(next, didservice.JWS2020ContextV1URI())
+
+	// Validate document. No more changes should be made to the document after this point.
+	if err = ManagedDocumentValidator(didservice.NewServiceResolver(r.didDocResolver)).Validate(next); err != nil {
+		return err
+	}
 
 	payload, err := json.Marshal(next)
 	if err != nil {


### PR DESCRIPTION
part of #1508 

This splits did doc validators in `NetworkDocumentValidator` that validates documents received through the network, and `ManagedDocumentValidator` that provides stricter validation on did documents managed by a node before they are published. 

The latter has an additional validator: `managedServiceValidator` provides addition validation on services before publication. All services are validated on every did document update. _Could this be an issue with something like automated key rotation if a service reference is no longer valid?_

remaining after this PR is finished
- go through APIs and didman to validate the new did doc before it is updated/published
- remove checks in the above that are now redundant
- move ServiceResolver interface to vdr/types with the rest