### PR TITLE
Network: remove DID from auth errors, since it's logged by the caller

### DIFF
--- a/network/transport/grpc/authenticator.go
+++ b/network/transport/grpc/authenticator.go
@@ -19,6 +19,7 @@
 package grpc
 
 import (
+	"errors"
 	"fmt"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/core"
@@ -52,7 +53,7 @@ func (t tlsAuthenticator) Authenticate(nodeDID did.DID, grpcPeer grpcPeer.Peer, 
 	// Resolve peer TLS certificate DNS names
 	tlsInfo, isTLS := grpcPeer.AuthInfo.(credentials.TLSInfo)
 	if !isTLS || len(tlsInfo.State.PeerCertificates) == 0 {
-		return peer, fmt.Errorf("missing TLS info (nodeDID=%s)", nodeDID)
+		return peer, errors.New("missing TLS info")
 	}
 	peerCertificate := tlsInfo.State.PeerCertificates[0]
 
@@ -65,7 +66,7 @@ func (t tlsAuthenticator) Authenticate(nodeDID did.DID, grpcPeer grpcPeer.Peer, 
 		nutsCommURL, err = url.Parse(nutsCommURLStr)
 	}
 	if err != nil {
-		return peer, fmt.Errorf("can't resolve %s service (nodeDID=%s): %w", transport.NutsCommServiceType, nodeDID, err)
+		return peer, fmt.Errorf("can't resolve %s service: %w", transport.NutsCommServiceType, err)
 	}
 
 	// Check whether one of the DNS names matches one of the NutsComm endpoints
@@ -74,7 +75,7 @@ func (t tlsAuthenticator) Authenticate(nodeDID did.DID, grpcPeer grpcPeer.Peer, 
 		log.Logger().
 			WithField(core.LogFieldDID, nodeDID).
 			Debugf("DNS names in peer certificate: %s", strings.Join(peerCertificate.DNSNames, ", "))
-		return peer, fmt.Errorf("none of the DNS names in the peer's TLS certificate match the NutsComm endpoint (nodeDID=%s)", nodeDID)
+		return peer, errors.New("none of the DNS names in the peer's TLS certificate match the NutsComm endpoint")
 	}
 
 	log.Logger().

--- a/network/transport/grpc/authenticator_test.go
+++ b/network/transport/grpc/authenticator_test.go
@@ -106,12 +106,12 @@ func Test_tlsAuthenticator_Authenticate(t *testing.T) {
 
 			authenticatedPeer, err := authenticator.Authenticate(nodeDID, grpcPeer, transportPeer)
 
-			assert.EqualError(t, err, "none of the DNS names in the peer's TLS certificate match the NutsComm endpoint (nodeDID=did:nuts:test)")
+			assert.EqualError(t, err, "none of the DNS names in the peer's TLS certificate match the NutsComm endpoint")
 			assert.Equal(t, transportPeer, authenticatedPeer)
 		})
 		t.Run("no TLS info", func(t *testing.T) {
 			authenticatedPeer, err := NewTLSAuthenticator(nil).Authenticate(nodeDID, peer.Peer{}, transportPeer)
-			assert.EqualError(t, err, "missing TLS info (nodeDID=did:nuts:test)")
+			assert.EqualError(t, err, "missing TLS info")
 			assert.Equal(t, transportPeer, authenticatedPeer)
 		})
 		t.Run("DID document not found", func(t *testing.T) {
@@ -122,7 +122,7 @@ func Test_tlsAuthenticator_Authenticate(t *testing.T) {
 
 			authenticatedPeer, err := authenticator.Authenticate(nodeDID, grpcPeer, transportPeer)
 
-			assert.EqualError(t, err, "can't resolve NutsComm service (nodeDID=did:nuts:test): unable to find the DID document")
+			assert.EqualError(t, err, "can't resolve NutsComm service: unable to find the DID document")
 			assert.Equal(t, transportPeer, authenticatedPeer)
 		})
 	})


### PR DESCRIPTION
It's already logged as `did` log field, no need to include it in the error message. It makes the log message unnecessarily harder to read:

```
time="2023-03-13T16:39:19+01:00" level=warning msg="Peer node DID could not be authenticated" did="did:nuts:EGPFSJaUuN1RBRReCvWBFzetpzZKTRJBtGg67jMi3uKF" error="none of the DNS names in the peer's TLS certificate match the NutsComm endpoint (nodeDID=did:nuts:EGPFSJaUuN1RBRReCvWBFzetpzZKTRJBtGg67jMi3uKF)" module=Network peerAddr="172.20.0.13:35724" peerAuthenticated=false peerDID= peerID=0b85e051-c01f-4b4e-8375-b1c95f46b380
```