### PR TITLE
VDR: Strict OpenAPI interfaces

### DIFF
--- a/codegen/configs/vdr_v1.yaml
+++ b/codegen/configs/vdr_v1.yaml
@@ -3,35 +3,9 @@ generate:
   echo-server: true
   client: true
   models: true
+  strict-server: true
 output-options:
   skip-prune: true
-  user-templates:
-    echo/echo-register.tmpl: "// PATCH: This template file was taken from pkg/codegen/templates/echo/echo-register.tmpl\n\n//
-      This is a simple interface which specifies echo.Route addition functions which\n//
-      are present on both echo.Echo and echo.Group, since we want to allow using\n//
-      either of them for path registration\ntype EchoRouter interface {\n\tCONNECT(path
-      string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) *echo.Route\n    DELETE(path
-      string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) *echo.Route\n    GET(path
-      string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) *echo.Route\n    HEAD(path
-      string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) *echo.Route\n    OPTIONS(path
-      string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) *echo.Route\n    PATCH(path
-      string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) *echo.Route\n    POST(path
-      string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) *echo.Route\n    PUT(path
-      string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) *echo.Route\n    TRACE(path
-      string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) *echo.Route\n}\n\ntype
-      Preprocessor interface {\n    Preprocess(operationID string, context echo.Context)\n}\n\ntype
-      ErrorStatusCodeResolver interface {\n\tResolveStatusCode(err error) int\n}\n\n//
-      RegisterHandlers adds each server route to the EchoRouter.\nfunc RegisterHandlers(router
-      EchoRouter, si ServerInterface) {\n    RegisterHandlersWithBaseURL(router, si,
-      \"\")\n}\n\n// Registers handlers, and prepends BaseURL to the paths, so that
-      the paths\n// can be served under a prefix.\nfunc RegisterHandlersWithBaseURL(router
-      EchoRouter, si ServerInterface, baseURL string) {\n{{if .}}\n    wrapper :=
-      ServerInterfaceWrapper{\n        Handler: si,\n    }\n{{end}}\n// PATCH: This
-      alteration wraps the call to the implementation in a function that sets the
-      \"OperationId\" context parameter,\n// so it can be used in error reporting
-      middleware.\n{{range .}}router.{{.Method}}(baseURL + \"{{.Path | swaggerUriToEchoUri}}\",
-      func(context echo.Context) error {\n        si.(Preprocessor).Preprocess(\"{{.OperationId}}\",
-      context)\n        return wrapper.{{.OperationId}}(context)\n    })\n{{end}}\n}\n"
   exclude-schemas:
   - DIDDocument
   - DIDDocumentMetadata

--- a/docs/_static/vdr/v1.yaml
+++ b/docs/_static/vdr/v1.yaml
@@ -32,7 +32,7 @@ paths:
         "200":
           description: "New DID has been created successfully. Returns the DID document."
           content:
-            application/json+did-document:
+            application/json:
               schema:
                 $ref: '#/components/schemas/DIDDocument'
         default:
@@ -115,7 +115,7 @@ paths:
         "200":
           description: DID document has been updated.
           content:
-            application/json+did-document:
+            application/json:
               schema:
                 $ref: '#/components/schemas/DIDDocument'
         default:
@@ -194,7 +194,7 @@ paths:
         "200":
           description: "New verification method has been created and added successfully. Returns the DID document."
           content:
-            application/json+did-document:
+            application/json:
               schema:
                 $ref: '#/components/schemas/VerificationMethod'
         default:

--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -3,7 +3,15 @@
 Release notes
 #############
 
-What has been changed, and how to update between versions.
+*************************
+(To be released)
+*************************
+
+Release date: ?
+
+- Some VDR OpenAPI operations specified ``application/json+did-document`` as Content-Type, while they actually returned ``application/json``.
+  This inconsistency is fixed by changing the OpenAPI specification to ``application/json``.
+
 
 *************************
 Hazelnut release (v5.1.0)

--- a/vdr/api/v1/api.go
+++ b/vdr/api/v1/api.go
@@ -20,8 +20,9 @@
 package v1
 
 import (
+	"context"
 	"fmt"
-	httpModule "github.com/nuts-foundation/nuts-node/http"
+	"github.com/nuts-foundation/nuts-node/audit"
 	"github.com/nuts-foundation/nuts-node/vdr"
 	"net/http"
 	"time"
@@ -35,7 +36,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 )
 
-var _ ServerInterface = (*Wrapper)(nil)
+var _ StrictServerInterface = (*Wrapper)(nil)
 var _ core.ErrorStatusCodeResolver = (*Wrapper)(nil)
 
 // Wrapper is needed to connect the implementation to the echo ServiceWrapper
@@ -58,100 +59,104 @@ func (a *Wrapper) ResolveStatusCode(err error) int {
 	})
 }
 
-// Preprocess is called just before the API operation itself is invoked.
-func (a *Wrapper) Preprocess(operationID string, context echo.Context) {
-	httpModule.Preprocess(context, a, vdr.ModuleName, operationID)
-}
-
 // DeleteVerificationMethod accepts a DID and a KeyIdentifier of a verificationMethod and calls the DocManipulator
 // to remove the verificationMethod from the given document.
-func (a *Wrapper) DeleteVerificationMethod(ctx echo.Context, didStr string, kidStr string) error {
-	id, err := did.ParseDID(didStr)
+func (a *Wrapper) DeleteVerificationMethod(ctx context.Context, request DeleteVerificationMethodRequestObject) (DeleteVerificationMethodResponseObject, error) {
+	id, err := did.ParseDID(request.Did)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	kid, err := did.ParseDIDURL(kidStr)
+	kid, err := did.ParseDIDURL(request.Kid)
 	if err != nil {
-		return core.InvalidInputError("given kid could not be parsed: %w", err)
+		return nil, core.InvalidInputError("given kid could not be parsed: %w", err)
 	}
 
-	err = a.DocManipulator.RemoveVerificationMethod(ctx.Request().Context(), *id, *kid)
+	err = a.DocManipulator.RemoveVerificationMethod(ctx, *id, *kid)
 	if err != nil {
-		return fmt.Errorf("could not remove verification method from document: %w", err)
+		return nil, fmt.Errorf("could not remove verification method from document: %w", err)
 	}
-	return ctx.NoContent(http.StatusNoContent)
+	return DeleteVerificationMethod204Response{}, nil
 }
 
 // AddNewVerificationMethod accepts a DID and adds a new VerificationMethod to that corresponding document.
-func (a *Wrapper) AddNewVerificationMethod(ctx echo.Context, id string) error {
-	d, err := did.ParseDID(id)
+func (a *Wrapper) AddNewVerificationMethod(ctx context.Context, request AddNewVerificationMethodRequestObject) (AddNewVerificationMethodResponseObject, error) {
+	d, err := did.ParseDID(request.Did)
 	if err != nil {
-		return err
-	}
-	req := AddNewVerificationMethodJSONRequestBody{}
-	if err := ctx.Bind(&req); err != nil {
-		return err
+		return nil, err
 	}
 
-	vm, err := a.DocManipulator.AddVerificationMethod(ctx.Request().Context(), *d, req.ToFlags(vdrDoc.DefaultCreationOptions().KeyFlags))
-	if err != nil {
-		return err
+	opts := request.Body
+	if opts == nil {
+		opts = &VerificationMethodRelationship{}
 	}
-	return ctx.JSON(http.StatusOK, *vm)
+
+	vm, err := a.DocManipulator.AddVerificationMethod(ctx, *d, opts.ToFlags(vdrDoc.DefaultCreationOptions().KeyFlags))
+	if err != nil {
+		return nil, err
+	}
+	return AddNewVerificationMethod200JSONResponse(*vm), nil
 }
 
 func (a *Wrapper) Routes(router core.EchoRouter) {
-	RegisterHandlers(router, a)
+	RegisterHandlers(router, NewStrictHandler(a, []StrictMiddlewareFunc{
+		func(f StrictHandlerFunc, operationID string) StrictHandlerFunc {
+			return func(ctx echo.Context, request interface{}) (response interface{}, err error) {
+				ctx.Set(core.OperationIDContextKey, operationID)
+				ctx.Set(core.ModuleNameContextKey, vdr.ModuleName)
+				ctx.Set(core.StatusCodeResolverContextKey, a)
+				return f(ctx, request)
+			}
+		},
+		func(f StrictHandlerFunc, operationID string) StrictHandlerFunc {
+			return audit.StrictMiddleware(f, vdr.ModuleName, operationID)
+		},
+	}))
 }
 
 // CreateDID creates a new DID Document and returns it.
-func (a *Wrapper) CreateDID(ctx echo.Context) error {
-	req := DIDCreateRequest{}
-	if err := ctx.Bind(&req); err != nil {
-		return err
-	}
-
+func (a *Wrapper) CreateDID(ctx context.Context, request CreateDIDRequestObject) (CreateDIDResponseObject, error) {
 	options := vdrDoc.DefaultCreationOptions()
-	if req.Controllers != nil {
-		for _, c := range *req.Controllers {
+	if request.Body.Controllers != nil {
+		for _, c := range *request.Body.Controllers {
 			id, err := did.ParseDID(c)
 			if err != nil {
-				return core.InvalidInputError("controller entry (%s) could not be parsed: %w", c, err)
+				return nil, core.InvalidInputError("controller entry (%s) could not be parsed: %w", c, err)
 			}
 			options.Controllers = append(options.Controllers, *id)
 		}
 	}
-	options.KeyFlags = req.VerificationMethodRelationship.ToFlags(options.KeyFlags)
-	if req.SelfControl != nil {
-		options.SelfControl = *req.SelfControl
+	options.KeyFlags = request.Body.VerificationMethodRelationship.ToFlags(options.KeyFlags)
+	if request.Body.SelfControl != nil {
+		options.SelfControl = *request.Body.SelfControl
 	}
 
-	doc, _, err := a.VDR.Create(ctx.Request().Context(), options)
+	doc, _, err := a.VDR.Create(ctx, options)
 	// if this operation leads to an error, it may return a 500
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// this API returns a DIDDocument according to spec, so it may return the business object
-	return ctx.JSON(http.StatusOK, *doc)
+	return CreateDID200JSONResponse(*doc), nil
 }
 
 // GetDID returns a DID document and DID document metadata based on a DID.
-func (a *Wrapper) GetDID(ctx echo.Context, targetDID string, params GetDIDParams) error {
-	d, err := did.ParseDID(targetDID)
+func (a *Wrapper) GetDID(ctx context.Context, request GetDIDRequestObject) (GetDIDResponseObject, error) {
+	d, err := did.ParseDID(request.Did)
 	if err != nil {
-		return core.InvalidInputError("given did is not valid: %w", err)
+		return nil, core.InvalidInputError("given did is not valid: %w", err)
 	}
 	resolverMetadata := &types.ResolveMetadata{AllowDeactivated: true}
 
+	params := request.Params
 	if params.VersionId != nil {
 		if params.VersionTime != nil {
-			return core.InvalidInputError("versionId and versionTime are mutually exclusive")
+			return nil, core.InvalidInputError("versionId and versionTime are mutually exclusive")
 		}
 		versionHash, err := hash.ParseHex(*params.VersionId)
 		if err != nil {
-			return core.InvalidInputError("given hash is not valid: %w", err)
+			return nil, core.InvalidInputError("given hash is not valid: %w", err)
 		}
 		resolverMetadata.Hash = &versionHash
 	}
@@ -159,14 +164,14 @@ func (a *Wrapper) GetDID(ctx echo.Context, targetDID string, params GetDIDParams
 	if params.VersionTime != nil {
 		versionTime, err := time.Parse(time.RFC3339, *params.VersionTime)
 		if err != nil {
-			return core.InvalidInputError("versionTime has invalid format: %w", err)
+			return nil, core.InvalidInputError("versionTime has invalid format: %w", err)
 		}
 		resolverMetadata.ResolveTime = &versionTime
 	}
 
 	doc, meta, err := a.DocResolver.Resolve(*d, resolverMetadata)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	resolutionResult := DIDResolutionResult{
@@ -174,14 +179,14 @@ func (a *Wrapper) GetDID(ctx echo.Context, targetDID string, params GetDIDParams
 		DocumentMetadata: *meta,
 	}
 
-	return ctx.JSON(http.StatusOK, resolutionResult)
+	return GetDID200JSONResponse(resolutionResult), nil
 }
 
-func (a *Wrapper) ConflictedDIDs(ctx echo.Context) error {
+func (a *Wrapper) ConflictedDIDs(_ context.Context, _ ConflictedDIDsRequestObject) (ConflictedDIDsResponseObject, error) {
 	docs, metas, err := a.VDR.ConflictedDocuments()
 	if err != nil {
 		// 500 internal server error
-		return err
+		return nil, err
 	}
 
 	// []docs, []meta to [](doc, meta)
@@ -193,38 +198,33 @@ func (a *Wrapper) ConflictedDIDs(ctx echo.Context) error {
 		}
 	}
 
-	return ctx.JSON(http.StatusOK, returnValues)
+	return ConflictedDIDs200JSONResponse(returnValues), nil
 }
 
 // UpdateDID updates a DID Document given a DID and DID Document body. It returns the updated DID Document.
-func (a *Wrapper) UpdateDID(ctx echo.Context, targetDID string) error {
-	d, err := did.ParseDID(targetDID)
+func (a *Wrapper) UpdateDID(ctx context.Context, request UpdateDIDRequestObject) (UpdateDIDResponseObject, error) {
+	d, err := did.ParseDID(request.Did)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	req := DIDUpdateRequest{}
-	if err := ctx.Bind(&req); err != nil {
-		return err
-	}
-
-	err = a.VDR.Update(ctx.Request().Context(), *d, req.Document)
+	err = a.VDR.Update(ctx, *d, request.Body.Document)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return ctx.JSON(http.StatusOK, req.Document)
+	return UpdateDID200JSONResponse(request.Body.Document), nil
 }
 
 // DeactivateDID deactivates a DID Document given a DID.
 // It returns a 200 and an empty body if the deactivation was successful.
-func (a *Wrapper) DeactivateDID(ctx echo.Context, targetDID string) error {
-	id, err := did.ParseDID(targetDID)
+func (a *Wrapper) DeactivateDID(ctx context.Context, request DeactivateDIDRequestObject) (DeactivateDIDResponseObject, error) {
+	id, err := did.ParseDID(request.Did)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	err = a.DocManipulator.Deactivate(ctx.Request().Context(), *id)
+	err = a.DocManipulator.Deactivate(ctx, *id)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return ctx.NoContent(http.StatusOK)
+	return &DeactivateDID200Response{}, nil
 }

--- a/vdr/api/v1/types.go
+++ b/vdr/api/v1/types.go
@@ -26,6 +26,9 @@ type DIDDocument = did.Document
 // DIDDocumentMetadata is an alias
 type DIDDocumentMetadata = types.DocumentMetadata
 
+// VerificationMethod is an alias
+type VerificationMethod = did.VerificationMethod
+
 // DIDCreateRequest defines model for DIDCreateRequest.
 type DIDCreateRequest struct {
 	VerificationMethodRelationship


### PR DESCRIPTION
This also changes the response content-type of `application/json+did-document` to `application/json`. The code generator doesn't play nice with specialized JSON types (it will treat it as a binary/stream type), and I think the same will applies to other JSON unmarshallers as well (needing extra mapping for the content type). So why not make everyone's life easier and just return `application/json`. It's just JSON, after all.