### PR TITLE
Status: pass context for healthchecks to allow timing out on external resources

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -241,7 +241,7 @@ type HealthCheckable interface {
 	Named
 	// CheckHealth performs health checks and returns the result. The function should not perform expensive or slow operations
 	// and should return as fast as possible.
-	CheckHealth() map[string]Health
+	CheckHealth(ctx context.Context) map[string]Health
 }
 
 // HealthStatus defines the result status of a health check.

--- a/core/engine_mock.go
+++ b/core/engine_mock.go
@@ -5,6 +5,7 @@
 package core
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -393,17 +394,17 @@ func (m *MockHealthCheckable) EXPECT() *MockHealthCheckableMockRecorder {
 }
 
 // CheckHealth mocks base method.
-func (m *MockHealthCheckable) CheckHealth() map[string]Health {
+func (m *MockHealthCheckable) CheckHealth(ctx context.Context) map[string]Health {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckHealth")
+	ret := m.ctrl.Call(m, "CheckHealth", ctx)
 	ret0, _ := ret[0].(map[string]Health)
 	return ret0
 }
 
 // CheckHealth indicates an expected call of CheckHealth.
-func (mr *MockHealthCheckableMockRecorder) CheckHealth() *gomock.Call {
+func (mr *MockHealthCheckableMockRecorder) CheckHealth(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckHealth", reflect.TypeOf((*MockHealthCheckable)(nil).CheckHealth))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckHealth", reflect.TypeOf((*MockHealthCheckable)(nil).CheckHealth), ctx)
 }
 
 // Name mocks base method.

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -70,8 +70,8 @@ type Crypto struct {
 	config  Config
 }
 
-func (client *Crypto) CheckHealth() map[string]core.Health {
-	return client.storage.CheckHealth()
+func (client *Crypto) CheckHealth(ctx context.Context) map[string]core.Health {
+	return client.storage.CheckHealth(ctx)
 }
 
 // NewCryptoInstance creates a new instance of the crypto engine.

--- a/crypto/storage/external/client.go
+++ b/crypto/storage/external/client.go
@@ -46,9 +46,9 @@ func (c APIClient) Name() string {
 	return "Crypto"
 }
 
-func (c APIClient) CheckHealth() map[string]core.Health {
+func (c APIClient) CheckHealth(ctx context.Context) map[string]core.Health {
 	results := make(map[string]core.Health)
-	response, err := c.httpClient.HealthCheckWithResponse(context.Background())
+	response, err := c.httpClient.HealthCheckWithResponse(ctx)
 	if err != nil {
 		results[StorageType] = core.Health{Status: core.HealthStatusDown, Details: fmt.Errorf("unable to connect to storage server: %w", err).Error()}
 		return results

--- a/crypto/storage/fs/fs.go
+++ b/crypto/storage/fs/fs.go
@@ -19,6 +19,7 @@
 package fs
 
 import (
+	"context"
 	"crypto"
 	"errors"
 	"fmt"
@@ -65,7 +66,7 @@ func (fsc fileSystemBackend) Name() string {
 	return StorageType
 }
 
-func (fsc fileSystemBackend) CheckHealth() map[string]core.Health {
+func (fsc fileSystemBackend) CheckHealth(_ context.Context) map[string]core.Health {
 	return map[string]core.Health{
 		"filesystem": {Status: core.HealthStatusUp},
 	}

--- a/crypto/storage/spi/mock.go
+++ b/crypto/storage/spi/mock.go
@@ -5,6 +5,7 @@
 package spi
 
 import (
+	context "context"
 	crypto "crypto"
 	reflect "reflect"
 
@@ -36,17 +37,17 @@ func (m *MockStorage) EXPECT() *MockStorageMockRecorder {
 }
 
 // CheckHealth mocks base method.
-func (m *MockStorage) CheckHealth() map[string]core.Health {
+func (m *MockStorage) CheckHealth(ctx context.Context) map[string]core.Health {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckHealth")
+	ret := m.ctrl.Call(m, "CheckHealth", ctx)
 	ret0, _ := ret[0].(map[string]core.Health)
 	return ret0
 }
 
 // CheckHealth indicates an expected call of CheckHealth.
-func (mr *MockStorageMockRecorder) CheckHealth() *gomock.Call {
+func (mr *MockStorageMockRecorder) CheckHealth(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckHealth", reflect.TypeOf((*MockStorage)(nil).CheckHealth))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckHealth", reflect.TypeOf((*MockStorage)(nil).CheckHealth), ctx)
 }
 
 // GetPrivateKey mocks base method.

--- a/crypto/storage/spi/wrapper.go
+++ b/crypto/storage/spi/wrapper.go
@@ -19,6 +19,7 @@
 package spi
 
 import (
+	"context"
 	"crypto"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/core"
@@ -36,8 +37,8 @@ func (w wrapper) Name() string {
 	return w.wrappedBackend.Name()
 }
 
-func (w wrapper) CheckHealth() map[string]core.Health {
-	return w.wrappedBackend.CheckHealth()
+func (w wrapper) CheckHealth(ctx context.Context) map[string]core.Health {
+	return w.wrappedBackend.CheckHealth(ctx)
 }
 
 // NewValidatedKIDBackendWrapper creates a new wrapper for storage backends.

--- a/crypto/test.go
+++ b/crypto/test.go
@@ -19,6 +19,7 @@
 package crypto
 
 import (
+	"context"
 	"crypto"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/crypto/storage/spi"
@@ -60,7 +61,7 @@ func (m memoryStorage) Name() string {
 	return "memory"
 }
 
-func (m memoryStorage) CheckHealth() map[string]core.Health {
+func (m memoryStorage) CheckHealth(_ context.Context) map[string]core.Health {
 	return map[string]core.Health{"memory": {Status: core.HealthStatusUp}}
 }
 

--- a/network/network.go
+++ b/network/network.go
@@ -84,7 +84,7 @@ type Network struct {
 }
 
 // CheckHealth performs health checks for the network engine.
-func (n *Network) CheckHealth() map[string]core.Health {
+func (n *Network) CheckHealth(ctx context.Context) map[string]core.Health {
 	results := make(map[string]core.Health)
 	if n.certificate.Leaf != nil {
 		// TLS enabled, verify the configured certificate

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -1037,6 +1037,7 @@ func TestNetwork_checkHealth(t *testing.T) {
 	require.NoError(t, err)
 	certificate.Leaf, err = x509.ParseCertificate(certificate.Certificate[0])
 	require.NoError(t, err)
+	ctx := context.Background()
 	t.Run("TLS", func(t *testing.T) {
 		t.Run("up", func(t *testing.T) {
 			n := Network{
@@ -1045,7 +1046,7 @@ func TestNetwork_checkHealth(t *testing.T) {
 				nodeDIDResolver: &transport.FixedNodeDIDResolver{},
 			}
 
-			result := n.CheckHealth()
+			result := n.CheckHealth(ctx)
 
 			assert.Equal(t, core.HealthStatusUp, result[healthTLS].Status)
 		})
@@ -1062,7 +1063,7 @@ func TestNetwork_checkHealth(t *testing.T) {
 				nodeDIDResolver: &transport.FixedNodeDIDResolver{},
 			}
 
-			result := n.CheckHealth()
+			result := n.CheckHealth(ctx)
 
 			assert.Equal(t, core.HealthStatusDown, result[healthTLS].Status)
 			assert.Equal(t, "x509: certificate signed by unknown authority", result[healthTLS].Details)
@@ -1092,7 +1093,7 @@ func TestNetwork_checkHealth(t *testing.T) {
 			cxt.network.nodeDIDResolver = &transport.FixedNodeDIDResolver{NodeDID: *nodeDID}
 			cxt.docResolver.EXPECT().Resolve(*nodeDID, nil).MinTimes(1).Return(completeDocument, &vdrTypes.DocumentMetadata{}, nil)
 
-			health := cxt.network.CheckHealth()
+			health := cxt.network.CheckHealth(ctx)
 
 			assert.Equal(t, core.HealthStatusUp, health[healthAuthConfig].Status)
 			assert.Nil(t, health["auth"].Details)
@@ -1101,7 +1102,7 @@ func TestNetwork_checkHealth(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			cxt := createNetwork(t, ctrl)
 
-			health := cxt.network.CheckHealth()
+			health := cxt.network.CheckHealth(ctx)
 
 			assert.Equal(t, core.HealthStatusUp, health[healthAuthConfig].Status)
 			assert.Equal(t, "no node DID", health[healthAuthConfig].Details)
@@ -1113,7 +1114,7 @@ func TestNetwork_checkHealth(t *testing.T) {
 			cxt.network.nodeDIDResolver = &transport.FixedNodeDIDResolver{NodeDID: *nodeDID}
 			cxt.docResolver.EXPECT().Resolve(*nodeDID, nil).Return(nil, nil, did.DeactivatedErr)
 
-			health := cxt.network.CheckHealth()
+			health := cxt.network.CheckHealth(ctx)
 
 			assert.Equal(t, core.HealthStatusDown, health[healthAuthConfig].Status)
 			assert.Equal(t, "DID document can't be resolved (did=did:nuts:test): supplied DID is deactivated", health[healthAuthConfig].Details)


### PR DESCRIPTION
For instance, external crypto providers (Vault or external). Or when the client already cancelled the request.

Fixes https://github.com/nuts-foundation/nuts-node/issues/1858