### PR TITLE
refactor tls.Config creation on grpc connection manager

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -19,7 +19,6 @@
 package auth
 
 import (
-	"crypto/tls"
 	"testing"
 
 	"github.com/nuts-foundation/nuts-node/core"
@@ -92,14 +91,6 @@ func TestAuth_Configure(t *testing.T) {
 		i := testInstance(t, authCfg)
 		err := i.Configure(invalidTLSServerConfig)
 		assert.EqualError(t, err, "unable to read trust store (file=non-existing): open non-existing: no such file or directory")
-	})
-}
-
-func Test_createTLSConfig(t *testing.T) {
-	t.Run("uses min. TLS version", func(t *testing.T) {
-		config := createTLSConfig(tls.Certificate{}, &core.TrustStore{})
-
-		assert.Equal(t, core.MinTLSVersion, config.MinVersion)
 	})
 }
 

--- a/crl/mock.go
+++ b/crl/mock.go
@@ -6,7 +6,7 @@ package crl
 
 import (
 	context "context"
-	tls "crypto/tls"
+	x509 "crypto/x509"
 	big "math/big"
 	reflect "reflect"
 
@@ -34,18 +34,6 @@ func NewMockValidator(ctrl *gomock.Controller) *MockValidator {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockValidator) EXPECT() *MockValidatorMockRecorder {
 	return m.recorder
-}
-
-// Configure mocks base method.
-func (m *MockValidator) Configure(config *tls.Config, maxValidityDays int) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Configure", config, maxValidityDays)
-}
-
-// Configure indicates an expected call of Configure.
-func (mr *MockValidatorMockRecorder) Configure(config, maxValidityDays interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Configure", reflect.TypeOf((*MockValidator)(nil).Configure), config, maxValidityDays)
 }
 
 // IsRevoked mocks base method.
@@ -100,4 +88,18 @@ func (m *MockValidator) SyncLoop(ctx context.Context) {
 func (mr *MockValidatorMockRecorder) SyncLoop(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncLoop", reflect.TypeOf((*MockValidator)(nil).SyncLoop), ctx)
+}
+
+// VerifyPeerCertificateFunction mocks base method.
+func (m *MockValidator) VerifyPeerCertificateFunction(maxValidityDays int) func([][]byte, [][]*x509.Certificate) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyPeerCertificateFunction", maxValidityDays)
+	ret0, _ := ret[0].(func([][]byte, [][]*x509.Certificate) error)
+	return ret0
+}
+
+// VerifyPeerCertificateFunction indicates an expected call of VerifyPeerCertificateFunction.
+func (mr *MockValidatorMockRecorder) VerifyPeerCertificateFunction(maxValidityDays interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyPeerCertificateFunction", reflect.TypeOf((*MockValidator)(nil).VerifyPeerCertificateFunction), maxValidityDays)
 }

--- a/crl/validator_test.go
+++ b/crl/validator_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
@@ -249,20 +248,19 @@ func TestValidator_IsRevoked(t *testing.T) {
 	})
 }
 
-func TestValidator_Configured(t *testing.T) {
+func TestValidator_VerifyPeerCertificateFunction(t *testing.T) {
 	crlValidator := NewValidator([]*x509.Certificate{}).(*validator)
 	crlValidator.bitSet = NewBitSet(1)
 
-	config := &tls.Config{}
-	crlValidator.Configure(config, 0)
+	f := crlValidator.VerifyPeerCertificateFunction(0)
 
-	assert.NotNil(t, config.VerifyPeerCertificate)
+	assert.NotNil(t, f)
 	data, err := os.ReadFile(pkiOverheidRootCA)
 	assert.NoError(t, err)
 
 	block, _ := pem.Decode(data)
 
-	err = config.VerifyPeerCertificate([][]byte{
+	err = f([][]byte{
 		block.Bytes,
 	}, nil)
 	assert.NoError(t, err)

--- a/network/transport/grpc/config.go
+++ b/network/transport/grpc/config.go
@@ -124,3 +124,31 @@ type Config struct {
 func (cfg Config) tlsEnabled() bool {
 	return cfg.trustStore != nil
 }
+
+func newServerTLSConfig(config Config) *tls.Config {
+	tlsConfig := newTLSConfig(config)
+	tlsConfig.ClientCAs = config.trustStore
+	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	tlsConfig.Certificates = []tls.Certificate{
+		*config.serverCert,
+	}
+	return tlsConfig
+}
+
+func newClientTLSConfig(config Config) *tls.Config {
+	tlsConfig := newTLSConfig(config)
+	tlsConfig.RootCAs = config.trustStore
+	tlsConfig.Certificates = []tls.Certificate{
+		*config.clientCert,
+	}
+	return tlsConfig
+}
+
+func newTLSConfig(config Config) *tls.Config {
+	tlsConfig := &tls.Config{
+		MinVersion:            core.MinTLSVersion,
+		VerifyPeerCertificate: config.crlValidator.VerifyPeerCertificateFunction(config.maxCRLValidityDays),
+	}
+
+	return tlsConfig
+}


### PR DESCRIPTION
closes #1959

It might be confusing that two tls.Config structs are being created, but this is actual a requirement because dialing out and listening to connections are two different things and therefore need their own signature.

I refactored some things so it might make more sense.

@gerardsn ? 