### PR TITLE
Test: fix timing issue in test

### DIFF
--- a/network/transport/v2/gossip/queue_test.go
+++ b/network/transport/v2/gossip/queue_test.go
@@ -76,7 +76,7 @@ func TestQueue_do(t *testing.T) {
 	assert.False(t, done2.Load())
 	wg.Done()
 	test.WaitFor(t, func() (bool, error) {
-		return done1.Load(), nil
+		return done1.Load() && done2.Load(), nil
 	}, 50*time.Millisecond, "timeout while waiting for mutexes")
 	assert.True(t, done1.Load())
 	assert.True(t, done2.Load())


### PR DESCRIPTION
CI sometimes fails because done2's value is evaluated before the toggling goroutine is scheduled