### PR TITLE
migrate irma auth config to current format

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -103,11 +103,11 @@ func (auth *Auth) OAuthClient() oauth.Client {
 
 // Configure the Auth struct by creating a validator and create an Irma server
 func (auth *Auth) Configure(config core.ServerConfig) error {
-	if auth.config.IrmaSchemeManager == "" {
+	if auth.config.Irma.SchemeManager == "" {
 		return errors.New("IRMA SchemeManager must be set")
 	}
 
-	if config.Strictmode && auth.config.IrmaSchemeManager != "pbdf" {
+	if config.Strictmode && auth.config.Irma.SchemeManager != "pbdf" {
 		return errors.New("in strictmode the only valid irma-scheme-manager is 'pbdf'")
 	}
 
@@ -119,8 +119,8 @@ func (auth *Auth) Configure(config core.ServerConfig) error {
 	auth.contractNotary = contract.NewNotary(contract.Config{
 		PublicURL:             auth.config.PublicURL,
 		IrmaConfigPath:        path.Join(config.Datadir, "irma"),
-		IrmaSchemeManager:     auth.config.IrmaSchemeManager,
-		AutoUpdateIrmaSchemas: auth.config.IrmaAutoUpdateSchemas,
+		IrmaSchemeManager:     auth.config.Irma.SchemeManager,
+		AutoUpdateIrmaSchemas: auth.config.Irma.AutoUpdateSchemas,
 		ContractValidators:    auth.config.ContractValidators,
 		ContractValidity:      contractValidity,
 		StrictMode:            config.Strictmode,

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -60,7 +60,7 @@ func TestAuth_Configure(t *testing.T) {
 
 	t.Run("error - no publicUrl", func(t *testing.T) {
 		authCfg := TestConfig()
-		authCfg.IrmaSchemeManager = "pbdf"
+		authCfg.Irma.SchemeManager = "pbdf"
 		i := testInstance(t, authCfg)
 		cfg := core.NewServerConfig()
 		cfg.Strictmode = true
@@ -69,7 +69,7 @@ func TestAuth_Configure(t *testing.T) {
 
 	t.Run("error - IRMA config failure", func(t *testing.T) {
 		authCfg := TestConfig()
-		authCfg.IrmaSchemeManager = "non-existing"
+		authCfg.Irma.SchemeManager = "non-existing"
 		i := testInstance(t, authCfg)
 		err := i.Configure(tlsServerConfig)
 		require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestAuth_Configure(t *testing.T) {
 
 	t.Run("error - IRMA scheme manager not set", func(t *testing.T) {
 		authCfg := TestConfig()
-		authCfg.IrmaSchemeManager = ""
+		authCfg.Irma.SchemeManager = ""
 		i := testInstance(t, authCfg)
 		err := i.Configure(tlsServerConfig)
 		assert.EqualError(t, err, "IRMA SchemeManager must be set")
@@ -85,7 +85,7 @@ func TestAuth_Configure(t *testing.T) {
 
 	t.Run("error - only 'pbdf' IRMA scheme manager allow in strict mode", func(t *testing.T) {
 		authCfg := TestConfig()
-		authCfg.IrmaSchemeManager = "demo"
+		authCfg.Irma.SchemeManager = "demo"
 		i := testInstance(t, authCfg)
 		serverConfig := core.NewServerConfig()
 		serverConfig.Strictmode = true

--- a/auth/cmd/cmd.go
+++ b/auth/cmd/cmd.go
@@ -46,9 +46,9 @@ func FlagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("auth", pflag.ContinueOnError)
 
 	defs := auth.DefaultConfig()
-	flags.String(ConfIrmaSchemeManager, defs.IrmaSchemeManager, "IRMA schemeManager to use for attributes. Can be either 'pbdf' or 'irma-demo'.")
+	flags.String(ConfIrmaSchemeManager, defs.Irma.SchemeManager, "IRMA schemeManager to use for attributes. Can be either 'pbdf' or 'irma-demo'.")
 	flags.String(ConfPublicURL, defs.PublicURL, "public URL which can be reached by a users IRMA client, this should include the scheme and domain: https://example.com. Additional paths should only be added if some sort of url-rewriting is done in a reverse-proxy.")
-	flags.Bool(ConfAutoUpdateIrmaSchemas, defs.IrmaAutoUpdateSchemas, "set if you want automatically update the IRMA schemas every 60 minutes.")
+	flags.Bool(ConfAutoUpdateIrmaSchemas, defs.Irma.AutoUpdateSchemas, "set if you want automatically update the IRMA schemas every 60 minutes.")
 	flags.Int(ConfHTTPTimeout, defs.HTTPTimeout, "HTTP timeout (in seconds) used by the Auth API HTTP client")
 	flags.Int(ConfClockSkew, defs.ClockSkew, "Allowed JWT Clock skew in milliseconds")
 	flags.StringSlice(ConfContractValidators, defs.ContractValidators, "sets the different contract validators to use")

--- a/auth/config.go
+++ b/auth/config.go
@@ -20,21 +20,27 @@ package auth
 
 // Config holds all the configuration params
 type Config struct {
-	IrmaSchemeManager     string   `koanf:"irma.schememanager"`
-	IrmaAutoUpdateSchemas bool     `koanf:"irma.autoupdateschemas"`
-	HTTPTimeout           int      `koanf:"http.timeout"`
-	PublicURL             string   `koanf:"publicurl"`
-	ClockSkew             int      `koanf:"clockskew"`
-	ContractValidators    []string `koanf:"contractvalidators"`
+	Irma               IrmaConfig `koanf:"irma"`
+	HTTPTimeout        int        `koanf:"http.timeout"`
+	PublicURL          string     `koanf:"publicurl"`
+	ClockSkew          int        `koanf:"clockskew"`
+	ContractValidators []string   `koanf:"contractvalidators"`
+}
+
+type IrmaConfig struct {
+	SchemeManager     string `koanf:"schememanager"`
+	AutoUpdateSchemas bool   `koanf:"autoupdateschemas"`
 }
 
 // DefaultConfig returns an instance of Config with the default values.
 func DefaultConfig() Config {
 	return Config{
-		IrmaSchemeManager:     "pbdf",
-		IrmaAutoUpdateSchemas: true,
-		HTTPTimeout:           30,
-		ClockSkew:             5000,
-		ContractValidators:    []string{"irma", "uzi", "dummy"},
+		Irma: IrmaConfig{
+			SchemeManager:     "pbdf",
+			AutoUpdateSchemas: true,
+		},
+		HTTPTimeout:        30,
+		ClockSkew:          5000,
+		ContractValidators: []string{"irma", "uzi", "dummy"},
 	}
 }


### PR DESCRIPTION
fixes #1845

config was always set to default 