### PR TITLE
Fix address logging in service discovery

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -386,7 +386,7 @@ func (n *Network) connectToKnownNodes(nodeDID did.DID) error {
 				}
 				log.Logger().
 					WithField(core.LogFieldDID, node.ID.String()).
-					WithField(core.LogFieldNodeAddress, nutsCommUrl).
+					WithField(core.LogFieldNodeAddress, nutsCommUrl.Host).
 					Info("Discovered Nuts node")
 				n.connectionManager.Connect(nutsCommUrl.Host)
 			}


### PR DESCRIPTION
changes relevant part of log line from: `nodeAddr="{{grpc   nuts.nl:5555   false false   }}"` to `nodeAddr=nuts.nl:5555`