### PR TITLE
Network: add authenticated plag to peer

### DIFF
--- a/core/logging.go
+++ b/core/logging.go
@@ -70,8 +70,10 @@ const (
 	LogFieldPeerID = "peerID"
 	// LogFieldPeerAddr is the log field key for peer addresses from the network module.
 	LogFieldPeerAddr = "peerAddr"
-	// LogFieldPeerNodeDID is the log field key for a peer's authenticated node DID from the network module.
+	// LogFieldPeerNodeDID is the log field key for a peer's node DID from the network module.
 	LogFieldPeerNodeDID = "peerDID"
+	// LogFieldPeerAuthenticated is the log field key for that indicates if the peer's node DID is authenticated.
+	LogFieldPeerAuthenticated = "peerAuthenticated"
 	// LogFieldTransactionRef is the log field key for a transaction reference from the network module.
 	LogFieldTransactionRef = "txRef"
 	// LogFieldTransactionType is the log field key for the payload type, of a transaction from the network module.

--- a/network/network.go
+++ b/network/network.go
@@ -231,7 +231,7 @@ func (n *Network) Configure(config core.ServerConfig) error {
 			if config.Strictmode {
 				return errors.New("disabling node DID in strict mode is not allowed")
 			}
-			authenticator = grpc.NewDummyAuthenticator(didservice.NewServiceResolver(n.didDocumentResolver))
+			authenticator = grpc.NewDummyAuthenticator(nil)
 		} else {
 			authenticator = grpc.NewTLSAuthenticator(didservice.NewServiceResolver(n.didDocumentResolver))
 		}

--- a/network/transport/grpc/authenticator_test.go
+++ b/network/transport/grpc/authenticator_test.go
@@ -51,6 +51,10 @@ func Test_tlsAuthenticator_Authenticate(t *testing.T) {
 
 	nodeDID := *nodeDID
 	query := ssi.MustParseURI(nodeDID.String() + "/serviceEndpoint?type=NutsComm")
+	expectedPeer := transport.Peer{
+		NodeDID:       nodeDID,
+		Authenticated: true,
+	}
 
 	t.Run("ok", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -61,7 +65,7 @@ func Test_tlsAuthenticator_Authenticate(t *testing.T) {
 		authenticatedPeer, err := authenticator.Authenticate(nodeDID, grpcPeer, transport.Peer{})
 
 		require.NoError(t, err)
-		assert.Equal(t, authenticatedPeer.NodeDID, nodeDID)
+		assert.Equal(t, expectedPeer, authenticatedPeer)
 	})
 	t.Run("ok - case insensitive comparison", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -72,7 +76,7 @@ func Test_tlsAuthenticator_Authenticate(t *testing.T) {
 		authenticatedPeer, err := authenticator.Authenticate(nodeDID, grpcPeer, transport.Peer{})
 
 		require.NoError(t, err)
-		assert.Equal(t, authenticatedPeer.NodeDID, nodeDID)
+		assert.Equal(t, expectedPeer, authenticatedPeer)
 	})
 	t.Run("ok - wildcard comparison", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -90,7 +94,7 @@ func Test_tlsAuthenticator_Authenticate(t *testing.T) {
 		authenticatedPeer, err := authenticator.Authenticate(nodeDID, grpcPeer, transport.Peer{})
 
 		require.NoError(t, err)
-		assert.Equal(t, authenticatedPeer.NodeDID, nodeDID)
+		assert.Equal(t, expectedPeer, authenticatedPeer)
 	})
 	t.Run("without acceptUnauthenticated", func(t *testing.T) {
 		transportPeer := transport.Peer{}
@@ -126,6 +130,7 @@ func Test_tlsAuthenticator_Authenticate(t *testing.T) {
 		transportPeer := transport.Peer{AcceptUnauthenticated: true}
 		expectedPeer := transport.Peer{
 			AcceptUnauthenticated: true,
+			Authenticated:         false,
 			NodeDID:               nodeDID,
 		}
 		t.Run("ok", func(t *testing.T) {
@@ -177,5 +182,7 @@ func TestDummyAuthenticator_Authenticate(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, *nodeDID, peer.NodeDID)
+		assert.True(t, peer.Authenticated)
+		assert.True(t, peer.AcceptUnauthenticated)
 	})
 }

--- a/network/transport/grpc/connection.go
+++ b/network/transport/grpc/connection.go
@@ -155,6 +155,7 @@ func (mc *conn) disconnect() {
 	peer := mc.Peer()
 	peer.ID = ""
 	peer.NodeDID = did.DID{}
+	peer.Authenticated = false
 	mc.setPeer(peer)
 }
 

--- a/network/transport/grpc/connection_mock.go
+++ b/network/transport/grpc/connection_mock.go
@@ -50,6 +50,20 @@ func (mr *MockConnectionMockRecorder) CloseError() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseError", reflect.TypeOf((*MockConnection)(nil).CloseError))
 }
 
+// IsAuthenticated mocks base method.
+func (m *MockConnection) IsAuthenticated() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsAuthenticated")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsAuthenticated indicates an expected call of IsAuthenticated.
+func (mr *MockConnectionMockRecorder) IsAuthenticated() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAuthenticated", reflect.TypeOf((*MockConnection)(nil).IsAuthenticated))
+}
+
 // IsConnected mocks base method.
 func (m *MockConnection) IsConnected() bool {
 	m.ctrl.T.Helper()

--- a/network/transport/grpc/predicate.go
+++ b/network/transport/grpc/predicate.go
@@ -71,3 +71,14 @@ func (predicate nodeDIDPredicate) Match(conn Connection) bool {
 func ByNodeDID(nodeDID did.DID) Predicate {
 	return nodeDIDPredicate{nodeDID: nodeDID}
 }
+
+type authenticatedPredicated struct {
+}
+
+func (predicate authenticatedPredicated) Match(conn Connection) bool {
+	return conn.IsAuthenticated()
+}
+
+func ByAuthenticated() Predicate {
+	return authenticatedPredicated{}
+}

--- a/network/transport/grpc/predicate_test.go
+++ b/network/transport/grpc/predicate_test.go
@@ -47,3 +47,8 @@ func TestByNotConnected(t *testing.T) {
 	assert.True(t, ByNotConnected().Match(&StubConnection{}))
 	assert.False(t, ByNotConnected().Match(&StubConnection{Open: true}))
 }
+
+func TestByAuthenticated(t *testing.T) {
+	assert.True(t, ByAuthenticated().Match(&StubConnection{Authenticated: true}))
+	assert.False(t, ByAuthenticated().Match(&StubConnection{}))
+}

--- a/network/transport/grpc/test.go
+++ b/network/transport/grpc/test.go
@@ -60,10 +60,11 @@ func (s StubConnectionList) AllMatching(_ ...Predicate) []Connection {
 
 // StubConnection is a stub implementation of the Connection interface
 type StubConnection struct {
-	Open     bool
-	NodeDID  did.DID
-	SentMsgs []interface{}
-	PeerID   transport.PeerID
+	Open          bool
+	NodeDID       did.DID
+	SentMsgs      []interface{}
+	PeerID        transport.PeerID
+	Authenticated bool
 }
 
 // Send sends a message to the connection
@@ -76,8 +77,9 @@ func (s *StubConnection) Send(_ Protocol, envelope interface{}, _ bool) error {
 // Peer returns the peer information of the connection
 func (s *StubConnection) Peer() transport.Peer {
 	return transport.Peer{
-		ID:      s.PeerID,
-		NodeDID: s.NodeDID,
+		ID:            s.PeerID,
+		NodeDID:       s.NodeDID,
+		Authenticated: s.Authenticated,
 	}
 }
 
@@ -89,6 +91,11 @@ func (s *StubConnection) IsConnected() bool {
 // IsProtocolConnected returns true if the connection is connected for the given protocol
 func (s *StubConnection) IsProtocolConnected(_ Protocol) bool {
 	return s.Open
+}
+
+// IsAuthenticated returns whether teh given connection is authenticated.
+func (s *StubConnection) IsAuthenticated() bool {
+	return s.Authenticated
 }
 
 func (s *StubConnection) CloseError() *status.Status {
@@ -115,7 +122,7 @@ func (s *StubConnection) stopConnecting() {
 	panic("implement me")
 }
 
-func (s *StubConnection) registerStream(_ Protocol, _ Stream) bool {
+func (s *StubConnection) registerStream(protocol Protocol, stream Stream) bool {
 	panic("implement me")
 }
 

--- a/network/transport/types.go
+++ b/network/transport/types.go
@@ -42,13 +42,16 @@ func (p PeerID) String() string {
 
 // Peer holds the properties of a remote node we're connected to
 type Peer struct {
-	// ID holds the unique identificator of the peer
+	// ID holds the unique identifier of the peer
 	ID PeerID
 	// Address holds the remote address of the node we're actually connected to
 	Address string
 	// NodeDID holds the DID that the peer uses to identify its node on the network.
-	// It is only set when properly authenticated.
+	// If Authenticated is true the NodeDID is verified.
+	// TODO: the statement above is incorrect when network.disablenodeauthentication == true
 	NodeDID did.DID
+	// Authenticated is true when NodeDID is set and authentication is successful.
+	Authenticated bool
 	// AcceptUnauthenticated indicates if a connection may be made with this Peer even if the NodeDID could not be authenticated.
 	AcceptUnauthenticated bool
 }
@@ -56,9 +59,10 @@ type Peer struct {
 // ToFields returns the peer as a map of fields, to be used when logging the peer details.
 func (p Peer) ToFields() logrus.Fields {
 	return map[string]interface{}{
-		core.LogFieldPeerID:      p.ID.String(),
-		core.LogFieldPeerAddr:    p.Address,
-		core.LogFieldPeerNodeDID: p.NodeDID.String(),
+		core.LogFieldPeerID:            p.ID.String(),
+		core.LogFieldPeerAddr:          p.Address,
+		core.LogFieldPeerNodeDID:       p.NodeDID.String(),
+		core.LogFieldPeerAuthenticated: p.Authenticated,
 	}
 }
 

--- a/network/transport/types_test.go
+++ b/network/transport/types_test.go
@@ -20,6 +20,7 @@ package transport
 
 import (
 	"errors"
+	"github.com/nuts-foundation/nuts-node/core"
 	"testing"
 
 	"github.com/nuts-foundation/go-did/did"
@@ -67,16 +68,18 @@ func Test_ParseAddress(t *testing.T) {
 }
 
 func TestPeer_ToFields(t *testing.T) {
-	peer := Peer{
-		ID:      "abc",
-		Address: "def",
-		NodeDID: did.MustParseDID("did:abc:123"),
-	}
+	peerLogFields := Peer{
+		ID:            "abc",
+		Address:       "def",
+		NodeDID:       did.MustParseDID("did:abc:123"),
+		Authenticated: true,
+	}.ToFields()
 
-	assert.Len(t, peer.ToFields(), 3)
-	assert.Equal(t, "abc", peer.ToFields()["peerID"])
-	assert.Equal(t, "def", peer.ToFields()["peerAddr"])
-	assert.Equal(t, "did:abc:123", peer.ToFields()["peerDID"])
+	assert.Len(t, peerLogFields, 4)
+	assert.Equal(t, "abc", peerLogFields[core.LogFieldPeerID])
+	assert.Equal(t, "def", peerLogFields[core.LogFieldPeerAddr])
+	assert.Equal(t, "did:abc:123", peerLogFields[core.LogFieldPeerNodeDID])
+	assert.True(t, peerLogFields[core.LogFieldPeerAuthenticated].(bool))
 }
 
 func TestNutsCommURL_UnmarshalJSON(t *testing.T) {

--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -145,7 +145,7 @@ func (p *protocol) handleTransactionPayloadQuery(peer transport.Peer, envelope *
 	}
 	if len(tx.PAL()) > 0 {
 		// Private TX, verify connection
-		if peer.NodeDID.Empty() {
+		if !peer.Authenticated {
 			// Connection isn't authenticated
 			log.Logger().
 				WithFields(peer.ToFields()).

--- a/network/transport/v2/handlers_test.go
+++ b/network/transport/v2/handlers_test.go
@@ -37,17 +37,20 @@ import (
 )
 
 var (
-	peer = transport.Peer{
-		ID:      "abc",
-		Address: "abc:5555",
+	peerDID, _      = did.ParseDID("did:nuts:peer")
+	otherPeerDID, _ = did.ParseDID("did:nuts:other-peer")
+	nodeDID, _      = did.ParseDID("did:nuts:node")
+	peer            = transport.Peer{
+		ID:            "abc",
+		Address:       "abc:5555",
+		NodeDID:       *peerDID,
+		Authenticated: false,
 	}
-	peerDID, _        = did.ParseDID("did:nuts:peer")
-	otherPeerDID, _   = did.ParseDID("did:nuts:other-peer")
-	nodeDID, _        = did.ParseDID("did:nuts:node")
 	authenticatedPeer = transport.Peer{
-		ID:      "abc",
-		Address: "abc:5555",
-		NodeDID: *peerDID,
+		ID:            "abc",
+		Address:       "abc:5555",
+		NodeDID:       *peerDID,
+		Authenticated: true,
 	}
 )
 

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -272,7 +272,7 @@ func (p *protocol) handlePrivateTxRetry(event dag.Event) (bool, error) {
 	// Broadcast query to all TX participants we've got a connection to
 	sent := false
 	for _, curr := range pal {
-		conn := p.connectionList.Get(grpc.ByConnected(), grpc.ByNodeDID(curr))
+		conn := p.connectionList.Get(grpc.ByConnected(), grpc.ByNodeDID(curr), grpc.ByAuthenticated())
 		if conn != nil {
 			err = conn.Send(p, &Envelope{Message: &Envelope_TransactionPayloadQuery{
 				TransactionPayloadQuery: &TransactionPayloadQuery{
@@ -293,7 +293,7 @@ func (p *protocol) handlePrivateTxRetry(event dag.Event) (bool, error) {
 	}
 
 	if !sent {
-		return false, fmt.Errorf("no connection to any of the participants (tx=%s, PAL=%v)", event.Hash.String(), pal)
+		return false, fmt.Errorf("no authenticated connection to any of the participants (tx=%s, PAL=%v)", event.Hash.String(), pal)
 	}
 
 	return false, nil

--- a/network/transport/v2/protocol_test.go
+++ b/network/transport/v2/protocol_test.go
@@ -368,14 +368,14 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 		}, nil, nil)
 		mocks.Decrypter.EXPECT().Decrypt(keyDID.String(), []byte{1}).Return([]byte(peerDID.String()), nil)
 		connectionList := grpc.NewMockConnectionList(mocks.Controller)
-		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*peerDID)).Return(nil)
+		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*peerDID), grpc.ByAuthenticated()).Return(nil)
 		proto.connectionList = connectionList
 
 		finished, err := proto.handlePrivateTxRetry(event)
 
 		assert.False(t, finished)
 		assert.False(t, errors.As(err, new(dag.EventFatal)))
-		assert.EqualError(t, err, fmt.Sprintf("no connection to any of the participants (tx=%s, PAL=[did:nuts:peer])", txOk.Ref().String()))
+		assert.EqualError(t, err, fmt.Sprintf("no authenticated connection to any of the participants (tx=%s, PAL=[did:nuts:peer])", txOk.Ref().String()))
 	})
 
 	t.Run("valid transaction fails when sending the payload query errors", func(t *testing.T) {
@@ -395,14 +395,14 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 			},
 		}}, false).Return(errors.New("random error"))
 		connectionList := grpc.NewMockConnectionList(mocks.Controller)
-		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*peerDID)).Return(conn)
+		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*peerDID), grpc.ByAuthenticated()).Return(conn)
 		proto.connectionList = connectionList
 
 		finished, err := proto.handlePrivateTxRetry(event)
 
 		assert.False(t, finished)
 		assert.False(t, errors.As(err, new(dag.EventFatal)))
-		assert.EqualError(t, err, fmt.Sprintf("no connection to any of the participants (tx=%s, PAL=[did:nuts:peer])", txOk.Ref().String()))
+		assert.EqualError(t, err, fmt.Sprintf("no authenticated connection to any of the participants (tx=%s, PAL=[did:nuts:peer])", txOk.Ref().String()))
 	})
 
 	t.Run("valid transaction is handled successfully", func(t *testing.T) {
@@ -421,7 +421,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 			},
 		}}, false).Return(nil)
 		connectionList := grpc.NewMockConnectionList(mocks.Controller)
-		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*peerDID)).Return(conn)
+		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*peerDID), grpc.ByAuthenticated()).Return(conn)
 		proto.connectionList = connectionList
 
 		finished, err := proto.handlePrivateTxRetry(event)
@@ -464,9 +464,9 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 			},
 		}}, false).Return(nil)
 		connectionList := grpc.NewMockConnectionList(mocks.Controller)
-		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*nodeDID)).Return(nil)
-		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*peerDID)).Return(conn1)
-		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*otherPeerDID)).Return(conn2)
+		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*nodeDID), grpc.ByAuthenticated()).Return(nil)
+		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*peerDID), grpc.ByAuthenticated()).Return(conn1)
+		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*otherPeerDID), grpc.ByAuthenticated()).Return(conn2)
 		proto.connectionList = connectionList
 
 		finished, err := proto.handlePrivateTxRetry(event)


### PR DESCRIPTION
This adds Peer.Authenticated to signal if a stream is authenticated or not.
closes #1664, and is part of a ongoing refactor on the connection manager (peer is not the right place for this flag)

`/status/diagnostics` currently has a `acceptunauthenticated: true/false` should this be replaced with the actual `Authenticated` value?