### PR TITLE
use transport.Peer in conversation instead of PeerID

### DIFF
--- a/network/transport/types.go
+++ b/network/transport/types.go
@@ -67,9 +67,6 @@ func (p Peer) ToFields() logrus.Fields {
 // Usable as map index, not usable for presentation.
 func (p Peer) Key() string {
 	// address is included since 2 connections may exist for a peer (inbound/outbound)
-	if p.NodeDID.Empty() {
-		return fmt.Sprintf("%s@%s", p.ID, p.Address)
-	}
 	return fmt.Sprintf("%s(%s)@%s", p.ID, p.NodeDID.String(), p.Address)
 }
 

--- a/network/transport/types.go
+++ b/network/transport/types.go
@@ -63,6 +63,16 @@ func (p Peer) ToFields() logrus.Fields {
 	}
 }
 
+// Key returns a unique key for this Peer including PeerID and NodeDID.
+// Usable as map index, not usable for presentation.
+func (p Peer) Key() string {
+	// address is included since 2 connections may exist for a peer (inbound/outbound)
+	if p.NodeDID.Empty() {
+		return fmt.Sprintf("%s@%s", p.ID, p.Address)
+	}
+	return fmt.Sprintf("%s(%s)@%s", p.ID, p.NodeDID.String(), p.Address)
+}
+
 // String returns the peer as string.
 func (p Peer) String() string {
 	if p.NodeDID.Empty() {

--- a/network/transport/v2/conversation.go
+++ b/network/transport/v2/conversation.go
@@ -82,14 +82,14 @@ type conversationManager struct {
 	mutex                  sync.RWMutex
 	conversations          map[string]*conversation
 	validity               time.Duration
-	lastPeerConversationID map[transport.PeerID]conversationID
+	lastPeerConversationID map[string]conversationID
 }
 
 func newConversationManager(validity time.Duration) *conversationManager {
 	return &conversationManager{
 		conversations:          map[string]*conversation{},
 		validity:               validity,
-		lastPeerConversationID: map[transport.PeerID]conversationID{},
+		lastPeerConversationID: map[string]conversationID{},
 	}
 }
 
@@ -138,7 +138,7 @@ func (cMan *conversationManager) resetTimeout(cid conversationID) {
 }
 
 // startConversation sets a conversationID on the envelope and stores the conversation
-func (cMan *conversationManager) startConversation(msg checkable, id transport.PeerID) *conversation {
+func (cMan *conversationManager) startConversation(msg checkable, peer transport.Peer) *conversation {
 	cid := newConversationID()
 
 	msg.setConversationID(cid)
@@ -152,10 +152,10 @@ func (cMan *conversationManager) startConversation(msg checkable, id transport.P
 	defer cMan.mutex.Unlock()
 
 	if _, ok := msg.(blockable); ok {
-		if cMan.hasActiveConversation(id) {
+		if cMan.hasActiveConversation(peer) {
 			return nil
 		}
-		cMan.lastPeerConversationID[id] = cid
+		cMan.lastPeerConversationID[peer.String()] = cid
 	}
 
 	cMan.conversations[cid.String()] = newConversation
@@ -163,8 +163,8 @@ func (cMan *conversationManager) startConversation(msg checkable, id transport.P
 	return newConversation
 }
 
-func (cMan *conversationManager) hasActiveConversation(id transport.PeerID) bool {
-	if lastPeerConv, ok := cMan.lastPeerConversationID[id]; ok {
+func (cMan *conversationManager) hasActiveConversation(peer transport.Peer) bool {
+	if lastPeerConv, ok := cMan.lastPeerConversationID[peer.String()]; ok {
 		if conversation, ok := cMan.conversations[lastPeerConv.String()]; ok {
 			if conversation.expiry.After(time.Now()) {
 				return true

--- a/network/transport/v2/conversation.go
+++ b/network/transport/v2/conversation.go
@@ -164,7 +164,7 @@ func (cMan *conversationManager) startConversation(msg checkable, peer transport
 }
 
 func (cMan *conversationManager) hasActiveConversation(peer transport.Peer) bool {
-	if lastPeerConv, ok := cMan.lastPeerConversationID[peer.String()]; ok {
+	if lastPeerConv, ok := cMan.lastPeerConversationID[peer.Key()]; ok {
 		if conversation, ok := cMan.conversations[lastPeerConv.String()]; ok {
 			if conversation.expiry.After(time.Now()) {
 				return true

--- a/network/transport/v2/conversation.go
+++ b/network/transport/v2/conversation.go
@@ -155,7 +155,7 @@ func (cMan *conversationManager) startConversation(msg checkable, peer transport
 		if cMan.hasActiveConversation(peer) {
 			return nil
 		}
-		cMan.lastPeerConversationID[peer.String()] = cid
+		cMan.lastPeerConversationID[peer.Key()] = cid
 	}
 
 	cMan.conversations[cid.String()] = newConversation

--- a/network/transport/v2/conversation_test.go
+++ b/network/transport/v2/conversation_test.go
@@ -95,7 +95,7 @@ func TestConversationManager_startConversation(t *testing.T) {
 		assert.NotNil(t, conv)
 		assert.Len(t, cMan.conversations, 1)
 		assert.Len(t, cMan.lastPeerConversationID, 1)
-		assert.Equal(t, conv.conversationID, cMan.lastPeerConversationID[testPeer.String()])
+		assert.Equal(t, conv.conversationID, cMan.lastPeerConversationID[testPeer.Key()])
 	})
 	t.Run("previous conversation still active", func(t *testing.T) {
 		cMan := newConversationManager(time.Millisecond)
@@ -106,7 +106,7 @@ func TestConversationManager_startConversation(t *testing.T) {
 		assert.Nil(t, conv)
 		assert.Len(t, cMan.conversations, 1)
 		assert.Len(t, cMan.lastPeerConversationID, 1)
-		assert.Equal(t, previousConv.conversationID, cMan.lastPeerConversationID[testPeer.String()])
+		assert.Equal(t, previousConv.conversationID, cMan.lastPeerConversationID[testPeer.Key()])
 	})
 	t.Run("State is not blocking", func(t *testing.T) {
 		msg := &Envelope_State{State: &State{}}
@@ -129,7 +129,7 @@ func TestConversationManager_startConversation(t *testing.T) {
 		assert.NotNil(t, conv)
 		assert.Len(t, cMan.conversations, 1)
 		assert.Len(t, cMan.lastPeerConversationID, 1)
-		assert.Equal(t, conv.conversationID, cMan.lastPeerConversationID[testPeer.String()])
+		assert.Equal(t, conv.conversationID, cMan.lastPeerConversationID[testPeer.Key()])
 	})
 	t.Run("previous conversation expired", func(t *testing.T) {
 		cMan := newConversationManager(time.Millisecond)
@@ -141,7 +141,7 @@ func TestConversationManager_startConversation(t *testing.T) {
 		assert.NotNil(t, conv)
 		assert.Len(t, cMan.conversations, 2) // expired but not yet evicted
 		assert.Len(t, cMan.lastPeerConversationID, 1)
-		assert.Equal(t, conv.conversationID, cMan.lastPeerConversationID[testPeer.String()])
+		assert.Equal(t, conv.conversationID, cMan.lastPeerConversationID[testPeer.Key()])
 		assert.NotEqual(t, conv.conversationID, previousConv.conversationID)
 	})
 	t.Run("one conversation per peer allowed", func(t *testing.T) {

--- a/network/transport/v2/conversation_test.go
+++ b/network/transport/v2/conversation_test.go
@@ -21,6 +21,7 @@ package v2
 
 import (
 	"context"
+	"github.com/nuts-foundation/nuts-node/network/transport"
 	"testing"
 	"time"
 
@@ -29,6 +30,8 @@ import (
 	"github.com/nuts-foundation/nuts-node/test"
 	"github.com/stretchr/testify/assert"
 )
+
+var testPeer = transport.Peer{ID: "peer"}
 
 func TestConversationID(t *testing.T) {
 	t.Run("new creates a v4 uuid", func(t *testing.T) {
@@ -73,7 +76,7 @@ func TestConversationManager_start(t *testing.T) {
 		TransactionListQuery: &TransactionListQuery{},
 	}
 
-	_ = cMan.startConversation(envelope, "peerID")
+	_ = cMan.startConversation(envelope, testPeer)
 
 	test.WaitFor(t, func() (bool, error) {
 		cMan.mutex.Lock()
@@ -87,30 +90,30 @@ func TestConversationManager_startConversation(t *testing.T) {
 	t.Run("peers first conversation", func(t *testing.T) {
 		cMan := newConversationManager(time.Millisecond)
 
-		conv := cMan.startConversation(msg, "peer")
+		conv := cMan.startConversation(msg, testPeer)
 
 		assert.NotNil(t, conv)
 		assert.Len(t, cMan.conversations, 1)
 		assert.Len(t, cMan.lastPeerConversationID, 1)
-		assert.Equal(t, conv.conversationID, cMan.lastPeerConversationID["peer"])
+		assert.Equal(t, conv.conversationID, cMan.lastPeerConversationID[testPeer.String()])
 	})
 	t.Run("previous conversation still active", func(t *testing.T) {
 		cMan := newConversationManager(time.Millisecond)
-		previousConv := cMan.startConversation(msg, "peer")
+		previousConv := cMan.startConversation(msg, testPeer)
 
-		conv := cMan.startConversation(msg, "peer")
+		conv := cMan.startConversation(msg, testPeer)
 
 		assert.Nil(t, conv)
 		assert.Len(t, cMan.conversations, 1)
 		assert.Len(t, cMan.lastPeerConversationID, 1)
-		assert.Equal(t, previousConv.conversationID, cMan.lastPeerConversationID["peer"])
+		assert.Equal(t, previousConv.conversationID, cMan.lastPeerConversationID[testPeer.String()])
 	})
 	t.Run("State is not blocking", func(t *testing.T) {
 		msg := &Envelope_State{State: &State{}}
 		cMan := newConversationManager(time.Millisecond)
-		_ = cMan.startConversation(msg, "peer")
+		_ = cMan.startConversation(msg, testPeer)
 
-		conv := cMan.startConversation(msg, "peer")
+		conv := cMan.startConversation(msg, testPeer)
 
 		assert.NotNil(t, conv)
 		assert.Len(t, cMan.conversations, 2)
@@ -118,34 +121,34 @@ func TestConversationManager_startConversation(t *testing.T) {
 	})
 	t.Run("previous conversation marked done", func(t *testing.T) {
 		cMan := newConversationManager(time.Millisecond)
-		previousConv := cMan.startConversation(msg, "peer")
+		previousConv := cMan.startConversation(msg, testPeer)
 		cMan.done(previousConv.conversationID)
 
-		conv := cMan.startConversation(msg, "peer")
+		conv := cMan.startConversation(msg, testPeer)
 
 		assert.NotNil(t, conv)
 		assert.Len(t, cMan.conversations, 1)
 		assert.Len(t, cMan.lastPeerConversationID, 1)
-		assert.Equal(t, conv.conversationID, cMan.lastPeerConversationID["peer"])
+		assert.Equal(t, conv.conversationID, cMan.lastPeerConversationID[testPeer.String()])
 	})
 	t.Run("previous conversation expired", func(t *testing.T) {
 		cMan := newConversationManager(time.Millisecond)
-		previousConv := cMan.startConversation(msg, "peer")
+		previousConv := cMan.startConversation(msg, testPeer)
 		previousConv.expiry = time.Time{}
 
-		conv := cMan.startConversation(msg, "peer")
+		conv := cMan.startConversation(msg, testPeer)
 
 		assert.NotNil(t, conv)
 		assert.Len(t, cMan.conversations, 2) // expired but not yet evicted
 		assert.Len(t, cMan.lastPeerConversationID, 1)
-		assert.Equal(t, conv.conversationID, cMan.lastPeerConversationID["peer"])
+		assert.Equal(t, conv.conversationID, cMan.lastPeerConversationID[testPeer.String()])
 		assert.NotEqual(t, conv.conversationID, previousConv.conversationID)
 	})
 	t.Run("one conversation per peer allowed", func(t *testing.T) {
 		cMan := newConversationManager(time.Millisecond)
-		_ = cMan.startConversation(msg, "other peer")
+		_ = cMan.startConversation(msg, transport.Peer{ID: "other peer"})
 
-		conv := cMan.startConversation(msg, "peer")
+		conv := cMan.startConversation(msg, testPeer)
 
 		assert.NotNil(t, conv)
 		assert.Len(t, cMan.conversations, 2)
@@ -158,7 +161,7 @@ func TestConversationManager_done(t *testing.T) {
 	envelope := &Envelope_TransactionListQuery{
 		TransactionListQuery: &TransactionListQuery{},
 	}
-	c := cMan.startConversation(envelope, "peerID")
+	c := cMan.startConversation(envelope, testPeer)
 
 	cMan.done(c.conversationID)
 
@@ -170,7 +173,7 @@ func TestConversationManager_resetTimeout(t *testing.T) {
 	envelope := &Envelope_TransactionListQuery{
 		TransactionListQuery: &TransactionListQuery{},
 	}
-	c := cMan.startConversation(envelope, "peerID")
+	c := cMan.startConversation(envelope, testPeer)
 	c.expiry = time.Time{}
 
 	cMan.resetTimeout(c.conversationID)
@@ -239,7 +242,7 @@ func TestConversationManager_checkTransactionRangeQuery(t *testing.T) {
 	}
 
 	t.Run("ok", func(t *testing.T) {
-		c := cMan.startConversation(envelope, "ok")
+		c := cMan.startConversation(envelope, transport.Peer{ID: "ok"})
 		response := &Envelope_TransactionList{
 			TransactionList: &TransactionList{
 				ConversationID: c.conversationID.slice(),
@@ -257,7 +260,7 @@ func TestConversationManager_checkTransactionRangeQuery(t *testing.T) {
 		assert.NotNil(t, c)
 	})
 	t.Run("error - TX LC out of requested range", func(t *testing.T) {
-		c := cMan.startConversation(envelope, "error - TX LC out of requested range")
+		c := cMan.startConversation(envelope, transport.Peer{ID: "error - TX LC out of requested range"})
 		response := &Envelope_TransactionList{
 			TransactionList: &TransactionList{
 				ConversationID: c.conversationID.slice(),
@@ -289,7 +292,7 @@ func TestConversationManager_checkTransactionListQuery(t *testing.T) {
 	}
 
 	t.Run("ok", func(t *testing.T) {
-		c := cMan.startConversation(request, "ok")
+		c := cMan.startConversation(request, transport.Peer{ID: "ok"})
 		response := &Envelope_TransactionList{
 			TransactionList: &TransactionList{
 				ConversationID: c.conversationID.slice(),
@@ -309,7 +312,7 @@ func TestConversationManager_checkTransactionListQuery(t *testing.T) {
 
 	t.Run("error - unknown conversation ID", func(t *testing.T) {
 		cid := conversationID("9dbacbabf0c6413591f7553ff4348753")
-		_ = cMan.startConversation(request, "error - unknown conversation ID")
+		_ = cMan.startConversation(request, transport.Peer{ID: "error - unknown conversation ID"})
 		response := &Envelope_TransactionList{
 			TransactionList: &TransactionList{
 				ConversationID: cid.slice(),
@@ -328,7 +331,7 @@ func TestConversationManager_checkTransactionListQuery(t *testing.T) {
 	})
 
 	t.Run("error - invalid response", func(t *testing.T) {
-		c := cMan.startConversation(request, "error - invalid response")
+		c := cMan.startConversation(request, transport.Peer{ID: "error - invalid response"})
 		response := &Envelope_TransactionList{
 			TransactionList: &TransactionList{
 				ConversationID: c.conversationID.slice(),
@@ -359,7 +362,7 @@ func TestConversationManager_checkState(t *testing.T) {
 	}
 
 	t.Run("ok", func(t *testing.T) {
-		c := cMan.startConversation(request, "ok")
+		c := cMan.startConversation(request, testPeer)
 		response := &Envelope_TransactionSet{
 			TransactionSet: &TransactionSet{
 				ConversationID: c.conversationID.slice(),
@@ -376,7 +379,7 @@ func TestConversationManager_checkState(t *testing.T) {
 
 	t.Run("error - unknown conversation ID", func(t *testing.T) {
 		cid := conversationID("9dbacbabf0c6413591f7553ff4348753")
-		_ = cMan.startConversation(request, "error - unknown conversation ID")
+		_ = cMan.startConversation(request, testPeer)
 		response := &Envelope_TransactionSet{
 			TransactionSet: &TransactionSet{
 				ConversationID: cid.slice(),
@@ -392,7 +395,7 @@ func TestConversationManager_checkState(t *testing.T) {
 	})
 
 	t.Run("error - invalid response", func(t *testing.T) {
-		c := cMan.startConversation(request, "error - invalid response")
+		c := cMan.startConversation(request, testPeer)
 		response := &Envelope_TransactionSet{
 			TransactionSet: &TransactionSet{
 				ConversationID: c.conversationID.slice(),

--- a/network/transport/v2/senders.go
+++ b/network/transport/v2/senders.go
@@ -74,7 +74,7 @@ func (p *protocol) sendTransactionListQuery(connection grpc.Connection, refs []h
 		},
 	}
 
-	conversation := p.cMan.startConversation(msg, connection.Peer().ID)
+	conversation := p.cMan.startConversation(msg, connection.Peer())
 	if conversation == nil {
 		log.Logger().
 			WithFields(connection.Peer().ToFields()).
@@ -118,7 +118,7 @@ func (p *protocol) sendTransactionRangeQuery(connection grpc.Connection, lcStart
 		},
 	}
 
-	conversation := p.cMan.startConversation(msg, connection.Peer().ID)
+	conversation := p.cMan.startConversation(msg, connection.Peer())
 	if conversation == nil {
 		log.Logger().
 			WithFields(connection.Peer().ToFields()).
@@ -174,7 +174,7 @@ func (p *protocol) sendState(connection grpc.Connection, xor hash.SHA256Hash, cl
 			LC:  clock,
 		},
 	}
-	conversation := p.cMan.startConversation(msg, connection.Peer().ID)
+	conversation := p.cMan.startConversation(msg, connection.Peer())
 	if conversation == nil {
 		log.Logger().
 			WithFields(connection.Peer().ToFields()).

--- a/network/transport/v2/senders_test.go
+++ b/network/transport/v2/senders_test.go
@@ -381,7 +381,7 @@ func performMultipleConversationsTest(t *testing.T, peer transport.Peer, sender 
 		mockConnection.EXPECT().Peer().Return(peer).AnyTimes()
 		// existing conversation for this peer
 		proto.cMan.conversations[conv.conversationID.String()] = conv
-		proto.cMan.lastPeerConversationID[peer.String()] = conv.conversationID
+		proto.cMan.lastPeerConversationID[peer.Key()] = conv.conversationID
 
 		err := sender(mockConnection, proto, mocks)
 
@@ -389,6 +389,6 @@ func performMultipleConversationsTest(t *testing.T, peer transport.Peer, sender 
 		// assert only conversation is the existing one
 		assert.Len(t, proto.cMan.conversations, 1)
 		assert.Equal(t, conv, proto.cMan.conversations[conv.conversationID.String()])
-		assert.Equal(t, conv.conversationID, proto.cMan.lastPeerConversationID[peer.String()])
+		assert.Equal(t, conv.conversationID, proto.cMan.lastPeerConversationID[peer.Key()])
 	})
 }

--- a/network/transport/v2/senders_test.go
+++ b/network/transport/v2/senders_test.go
@@ -121,7 +121,7 @@ func TestProtocol_sendTransactionList(t *testing.T) {
 }
 
 func TestProtocol_sendTransactionRangeQuery(t *testing.T) {
-	peerID := transport.PeerID("1")
+	peer := transport.Peer{ID: "1"}
 
 	t.Run("ok", func(t *testing.T) {
 		proto, mocks := newTestProtocol(t, nil)
@@ -140,7 +140,7 @@ func TestProtocol_sendTransactionRangeQuery(t *testing.T) {
 		assert.NotNil(t, actualEnvelope.GetTransactionRangeQuery().GetConversationID())
 	})
 
-	performMultipleConversationsTest(t, peerID, func(c grpc.Connection, p *protocol, mocks protocolMocks) error {
+	performMultipleConversationsTest(t, peer, func(c grpc.Connection, p *protocol, mocks protocolMocks) error {
 		return p.sendTransactionRangeQuery(c, 1, 5)
 	})
 	performSendErrorTest(t, gomock.Any(), func(c grpc.Connection, p *protocol, _ protocolMocks) error {
@@ -149,7 +149,7 @@ func TestProtocol_sendTransactionRangeQuery(t *testing.T) {
 }
 
 func TestProtocol_sendTransactionListQuery(t *testing.T) {
-	peerID := transport.PeerID("1")
+	peer := transport.Peer{ID: "1"}
 
 	t.Run("ok", func(t *testing.T) {
 		proto, mocks := newTestProtocol(t, nil)
@@ -168,7 +168,7 @@ func TestProtocol_sendTransactionListQuery(t *testing.T) {
 		assert.NotNil(t, actualEnvelope.GetTransactionListQuery().GetConversationID())
 	})
 
-	performMultipleConversationsTest(t, peerID, func(c grpc.Connection, p *protocol, mocks protocolMocks) error {
+	performMultipleConversationsTest(t, peer, func(c grpc.Connection, p *protocol, mocks protocolMocks) error {
 		return p.sendTransactionListQuery(c, []hash.SHA256Hash{hash.FromSlice([]byte("list query"))})
 	})
 	performSendErrorTest(t, gomock.Any(), func(c grpc.Connection, p *protocol, _ protocolMocks) error {
@@ -355,7 +355,7 @@ func performSendErrorTest(t *testing.T, envelope gomock.Matcher, sender func(grp
 
 // performMultipleConversationsTest asserts that a node can have only 1 active conversation with a peer.
 // This is only relevant for senders that start new conversations (request messages).
-func performMultipleConversationsTest(t *testing.T, peerID transport.PeerID, sender func(grpc.Connection, *protocol, protocolMocks) error) {
+func performMultipleConversationsTest(t *testing.T, peer transport.Peer, sender func(grpc.Connection, *protocol, protocolMocks) error) {
 	conv := &conversation{
 		conversationID: newConversationID(),
 		expiry:         time.Now().Add(time.Minute),
@@ -378,10 +378,10 @@ func performMultipleConversationsTest(t *testing.T, peerID transport.PeerID, sen
 	t.Run("ok - peer already in a conversation", func(t *testing.T) {
 		proto, mocks := newTestProtocol(t, nil)
 		mockConnection := grpc.NewMockConnection(mocks.Controller)
-		mockConnection.EXPECT().Peer().Return(transport.Peer{ID: peerID}).AnyTimes()
+		mockConnection.EXPECT().Peer().Return(peer).AnyTimes()
 		// existing conversation for this peer
 		proto.cMan.conversations[conv.conversationID.String()] = conv
-		proto.cMan.lastPeerConversationID[peerID] = conv.conversationID
+		proto.cMan.lastPeerConversationID[peer.String()] = conv.conversationID
 
 		err := sender(mockConnection, proto, mocks)
 
@@ -389,6 +389,6 @@ func performMultipleConversationsTest(t *testing.T, peerID transport.PeerID, sen
 		// assert only conversation is the existing one
 		assert.Len(t, proto.cMan.conversations, 1)
 		assert.Equal(t, conv, proto.cMan.conversations[conv.conversationID.String()])
-		assert.Equal(t, conv.conversationID, proto.cMan.lastPeerConversationID[peerID])
+		assert.Equal(t, conv.conversationID, proto.cMan.lastPeerConversationID[peer.String()])
 	})
 }


### PR DESCRIPTION
fixes #1950 

replaced peerID in conversation map with `Peer.String()`.