### PR TITLE
allow for custom AuthorizationTokenBuilder on API Client

### DIFF
--- a/core/config_test.go
+++ b/core/config_test.go
@@ -45,6 +45,7 @@ func Test_ListMerging(t *testing.T) {
 			system.RegisterEngine(testEngine)
 			// Load the system
 			require.NoError(t, system.Load(cmd.Flags()))
+			system.Config.Datadir = t.TempDir()
 			// Configure system and the engines
 			assert.Nil(t, system.Configure())
 
@@ -56,6 +57,7 @@ func Test_ListMerging(t *testing.T) {
 			os.Args = []string{"command", "--configfile", "test/config/testengine.yaml"}
 			testEngine := &TestEngine{}
 			system := NewSystem()
+			system.Config.Datadir = t.TempDir()
 
 			// create a dummy command with the serverFlagSet and the testEngine flagSet:
 			cmd := &cobra.Command{}
@@ -71,6 +73,7 @@ func Test_ListMerging(t *testing.T) {
 			system.RegisterEngine(testEngine)
 			// Load the system
 			require.NoError(t, system.Load(cmd.Flags()))
+			system.Config.Datadir = t.TempDir()
 			// Configure system and the engines
 			assert.Nil(t, system.Configure())
 

--- a/core/http_client.go
+++ b/core/http_client.go
@@ -74,7 +74,7 @@ func (w httpRequestDoerAdapter) Do(req *http.Request) (*http.Response, error) {
 // This does not use the generated client options for e.g. authentication,
 // because each generated OpenAPI client reimplements the client options using structs,
 // which makes them incompatible with each other, making it impossible to use write generic client code for common traits like authorization.
-func CreateHTTPClient(cfg ClientConfig) (HTTPRequestDoer, error) {
+func CreateHTTPClient(cfg ClientConfig, builder AuthorizationTokenBuilder) (HTTPRequestDoer, error) {
 	var result *httpRequestDoerAdapter
 	client := &http.Client{}
 	client.Timeout = cfg.Timeout
@@ -82,27 +82,60 @@ func CreateHTTPClient(cfg ClientConfig) (HTTPRequestDoer, error) {
 		fn: client.Do,
 	}
 
-	// Add auth interceptor if configured
-	authToken, err := cfg.GetAuthToken()
-	if err != nil {
-		return nil, err
+	if builder == nil {
+		// Add auth interceptor if configured
+		authToken, err := cfg.GetAuthToken()
+		if err != nil {
+			return nil, err
+		}
+
+		if len(authToken) > 0 {
+			builder = legacyTokenBuilder{token: authToken}
+
+		}
 	}
-	if len(authToken) > 0 {
-		fn := result.fn
-		result = &httpRequestDoerAdapter{fn: func(req *http.Request) (*http.Response, error) {
-			req.Header.Set("Authorization", "Bearer "+authToken)
-			return fn(req)
-		}}
+
+	if builder == nil {
+		builder = noAuth{}
 	}
+
+	fn := result.fn
+	result = &httpRequestDoerAdapter{fn: func(req *http.Request) (*http.Response, error) {
+		token := builder.Create()
+		if len(token) > 0 {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		return fn(req)
+	}}
 
 	return result, nil
 }
 
 // MustCreateHTTPClient is like CreateHTTPClient but panics if it returns an error.
-func MustCreateHTTPClient(cfg ClientConfig) HTTPRequestDoer {
-	client, err := CreateHTTPClient(cfg)
+func MustCreateHTTPClient(cfg ClientConfig, builder AuthorizationTokenBuilder) HTTPRequestDoer {
+	client, err := CreateHTTPClient(cfg, builder)
 	if err != nil {
 		panic(err)
 	}
 	return client
+}
+
+// AuthorizationTokenBuilder holds methods for creating a bearer token for an HTTP request
+type AuthorizationTokenBuilder interface {
+	Create() string
+}
+
+type legacyTokenBuilder struct {
+	token string
+}
+
+func (ltb legacyTokenBuilder) Create() string {
+	return ltb.token
+}
+
+type noAuth struct {
+}
+
+func (atb noAuth) Create() string {
+	return ""
 }

--- a/core/http_client.go
+++ b/core/http_client.go
@@ -74,6 +74,7 @@ func (w httpRequestDoerAdapter) Do(req *http.Request) (*http.Response, error) {
 // This does not use the generated client options for e.g. authentication,
 // because each generated OpenAPI client reimplements the client options using structs,
 // which makes them incompatible with each other, making it impossible to use write generic client code for common traits like authorization.
+// If the given authorization token builder is non-nil, it calls it and passes the resulting token as bearer token with requests.
 func CreateHTTPClient(cfg ClientConfig, generator AuthorizationTokenGenerator) (HTTPRequestDoer, error) {
 	var result *httpRequestDoerAdapter
 	client := &http.Client{}

--- a/core/http_client.go
+++ b/core/http_client.go
@@ -91,7 +91,6 @@ func CreateHTTPClient(cfg ClientConfig, builder AuthorizationTokenBuilder) (HTTP
 
 		if len(authToken) > 0 {
 			builder = legacyTokenBuilder{token: authToken}
-
 		}
 	}
 

--- a/core/http_client.go
+++ b/core/http_client.go
@@ -101,7 +101,10 @@ func CreateHTTPClient(cfg ClientConfig, builder AuthorizationTokenBuilder) (HTTP
 
 	fn := result.fn
 	result = &httpRequestDoerAdapter{fn: func(req *http.Request) (*http.Response, error) {
-		token := builder.Create()
+		token, err := builder.Create()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate authorization token: %w", err)
+		}
 		if len(token) > 0 {
 			req.Header.Set("Authorization", "Bearer "+token)
 		}
@@ -122,20 +125,20 @@ func MustCreateHTTPClient(cfg ClientConfig, builder AuthorizationTokenBuilder) H
 
 // AuthorizationTokenBuilder holds methods for creating a bearer token for an HTTP request
 type AuthorizationTokenBuilder interface {
-	Create() string
+	Create() (string, error)
 }
 
 type legacyTokenBuilder struct {
 	token string
 }
 
-func (ltb legacyTokenBuilder) Create() string {
-	return ltb.token
+func (ltb legacyTokenBuilder) Create() (string, error) {
+	return ltb.token, nil
 }
 
 type noAuth struct {
 }
 
-func (atb noAuth) Create() string {
-	return ""
+func (atb noAuth) Create() (string, error) {
+	return "", nil
 }

--- a/core/http_client_test.go
+++ b/core/http_client_test.go
@@ -66,7 +66,7 @@ func TestHTTPClient(t *testing.T) {
 		assert.Equal(t, "Bearer test", authToken)
 	})
 	t.Run("with custom token builder", func(t *testing.T) {
-		client, err := CreateHTTPClient(ClientConfig{}, legacyTokenBuilder{token: "test"})
+		client, err := CreateHTTPClient(ClientConfig{}, newLegacyTokenGenerator("test"))
 		require.NoError(t, err)
 
 		req, _ := stdHttp.NewRequest(stdHttp.MethodGet, server.URL, nil)
@@ -77,7 +77,7 @@ func TestHTTPClient(t *testing.T) {
 		assert.Equal(t, "Bearer test", authToken)
 	})
 	t.Run("with errored token builder", func(t *testing.T) {
-		client, err := CreateHTTPClient(ClientConfig{}, errTokenBuilder{})
+		client, err := CreateHTTPClient(ClientConfig{}, newErrorTokenBuilder())
 		require.NoError(t, err)
 
 		req, _ := stdHttp.NewRequest(stdHttp.MethodGet, server.URL, nil)
@@ -125,8 +125,8 @@ func (r readCloser) Close() error {
 	return nil
 }
 
-type errTokenBuilder struct{}
-
-func (etb errTokenBuilder) Create() (string, error) {
-	return "", errors.New("error")
+func newErrorTokenBuilder() AuthorizationTokenGenerator {
+	return func() (string, error) {
+		return "", errors.New("error")
+	}
 }

--- a/didman/api/v1/client.go
+++ b/didman/api/v1/client.go
@@ -28,11 +28,11 @@ import (
 // HTTPClient holds the server address and other basic settings for the http client
 type HTTPClient struct {
 	core.ClientConfig
-	TokenBuilder core.AuthorizationTokenBuilder
+	TokenGenerator core.AuthorizationTokenGenerator
 }
 
 func (hb HTTPClient) client() ClientInterface {
-	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig, hb.TokenBuilder)))
+	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig, hb.TokenGenerator)))
 	if err != nil {
 		panic(err)
 	}

--- a/didman/api/v1/client.go
+++ b/didman/api/v1/client.go
@@ -28,10 +28,11 @@ import (
 // HTTPClient holds the server address and other basic settings for the http client
 type HTTPClient struct {
 	core.ClientConfig
+	TokenBuilder core.AuthorizationTokenBuilder
 }
 
 func (hb HTTPClient) client() ClientInterface {
-	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig)))
+	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig, hb.TokenBuilder)))
 	if err != nil {
 		panic(err)
 	}

--- a/network/api/v1/client.go
+++ b/network/api/v1/client.go
@@ -33,6 +33,7 @@ import (
 // HTTPClient holds the server address and other basic settings for the http client
 type HTTPClient struct {
 	core.ClientConfig
+	TokenBuilder core.AuthorizationTokenBuilder
 }
 
 // GetTransactionPayload retrieves the transaction payload for the given transaction. If the transaction or payload is not found
@@ -128,7 +129,7 @@ func (hb HTTPClient) Reprocess(contentType string) error {
 }
 
 func (hb HTTPClient) client() ClientInterface {
-	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig)))
+	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig, hb.TokenBuilder)))
 	if err != nil {
 		panic(err)
 	}

--- a/network/api/v1/client.go
+++ b/network/api/v1/client.go
@@ -33,7 +33,7 @@ import (
 // HTTPClient holds the server address and other basic settings for the http client
 type HTTPClient struct {
 	core.ClientConfig
-	TokenBuilder core.AuthorizationTokenBuilder
+	TokenGenerator core.AuthorizationTokenGenerator
 }
 
 // GetTransactionPayload retrieves the transaction payload for the given transaction. If the transaction or payload is not found
@@ -129,7 +129,7 @@ func (hb HTTPClient) Reprocess(contentType string) error {
 }
 
 func (hb HTTPClient) client() ClientInterface {
-	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig, hb.TokenBuilder)))
+	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig, hb.TokenGenerator)))
 	if err != nil {
 		panic(err)
 	}

--- a/vcr/api/v2/client.go
+++ b/vcr/api/v2/client.go
@@ -31,11 +31,11 @@ import (
 // HTTPClient holds the server address and other basic settings for the http client
 type HTTPClient struct {
 	core.ClientConfig
-	TokenBuilder core.AuthorizationTokenBuilder
+	TokenGenerator core.AuthorizationTokenGenerator
 }
 
 func (hb HTTPClient) client() ClientInterface {
-	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig, hb.TokenBuilder)))
+	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig, hb.TokenGenerator)))
 	if err != nil {
 		panic(err)
 	}

--- a/vcr/api/v2/client.go
+++ b/vcr/api/v2/client.go
@@ -31,10 +31,11 @@ import (
 // HTTPClient holds the server address and other basic settings for the http client
 type HTTPClient struct {
 	core.ClientConfig
+	TokenBuilder core.AuthorizationTokenBuilder
 }
 
 func (hb HTTPClient) client() ClientInterface {
-	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig)))
+	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig, hb.TokenBuilder)))
 	if err != nil {
 		panic(err)
 	}

--- a/vdr/api/v1/client.go
+++ b/vdr/api/v1/client.go
@@ -32,10 +32,11 @@ import (
 // HTTPClient holds the server address and other basic settings for the http client
 type HTTPClient struct {
 	core.ClientConfig
+	tokenBuilder core.AuthorizationTokenBuilder
 }
 
 func (hb HTTPClient) client() ClientInterface {
-	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig)))
+	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig, hb.tokenBuilder)))
 	if err != nil {
 		panic(err)
 	}

--- a/vdr/api/v1/client.go
+++ b/vdr/api/v1/client.go
@@ -32,11 +32,11 @@ import (
 // HTTPClient holds the server address and other basic settings for the http client
 type HTTPClient struct {
 	core.ClientConfig
-	tokenBuilder core.AuthorizationTokenBuilder
+	TokenGenerator core.AuthorizationTokenGenerator
 }
 
 func (hb HTTPClient) client() ClientInterface {
-	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig, hb.tokenBuilder)))
+	response, err := NewClientWithResponses(hb.GetAddress(), WithHTTPClient(core.MustCreateHTTPClient(hb.ClientConfig, hb.TokenGenerator)))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
closes #1891 

Using the client API lib for our APIs involved creating a `api.HTTPClient` for various packages and then calling its methods. It was not possible to inject an alternative TokenBuilder in this process. Especially the registry admin benefits from this since it needs to inject its own token builder.

the registry creates clients like:
```
vdrClient := vdrAPI.HTTPClient{
	ServerAddress: config.NutsNodeAddress,
	Timeout:       apiTimeout,
}
```

This PR allows for adding an AuthorizationTokenBuilder impl

note: fixed `data` dir creation from `config_test.go`