### PR TITLE
Crypto: Add KID check wrapper for crypto storage backends

### DIFF
--- a/crypto/decryptor.go
+++ b/crypto/decryptor.go
@@ -25,9 +25,6 @@ import (
 
 // Decrypt decrypts the `cipherText` with key `kid`
 func (client *Crypto) Decrypt(kid string, cipherText []byte) ([]byte, error) {
-	if err := validateKID(kid); err != nil {
-		return nil, err
-	}
 	key, err := client.storage.GetPrivateKey(kid)
 	if err != nil {
 		return nil, err

--- a/crypto/jwx.go
+++ b/crypto/jwx.go
@@ -49,9 +49,6 @@ func isAlgorithmSupported(alg jwa.SignatureAlgorithm) bool {
 
 // SignJWT creates a signed JWT given a legalEntity and map of claims
 func (client *Crypto) SignJWT(claims map[string]interface{}, kid string) (token string, err error) {
-	if err = validateKID(kid); err != nil {
-		return "", err
-	}
 	privateKey, err := client.storage.GetPrivateKey(kid)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
@@ -74,9 +71,6 @@ func (client *Crypto) SignJWT(claims map[string]interface{}, kid string) (token 
 
 // SignJWS creates a signed JWS using the indicated key and map of headers and payload as bytes.
 func (client *Crypto) SignJWS(payload []byte, headers map[string]interface{}, kid string, detached bool) (token string, err error) {
-	if err = validateKID(kid); err != nil {
-		return "", err
-	}
 	privateKey, err := client.storage.GetPrivateKey(kid)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {

--- a/crypto/storage/fs.go
+++ b/crypto/storage/fs.go
@@ -74,13 +74,13 @@ func NewFileSystemBackend(fspath string) (Storage, error) {
 	return fsc, nil
 }
 
-func (fsc *fileSystemBackend) PrivateKeyExists(kid string) bool {
+func (fsc fileSystemBackend) PrivateKeyExists(kid string) bool {
 	_, err := os.Stat(fsc.getEntryPath(kid, privateKeyEntry))
 	return err == nil
 }
 
 // GetPrivateKey loads the private key for the given legalEntity from disk. Since a legalEntity has a URI as identifier, the URI is base64 encoded and postfixed with '_private.pem'. Keys are stored in pem format and are 2k RSA keys.
-func (fsc *fileSystemBackend) GetPrivateKey(kid string) (crypto.Signer, error) {
+func (fsc fileSystemBackend) GetPrivateKey(kid string) (crypto.Signer, error) {
 	data, err := fsc.readEntry(kid, privateKeyEntry)
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func (fsc *fileSystemBackend) GetPrivateKey(kid string) (crypto.Signer, error) {
 }
 
 // SavePrivateKey saves the private key for the given key to disk. Files are postfixed with '_private.pem'. Keys are stored in pem format.
-func (fsc *fileSystemBackend) SavePrivateKey(kid string, key crypto.PrivateKey) error {
+func (fsc fileSystemBackend) SavePrivateKey(kid string, key crypto.PrivateKey) error {
 	filenamePath := fsc.getEntryPath(kid, privateKeyEntry)
 	outFile, err := os.OpenFile(filenamePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, os.FileMode(0600))
 
@@ -113,7 +113,7 @@ func (fsc *fileSystemBackend) SavePrivateKey(kid string, key crypto.PrivateKey) 
 	return err
 }
 
-func (fsc *fileSystemBackend) ListPrivateKeys() []string {
+func (fsc fileSystemBackend) ListPrivateKeys() []string {
 	var result []string
 	_ = filepath.Walk(fsc.fspath, func(path string, info fs.FileInfo, err error) error {
 		if !info.IsDir() && strings.HasSuffix(info.Name(), string(privateKeyEntry)) {
@@ -139,8 +139,8 @@ func (fsc fileSystemBackend) readEntry(kid string, entryType entryType) ([]byte,
 	return data, nil
 }
 
-func (fsc fileSystemBackend) getEntryPath(key string, entryType entryType) string {
-	return filepath.Join(fsc.fspath, getEntryFileName(key, entryType))
+func (fsc fileSystemBackend) getEntryPath(kid string, entryType entryType) string {
+	return filepath.Join(fsc.fspath, getEntryFileName(kid, entryType))
 }
 
 func getEntryFileName(kid string, entryType entryType) string {

--- a/crypto/storage/wrapper.go
+++ b/crypto/storage/wrapper.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package storage
 
 import (

--- a/crypto/storage/wrapper.go
+++ b/crypto/storage/wrapper.go
@@ -1,0 +1,55 @@
+package storage
+
+import (
+	"crypto"
+	"fmt"
+	"regexp"
+)
+
+// wrapper wraps a Storage backend and checks the validity of the kid on each of the relevant functions before
+// forwarding the call to the wrapped backend.
+type wrapper struct {
+	kidPattern     *regexp.Regexp
+	wrappedBackend Storage
+}
+
+// NewValidatedKIDBackendWrapper creates a new wrapper for storage backends.
+// Every call to the backend which takes a kid as param, gets the kid validated against the provided kidPattern.
+func NewValidatedKIDBackendWrapper(backend Storage, kidPattern *regexp.Regexp) Storage {
+	return wrapper{
+		kidPattern:     kidPattern,
+		wrappedBackend: backend,
+	}
+}
+
+func (w wrapper) validateKID(kid string) error {
+	if !w.kidPattern.MatchString(kid) {
+		return fmt.Errorf("invalid key ID: %s", kid)
+	}
+	return nil
+}
+
+func (w wrapper) GetPrivateKey(kid string) (crypto.Signer, error) {
+	if err := w.validateKID(kid); err != nil {
+		return nil, err
+	}
+	return w.wrappedBackend.GetPrivateKey(kid)
+}
+
+func (w wrapper) PrivateKeyExists(kid string) bool {
+	if err := w.validateKID(kid); err != nil {
+		return false
+	}
+	return w.wrappedBackend.PrivateKeyExists(kid)
+}
+
+func (w wrapper) SavePrivateKey(kid string, key crypto.PrivateKey) error {
+	if err := w.validateKID(kid); err != nil {
+		return err
+	}
+	return w.wrappedBackend.SavePrivateKey(kid, key)
+}
+
+func (w wrapper) ListPrivateKeys() []string {
+	return w.wrappedBackend.ListPrivateKeys()
+}

--- a/crypto/storage/wrapper_test.go
+++ b/crypto/storage/wrapper_test.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package storage
 
 import (
@@ -17,6 +35,7 @@ var goodKIDs = []string{
 }
 var badKIDs = []string{
 	"../server-certificate",
+	"/etc/passwd",
 	"\\",
 	"",
 	"\t",
@@ -60,7 +79,6 @@ func TestWrapper_GetPrivateKey(t *testing.T) {
 }
 
 func TestWrapper_PrivateKeyExists(t *testing.T) {
-
 	t.Run("expect error for bad KIDs", func(t *testing.T) {
 		w := wrapper{kidPattern: kidPattern}
 		for _, kid := range badKIDs {
@@ -83,7 +101,6 @@ func TestWrapper_PrivateKeyExists(t *testing.T) {
 }
 
 func TestWrapper_SavePrivateKey(t *testing.T) {
-
 	t.Run("expect error for bad KIDs", func(t *testing.T) {
 		w := wrapper{kidPattern: kidPattern}
 		for _, kid := range badKIDs {
@@ -106,7 +123,6 @@ func TestWrapper_SavePrivateKey(t *testing.T) {
 }
 
 func TestWrapper_ListPrivateKeys(t *testing.T) {
-
 	t.Run("expect call to wrapped backend", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockStorage := NewMockStorage(ctrl)

--- a/crypto/storage/wrapper_test.go
+++ b/crypto/storage/wrapper_test.go
@@ -1,0 +1,120 @@
+package storage
+
+import (
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"testing"
+)
+
+var kidPattern = regexp.MustCompile(`^[\da-zA-Z_\- :#.]+$`)
+
+var goodKIDs = []string{
+	"admin-token-signing-key",
+	"did:nuts:2pgo54Z3ytC5EdjBicuJPe5gHyAsjF6rVio1FadSX74j#GxL7A5XNFr_tHcBW_fKCndGGko8DKa2ivPgJAGR0krA",
+	"did:nuts:3dGjPPeEuHsyNMgJwHkGX3HuJkEEnZ8H19qBqTaqLDbt#JwIR4Vct-EELNKeeB0BZ8Uff_rCZIrOhoiyp5LDFl68",
+	"did:nuts:BC5MtUzAncmfuGejPFGEgM2k8UfrKZVbbGyFeoG9JEEn#l2swLI0wus8gnzbI3sQaaiE7Yvv2qOUioaIZ8y_JZXs",
+}
+var badKIDs = []string{
+	"../server-certificate",
+	"\\",
+	"",
+	"\t",
+}
+
+func TestWrapper(t *testing.T) {
+	w := wrapper{kidPattern: kidPattern}
+
+	t.Run("good KIDs", func(t *testing.T) {
+		for _, kid := range goodKIDs {
+			assert.NoError(t, w.validateKID(kid))
+		}
+	})
+	t.Run("bad KIDs", func(t *testing.T) {
+		for _, kid := range badKIDs {
+			assert.Error(t, w.validateKID(kid))
+		}
+	})
+}
+
+func TestWrapper_GetPrivateKey(t *testing.T) {
+	t.Run("expect error for bad KIDs", func(t *testing.T) {
+		w := wrapper{kidPattern: kidPattern}
+		for _, kid := range badKIDs {
+			_, err := w.GetPrivateKey(kid)
+			assert.Error(t, err)
+		}
+	})
+	t.Run("expect call to wrapped backend for good KIDs", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockStorage := NewMockStorage(ctrl)
+		w := NewValidatedKIDBackendWrapper(mockStorage, kidPattern)
+
+		for _, kid := range goodKIDs {
+			mockStorage.EXPECT().GetPrivateKey(kid)
+			_, err := w.GetPrivateKey(kid)
+			assert.NoError(t, err)
+		}
+		ctrl.Finish()
+	})
+}
+
+func TestWrapper_PrivateKeyExists(t *testing.T) {
+
+	t.Run("expect error for bad KIDs", func(t *testing.T) {
+		w := wrapper{kidPattern: kidPattern}
+		for _, kid := range badKIDs {
+			exists := w.PrivateKeyExists(kid)
+			assert.False(t, exists)
+		}
+	})
+	t.Run("expect call to wrapped backend for good KIDs", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockStorage := NewMockStorage(ctrl)
+		w := NewValidatedKIDBackendWrapper(mockStorage, kidPattern)
+
+		for _, kid := range goodKIDs {
+			mockStorage.EXPECT().PrivateKeyExists(kid).Return(true)
+			exists := w.PrivateKeyExists(kid)
+			assert.True(t, exists)
+		}
+		ctrl.Finish()
+	})
+}
+
+func TestWrapper_SavePrivateKey(t *testing.T) {
+
+	t.Run("expect error for bad KIDs", func(t *testing.T) {
+		w := wrapper{kidPattern: kidPattern}
+		for _, kid := range badKIDs {
+			err := w.SavePrivateKey(kid, nil)
+			assert.Error(t, err)
+		}
+	})
+	t.Run("expect call to wrapped backend for good KIDs", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockStorage := NewMockStorage(ctrl)
+		w := NewValidatedKIDBackendWrapper(mockStorage, kidPattern)
+
+		for _, kid := range goodKIDs {
+			mockStorage.EXPECT().SavePrivateKey(kid, gomock.Any())
+			err := w.SavePrivateKey(kid, nil)
+			assert.NoError(t, err)
+		}
+		ctrl.Finish()
+	})
+}
+
+func TestWrapper_ListPrivateKeys(t *testing.T) {
+
+	t.Run("expect call to wrapped backend", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockStorage := NewMockStorage(ctrl)
+		w := NewValidatedKIDBackendWrapper(mockStorage, kidPattern)
+
+		mockStorage.EXPECT().ListPrivateKeys().Return([]string{"foo", "bar"})
+		keys := w.ListPrivateKeys()
+		assert.Equal(t, []string{"foo", "bar"}, keys)
+		ctrl.Finish()
+	})
+}

--- a/jsonld/testsuite/compat_test.go
+++ b/jsonld/testsuite/compat_test.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package testsuite
 
 import (


### PR DESCRIPTION
Fixes: NTS-007 #1723

Adds a wrapper for storage engines. For each function that accepts a kid param, the param gets validated for a provided kidPattern. This allows for multiple kid patterns in the future.

CodeScanning fails because we use a var in a path, which is true if you don't wrap the FS backend. So, perhaps someone can double check if this can be marked as invalid?