### PR TITLE
change startup order for VDR and network

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -221,8 +221,8 @@ func CreateSystem(shutdownCallback context.CancelFunc) *core.System {
 	system.RegisterEngine(cryptoInstance)
 	// the order of the next 3 modules is fixed due to configure and start dependencies
 	system.RegisterEngine(credentialInstance)
-	system.RegisterEngine(networkInstance)
 	system.RegisterEngine(vdrInstance)
+	system.RegisterEngine(networkInstance)
 	system.RegisterEngine(authInstance)
 	system.RegisterEngine(didmanInstance)
 	// HTTP engine MUST be registered last, because when started it dispatches HTTP calls to the registered routes.

--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -12,6 +12,7 @@ Coconut update (v5.1.0)
 Release date: **DRAFT**
 
 - Default value of strictmode changed to true
+- Internal storage of VDR has changed. A migration will run at startup. If the node is stopped during this process, DID Documents will have to be reprocessed manually (restore functionality)
 
 **Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v5.0.0...v5.1.0
 

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -78,16 +78,20 @@ func NewAmbassador(networkClient network.Transactions, didStore didstore.Store, 
 	}
 }
 
-// Configure instructs the ambassador to start receiving DID Documents from the network.
 func (n *ambassador) Configure() error {
-	return n.networkClient.Subscribe("vdr", n.handleNetworkEvent,
+	return nil
+}
+
+func (n *ambassador) Start() error {
+	err := n.networkClient.Subscribe("vdr", n.handleNetworkEvent,
 		n.networkClient.WithPersistency(),
 		network.WithSelectionFilter(func(event dag.Event) bool {
 			return event.Type == dag.PayloadEventType && event.Transaction.PayloadType() == didDocumentType
 		}))
-}
+	if err != nil {
+		return err
+	}
 
-func (n *ambassador) Start() error {
 	stream := events.NewDisposableStream(
 		fmt.Sprintf("%s_%s", events.ReprocessStream, "VDR"),
 		[]string{fmt.Sprintf("%s.%s", events.ReprocessStream, didDocumentType)},

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/golang/mock/gomock"
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
-	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network"
@@ -244,18 +243,6 @@ func TestNewVDR(t *testing.T) {
 	vdr := NewVDR(cfg, nil, nil, nil, nil)
 	assert.IsType(t, &VDR{}, vdr)
 	assert.Equal(t, vdr.config, cfg)
-}
-
-func TestVDR_Configure(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	tx := network.NewMockTransactions(ctrl)
-	// Make sure configuring VDR subscribes to network
-	tx.EXPECT().WithPersistency()
-	tx.EXPECT().Subscribe("vdr", gomock.Any(), gomock.Any())
-	cfg := Config{}
-	vdr := NewVDR(cfg, nil, tx, nil, nil)
-	err := vdr.Configure(*core.NewServerConfig())
-	require.NoError(t, err)
 }
 
 func TestVDR_Migrate(t *testing.T) {


### PR DESCRIPTION
fixes #1823 

the network engine was started before the VDR engine. With the new DID store, the migration is run at startup which was too late for the network engine.

now the VDR engine starts before the network engine. VDR ambassador subscription on the network is now started in Start and not in Configure.