### PR TITLE
Core: Remove prometheus metrics for http requests

### DIFF
--- a/core/metrics.go
+++ b/core/metrics.go
@@ -20,7 +20,6 @@
 package core
 
 import (
-	promEcho "github.com/labstack/echo-contrib/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"net/http"
 
@@ -38,8 +37,7 @@ func NewMetricsEngine() Engine {
 }
 
 type metrics struct {
-	prometheusMiddleware *promEcho.Prometheus
-	collectors           []prometheus.Collector
+	collectors []prometheus.Collector
 }
 
 func (e *metrics) Name() string {
@@ -54,15 +52,10 @@ func (e *metrics) Shutdown() error {
 	for _, collector := range e.collectors {
 		prometheus.Unregister(collector)
 	}
-	// echo-contrib/prometheus does not unregister metrics on shutdown, so we do it manually
-	for _, curr := range e.prometheusMiddleware.MetricsList {
-		prometheus.Unregister(curr.MetricCollector)
-	}
 	return nil
 }
 
 func (e *metrics) Routes(router EchoRouter) {
-	router.Use(e.prometheusMiddleware.HandlerFunc)
 	router.Add(http.MethodGet, "/metrics", echo.WrapHandler(promhttp.Handler()))
 }
 
@@ -79,19 +72,6 @@ func (e *metrics) Configure(_ ServerConfig) error {
 		if err := prometheus.Register(c); err != nil && err.Error() != are.Error() {
 			return err
 		}
-	}
-
-	// Echo collector
-	e.prometheusMiddleware = promEcho.NewPrometheus("http", nil)
-	// Fix for NTS-009: Prevent flooding the metrics with garbage
-	e.prometheusMiddleware.RequestCounterURLLabelMappingFunc = func(c echo.Context) string {
-		path := c.Path()
-		runes := []rune(path)
-		const maxPathLength = 200
-		if len(runes) > maxPathLength {
-			return string(runes[:maxPathLength]) + "..."
-		}
-		return path
 	}
 
 	return nil

--- a/core/metrics.go
+++ b/core/metrics.go
@@ -83,6 +83,16 @@ func (e *metrics) Configure(_ ServerConfig) error {
 
 	// Echo collector
 	e.prometheusMiddleware = promEcho.NewPrometheus("http", nil)
+	// Fix for NTS-009: Prevent flooding the metrics with garbage
+	e.prometheusMiddleware.RequestCounterURLLabelMappingFunc = func(c echo.Context) string {
+		path := c.Path()
+		runes := []rune(path)
+		const maxPathLength = 200
+		if len(runes) > maxPathLength {
+			return string(runes[:maxPathLength]) + "..."
+		}
+		return path
+	}
 
 	return nil
 }

--- a/core/metrics_test.go
+++ b/core/metrics_test.go
@@ -78,6 +78,19 @@ func TestNewMetricsEngine_Metrics(t *testing.T) {
 		assert.Contains(t, response, "http_request_duration_")
 	})
 
+	t.Run("limit path length", func(t *testing.T) {
+		// Request an HTTP endpoint to make sure some HTTP metrics are collected
+		path := "/status/diagnostics"
+		for i := 1; i < 210; i++ {
+			path += "x"
+		}
+		_ = requestPath(path)
+
+		response := requestMetrics()
+
+		assert.Contains(t, response, "xxx...")
+	})
+
 }
 
 func TestMetricsEngine_Lifecycle(t *testing.T) {

--- a/docs/pages/deployment/monitoring.rst
+++ b/docs/pages/deployment/monitoring.rst
@@ -146,7 +146,6 @@ The Nuts service executable exports the following metric namespaces:
 * ``process_`` contains OS metrics related to the process
 * ``go_`` contains Go metrics related to the process
 * ``http_`` contains metrics related to HTTP calls to the Nuts node
-* ``promhttp_`` contains metrics related to HTTP calls to the Nuts node's ``/metrics`` endpoint
 
 Network DAG Visualization
 *************************

--- a/docs/pages/deployment/monitoring.rst
+++ b/docs/pages/deployment/monitoring.rst
@@ -145,7 +145,7 @@ The Nuts service executable exports the following metric namespaces:
 * ``nuts_`` contains metrics related to the functioning of the Nuts node
 * ``process_`` contains OS metrics related to the process
 * ``go_`` contains Go metrics related to the process
-* ``http_`` contains metrics related to HTTP calls to the Nuts node
+* ``promhttp_`` contains metrics related to HTTP calls to the Nuts node's ``/metrics`` endpoint
 
 Network DAG Visualization
 *************************

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/vault/api v1.8.2
 	github.com/knadh/koanf v1.4.5
-	github.com/labstack/echo-contrib v0.13.1
 	github.com/labstack/echo/v4 v4.10.0
 	github.com/lestrrat-go/jwx v1.2.25
 	github.com/magiconair/properties v1.8.7

--- a/go.sum
+++ b/go.sum
@@ -67,7 +67,6 @@ github.com/alicebob/miniredis/v2 v2.30.0/go.mod h1:84TWKZlxYkfgMucPBf5SOQBYJceZe
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
-github.com/appleboy/gofight/v2 v2.1.2 h1:VOy3jow4vIK8BRQJoC/I9muxyYlJ2yb9ht2hZoS3rf4=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.3.10 h1:FR+drcQStOe+32sYyJYyZ7FIdgoGGBnwLl+flodp8Uo=
@@ -463,8 +462,6 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/labstack/echo-contrib v0.13.1 h1:9TktDom9FJKhkKO45YvV4klW8IedtSUp/k85gZVdZ28=
-github.com/labstack/echo-contrib v0.13.1/go.mod h1:LdM7aOHAYLOPmAAGXXG9TuN4h5sh6dPEu4pb6W2HKuU=
 github.com/labstack/echo/v4 v4.10.0 h1:5CiyngihEO4HXsz3vVsJn7f8xAlWwRr3aY6Ih280ZKA=
 github.com/labstack/echo/v4 v4.10.0/go.mod h1:S/T/5fy/GigaXnHTkh0ZGe4LpkkQysvRjFMSUTkDRNQ=
 github.com/labstack/gommon v0.4.0 h1:y7cvthEAEbU0yHOf4axH8ZG2NH8knB9iNSoTO8dyIk8=


### PR DESCRIPTION
Fixes NTS-009: #1716

First solution was limiting the logged http path to 200 chars.
After discussion in the comments, I changed the solution to removing http metrics logging completely.

There is still a mention of a `http_` prefix in the docs, but I think this won't hurt or confuse the reader.