### PR TITLE
fix finding issued credentials

### DIFF
--- a/vcr/api/v2/api.go
+++ b/vcr/api/v2/api.go
@@ -173,7 +173,7 @@ func (w *Wrapper) SearchIssuedVCs(ctx echo.Context, params SearchIssuedVCsParams
 		return core.InvalidInputError("invalid credentialType: %w", err)
 	}
 
-	foundVCs, err := w.VCR.Issuer().SearchCredential(ssi.URI{}, *credentialType, *issuerDID, subjectID)
+	foundVCs, err := w.VCR.Issuer().SearchCredential(*credentialType, *issuerDID, subjectID)
 	if err != nil {
 		return err
 	}

--- a/vcr/api/v2/api.go
+++ b/vcr/api/v2/api.go
@@ -48,8 +48,8 @@ var clockFn = func() time.Time {
 // Wrapper implements the generated interface from oapi-codegen
 // It parses and checks the params. Handles errors and returns the appropriate response.
 type Wrapper struct {
-	ContextManager     jsonld.JSONLD
-	VCR                vcr.VCR
+	ContextManager jsonld.JSONLD
+	VCR            vcr.VCR
 }
 
 // Routes registers the handler to the echo router

--- a/vcr/api/v2/api.go
+++ b/vcr/api/v2/api.go
@@ -38,7 +38,6 @@ import (
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/vcr"
-	"github.com/nuts-foundation/nuts-node/vcr/issuer"
 	"github.com/nuts-foundation/nuts-node/vcr/signature/proof"
 )
 
@@ -49,7 +48,6 @@ var clockFn = func() time.Time {
 // Wrapper implements the generated interface from oapi-codegen
 // It parses and checks the params. Handles errors and returns the appropriate response.
 type Wrapper struct {
-	CredentialResolver issuer.CredentialSearcher
 	ContextManager     jsonld.JSONLD
 	VCR                vcr.VCR
 }

--- a/vcr/api/v2/api_test.go
+++ b/vcr/api/v2/api_test.go
@@ -290,7 +290,6 @@ func TestWrapper_SearchIssuedVCs(t *testing.T) {
 	vcID := issuerID
 	vcID.Fragment = "1"
 	subjectIDString := subjectID.String()
-	contextURI := ssi.MustParseURI("")
 	testCredential := ssi.MustParseURI("TestCredential")
 
 	foundVC := vc.VerifiableCredential{
@@ -302,7 +301,7 @@ func TestWrapper_SearchIssuedVCs(t *testing.T) {
 
 	t.Run("ok - with subject, no results", func(t *testing.T) {
 		testContext := newMockContext(t)
-		testContext.mockIssuer.EXPECT().SearchCredential(contextURI, testCredential, *issuerDID, &subjectID)
+		testContext.mockIssuer.EXPECT().SearchCredential(testCredential, *issuerDID, &subjectID)
 
 		testContext.echo.EXPECT().JSON(http.StatusOK, SearchVCResults{VerifiableCredentials: []SearchVCResult{}})
 
@@ -317,7 +316,7 @@ func TestWrapper_SearchIssuedVCs(t *testing.T) {
 
 	t.Run("ok - without subject, 1 result", func(t *testing.T) {
 		testContext := newMockContext(t)
-		testContext.mockIssuer.EXPECT().SearchCredential(contextURI, testCredential, *issuerDID, nil).Return([]VerifiableCredential{foundVC}, nil)
+		testContext.mockIssuer.EXPECT().SearchCredential(testCredential, *issuerDID, nil).Return([]VerifiableCredential{foundVC}, nil)
 		testContext.mockVerifier.EXPECT().GetRevocation(vcID).Return(nil, verifier.ErrNotFound)
 		testContext.echo.EXPECT().JSON(http.StatusOK, SearchVCResults{VerifiableCredentials: []SearchVCResult{{VerifiableCredential: foundVC}}})
 
@@ -332,7 +331,7 @@ func TestWrapper_SearchIssuedVCs(t *testing.T) {
 	t.Run("ok - without subject, 1 result, revoked", func(t *testing.T) {
 		revocation := &Revocation{Reason: "because of reasons"}
 		testContext := newMockContext(t)
-		testContext.mockIssuer.EXPECT().SearchCredential(contextURI, testCredential, *issuerDID, nil).Return([]VerifiableCredential{foundVC}, nil)
+		testContext.mockIssuer.EXPECT().SearchCredential(testCredential, *issuerDID, nil).Return([]VerifiableCredential{foundVC}, nil)
 		testContext.mockVerifier.EXPECT().GetRevocation(vcID).Return(revocation, nil)
 		testContext.echo.EXPECT().JSON(http.StatusOK, SearchVCResults{VerifiableCredentials: []SearchVCResult{{VerifiableCredential: foundVC, Revocation: revocation}}})
 
@@ -384,7 +383,7 @@ func TestWrapper_SearchIssuedVCs(t *testing.T) {
 
 	t.Run("error - CredentialResolver returns error", func(t *testing.T) {
 		testContext := newMockContext(t)
-		testContext.mockIssuer.EXPECT().SearchCredential(contextURI, testCredential, *issuerDID, nil).Return(nil, errors.New("b00m!"))
+		testContext.mockIssuer.EXPECT().SearchCredential(testCredential, *issuerDID, nil).Return(nil, errors.New("b00m!"))
 
 		params := SearchIssuedVCsParams{
 			CredentialType: "TestCredential",

--- a/vcr/issuer/interface.go
+++ b/vcr/issuer/interface.go
@@ -83,5 +83,6 @@ type Store interface {
 // It is a separate interface from Store so when an object only needs resolving, it only needs the resolver.
 type CredentialSearcher interface {
 	// SearchCredential searches for issued credentials
+	// If the passed context is empty, it'll not be part of the search query on the DB.
 	SearchCredential(context ssi.URI, credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error)
 }

--- a/vcr/issuer/interface.go
+++ b/vcr/issuer/interface.go
@@ -84,5 +84,5 @@ type Store interface {
 type CredentialSearcher interface {
 	// SearchCredential searches for issued credentials
 	// If the passed context is empty, it'll not be part of the search query on the DB.
-	SearchCredential(context ssi.URI, credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error)
+	SearchCredential(credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error)
 }

--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -267,6 +267,6 @@ func (i issuer) isRevoked(credentialID ssi.URI) (bool, error) {
 	}
 }
 
-func (i issuer) SearchCredential(context ssi.URI, credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error) {
-	return i.store.SearchCredential(context, credentialType, issuer, subject)
+func (i issuer) SearchCredential(credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error) {
+	return i.store.SearchCredential(credentialType, issuer, subject)
 }

--- a/vcr/issuer/leia_store.go
+++ b/vcr/issuer/leia_store.go
@@ -98,8 +98,11 @@ func (s leiaIssuerStore) StoreCredential(vc vc.VerifiableCredential) error {
 
 func (s leiaIssuerStore) SearchCredential(jsonLDContext ssi.URI, credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error) {
 	query := leia.New(leia.Eq(leia.NewJSONPath("issuer"), leia.MustParseScalar(issuer.String()))).
-		And(leia.Eq(leia.NewJSONPath("type"), leia.MustParseScalar(credentialType.String()))).
-		And(leia.Eq(leia.NewJSONPath("@context"), leia.MustParseScalar(jsonLDContext.String())))
+		And(leia.Eq(leia.NewJSONPath("type"), leia.MustParseScalar(credentialType.String())))
+
+	if len(jsonLDContext.String()) != 0 {
+		query = query.And(leia.Eq(leia.NewJSONPath("@context"), leia.MustParseScalar(jsonLDContext.String())))
+	}
 
 	if subject != nil {
 

--- a/vcr/issuer/leia_store.go
+++ b/vcr/issuer/leia_store.go
@@ -96,16 +96,11 @@ func (s leiaIssuerStore) StoreCredential(vc vc.VerifiableCredential) error {
 	return s.issuedCredentials.Add([]leia.Document{vcAsBytes})
 }
 
-func (s leiaIssuerStore) SearchCredential(jsonLDContext ssi.URI, credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error) {
+func (s leiaIssuerStore) SearchCredential(credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error) {
 	query := leia.New(leia.Eq(leia.NewJSONPath("issuer"), leia.MustParseScalar(issuer.String()))).
 		And(leia.Eq(leia.NewJSONPath("type"), leia.MustParseScalar(credentialType.String())))
 
-	if len(jsonLDContext.String()) != 0 {
-		query = query.And(leia.Eq(leia.NewJSONPath("@context"), leia.MustParseScalar(jsonLDContext.String())))
-	}
-
 	if subject != nil {
-
 		if subjectString := subject.String(); subjectString != "" {
 			query = query.And(leia.Eq(leia.NewJSONPath(credential.CredentialSubjectPath), leia.MustParseScalar(subjectString)))
 		}

--- a/vcr/issuer/leia_store_test.go
+++ b/vcr/issuer/leia_store_test.go
@@ -120,6 +120,15 @@ func Test_leiaStore_StoreAndSearchCredential(t *testing.T) {
 				assert.Equal(t, vcToStore, foundVC)
 			})
 
+			t.Run("without context", func(t *testing.T) {
+				res, err := sut.SearchCredential(ssi.URI{}, vcToStore.Type[0], *issuerDID, nil)
+				assert.NoError(t, err)
+				require.Len(t, res, 1)
+
+				foundVC := res[0]
+				assert.Equal(t, vcToStore, foundVC)
+			})
+
 			t.Run("no results", func(t *testing.T) {
 
 				t.Run("unknown issuer", func(t *testing.T) {

--- a/vcr/issuer/leia_store_test.go
+++ b/vcr/issuer/leia_store_test.go
@@ -103,7 +103,7 @@ func Test_leiaStore_StoreAndSearchCredential(t *testing.T) {
 			subjectID := ssi.MustParseURI("did:nuts:GvkzxsezHvEc8nGhgz6Xo3jbqkHwswLmWw3CYtCm7hAW")
 
 			t.Run("for all issued credentials for a issuer", func(t *testing.T) {
-				res, err := sut.SearchCredential(vcToStore.Context[1], vcToStore.Type[0], *issuerDID, nil)
+				res, err := sut.SearchCredential(vcToStore.Type[0], *issuerDID, nil)
 				assert.NoError(t, err)
 				require.Len(t, res, 1)
 
@@ -112,7 +112,7 @@ func Test_leiaStore_StoreAndSearchCredential(t *testing.T) {
 			})
 
 			t.Run("for all issued credentials for a issuer and subject", func(t *testing.T) {
-				res, err := sut.SearchCredential(vcToStore.Context[0], vcToStore.Type[0], *issuerDID, &subjectID)
+				res, err := sut.SearchCredential(vcToStore.Type[0], *issuerDID, &subjectID)
 				assert.NoError(t, err)
 				require.Len(t, res, 1)
 
@@ -121,7 +121,7 @@ func Test_leiaStore_StoreAndSearchCredential(t *testing.T) {
 			})
 
 			t.Run("without context", func(t *testing.T) {
-				res, err := sut.SearchCredential(ssi.URI{}, vcToStore.Type[0], *issuerDID, nil)
+				res, err := sut.SearchCredential(vcToStore.Type[0], *issuerDID, nil)
 				assert.NoError(t, err)
 				require.Len(t, res, 1)
 
@@ -133,21 +133,21 @@ func Test_leiaStore_StoreAndSearchCredential(t *testing.T) {
 
 				t.Run("unknown issuer", func(t *testing.T) {
 					unknownIssuerDID, _ := did.ParseDID("did:nuts:123")
-					res, err := sut.SearchCredential(vcToStore.Context[0], vcToStore.Type[0], *unknownIssuerDID, nil)
+					res, err := sut.SearchCredential(vcToStore.Type[0], *unknownIssuerDID, nil)
 					assert.NoError(t, err)
 					require.Len(t, res, 0)
 				})
 
 				t.Run("unknown credentialType", func(t *testing.T) {
 					unknownType := ssi.MustParseURI("unknownType")
-					res, err := sut.SearchCredential(vcToStore.Context[0], unknownType, *issuerDID, nil)
+					res, err := sut.SearchCredential(unknownType, *issuerDID, nil)
 					assert.NoError(t, err)
 					require.Len(t, res, 0)
 				})
 
 				t.Run("unknown subject", func(t *testing.T) {
 					unknownSubject := ssi.MustParseURI("did:nuts:unknown")
-					res, err := sut.SearchCredential(vcToStore.Context[0], vcToStore.Type[0], *issuerDID, &unknownSubject)
+					res, err := sut.SearchCredential(vcToStore.Type[0], *issuerDID, &unknownSubject)
 					assert.NoError(t, err)
 					require.Len(t, res, 0)
 				})

--- a/vcr/issuer/mock.go
+++ b/vcr/issuer/mock.go
@@ -160,18 +160,18 @@ func (mr *MockIssuerMockRecorder) Revoke(ctx, credentialID interface{}) *gomock.
 }
 
 // SearchCredential mocks base method.
-func (m *MockIssuer) SearchCredential(context, credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error) {
+func (m *MockIssuer) SearchCredential(credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchCredential", context, credentialType, issuer, subject)
+	ret := m.ctrl.Call(m, "SearchCredential", credentialType, issuer, subject)
 	ret0, _ := ret[0].([]vc.VerifiableCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchCredential indicates an expected call of SearchCredential.
-func (mr *MockIssuerMockRecorder) SearchCredential(context, credentialType, issuer, subject interface{}) *gomock.Call {
+func (mr *MockIssuerMockRecorder) SearchCredential(credentialType, issuer, subject interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchCredential", reflect.TypeOf((*MockIssuer)(nil).SearchCredential), context, credentialType, issuer, subject)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchCredential", reflect.TypeOf((*MockIssuer)(nil).SearchCredential), credentialType, issuer, subject)
 }
 
 // MockStore is a mock of Store interface.
@@ -256,18 +256,18 @@ func (mr *MockStoreMockRecorder) GetRevocation(id interface{}) *gomock.Call {
 }
 
 // SearchCredential mocks base method.
-func (m *MockStore) SearchCredential(context, credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error) {
+func (m *MockStore) SearchCredential(credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchCredential", context, credentialType, issuer, subject)
+	ret := m.ctrl.Call(m, "SearchCredential", credentialType, issuer, subject)
 	ret0, _ := ret[0].([]vc.VerifiableCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchCredential indicates an expected call of SearchCredential.
-func (mr *MockStoreMockRecorder) SearchCredential(context, credentialType, issuer, subject interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) SearchCredential(credentialType, issuer, subject interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchCredential", reflect.TypeOf((*MockStore)(nil).SearchCredential), context, credentialType, issuer, subject)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchCredential", reflect.TypeOf((*MockStore)(nil).SearchCredential), credentialType, issuer, subject)
 }
 
 // StoreCredential mocks base method.
@@ -322,16 +322,16 @@ func (m *MockCredentialSearcher) EXPECT() *MockCredentialSearcherMockRecorder {
 }
 
 // SearchCredential mocks base method.
-func (m *MockCredentialSearcher) SearchCredential(context, credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error) {
+func (m *MockCredentialSearcher) SearchCredential(credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchCredential", context, credentialType, issuer, subject)
+	ret := m.ctrl.Call(m, "SearchCredential", credentialType, issuer, subject)
 	ret0, _ := ret[0].([]vc.VerifiableCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchCredential indicates an expected call of SearchCredential.
-func (mr *MockCredentialSearcherMockRecorder) SearchCredential(context, credentialType, issuer, subject interface{}) *gomock.Call {
+func (mr *MockCredentialSearcherMockRecorder) SearchCredential(credentialType, issuer, subject interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchCredential", reflect.TypeOf((*MockCredentialSearcher)(nil).SearchCredential), context, credentialType, issuer, subject)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchCredential", reflect.TypeOf((*MockCredentialSearcher)(nil).SearchCredential), credentialType, issuer, subject)
 }


### PR DESCRIPTION
fixes #1910 

The problem was that the query part for the JSON-LD context did an equal to `""`.

Changed it to only include that query part if the context is actually non-empty.
Requiring the `@context` to be non-nil for VCs is overkill since every VC will have a JSON-LD context.