### PR TITLE
Status: detailed diagnostics on separate endpoints

### DIFF
--- a/core/diagnostics.go
+++ b/core/diagnostics.go
@@ -21,6 +21,11 @@ package core
 
 import "fmt"
 
+// MappedDiagnosable is implemented by types that want to
+type MappedDiagnosable interface {
+	MappedDiagnostics() map[string]func() Diagnosable
+}
+
 // DiagnosticResult are the result of different checks giving information on how well the system is doing
 type DiagnosticResult interface {
 	// Name returns a simple and understandable name of the check

--- a/core/engine.go
+++ b/core/engine.go
@@ -33,6 +33,12 @@ type Routable interface {
 	Routes(router EchoRouter)
 }
 
+// Routable enables connecting a REST API to the echo server. The API wrappers should implement this interface
+type Routable interface {
+	// Routes configures the HTTP routes on the given router
+	Routes(router EchoRouter)
+}
+
 // NewSystem creates a new, empty System.
 func NewSystem() *System {
 	serverCfg := NewServerConfig()

--- a/core/status/engine.go
+++ b/core/status/engine.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 	"net/http"
+	"path"
 	"strings"
 	"time"
 
@@ -63,6 +64,13 @@ func (s *status) Routes(router core.EchoRouter) {
 	router.Add(http.MethodGet, statusEndpoint, echo.StaticFileHandler("overview.html", overviewPageResource))
 	router.Add(http.MethodGet, diagnosticsEndpoint, s.diagnosticsOverview)
 	router.Add(http.MethodGet, checkHealthEndpoint, s.checkHealth)
+	// Register mapped diagnostics
+	s.system.VisitEngines(func(engine core.Engine) {
+		m := engine.(core.MappedDiagnosable)
+		for mappedPath, provider := range m.MappedDiagnostics() {
+			router.Add(http.MethodGet, path.Join(diagnosticsEndpoint, mappedPath))
+		}
+	})
 }
 
 func (s *status) diagnosticsOverview(ctx echo.Context) error {

--- a/core/status/engine.go
+++ b/core/status/engine.go
@@ -21,6 +21,7 @@ package status
 
 import (
 	"bytes"
+	"embed"
 	"fmt"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -37,6 +38,9 @@ const moduleName = "Status"
 const diagnosticsEndpoint = "/status/diagnostics"
 const statusEndpoint = "/status"
 const checkHealthEndpoint = "/health"
+
+//go:embed overview.html
+var overviewPageResource embed.FS
 
 type status struct {
 	system    *core.System
@@ -56,8 +60,8 @@ func (s *status) Name() string {
 }
 
 func (s *status) Routes(router core.EchoRouter) {
+	router.Add(http.MethodGet, statusEndpoint, echo.StaticFileHandler("overview.html", overviewPageResource))
 	router.Add(http.MethodGet, diagnosticsEndpoint, s.diagnosticsOverview)
-	router.Add(http.MethodGet, statusEndpoint, statusOK)
 	router.Add(http.MethodGet, checkHealthEndpoint, s.checkHealth)
 }
 
@@ -155,9 +159,4 @@ func (s *status) doCheckHealth() core.Health {
 		Details: results,
 	}
 	return result
-}
-
-// statusOK returns 200 OK with an "OK" body
-func statusOK(ctx echo.Context) error {
-	return ctx.String(http.StatusOK, "OK")
 }

--- a/core/status/overview.html
+++ b/core/status/overview.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+    <title>Nuts Node Status</title>
+</head>
+<body>
+<h1>Nuts Node Status</h1>
+<p>
+    The following endpoints can be used to assess the status of the node:
+</p>
+<ul>
+    <li><a href="./health">Health checks (JSON)</a></li>
+    <li><a href="./metrics">Prometheus metrics</a></li>
+    <li><a href="status/diagnostics">Diagnostics overview (YAML/JSON)</a></li>
+</ul>
+</body>
+</html>

--- a/network/api/v1/api.go
+++ b/network/api/v1/api.go
@@ -53,6 +53,7 @@ func (a *Wrapper) Routes(router core.EchoRouter) {
 			return audit.StrictMiddleware(f, network.ModuleName, operationID)
 		},
 	}))
+	router.GET("/network/status/")
 }
 
 // ListTransactions lists all transactions

--- a/network/interface.go
+++ b/network/interface.go
@@ -21,6 +21,7 @@ package network
 import (
 	"context"
 	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/network/dag"
 	"github.com/nuts-foundation/nuts-node/network/transport"
@@ -59,6 +60,8 @@ type Transactions interface {
 	WithPersistency() SubscriberOption
 	// DiscoverServices should be called by the VDR to let the network know it has processed and verified a document (update) for the DID.
 	DiscoverServices(updatedDID did.DID)
+
+	DiagnosticsProviders() map[string]core.DiagnosticsProvider
 }
 
 // EventType defines a type for specifying the kind of events that can be published/subscribed on the Network.

--- a/network/network.go
+++ b/network/network.go
@@ -678,6 +678,13 @@ func (n *Network) Shutdown() error {
 	return nil
 }
 
+func (n *Network) MappedDiagnostics() map[string]func() core.DiagnosticResult {
+	n.connectionManager.
+	return map[string]func() core.DiagnosticResult{
+		"connectors"
+	}
+}
+
 // Diagnostics collects and returns diagnostics for the Network engine.
 func (n *Network) Diagnostics() []core.DiagnosticResult {
 	var results = make([]core.DiagnosticResult, 0)


### PR DESCRIPTION
Checkin of earlier POC.

To support more detailed diagnostics without cluttering the "main" diagnostics page.

Each engine that wants to provide detailed diagnostics should register 