### PR TITLE
Network: reduce backoff when connected to unexpected DID

### DIFF
--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -392,8 +392,8 @@ func Test_grpcConnectionManager_dial(t *testing.T) {
 			<-ctx.Done()
 			assert.ErrorIs(t, ctx.Err(), context.Canceled, "context expired")
 
-			// backoff is set to a ridiculously large value
-			assert.Less(t, 365*24*time.Hour, cont.backoff.Value())
+			// backoff is set to a large value
+			assert.Less(t, 23*time.Hour, cont.backoff.Value())
 
 			// connection is removed again
 			assert.Empty(t, client.connections.list)


### PR DESCRIPTION
closes #1925

Also changed the log level from Warn to Info when the node fails to connect a stream after having successfully setting up a gRPC connection.