### PR TITLE
Auth: log OAuth2 error responses on INFO client-side

### DIFF
--- a/auth/api/v1/client/client.go
+++ b/auth/api/v1/client/client.go
@@ -76,7 +76,12 @@ func (h HTTPClient) CreateAccessToken(ctx context.Context, endpointURL url.URL, 
 
 	if err := core.TestResponseCode(http.StatusOK, response); err != nil {
 		rse := err.(core.HttpError)
-		log.Logger().WithError(err).Debugf("Erroneous CreateAccessToken response: %s", string(rse.ResponseBody))
+		// Cut off the response body to 100 characters max to prevent logging of large responses
+		responseBodyString := string(rse.ResponseBody)
+		if len(responseBodyString) > 100 {
+			responseBodyString = responseBodyString[:100] + "...(clipped)"
+		}
+		log.Logger().WithError(err).Infof("Erroneous CreateAccessToken response (len=%d): %s", len(rse.ResponseBody), responseBodyString)
 		return nil, &oauthAPIError{err: err, statusCode: response.StatusCode}
 	}
 


### PR DESCRIPTION
So it is generally logged without having to set the node to DEBUG.