### PR TITLE
Storage: handle ErrKeyNotFound returned by stoabs.Reader.Get

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b
 	github.com/nuts-foundation/go-did v0.4.0
 	github.com/nuts-foundation/go-leia/v3 v3.3.0
-	github.com/nuts-foundation/go-stoabs v1.5.2-0.20230102153250-1f45f5144b28
+	github.com/nuts-foundation/go-stoabs v1.6.0
 	github.com/piprate/json-gold v0.5.1-0.20221121142341-01873264bae4
 	github.com/privacybydesign/irmago v0.10.0
 	github.com/prometheus/client_golang v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b
 	github.com/nuts-foundation/go-did v0.4.0
 	github.com/nuts-foundation/go-leia/v3 v3.3.0
-	github.com/nuts-foundation/go-stoabs v1.5.1
+	github.com/nuts-foundation/go-stoabs v1.5.2-0.20230102153250-1f45f5144b28
 	github.com/piprate/json-gold v0.5.1-0.20221121142341-01873264bae4
 	github.com/privacybydesign/irmago v0.10.0
 	github.com/prometheus/client_golang v1.14.0
@@ -76,7 +76,7 @@ require (
 	github.com/go-chi/chi v3.3.3+incompatible // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-redis/redis/v8 v8.11.4 // indirect
-	github.com/go-redsync/redsync/v4 v4.6.0 // indirect
+	github.com/go-redsync/redsync/v4 v4.7.1 // indirect
 	github.com/go-sql-driver/mysql v1.5.0 // indirect
 	github.com/goccy/go-json v0.9.11 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/go-redis/redis/v9 v9.0.0-rc.2 h1:IN1eI8AvJJeWHjMW/hlFAv2sAfvTun2DVksD
 github.com/go-redis/redis/v9 v9.0.0-rc.2/go.mod h1:cgBknjwcBJa2prbnuHH/4k/Mlj4r0pWNV2HBanHujfY=
 github.com/go-redsync/redsync/v4 v4.6.0 h1:CXpvsHB3XzktCleBu2Vo9Df0/qInrTG3jgzhvLzyk+U=
 github.com/go-redsync/redsync/v4 v4.6.0/go.mod h1:IxV3sygNwjOERTXrj3XvNMSb1tgNgic8GvM8alwnWcM=
+github.com/go-redsync/redsync/v4 v4.7.1 h1:j5rmHCdN5qCEWp5oA2XEbGwtD4LZblqkhbcjCUsfNhs=
+github.com/go-redsync/redsync/v4 v4.7.1/go.mod h1:IxV3sygNwjOERTXrj3XvNMSb1tgNgic8GvM8alwnWcM=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -578,6 +580,8 @@ github.com/nuts-foundation/go-leia/v3 v3.3.0 h1:d0AIihk8nF6QCMpA9I01ZS+pp+GCgoJh
 github.com/nuts-foundation/go-leia/v3 v3.3.0/go.mod h1:Md202F2wpwkXGtOUzyqs0p1Y96+wOY8lpmDT9nuaxE0=
 github.com/nuts-foundation/go-stoabs v1.5.1 h1:xQZ3YxwgmALLSiABor1cQQtEDPeB8jVd8CjzRNFYpGk=
 github.com/nuts-foundation/go-stoabs v1.5.1/go.mod h1:cE/Msdaie74PeMCX38ixRy3M9hpdIO7rmSZMCKt7qKg=
+github.com/nuts-foundation/go-stoabs v1.5.2-0.20230102153250-1f45f5144b28 h1:3qCLBEylU8HcReqvfbptZp6bZYVf2irepB6iXJJPr4U=
+github.com/nuts-foundation/go-stoabs v1.5.2-0.20230102153250-1f45f5144b28/go.mod h1:oSAv/Ktj0vVI7qQ7d2RNLVv5VPclTK/eopxqpo+ryTE=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/go.sum
+++ b/go.sum
@@ -155,7 +155,7 @@ github.com/deepmap/oapi-codegen v1.12.4 h1:pPmn6qI9MuOtCz82WY2Xaw46EQjgvxednXXrP
 github.com/deepmap/oapi-codegen v1.12.4/go.mod h1:3lgHGMu6myQ2vqbbTXH2H1o4eXFTGnFiDaOaKKl5yas=
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd h1:83Wprp6ROGeiHFAP8WJdI2RoxALQYgdllERc3N5N2DM=
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
-github.com/dgraph-io/badger/v3 v3.2103.4 h1:WE1B07YNTTJTtG9xjBcSW2wn0RJLyiV99h959RKZqM4=
+github.com/dgraph-io/badger/v3 v3.2103.5 h1:ylPa6qzbjYRQMU6jokoj4wzcaweHylt//CH0AKt0akg=
 github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWajOK8=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
@@ -222,8 +222,6 @@ github.com/go-redis/redis/v8 v8.11.4/go.mod h1:2Z2wHZXdQpCDXEGzqMockDpNyYvi2l4Px
 github.com/go-redis/redis/v9 v9.0.0-beta.2/go.mod h1:Bldcd/M/bm9HbnNPi/LUtYBSD8ttcZYBMupwMXhdU0o=
 github.com/go-redis/redis/v9 v9.0.0-rc.2 h1:IN1eI8AvJJeWHjMW/hlFAv2sAfvTun2DVksDDJ3a6a0=
 github.com/go-redis/redis/v9 v9.0.0-rc.2/go.mod h1:cgBknjwcBJa2prbnuHH/4k/Mlj4r0pWNV2HBanHujfY=
-github.com/go-redsync/redsync/v4 v4.6.0 h1:CXpvsHB3XzktCleBu2Vo9Df0/qInrTG3jgzhvLzyk+U=
-github.com/go-redsync/redsync/v4 v4.6.0/go.mod h1:IxV3sygNwjOERTXrj3XvNMSb1tgNgic8GvM8alwnWcM=
 github.com/go-redsync/redsync/v4 v4.7.1 h1:j5rmHCdN5qCEWp5oA2XEbGwtD4LZblqkhbcjCUsfNhs=
 github.com/go-redsync/redsync/v4 v4.7.1/go.mod h1:IxV3sygNwjOERTXrj3XvNMSb1tgNgic8GvM8alwnWcM=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
@@ -578,10 +576,8 @@ github.com/nuts-foundation/go-did v0.4.0 h1:HyzyDOup3Mwt8t8PESQeipW3y8KHDf/XNlBb
 github.com/nuts-foundation/go-did v0.4.0/go.mod h1:FfY394+fFTGXQeYTzIFAHlzGZfPYpL0XygmtHb5Xjdg=
 github.com/nuts-foundation/go-leia/v3 v3.3.0 h1:d0AIihk8nF6QCMpA9I01ZS+pp+GCgoJhblTNkyIZz40=
 github.com/nuts-foundation/go-leia/v3 v3.3.0/go.mod h1:Md202F2wpwkXGtOUzyqs0p1Y96+wOY8lpmDT9nuaxE0=
-github.com/nuts-foundation/go-stoabs v1.5.1 h1:xQZ3YxwgmALLSiABor1cQQtEDPeB8jVd8CjzRNFYpGk=
-github.com/nuts-foundation/go-stoabs v1.5.1/go.mod h1:cE/Msdaie74PeMCX38ixRy3M9hpdIO7rmSZMCKt7qKg=
-github.com/nuts-foundation/go-stoabs v1.5.2-0.20230102153250-1f45f5144b28 h1:3qCLBEylU8HcReqvfbptZp6bZYVf2irepB6iXJJPr4U=
-github.com/nuts-foundation/go-stoabs v1.5.2-0.20230102153250-1f45f5144b28/go.mod h1:oSAv/Ktj0vVI7qQ7d2RNLVv5VPclTK/eopxqpo+ryTE=
+github.com/nuts-foundation/go-stoabs v1.6.0 h1:wH66y4pwtQ/7PBTNXP8SAKzKRmcq+ITqFEAMat4RTrA=
+github.com/nuts-foundation/go-stoabs v1.6.0/go.mod h1:oSAv/Ktj0vVI7qQ7d2RNLVv5VPclTK/eopxqpo+ryTE=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/network/dag/dag.go
+++ b/network/dag/dag.go
@@ -106,7 +106,8 @@ func (d *dag) Migrate() error {
 			log.Logger().Info("Highest LC value not stored, migrating...")
 			highestLC := d.getHighestClockLegacy(tx)
 			err = d.setHighestClockValue(tx, highestLC)
-		} else if err != nil {
+		}
+		if err != nil {
 			return err
 		}
 
@@ -117,7 +118,8 @@ func (d *dag) Migrate() error {
 			log.Logger().Info("Number of transactions not stored, migrating...")
 			numberOfTXs := d.getNumberOfTransactionsLegacy(tx)
 			err = d.setNumberOfTransactions(tx, numberOfTXs)
-		} else if err != nil {
+		}
+		if err != nil {
 			return err
 		}
 
@@ -127,6 +129,7 @@ func (d *dag) Migrate() error {
 		if errors.Is(err, stoabs.ErrKeyNotFound) {
 			log.Logger().Info("Head not stored in metadata, migrating...")
 			heads := d.headsLegacy(tx)
+			err = nil            // reset error
 			if len(heads) != 0 { // ignore for empty node
 				var latestHead hash.SHA256Hash
 				var latestLC uint32
@@ -147,7 +150,8 @@ func (d *dag) Migrate() error {
 
 				err = d.setHead(tx, latestHead)
 			}
-		} else if err != nil {
+		}
+		if err != nil {
 			return err
 		}
 

--- a/network/dag/notifier_test.go
+++ b/network/dag/notifier_test.go
@@ -179,7 +179,7 @@ func TestNotifier_Save(t *testing.T) {
 		kvStore.ReadShelf(ctx, s.(*notifier).shelfName(), func(reader stoabs.Reader) error {
 			data, err := reader.Get(stoabs.BytesKey(event.Hash.Slice()))
 
-			assert.NoError(t, err)
+			assert.ErrorIs(t, err, stoabs.ErrKeyNotFound)
 			assert.Nil(t, data)
 
 			return nil
@@ -199,7 +199,7 @@ func TestNotifier_Save(t *testing.T) {
 		kvStore.ReadShelf(ctx, s.shelfName(), func(reader stoabs.Reader) error {
 			data, err := reader.Get(stoabs.BytesKey(event.Hash.Slice()))
 
-			assert.NoError(t, err)
+			assert.ErrorIs(t, err, stoabs.ErrKeyNotFound)
 			assert.Nil(t, data)
 
 			return nil

--- a/network/dag/payloadstore.go
+++ b/network/dag/payloadstore.go
@@ -52,11 +52,11 @@ func (store payloadStore) isPayloadPresent(tx stoabs.ReadTx, payloadHash hash.SH
 func (store payloadStore) readPayload(tx stoabs.ReadTx, payloadHash hash.SHA256Hash) ([]byte, error) {
 	reader := tx.GetShelfReader(payloadsShelf)
 	data, err := reader.Get(stoabs.NewHashKey(payloadHash))
+	if errors.Is(err, stoabs.ErrKeyNotFound) {
+		return nil, ErrPayloadNotFound
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to read payload (hash=%s): %w", payloadHash, err)
-	}
-	if data == nil {
-		return nil, ErrPayloadNotFound
 	}
 	return data, nil
 }

--- a/network/transport/grpc/backoff.go
+++ b/network/transport/grpc/backoff.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"errors"
 	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/nuts-node/network/log"
 	"math/rand"
@@ -164,11 +165,11 @@ func (p persistingBackoff) read() persistedBackoff {
 	var result persistedBackoff
 	err := p.store.ReadShelf(context.Background(), "backoff", func(reader stoabs.Reader) error {
 		data, err := reader.Get(stoabs.BytesKey(p.peerAddress))
+		if errors.Is(err, stoabs.ErrKeyNotFound) {
+			return nil
+		}
 		if err != nil {
 			return err
-		}
-		if data == nil {
-			return nil
 		}
 		return gob.NewDecoder(bytes.NewReader(data)).Decode(&result)
 	})

--- a/network/transport/v2/protocol_test.go
+++ b/network/transport/v2/protocol_test.go
@@ -293,7 +293,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 
 		assert.False(t, finished)
 		assert.False(t, errors.As(err, new(dag.EventFatal)))
-		assert.EqualError(t, err, fmt.Sprintf("unable to read payload (tx=%s): Database Error: random error", txOk.Ref().String()))
+		assert.EqualError(t, err, fmt.Sprintf("unable to read payload (tx=%s): database error: random error", txOk.Ref().String()))
 	})
 
 	t.Run("Finishes job when payload is already there", func(t *testing.T) {
@@ -337,7 +337,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 
 		assert.False(t, finished)
 		assert.False(t, errors.As(err, new(dag.EventFatal)))
-		assert.EqualError(t, err, fmt.Sprintf("failed to decrypt PAL header (tx=%s): Database Error: random error", txOk.Ref()))
+		assert.EqualError(t, err, fmt.Sprintf("failed to decrypt PAL header (tx=%s): database error: random error", txOk.Ref()))
 	})
 
 	t.Run("errors when decryption fails because the key-agreement key could not be found", func(t *testing.T) {

--- a/storage/bbolt_test.go
+++ b/storage/bbolt_test.go
@@ -71,8 +71,9 @@ func Test_bboltDatabase_performBackup(t *testing.T) {
 		// Read value and compare
 		var actualValue []byte
 		err = store.ReadShelf(ctx, "data", func(reader stoabs.Reader) error {
-			actualValue, _ = reader.Get(key)
-			return nil
+			var err error
+			actualValue, err = reader.Get(key)
+			return err
 		})
 		require.NoError(t, err)
 		assert.Equal(t, value, actualValue)
@@ -102,11 +103,12 @@ func Test_bboltDatabase_performBackup(t *testing.T) {
 
 		// Read value and compare
 		var actualValue []byte
-		err := store.ReadShelf(ctx, "data", func(reader stoabs.Reader) error {
-			actualValue, _ = reader.Get(key)
-			return nil
+		txErr := store.ReadShelf(ctx, "data", func(reader stoabs.Reader) error {
+			var err error
+			actualValue, err = reader.Get(key)
+			return err
 		})
-		require.NoError(t, err)
+		require.NoError(t, txErr)
 		assert.Equal(t, newValue, actualValue)
 	})
 }

--- a/storage/redis_test.go
+++ b/storage/redis_test.go
@@ -210,7 +210,7 @@ func Test_redisDatabase_createStore(t *testing.T) {
 			redis7.PingAttemptBackoff = 0
 			_, err = db.createStore("unit", "test")
 			// We don't have Sentinel support in Miniredis, but we can check that the client attempted to connect using Sentinel
-			assert.EqualError(t, err, "unable to connect to Redis database: Database Error: redis: all sentinels specified in configuration are unreachable")
+			assert.EqualError(t, err, "unable to connect to Redis database: database error: redis: all sentinels specified in configuration are unreachable")
 		})
 	})
 }

--- a/vdr/store/store.go
+++ b/vdr/store/store.go
@@ -136,7 +136,8 @@ func (s *store) Update(id did.DID, current hash.SHA256Hash, next did.Document, m
 
 		latestBytes, err := metadataWriter.Get(stoabs.BytesKey(latestRef))
 		if errors.Is(err, stoabs.ErrKeyNotFound) {
-			return vdr.ErrNotFound // TODO: is this correct? existence of a latestRef ~10 lines up means that this error cannot occur
+			// Existence of a latestRef means that this error should never occur. Could indicate corrupted DB.
+			err = fmt.Errorf("latest document metadata missing for %s (metadataShelfRef=%s)", didString, latestRef)
 		}
 		if err != nil {
 			return err


### PR DESCRIPTION
Implements changes in https://github.com/nuts-foundation/go-stoabs/pull/41

Prevents some potential nil dereferencing in cases where `data, err := staobs.Reader.Get()` returns double nil