### PR TITLE
Didman: remove redundant compound service validation

### DIFF
--- a/didman/didman.go
+++ b/didman/didman.go
@@ -175,9 +175,6 @@ func (d *didman) AddCompoundService(id did.DID, serviceType string, endpoints ma
 		WithField(core.LogFieldServiceType, serviceType).
 		WithField(core.LogFieldServiceEndpoint, endpoints).
 		Debug("Adding compound service")
-	if err := d.validateCompoundServiceEndpoint(endpoints); err != nil {
-		return nil, err
-	}
 
 	// transform service references to map[string]interface{}
 	serviceEndpoint := map[string]interface{}{}
@@ -465,27 +462,6 @@ func (d *didman) resolveOrganizationDIDDocument(organization vc.VerifiableCreden
 	return document, *organizationDID, err
 }
 
-// validateCompoundServiceEndpoint validates the serviceEndpoint of a compound service. The serviceEndpoint is passed
-// as a map of URIs that are either absolute URL endpoints or references that resolve to absolute URL endpoints. If validation fails an error is returned.
-// If all endpoints are valid nil is returned.
-func (d *didman) validateCompoundServiceEndpoint(endpoints map[string]ssi.URI) error {
-	// Cache resolved DID documents because most of the time a compound service will refer the same DID document in all service references.
-	cache := make(map[string]*did.Document, 0)
-	for _, serviceRef := range endpoints {
-		if didservice.IsServiceReference(serviceRef.String()) {
-			err := didservice.ValidateServiceReference(serviceRef)
-			if err != nil {
-				return ErrReferencedServiceNotAnEndpoint{Cause: err}
-			}
-			_, err = d.serviceResolver.ResolveEx(serviceRef, 0, didservice.DefaultMaxServiceReferenceDepth, cache)
-			if err != nil {
-				return ErrReferencedServiceNotAnEndpoint{Cause: err}
-			}
-		}
-	}
-	return nil
-}
-
 func filterCompoundServices(doc *did.Document) []did.Service {
 	var compoundServices []did.Service
 	for _, service := range doc.Service {
@@ -531,7 +507,6 @@ func (d *didman) addService(id did.DID, serviceType string, serviceEndpoint inte
 		Type:            serviceType,
 		ServiceEndpoint: serviceEndpoint,
 	}
-	service.ID = ssi.URI{}
 	service.ID = generateIDForService(id, *service)
 
 	// Add on DID Document and update

--- a/vdr/validators.go
+++ b/vdr/validators.go
@@ -87,15 +87,15 @@ func (v verificationMethodValidator) verifyThumbprint(method *did.VerificationMe
 }
 
 type InvalidServiceError struct {
-	error
+	Cause error
 }
 
 func (e InvalidServiceError) Error() string {
-	return fmt.Sprintf("invalid service: %s", e.error.Error())
+	return "invalid service: " + e.Cause.Error()
 }
 
 func (e InvalidServiceError) Unwrap() error {
-	return e.error
+	return e.Cause
 }
 
 // basicServiceValidator validates service.ID and service.Type of the Services of a DID Document.

--- a/vdr/validators.go
+++ b/vdr/validators.go
@@ -86,15 +86,15 @@ func (v verificationMethodValidator) verifyThumbprint(method *did.VerificationMe
 	return nil
 }
 
-type invalidServiceError struct {
+type InvalidServiceError struct {
 	error
 }
 
-func (e invalidServiceError) Error() string {
+func (e InvalidServiceError) Error() string {
 	return fmt.Sprintf("invalid service: %s", e.error.Error())
 }
 
-func (e invalidServiceError) Unwrap() error {
+func (e InvalidServiceError) Unwrap() error {
 	return e.error
 }
 
@@ -108,13 +108,13 @@ func (b basicServiceValidator) Validate(document did.Document) error {
 	for _, service := range document.Service {
 		// service.id
 		if err := verifyDocumentEntryID(document.ID, service.ID, knownServiceIDs); err != nil {
-			return invalidServiceError{err}
+			return InvalidServiceError{err}
 		}
 
 		// service.type
 		if knownServiceTypes[service.Type] {
 			// RFC006 §4: A DID Document MAY NOT contain more than one service with the same type.
-			return invalidServiceError{types.ErrDuplicateService}
+			return InvalidServiceError{types.ErrDuplicateService}
 		}
 		knownServiceTypes[service.Type] = true
 	}
@@ -134,10 +134,10 @@ func (m managedServiceValidator) Validate(document did.Document) error {
 	// TODO: this should probably happen somewhere else
 	bytes, err := document.MarshalJSON()
 	if err != nil {
-		return invalidServiceError{err}
+		return InvalidServiceError{err}
 	}
 	if err = document.UnmarshalJSON(bytes); err != nil {
-		return invalidServiceError{err}
+		return InvalidServiceError{err}
 	}
 
 	// make sure that it resolves when if it's a reference
@@ -171,7 +171,7 @@ func (m managedServiceValidator) Validate(document did.Document) error {
 			err = errors.New("invalid service format")
 		}
 		if err != nil {
-			return invalidServiceError{err}
+			return InvalidServiceError{err}
 		}
 
 		// specific service.Type need additional validation
@@ -181,7 +181,7 @@ func (m managedServiceValidator) Validate(document did.Document) error {
 			ServiceEndpoint: resolvedEndpoint,
 		}
 		if err = serviceTypeValidation(resolvedService); err != nil {
-			return invalidServiceError{fmt.Errorf("%s: %w", service.Type, err)}
+			return InvalidServiceError{fmt.Errorf("%s: %w", service.Type, err)}
 		}
 	}
 	return nil


### PR DESCRIPTION
validation now takes place in vdr.Update

invalid service error was previously incorrectly mapped to 406, is the specced 400 now