### PR TITLE
fix correct loading order of data in issuer store

### DIFF
--- a/vcr/issuer/leia_store.go
+++ b/vcr/issuer/leia_store.go
@@ -259,10 +259,9 @@ func (s leiaIssuerStore) backupStorePresent(backupShelf string) bool {
 	backupPresent := false
 
 	_ = s.backupStore.ReadShelf(context.Background(), backupShelf, func(reader stoabs.Reader) error {
-		return reader.Iterate(func(key stoabs.Key, value []byte) error {
-			backupPresent = true
-			return nil
-		}, stoabs.BytesKey{})
+		isEmpty, err := reader.Empty()
+		backupPresent = !isEmpty
+		return err
 	})
 
 	return backupPresent

--- a/vcr/issuer/leia_store.go
+++ b/vcr/issuer/leia_store.go
@@ -62,20 +62,20 @@ func NewLeiaIssuerStore(dbPath string, backupStore stoabs.KVStore) (Store, error
 		backupStore:        backupStore,
 	}
 
+	// initialize indices, this is required for handleRestore. Without the index metadata it can't iterate and detect data entries.
+	if err = newLeiaStore.createIssuedIndices(issuedCollection); err != nil {
+		return nil, err
+	}
+	if err = newLeiaStore.createRevokedIndices(revokedCollection); err != nil {
+		return nil, err
+	}
+
 	// handle backup/restore for issued credentials
 	if err = newLeiaStore.handleRestore(issuedCollection, issuedBackupShelf, "id"); err != nil {
 		return nil, err
 	}
 	// handle backup/restore for revocations
 	if err = newLeiaStore.handleRestore(revokedCollection, revocationBackupShelf, credential.RevocationSubjectPath); err != nil {
-		return nil, err
-	}
-
-	// initialize indices
-	if err = newLeiaStore.createIssuedIndices(issuedCollection); err != nil {
-		return nil, err
-	}
-	if err = newLeiaStore.createRevokedIndices(revokedCollection); err != nil {
 		return nil, err
 	}
 	return newLeiaStore, nil

--- a/vcr/issuer/leia_store_test.go
+++ b/vcr/issuer/leia_store_test.go
@@ -404,11 +404,7 @@ func TestNewLeiaIssuerStore(t *testing.T) {
 		// now create a new store with a mock backup and show that ReadShelf is only called once.
 		// additional calls to the backup store would indicate the main store is empty and the backup is used to restore the main storage.
 		reader := stoabs.NewMockReader(ctrl)
-		reader.EXPECT().Iterate(gomock.Any(), gomock.Any()).DoAndReturn(func(callback interface{}, keyType interface{}) error {
-			f := callback.(stoabs.CallerFn)
-			f(stoabs.BytesKey{}, []byte{})
-			return nil
-		})
+		reader.EXPECT().Empty().Return(false, nil)
 		backupMockStore.EXPECT().ReadShelf(gomock.Any(), "credentials", gomock.Any()).DoAndReturn(func(context interface{}, shelfName interface{}, callback interface{}) error {
 			f := callback.(func(reader stoabs.Reader) error)
 			return f(reader)


### PR DESCRIPTION
fixes #1909 

Indices had to be created first.
Added test shows that existing data is now correctly detected and no loading of the backup is done.