### PR TITLE
Core: originate errors from modules in system lifecycle

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -117,7 +117,7 @@ func (system *System) Shutdown() error {
 		name := engineName(curr)
 		coreLogger.Infof("Stopping %s...", name)
 		if err := curr.Shutdown(); err != nil {
-			err = fmt.Errorf("unable to shutdown %s: %w", name, err)
+			return fmt.Errorf("unable to shutdown %s: %w", name, err)
 		}
 		coreLogger.Infof("Stopped %s", name)
 	}

--- a/crypto/cmd/cmd.go
+++ b/crypto/cmd/cmd.go
@@ -77,7 +77,7 @@ func fs2ExternalStore() *cobra.Command {
 			config := instance.Config().(*cryptoEngine.Config)
 			targetStorage, err := external.NewAPIClient(config.External)
 			if err != nil {
-				return err
+				return fmt.Errorf("unable to set up external crypto API client: %w", err)
 			}
 
 			directory := args[0]

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -106,7 +106,7 @@ func (client *Crypto) setupStorageAPIBackend() error {
 	log.Logger().Debug("Setting up StorageAPI backend for storage of private key material.")
 	apiBackend, err := external.NewAPIClient(client.config.External)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to set up external crypto API client: %w", err)
 	}
 	client.storage = spi.NewValidatedKIDBackendWrapper(apiBackend, kidPattern)
 	return nil


### PR DESCRIPTION
After upgrading from v5.1.0-rc1 to v5.1.0 I got the error: "Failed to start server" (err = invalid url: empty), without further context to find out what was configured incorrectly. Turned out `crypto.external.address` was unset (because it was renamed from `.url`).

Added error wrapping for external crypto client setup and module lifecycle errors, to help pinpointing which module causes the error.