### PR TITLE
Improve consistancy of NutsComm Endpoint validation

### DIFF
--- a/auth/services/oauth/oauth.go
+++ b/auth/services/oauth/oauth.go
@@ -458,7 +458,7 @@ func (s *service) validateAuthorizationCredentials(context *validationContext) e
 			return fmt.Errorf("issuer %s of authorization credential with ID: %s does not match jwt.sub: %s", authCred.Issuer.String(), authCred.ID.String(), sub)
 		}
 
-		//The credential credentialSubject.id equals the iss field of the JWT.
+		// The credential credentialSubject.id equals the iss field of the JWT.
 		authCredSubjects := make([]credential.NutsAuthorizationCredentialSubject, 0)
 		if err := authCred.UnmarshalCredentialSubject(&authCredSubjects); err != nil {
 			return fmt.Errorf(errInvalidVCClaim, err)

--- a/didman/types.go
+++ b/didman/types.go
@@ -21,10 +21,9 @@ package didman
 
 import (
 	"context"
-	"net/url"
-
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
+	"net/url"
 )
 
 // ContactInformationServiceType contains the DID service type used for services that contain node contact information.

--- a/network/network.go
+++ b/network/network.go
@@ -416,7 +416,7 @@ func (n *Network) validateNodeDID(nodeDID did.DID) error {
 		return errors.New("missing TLS certificate")
 	}
 	if err = n.certificate.Leaf.VerifyHostname(nutsCommURL.Hostname()); err != nil {
-		return fmt.Errorf("none of the DNS names in TLS certificate match the %s service endpoint (nodeDID=%s, %s=%s)", transport.NutsCommServiceType, nodeDID, transport.NutsCommServiceType, nutsCommURL)
+		return fmt.Errorf("none of the DNS names in TLS certificate match the %s service endpoint (nodeDID=%s, %s=%s)", transport.NutsCommServiceType, nodeDID, transport.NutsCommServiceType, nutsCommURL.String())
 	}
 
 	return nil

--- a/network/network.go
+++ b/network/network.go
@@ -375,7 +375,7 @@ func (n *Network) connectToKnownNodes(nodeDID did.DID) error {
 					WithField(core.LogFieldDID, node.ID.String()).
 					WithField(core.LogFieldNodeAddress, nutsCommUrl).
 					Info("Discovered Nuts node")
-				n.connectionManager.Connect(nutsCommUrl.URL().Host)
+				n.connectionManager.Connect(nutsCommUrl.Hostname())
 			}
 		}
 	}
@@ -415,7 +415,7 @@ func (n *Network) validateNodeDID(nodeDID did.DID) error {
 	if n.certificate.Leaf == nil { // n.config.DisableNodeAuthentication is for incoming connections.
 		return errors.New("missing TLS certificate")
 	}
-	if err = n.certificate.Leaf.VerifyHostname(nutsCommURL.URL().Hostname()); err != nil {
+	if err = n.certificate.Leaf.VerifyHostname(nutsCommURL.Hostname()); err != nil {
 		return fmt.Errorf("none of the DNS names in TLS certificate match the %s service endpoint (nodeDID=%s, %s=%s)", transport.NutsCommServiceType, nodeDID, transport.NutsCommServiceType, nutsCommURL)
 	}
 

--- a/network/network.go
+++ b/network/network.go
@@ -375,7 +375,7 @@ func (n *Network) connectToKnownNodes(nodeDID did.DID) error {
 					WithField(core.LogFieldDID, node.ID.String()).
 					WithField(core.LogFieldNodeAddress, nutsCommUrl).
 					Info("Discovered Nuts node")
-				n.connectionManager.Connect(nutsCommUrl.Hostname())
+				n.connectionManager.Connect(nutsCommUrl.Host)
 			}
 		}
 	}

--- a/network/network.go
+++ b/network/network.go
@@ -363,28 +363,19 @@ func (n *Network) connectToKnownNodes(nodeDID did.DID) error {
 	inner:
 		for _, service := range node.Service {
 			if service.Type == transport.NutsCommServiceType {
-				var nutsCommStr string
-				if err = service.UnmarshalServiceEndpoint(&nutsCommStr); err != nil {
+				var nutsCommUrl transport.NutsCommURL
+				if err = service.UnmarshalServiceEndpoint(&nutsCommUrl); err != nil {
 					log.Logger().
 						WithError(err).
 						WithField(core.LogFieldDID, node.ID.String()).
 						Warn("Failed to extract NutsComm address from service")
 					continue inner
 				}
-				address, err := transport.ParseNutsCommAddress(nutsCommStr)
-				if err != nil {
-					log.Logger().
-						WithError(err).
-						WithField(core.LogFieldDID, node.ID.String()).
-						WithField(core.LogFieldNodeAddress, nutsCommStr).
-						Warn("Invalid NutsComm address in service")
-					continue inner
-				}
 				log.Logger().
 					WithField(core.LogFieldDID, node.ID.String()).
-					WithField(core.LogFieldNodeAddress, address.String()).
+					WithField(core.LogFieldNodeAddress, nutsCommUrl).
 					Info("Discovered Nuts node")
-				n.connectionManager.Connect(address.Host)
+				n.connectionManager.Connect(nutsCommUrl.URL().Host)
 			}
 		}
 	}
@@ -415,12 +406,8 @@ func (n *Network) validateNodeDID(nodeDID did.DID) error {
 	if err != nil {
 		return fmt.Errorf("unable to resolve %s service endpoint, register it on the DID document (did=%s): %v", transport.NutsCommServiceType, nodeDID, err)
 	}
-	var nutsCommURLStr string
-	if err = nutsCommService.UnmarshalServiceEndpoint(&nutsCommURLStr); err != nil {
-		return fmt.Errorf("invalid %s service endpoint: %w", transport.NutsCommServiceType, err)
-	}
-	nutsCommURL, err := transport.ParseNutsCommAddress(nutsCommURLStr)
-	if err != nil {
+	var nutsCommURL transport.NutsCommURL
+	if err = nutsCommService.UnmarshalServiceEndpoint(&nutsCommURL); err != nil {
 		return fmt.Errorf("invalid %s service endpoint: %w", transport.NutsCommServiceType, err)
 	}
 
@@ -428,8 +415,8 @@ func (n *Network) validateNodeDID(nodeDID did.DID) error {
 	if n.certificate.Leaf == nil { // n.config.DisableNodeAuthentication is for incoming connections.
 		return errors.New("missing TLS certificate")
 	}
-	if err = n.certificate.Leaf.VerifyHostname(nutsCommURL.Hostname()); err != nil {
-		return fmt.Errorf("none of the DNS names in TLS certificate match the %s service endpoint (nodeDID=%s, %s=%s)", transport.NutsCommServiceType, nodeDID, transport.NutsCommServiceType, nutsCommURL.String())
+	if err = n.certificate.Leaf.VerifyHostname(nutsCommURL.URL().Hostname()); err != nil {
+		return fmt.Errorf("none of the DNS names in TLS certificate match the %s service endpoint (nodeDID=%s, %s=%s)", transport.NutsCommServiceType, nodeDID, transport.NutsCommServiceType, nutsCommURL)
 	}
 
 	return nil

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -661,7 +661,7 @@ func TestNetwork_Start(t *testing.T) {
 
 			err := cxt.network.Start()
 
-			assert.EqualError(t, err, "invalid NodeDID configuration: invalid NutsComm service endpoint: json: cannot unmarshal object into Go value of type string")
+			assert.EqualError(t, err, "invalid NodeDID configuration: invalid NutsComm service endpoint: endpoint not a string")
 		})
 		t.Run("error - cannot parse NutsComm service", func(t *testing.T) {
 			old := completeDocument.Service[0].ServiceEndpoint

--- a/network/transport/types.go
+++ b/network/transport/types.go
@@ -156,7 +156,9 @@ var reservedAddresses = []string{
 
 // NutsCommURL is the type which can be used to store a NutsComm endpoint in a DID Document.
 // It contains the checks to validate if the endpoint is valid.
-type NutsCommURL string
+type NutsCommURL struct {
+	url.URL
+}
 
 func (s *NutsCommURL) UnmarshalJSON(bytes []byte) error {
 	var str string
@@ -167,12 +169,6 @@ func (s *NutsCommURL) UnmarshalJSON(bytes []byte) error {
 	if err != nil {
 		return err
 	}
-	*s = NutsCommURL(endpoint.String())
+	*s = NutsCommURL{*endpoint}
 	return nil
-}
-
-func (s *NutsCommURL) URL() *url.URL {
-	// should never fail since it's already validated
-	url, _ := url.Parse(string(*s))
-	return url
 }

--- a/network/transport/types.go
+++ b/network/transport/types.go
@@ -19,6 +19,7 @@
 package transport
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -101,13 +102,13 @@ const NutsCommServiceType = "NutsComm"
 // The input must include the protocol scheme (e.g. grpc://).
 // The address must NOT be an IP address.
 // The input must not be a reserved address or TLD as described in RFC2606 or https://www.ietf.org/archive/id/draft-chapin-rfc2606bis-00.html.
-func ParseNutsCommAddress(input string) (*url.URL, error) {
+func parseNutsCommAddress(input string) (*url.URL, error) {
 	parsed, err := url.Parse(input)
 	if err != nil {
 		return nil, err
 	}
 	if parsed.Scheme != "grpc" {
-		return nil, errors.New("invalid URL scheme")
+		return nil, errors.New("scheme must be grpc")
 	}
 	if net.ParseIP(parsed.Hostname()) != nil {
 		return nil, errors.New("hostname is IP")
@@ -151,4 +152,27 @@ var reservedAddresses = []string{
 	"example.com",
 	"example.net",
 	"example.org",
+}
+
+// NutsCommURL is the type which can be used to store a NutsComm endpoint in a DID Document.
+// It contains the checks to validate if the endpoint is valid.
+type NutsCommURL string
+
+func (s *NutsCommURL) UnmarshalJSON(bytes []byte) error {
+	var str string
+	if err := json.Unmarshal(bytes, &str); err != nil {
+		return errors.New("endpoint not a string")
+	}
+	endpoint, err := parseNutsCommAddress(str)
+	if err != nil {
+		return err
+	}
+	*s = NutsCommURL(endpoint.String())
+	return nil
+}
+
+func (s *NutsCommURL) URL() *url.URL {
+	// should never fail since it's already validated
+	url, _ := url.Parse(string(*s))
+	return url
 }

--- a/network/transport/types_test.go
+++ b/network/transport/types_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func Test_ParseAddress(t *testing.T) {
-	errScheme := errors.New("invalid URL scheme")
+	errScheme := errors.New("scheme must be grpc")
 	errIsIp := errors.New("hostname is IP")
 	errIsReserved := errors.New("hostname is reserved")
 
@@ -53,7 +53,7 @@ func Test_ParseAddress(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		addr, err := ParseNutsCommAddress(tc.input)
+		addr, err := parseNutsCommAddress(tc.input)
 		if tc.err == nil {
 			// valid test cases
 			assert.Equal(t, tc.output, addr.Host, "test case: %v", tc)

--- a/network/transport/types_test.go
+++ b/network/transport/types_test.go
@@ -78,3 +78,25 @@ func TestPeer_ToFields(t *testing.T) {
 	assert.Equal(t, "def", peer.ToFields()["peerAddr"])
 	assert.Equal(t, "did:abc:123", peer.ToFields()["peerDID"])
 }
+
+func TestNutsCommURL_UnmarshalJSON(t *testing.T) {
+	t.Run("ok - valid url", func(t *testing.T) {
+		var url NutsCommURL
+		err := url.UnmarshalJSON([]byte(`"grpc://foo.bar:5050"`))
+		assert.NoError(t, err)
+		assert.Equal(t, "foo.bar:5050", url.URL().Host)
+	})
+
+	t.Run("error - invalid url, missing grpc", func(t *testing.T) {
+		var url NutsCommURL
+		err := url.UnmarshalJSON([]byte(`"foo.bar:5050"`))
+		assert.EqualError(t, err, "scheme must be grpc")
+	})
+
+	t.Run("error - not a string", func(t *testing.T) {
+		var url NutsCommURL
+		err := url.UnmarshalJSON([]byte(`123`))
+		assert.EqualError(t, err, "endpoint not a string")
+
+	})
+}

--- a/network/transport/types_test.go
+++ b/network/transport/types_test.go
@@ -84,7 +84,7 @@ func TestNutsCommURL_UnmarshalJSON(t *testing.T) {
 		var url NutsCommURL
 		err := url.UnmarshalJSON([]byte(`"grpc://foo.bar:5050"`))
 		assert.NoError(t, err)
-		assert.Equal(t, "foo.bar:5050", url.URL().Host)
+		assert.Equal(t, "foo.bar:5050", url.Host)
 	})
 
 	t.Run("error - invalid url, missing grpc", func(t *testing.T) {

--- a/vcr/issuer/network_publisher.go
+++ b/vcr/issuer/network_publisher.go
@@ -144,6 +144,10 @@ func (p networkPublisher) resolveNutsCommServiceOwner(DID did.DID) (*did.DID, er
 	if err != nil {
 		return nil, fmt.Errorf("could not resolve NutsComm service owner: %w", err)
 	}
+	var nutsCommEndpoint transport.NutsCommURL
+	if err := service.UnmarshalServiceEndpoint(&nutsCommEndpoint); err != nil {
+		return nil, fmt.Errorf("could not resolve NutsComm service owner: %w", err)
+	}
 	serviceID := service.ID
 	serviceID.Fragment = ""
 	serviceID.Path = ""

--- a/vdr/validators.go
+++ b/vdr/validators.go
@@ -21,13 +21,13 @@ package vdr
 import (
 	"errors"
 	"fmt"
+	"github.com/nuts-foundation/nuts-node/network/transport"
 
 	"github.com/lestrrat-go/jwx/jwk"
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/vdr/didservice"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
-	"net/url"
 )
 
 // NetworkDocumentValidator creates a DID Document validator that checks for inconsistencies in the DID Document:
@@ -224,14 +224,9 @@ func serviceTypeValidation(service did.Service) error {
 
 func validateNutsCommEndpoint(service did.Service) error {
 	// RFC015 $3.2: NutsComm rules
-	var endpointStr string
-	if err := service.UnmarshalServiceEndpoint(&endpointStr); err != nil {
-		return errors.New("endpoint not a string")
-	}
-	if URL, err := url.Parse(endpointStr); err != nil {
+	var ncEndpoint transport.NutsCommURL
+	if err := service.UnmarshalServiceEndpoint(&ncEndpoint); err != nil {
 		return err
-	} else if URL.Scheme != "grpc" {
-		return errors.New("scheme must be grpc")
 	}
 	return nil
 }


### PR DESCRIPTION
This PR introduces a NutsCommURL type which is a string.
This type validates itself during unmarshalling. Makes everything a bit more consistent.