### PR TITLE
Audit: log events on custom 'audit' log level

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -39,9 +39,11 @@ const (
 
 const auditLogLevel = "audit"
 
+// auditLoggerInstance is the logger for auditing. Do not use directly, call auditLogger() instead.
 var auditLoggerInstance *logrus.Logger
 var initAuditLoggerOnce = &sync.Once{}
 
+// auditLogger returns the initialized logger instance intended for audit logging.
 func auditLogger() *logrus.Logger {
 	initAuditLoggerOnce.Do(func() {
 		// Create new logger with custom Formatter, which makes sures the log level is always "audit".

--- a/audit/audit.go
+++ b/audit/audit.go
@@ -47,9 +47,13 @@ var initAuditLoggerOnce = &sync.Once{}
 func auditLogger() *logrus.Logger {
 	initAuditLoggerOnce.Do(func() {
 		// Create new logger with custom Formatter, which makes sures the log level is always "audit".
-		// Also override the level for this level, to make sure it is not influenced by a lower log verbosity.
+		// Also override the level for this logger, to make sure it is not influenced by a lower log verbosity.
+		auditFormatter, err := newAuditFormatter(logrus.StandardLogger().Formatter)
+		if err != nil {
+			panic(fmt.Sprintf("audit: failed to create audit logger: %v", err))
+		}
 		auditLoggerInstance = logrus.New()
-		auditLoggerInstance.SetFormatter(&auditFormatter{underlyingFormatter: logrus.StandardLogger().Formatter})
+		auditLoggerInstance.SetFormatter(auditFormatter)
 		auditLoggerInstance.SetLevel(logrus.InfoLevel)
 	})
 	return auditLoggerInstance
@@ -82,43 +86,58 @@ func InfoFromContext(ctx context.Context) *Info {
 	return nil
 }
 
-type auditFormatter struct {
-	underlyingFormatter logrus.Formatter
+func newAuditFormatter(formatter logrus.Formatter) (logrus.Formatter, error) {
+	switch f := formatter.(type) {
+	case *logrus.JSONFormatter:
+		return jsonAuditFormatter{formatter: f}, nil
+	case *logrus.TextFormatter:
+		return textAuditFormatter{formatter: f}, nil
+	default:
+		return nil, fmt.Errorf("audit: unsupported log formatter: %T", f)
+	}
 }
 
-func (a auditFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+type jsonAuditFormatter struct {
+	formatter *logrus.JSONFormatter
+}
+
+type textAuditFormatter struct {
+	formatter *logrus.TextFormatter
+}
+
+func (a textAuditFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	// Make log level predictable for easier replacement later
 	// (then level color for colored output is known beforehand, which is 36 for info)
 	// See sirupsen/logrus@v1.9.0/text_formatter.go:19
 	entry.Level = logrus.InfoLevel
 
-	formattedEntry, err := a.underlyingFormatter.Format(entry)
+	formattedEntry, err := a.formatter.Format(entry)
 	if err != nil {
 		return nil, err
 	}
-	// Replace log level in formatted log message
-	switch a.underlyingFormatter.(type) {
-	case *logrus.JSONFormatter:
-		var logAsJSON map[string]interface{}
-		err := json.Unmarshal(formattedEntry, &logAsJSON)
-		if err != nil {
-			return nil, fmt.Errorf("audit: failed to unmarshal log entry: %w", err)
-		}
-		logAsJSON["level"] = auditLogLevel
-		return json.Marshal(logAsJSON)
-	case *logrus.TextFormatter:
-		coloredPrefix := []byte("\x1b[36mINFO")
-		if bytes.HasPrefix(formattedEntry, coloredPrefix) {
-			// Colored output
-			coloredResult := append(formattedEntry[0:len(coloredPrefix)-4], []byte(strings.ToUpper(auditLogLevel))...)
-			coloredResult = append(coloredResult, formattedEntry[len(coloredPrefix)+4:]...)
-			return coloredResult, nil
-		}
-		// Non-colored output
-		return bytes.Replace(formattedEntry, []byte("level="+entry.Level.String()), []byte("level="+auditLogLevel), 1), nil
-	default:
-		return nil, fmt.Errorf("audit: unsupported log formatter: %T", a.underlyingFormatter)
+	coloredPrefix := []byte("\x1b[36mINFO")
+	if bytes.HasPrefix(formattedEntry, coloredPrefix) {
+		// Colored output
+		coloredResult := append(formattedEntry[0:len(coloredPrefix)-4], []byte(strings.ToUpper(auditLogLevel))...)
+		coloredResult = append(coloredResult, formattedEntry[len(coloredPrefix)+4:]...)
+		return coloredResult, nil
 	}
+	// Non-colored output
+	return bytes.Replace(formattedEntry, []byte("level="+entry.Level.String()), []byte("level="+auditLogLevel), 1), nil
+}
+
+func (a jsonAuditFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	formattedEntry, err := a.formatter.Format(entry)
+	if err != nil {
+		return nil, err
+	}
+	var logAsJSON map[string]interface{}
+	err = json.Unmarshal(formattedEntry, &logAsJSON)
+	if err != nil {
+		return nil, fmt.Errorf("audit: failed to unmarshal log entry: %w", err)
+	}
+	logAsJSON["level"] = auditLogLevel
+	return json.Marshal(logAsJSON)
 }
 
 // Log logs the given message as an audit event. The context must contain audit information.

--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -22,6 +22,9 @@ import (
 	"context"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -44,4 +47,65 @@ func TestLog(t *testing.T) {
 			Log(TestContext(), logrus.NewEntry(logrus.StandardLogger()), "")
 		})
 	})
+}
+
+func Test_auditLogger(t *testing.T) {
+	t.Run("invalid formatter", func(t *testing.T) {
+		initAuditLoggerOnce = &sync.Once{}
+		logrus.StandardLogger().SetFormatter(&textAuditFormatter{})
+		assert.Panics(t, func() {
+			auditLogger()
+		})
+	})
+}
+
+func Test_newAuditFormatter(t *testing.T) {
+	t.Run("unsupported", func(t *testing.T) {
+		f, err := newAuditFormatter(&textAuditFormatter{})
+
+		assert.Nil(t, f)
+		assert.Error(t, err)
+	})
+}
+
+func Test_textAuditFormatter(t *testing.T) {
+	t.Run("colored", func(t *testing.T) {
+		textFormatter := &logrus.TextFormatter{}
+		textFormatter.ForceColors = true
+		f, err := newAuditFormatter(textFormatter)
+		require.NoError(t, err)
+
+		actual, err := f.Format(logEntry())
+
+		require.NoError(t, err)
+		assert.Contains(t, string(actual), "Hello, World!")
+		assert.NotContains(t, string(actual), "INFO")
+		assert.True(t, strings.HasPrefix(string(actual), "\x1b[36mAUDIT["))
+	})
+	t.Run("non-colored", func(t *testing.T) {
+		f, err := newAuditFormatter(&logrus.TextFormatter{})
+		require.NoError(t, err)
+
+		actual, err := f.Format(logEntry())
+
+		require.NoError(t, err)
+		assert.Equal(t, `time="0001-01-01T00:00:00Z" level=audit msg="Hello, World!" foo=bar`+"\n", string(actual))
+	})
+}
+
+func Test_jsonAuditFormatter(t *testing.T) {
+	f, err := newAuditFormatter(&logrus.JSONFormatter{})
+	require.NoError(t, err)
+
+	actual, err := f.Format(logEntry())
+
+	require.NoError(t, err)
+	assert.Equal(t, string(actual), `{"foo":"bar","level":"audit","msg":"Hello, World!","time":"0001-01-01T00:00:00Z"}`)
+}
+
+func logEntry() *logrus.Entry {
+	e := logrus.StandardLogger().WithField("foo", "bar")
+	e.Level = logrus.InfoLevel
+	e.Message = "Hello, World!"
+	return e
 }

--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -64,7 +64,7 @@ func Test_newAuditFormatter(t *testing.T) {
 		f, err := newAuditFormatter(&textAuditFormatter{})
 
 		assert.Nil(t, f)
-		assert.Error(t, err)
+		assert.EqualError(t, err, "audit: unsupported log formatter: *audit.textAuditFormatter")
 	})
 }
 

--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -33,7 +33,6 @@ func TestLog(t *testing.T) {
 
 		assert.Equal(t, "test", actual.Data["event"])
 		assert.Equal(t, TestActor, actual.Data["actor"])
-		assert.Equal(t, "audit", actual.Data["log"])
 	})
 	t.Run("it panics when no actor is set", func(t *testing.T) {
 		assert.Panics(t, func() {

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -158,6 +158,7 @@ func (client *Crypto) New(ctx context.Context, namingFunc KIDNamingFunc) (Key, e
 	if err != nil {
 		return nil, err
 	}
+
 	audit.Log(ctx, log.Logger(), audit.CryptoNewKeyEvent).Infof("Generating new key pair: %s", kid)
 	if client.storage.PrivateKeyExists(kid) {
 		return nil, errors.New("key with the given ID already exists")

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/audit"
 	"github.com/nuts-foundation/nuts-node/crypto/storage/fs"
 	"github.com/nuts-foundation/nuts-node/crypto/storage/spi"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
@@ -59,6 +60,8 @@ func TestCrypto_Exists(t *testing.T) {
 
 func TestCrypto_New(t *testing.T) {
 	client := createCrypto(t)
+
+	logrus.StandardLogger().SetFormatter(&logrus.JSONFormatter{})
 
 	t.Run("ok", func(t *testing.T) {
 		kid := "kid"

--- a/crypto/log/logger.go
+++ b/crypto/log/logger.go
@@ -29,7 +29,3 @@ var _logger = logrus.StandardLogger().WithField(core.LogFieldModule, "Crypto")
 func Logger() *logrus.Entry {
 	return _logger
 }
-
-func Audit(subject string) *logrus.Entry {
-	return Logger().WithField(core.LogFieldAuditSubject, subject)
-}

--- a/docs/pages/deployment/audit-logging.rst
+++ b/docs/pages/deployment/audit-logging.rst
@@ -8,11 +8,11 @@ Audit Logging
 
 Important events are logged as audit events. Examples are creation of a new cryptographic key pair or its usage when signing or decrypting.
 
-Audit events are logged to application log and can be recognized by the ``log`` field being set to ``audit``.
+Audit events are logged to application log and can be recognized by the ``audit`` log level.
 In addition, the events contain the following fields:
 
 - ``operation`` which contains name action that was performed
 - ``actor`` which contains the name of the user/system that performed the action.
 
 To redirect the audit log to safe storage, it is advised to use a log processor (e.g. `Fluentbit <https://fluentbit.io/>`_).
-You can use the ``log`` field to detect audit logs and redirect it to a separate log collector.
+You can use the ``audit`` log level to detect audit logs and redirect it to a separate log collector.


### PR DESCRIPTION
Needs some more test coverage, but first review round to see if it's not too hacky.

It creates a new logger, specifically for auditing. At first use, it copies the Formatter from the standard logger and decorates it with a Formatter that alters the log level using byte comparison. The order of default fields is hardcoded, so it only replaces the first occurence.

Fixes #1888

Text output:
```
time="2023-02-13T15:52:47+01:00" level=audit msg="Generating new key pair: kid" actor=test-actor event=CreateNewKey module=Crypto operation=TestModule.TestOperation
```

Colored text output:
```
AUDIT[0000] Generating new key pair: kid                  actor=test-actor event=CreateNewKey module=Crypto operation=TestModule.TestOperation
```

JSON output:
```
{"actor":"test-actor","event":"CreateNewKey","level":"audit","module":"Crypto","msg":"Generating new key pair: kid","operation":"TestModule.TestOperation","time":"2023-02-13T15:54:57+01:00"}
```