### PR TITLE
Network: fix racy behavior of backoff persist on shutdown

### DIFF
--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -36,7 +36,6 @@ import (
 	grpcPeer "google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	"net"
-	"sync"
 	"time"
 )
 
@@ -546,18 +545,4 @@ func (s *grpcConnectionManager) registerPrometheusMetrics() {
 		Help:      "Number of gRPC messages received per protocol and message type.",
 	}, []string{"protocol", "message_type"})
 	_ = prometheus.Register(s.recvMessagesCounter)
-}
-
-func waitWithTimeout(wg *sync.WaitGroup, timeOut time.Duration) bool {
-	completed := make(chan bool)
-	go func() {
-		defer close(completed)
-		wg.Wait()
-	}()
-	select {
-	case <-completed:
-		return false
-	case <-time.After(timeOut):
-		return true
-	}
 }

--- a/network/transport/grpc/outbound_connector_test.go
+++ b/network/transport/grpc/outbound_connector_test.go
@@ -101,7 +101,7 @@ func Test_connector_stats(t *testing.T) {
 			return true
 		}, newTestBackoff())
 
-		connector.tryConnect()
+		connector.tryConnect(context.Background())
 		stats := connector.stats()
 
 		now := time.Now().Add(time.Second * -1)

--- a/network/transport/v2/peer_diagnostics.go
+++ b/network/transport/v2/peer_diagnostics.go
@@ -46,17 +46,15 @@ func newPeerDiagnosticsManager(provider func() transport.Diagnostics, sender fun
 
 func (m *peerDiagnosticsManager) start(ctx context.Context, broadcastInterval time.Duration) {
 	ticker := time.NewTicker(broadcastInterval)
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				ticker.Stop()
-				return
-			case <-ticker.C:
-				m.sender(m.provider())
-			}
+	for {
+		select {
+		case <-ctx.Done():
+			ticker.Stop()
+			return
+		case <-ticker.C:
+			m.sender(m.provider())
 		}
-	}()
+	}
 }
 
 func (m *peerDiagnosticsManager) handleReceived(peerID transport.PeerID, received *Diagnostics) {

--- a/network/transport/v2/peer_diagnostics_test.go
+++ b/network/transport/v2/peer_diagnostics_test.go
@@ -39,7 +39,7 @@ func Test_PeerDiagnosticsManager(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		manager.start(ctx, 5*time.Millisecond)
+		go manager.start(ctx, 5*time.Millisecond)
 
 		// Wait for the calls
 		wg.Done()

--- a/network/transport/v2/transactionlist_handler.go
+++ b/network/transport/v2/transactionlist_handler.go
@@ -58,25 +58,26 @@ func newTransactionListHandler(ctx context.Context, fn handleFunc) *transactionL
 }
 
 func (tlh *transactionListHandler) start() {
-	go func() {
-		for {
-			select {
-			case <-tlh.ctx.Done():
-				return
-			case pe := <-tlh.ch:
-				if err := tlh.fn(pe.peer, pe.envelope); err != nil {
-					log.Logger().
-						WithError(err).
-						WithFields(pe.peer.ToFields()).
-						WithField(core.LogFieldMessageType, fmt.Sprintf("%T", pe.envelope.Message)).
-						Error("Error handling message")
-				}
+	for {
+		select {
+		case <-tlh.ctx.Done():
+			log.Logger().Info("transactionListHandler done")
+			return
+		case pe := <-tlh.ch:
+			log.Logger().Info("transactionListHandler working")
+			if err := tlh.fn(pe.peer, pe.envelope); err != nil {
+				log.Logger().
+					WithError(err).
+					WithFields(pe.peer.ToFields()).
+					WithField(core.LogFieldMessageType, fmt.Sprintf("%T", pe.envelope.Message)).
+					Error("Error handling message")
 			}
+			log.Logger().Info("transactionListHandler work done")
 		}
-	}()
+	}
 }
 
-func (p *protocol) handleTransactionList(peer transport.Peer, envelope *Envelope) error {
+func (p *protocol) handleTransactionList(ctx context.Context, peer transport.Peer, envelope *Envelope) error {
 	subEnvelope := envelope.Message.(*Envelope_TransactionList)
 	msg := envelope.GetTransactionList()
 	cid := conversationID(msg.ConversationID)
@@ -97,8 +98,11 @@ func (p *protocol) handleTransactionList(peer transport.Peer, envelope *Envelope
 		return err
 	}
 
-	ctx := context.Background()
 	for i, tx := range txs {
+		if ctx.Err() != nil {
+			// For loop might be long-running, support cancellation
+			break
+		}
 		// TODO does this always trigger fetching missing payloads? (through observer on DAG) Prolly not for v2
 		if len(tx.PAL()) == 0 && len(msg.Transactions[i].Payload) == 0 {
 			return fmt.Errorf("peer did not provide payload for transaction (tx=%s)", tx.Ref())

--- a/network/transport/v2/transactionlist_handler_test.go
+++ b/network/transport/v2/transactionlist_handler_test.go
@@ -49,7 +49,7 @@ func TestTransactionListHandler(t *testing.T) {
 			return nil
 		}
 		tlh := newTransactionListHandler(ctx, handlerFunc)
-		tlh.start()
+		go tlh.start()
 
 		tlh.ch <- peerEnvelope{}
 
@@ -82,7 +82,19 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 		envelope := envelopeWithConversation(conversation)
 		mocks.State.EXPECT().Add(context.Background(), tx, payload).Return(nil)
 
-		err := p.handleTransactionList(peer, envelope)
+		err := p.handleTransactionList(context.Background(), peer, envelope)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("supports cancellations", func(t *testing.T) {
+		p, _ := newTestProtocol(t, nil)
+		conversation := p.cMan.startConversation(request, peerID)
+		envelope := envelopeWithConversation(conversation)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := p.handleTransactionList(ctx, peer, envelope)
 
 		assert.NoError(t, err)
 	})
@@ -93,7 +105,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 		envelope := envelopeWithConversation(conversation)
 		mocks.State.EXPECT().Add(context.Background(), tx, payload).Return(nil)
 
-		err := p.handleTransactionList(peer, envelope)
+		err := p.handleTransactionList(context.Background(), peer, envelope)
 
 		assert.NoError(t, err)
 	})
@@ -106,7 +118,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(hash.FromSlice([]byte("stateXor")), uint32(7))
 		mocks.Sender.EXPECT().sendState(peer.ID, hash.FromSlice([]byte("stateXor")), uint32(7))
 
-		err := p.handleTransactionList(peer, envelope)
+		err := p.handleTransactionList(context.Background(), peer, envelope)
 
 		assert.NoError(t, err)
 		assert.Nil(t, p.cMan.conversations[conversation.conversationID.String()])
@@ -118,7 +130,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 		envelope := envelopeWithConversation(conversation)
 		mocks.State.EXPECT().Add(context.Background(), tx, payload).Return(nil)
 
-		err := p.handleTransactionList(peer, envelope)
+		err := p.handleTransactionList(context.Background(), peer, envelope)
 
 		assert.NoError(t, err)
 		assert.Nil(t, p.cMan.conversations[conversation.conversationID.String()])
@@ -133,7 +145,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 		conversation.expiry = cStartTime
 		mocks.State.EXPECT().Add(context.Background(), tx, payload).Return(nil)
 
-		err := p.handleTransactionList(peer, &Envelope{Message: &Envelope_TransactionList{
+		err := p.handleTransactionList(context.Background(), peer, &Envelope{Message: &Envelope_TransactionList{
 			TransactionList: &TransactionList{
 				ConversationID: conversation.conversationID.slice(),
 				Transactions:   []*Transaction{{Data: data, Payload: payload}},
@@ -154,7 +166,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 		envelope := envelopeWithConversation(conversation)
 		mocks.State.EXPECT().Add(context.Background(), tx, payload).Return(errors.New("custom"))
 
-		err := p.handleTransactionList(peer, envelope)
+		err := p.handleTransactionList(context.Background(), peer, envelope)
 
 		assert.EqualError(t, err, fmt.Sprintf("unable to add received transaction to DAG (tx=%s): custom", tx.Ref().String()))
 	})
@@ -163,7 +175,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 		p, _ := newTestProtocol(t, nil)
 		conversation := p.cMan.startConversation(request, peerID)
 
-		err := p.handleTransactionList(peer, &Envelope{Message: &Envelope_TransactionList{
+		err := p.handleTransactionList(context.Background(), peer, &Envelope{Message: &Envelope_TransactionList{
 			TransactionList: &TransactionList{
 				ConversationID: conversation.conversationID.slice(),
 				Transactions:   []*Transaction{{Data: data}},
@@ -177,7 +189,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 		p, _ := newTestProtocol(t, nil)
 		conversation := p.cMan.startConversation(request, peerID)
 
-		err := p.handleTransactionList(peer, &Envelope{Message: &Envelope_TransactionList{
+		err := p.handleTransactionList(context.Background(), peer, &Envelope{Message: &Envelope_TransactionList{
 			TransactionList: &TransactionList{
 				ConversationID: conversation.conversationID.slice(),
 				Transactions:   []*Transaction{{Data: []byte{1}}},
@@ -191,7 +203,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 		p, _ := newTestProtocol(t, nil)
 		conversationID := newConversationID()
 
-		err := p.handleTransactionList(peer, &Envelope{Message: &Envelope_TransactionList{
+		err := p.handleTransactionList(context.Background(), peer, &Envelope{Message: &Envelope_TransactionList{
 			TransactionList: &TransactionList{
 				ConversationID: conversationID.slice(),
 			},


### PR DESCRIPTION
The problem was that `openOutboundStream`, a goroutine which blocks until the gRPC connection is closed, tried to reset the backoff timer after the storage engine already shut down. The function is (through intermediates) called by `outboundConnector.start` in a goroutine, and while the component has a `stop()` function, it doesn't wait until the goroutine exits. So what happened, was:

- Connection is active (goroutine blocked by `openOutboundStream()`)
- Kill signal, tells gRPC connections (through context cancellation) to shut down
- `openOutboundStream()` unblocks
- Meanwhile storage engine already shut down, since network module didn't wait until all subcomponents were shut down
- `openOutboundStream()` tries to reset backoff, which fails and renders an error

Fixed this by letting `outboundConnector.stop()` (called by `grpcConnectionManager.Stop()`) block the connector loop has stopped. To let current connection attempts (e.g. attempts to dead hosts, which may take a few seconds to time-out) not block shutdown, `outboundConnector.tryConnect()` now gets passed the context used to cancel the connector loop.

Also added logging exemptions to avoid logging `context.Canceled` as errors (they're normal shutdown artifacts).

Requires https://github.com/nuts-foundation/nuts-node/pull/1901