### PR TITLE
Network: grpcConnectionManager construction can return errors to prevent panics

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -140,7 +140,10 @@ func (auth *Auth) Configure(config core.ServerConfig) error {
 			return err
 		}
 
-		validator := crl.New(trustStore.Certificates())
+		validator, err := crl.New(trustStore.Certificates())
+		if err != nil {
+			return err
+		}
 		tlsConfig = &tls.Config{
 			Certificates: []tls.Certificate{clientCertificate},
 			RootCAs:      trustStore.CertPool,

--- a/auth/services/x509/uzi_validator.go
+++ b/auth/services/x509/uzi_validator.go
@@ -174,7 +174,10 @@ func NewUziValidator(env UziEnv, contractTemplates *contract.TemplateStore, crlV
 	}
 
 	if crlValidator == nil {
-		crlValidator = crl.New(append(roots[:], intermediates...))
+		crlValidator, err = crl.New(append(roots[:], intermediates...))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	validator = &UziValidator{

--- a/network/network.go
+++ b/network/network.go
@@ -265,13 +265,20 @@ func (n *Network) Configure(config core.ServerConfig) error {
 			return fmt.Errorf("failed to open connections store: %w", err)
 		}
 
-		n.connectionManager = grpc.NewGRPCConnectionManager(
-			grpc.NewConfig(n.config.GrpcAddr, n.peerID, grpcOpts...),
+		connectionManCfg, err := grpc.NewConfig(n.config.GrpcAddr, n.peerID, grpcOpts...)
+		if err != nil {
+			return err
+		}
+		n.connectionManager, err = grpc.NewGRPCConnectionManager(
+			connectionManCfg,
 			connectionStore,
 			n.nodeDID,
 			authenticator,
 			n.protocols...,
 		)
+		if err != nil {
+			return err
+		}
 	}
 
 	// register callback from DAG to other engines, with payload only.

--- a/network/transport/grpc/config_test.go
+++ b/network/transport/grpc/config_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/network/transport"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -34,7 +35,8 @@ func TestConfig_tlsEnabled(t *testing.T) {
 
 func TestNewConfig(t *testing.T) {
 	t.Run("without TLS", func(t *testing.T) {
-		cfg := NewConfig(":1234", "foo")
+		cfg, err := NewConfig(":1234", "foo")
+		require.NoError(t, err)
 		assert.Equal(t, transport.PeerID("foo"), cfg.peerID)
 		assert.Equal(t, ":1234", cfg.listenAddress)
 		assert.Nil(t, cfg.serverCert)
@@ -46,7 +48,8 @@ func TestNewConfig(t *testing.T) {
 		ts := &core.TrustStore{
 			CertPool: x509.NewCertPool(),
 		}
-		cfg := NewConfig(":1234", "foo", WithTLS(cert, ts))
+		cfg, err := NewConfig(":1234", "foo", WithTLS(cert, ts))
+		require.NoError(t, err)
 		assert.Equal(t, &cert, cfg.clientCert)
 		assert.Equal(t, &cert, cfg.serverCert)
 		assert.Same(t, ts.CertPool, cfg.trustStore)

--- a/network/transport/grpc/config_test.go
+++ b/network/transport/grpc/config_test.go
@@ -34,6 +34,8 @@ func TestConfig_tlsEnabled(t *testing.T) {
 }
 
 func TestNewConfig(t *testing.T) {
+	tlsCert, _ := tls.LoadX509KeyPair("../../test/certificate-and-key.pem", "../../test/certificate-and-key.pem")
+	x509Cert, _ := x509.ParseCertificates(tlsCert.Certificate[0])
 	t.Run("without TLS", func(t *testing.T) {
 		cfg, err := NewConfig(":1234", "foo")
 		require.NoError(t, err)
@@ -44,14 +46,23 @@ func TestNewConfig(t *testing.T) {
 		assert.Nil(t, cfg.trustStore)
 	})
 	t.Run("with TLS", func(t *testing.T) {
-		cert, _ := tls.LoadX509KeyPair("../../test/certificate-and-key.pem", "../../test/certificate-and-key.pem")
 		ts := &core.TrustStore{
 			CertPool: x509.NewCertPool(),
 		}
-		cfg, err := NewConfig(":1234", "foo", WithTLS(cert, ts))
+		cfg, err := NewConfig(":1234", "foo", WithTLS(tlsCert, ts))
 		require.NoError(t, err)
-		assert.Equal(t, &cert, cfg.clientCert)
-		assert.Equal(t, &cert, cfg.serverCert)
+		assert.Equal(t, &tlsCert, cfg.clientCert)
+		assert.Equal(t, &tlsCert, cfg.serverCert)
+		assert.Same(t, ts.CertPool, cfg.trustStore)
+	})
+	t.Run("error - invalid TLS config", func(t *testing.T) {
+		ts := &core.TrustStore{
+			CertPool: core.NewCertPool(x509Cert),
+		}
+		cfg, err := NewConfig(":1234", "foo", WithTLS(tlsCert, ts))
+		require.NoError(t, err)
+		assert.Equal(t, &tlsCert, cfg.clientCert)
+		assert.Equal(t, &tlsCert, cfg.serverCert)
 		assert.Same(t, ts.CertPool, cfg.trustStore)
 	})
 }

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -20,7 +20,6 @@ package grpc
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -64,6 +63,8 @@ var MaxMessageSizeInBytes = defaultMaxMessageSizeInBytes
 // defaultInterceptors aids testing
 var defaultInterceptors []grpc.StreamServerInterceptor
 
+var _ transport.ConnectionManager = (*grpcConnectionManager)(nil)
+
 type fatalError struct {
 	error
 }
@@ -79,7 +80,7 @@ func (s fatalError) Unwrap() error {
 type dialer func(ctx context.Context, target string, opts ...grpc.DialOption) (conn *grpc.ClientConn, err error)
 
 // NewGRPCConnectionManager creates a new ConnectionManager that accepts/creates connections which communicate using the given protocols.
-func NewGRPCConnectionManager(config Config, connectionStore stoabs.KVStore, nodeDID did.DID, authenticator Authenticator, protocols ...transport.Protocol) transport.ConnectionManager {
+func NewGRPCConnectionManager(config Config, connectionStore stoabs.KVStore, nodeDID did.DID, authenticator Authenticator, protocols ...transport.Protocol) (*grpcConnectionManager, error) {
 	var grpcProtocols []Protocol
 	for _, curr := range protocols {
 		// For now, only gRPC protocols are supported
@@ -91,12 +92,12 @@ func NewGRPCConnectionManager(config Config, connectionStore stoabs.KVStore, nod
 
 	// client tls
 	tlsDialOption := grpc.WithTransportCredentials(insecure.NewCredentials()) // No TLS, requires 'insecure' flag
-	var tlsServer *tls.Config
 	if config.tlsEnabled() {
-		tlsDialOption = grpc.WithTransportCredentials(credentials.NewTLS(newClientTLSConfig(config))) // TLS authentication
-		if config.serverCert != nil {
-			tlsServer = newServerTLSConfig(config)
+		clientTlsConfig, err := newClientTLSConfig(config)
+		if err != nil {
+			return nil, err
 		}
+		tlsDialOption = grpc.WithTransportCredentials(credentials.NewTLS(clientTlsConfig)) // TLS authentication
 	}
 
 	cm := &grpcConnectionManager{
@@ -117,13 +118,12 @@ func NewGRPCConnectionManager(config Config, connectionStore stoabs.KVStore, nod
 			grpc.WithUserAgent(core.UserAgent()),
 			tlsDialOption,
 		},
-		tlsServer: tlsServer,
 	}
 	cm.addressBook = newAddressBook(connectionStore, config.backoffCreator)
 	cm.registerPrometheusMetrics()
 	cm.ctx, cm.ctxCancel = context.WithCancel(context.Background())
 
-	return cm
+	return cm, nil
 }
 
 // grpcConnectionManager is a ConnectionManager that does not discover peers on its own, but just connects to the peers for which Connect() is called.
@@ -131,7 +131,6 @@ type grpcConnectionManager struct {
 	protocols           []Protocol
 	config              Config
 	grpcServer          *grpc.Server
-	tlsServer           *tls.Config
 	ctx                 context.Context
 	ctxCancel           func()
 	listener            net.Listener
@@ -152,7 +151,7 @@ type grpcConnectionManager struct {
 }
 
 // newGrpcServer configures a new grpc.Server. context.Context is used to cancel the crlValidator
-func newGrpcServer(config Config, tlsServer *tls.Config) (*grpc.Server, error) {
+func newGrpcServer(config Config) (*grpc.Server, error) {
 	serverOpts := []grpc.ServerOption{
 		grpc.MaxRecvMsgSize(MaxMessageSizeInBytes),
 		grpc.MaxSendMsgSize(MaxMessageSizeInBytes),
@@ -166,13 +165,13 @@ func newGrpcServer(config Config, tlsServer *tls.Config) (*grpc.Server, error) {
 		// Some form of TLS is enabled
 		if config.serverCert != nil {
 			// TLS is terminated at the Nuts node (no offloading)
+			tlsServer, err := newServerTLSConfig(config)
+			if err != nil {
+				return nil, err
+			}
 			serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(tlsServer)))
 		} else {
 			// TLS offloading for incoming traffic
-			if config.clientCertHeaderName == "" {
-				// Invalid config
-				return nil, errors.New("tls.certheader must be configured to enable TLS offloading ")
-			}
 			serverInterceptors = append(serverInterceptors, newAuthenticationInterceptor(config.clientCertHeaderName))
 		}
 	} else {
@@ -214,7 +213,7 @@ func (s *grpcConnectionManager) Start() error {
 	}
 
 	// Create gRPC server for inbound connectionList and associate it with the protocols
-	s.grpcServer, err = newGrpcServer(s.config, s.tlsServer)
+	s.grpcServer, err = newGrpcServer(s.config)
 	if err != nil {
 		return err
 	}

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -171,7 +171,7 @@ func newGrpcServer(config Config) (*grpc.Server, error) {
 			}
 			serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(tlsServer)))
 		} else {
-			// TLS offloading for incoming traffic
+			// TLS offloading for incoming traffic. config.clientCertHeaderName is validated during config creation.
 			serverInterceptors = append(serverInterceptors, newAuthenticationInterceptor(config.clientCertHeaderName))
 		}
 	} else {

--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -58,28 +58,38 @@ import (
 // newBufconnConfig creates a new Config like NewConfig, but configures an in-memory bufconn listener instead of a TCP listener.
 func newBufconnConfig(peerID transport.PeerID, options ...ConfigOption) (Config, *bufconn.Listener) {
 	bufnet := bufconn.Listen(1024 * 1024)
-	return NewConfig("bufnet", peerID, append(options[:], func(config *Config) {
+	cfg, err := NewConfig("bufnet", peerID, append(options[:], func(config *Config) error {
 		config.listener = func(_ string) (net.Listener, error) {
 			return bufnet, nil
 		}
-	})...), bufnet
+		return nil
+	})...)
+	if err != nil {
+		panic(err)
+	}
+	return cfg, bufnet
 }
 
 // withBufconnDialer can be used to redirect outbound connections to a predetermined bufconn listener.
 func withBufconnDialer(listener *bufconn.Listener) ConfigOption {
-	return func(config *Config) {
+	return func(config *Config) error {
 		config.dialer = func(ctx context.Context, target string, opts ...grpc.DialOption) (conn *grpc.ClientConn, err error) {
 			return grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 				return listener.Dial()
 			}), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		}
+		return nil
 	}
 }
 
 func Test_grpcConnectionManager_Connect(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		p := &TestProtocol{}
-		cm := NewGRPCConnectionManager(NewConfig("", "test"), createKVStore(t), *nodeDID, nil, p).(*grpcConnectionManager)
+
+		cfg, err := NewConfig("", "test")
+		require.NoError(t, err)
+		cm, err := NewGRPCConnectionManager(cfg, createKVStore(t), *nodeDID, nil, p)
+		require.NoError(t, err)
 		bo := &trackingBackoff{mux: &sync.Mutex{}}
 		cm.addressBook.backoffCreator = func() Backoff { return bo }
 		delayFn := func(delay time.Duration) *time.Duration { return &delay }
@@ -107,9 +117,12 @@ func Test_grpcConnectionManager_Connect(t *testing.T) {
 		p := &TestProtocol{}
 		ts, _ := core.LoadTrustStore("../../test/truststore.pem")
 		clientCert, _ := tls.LoadX509KeyPair("../../test/certificate-and-key.pem", "../../test/certificate-and-key.pem")
-		config := NewConfig("", "test", WithTLS(clientCert, ts))
 
-		cm := NewGRPCConnectionManager(config, createKVStore(t), *nodeDID, nil, p).(*grpcConnectionManager)
+		config, err := NewConfig("", "test", WithTLS(clientCert, ts))
+		require.NoError(t, err)
+
+		cm, err := NewGRPCConnectionManager(config, createKVStore(t), *nodeDID, nil, p)
+		require.NoError(t, err)
 
 		cm.Connect(fmt.Sprintf("127.0.0.1:%d", test.FreeTCPPort()), did.DID{}, nil)
 
@@ -123,7 +136,10 @@ func Test_grpcConnectionManager_Connect(t *testing.T) {
 
 	t.Run("duplicate connection", func(t *testing.T) {
 		p := &TestProtocol{}
-		cm := NewGRPCConnectionManager(NewConfig("", "test"), createKVStore(t), *nodeDID, nil, p).(*grpcConnectionManager)
+		cfg, err := NewConfig("", "test")
+		require.NoError(t, err)
+		cm, err := NewGRPCConnectionManager(cfg, createKVStore(t), *nodeDID, nil, p)
+		require.NoError(t, err)
 
 		peerAddress := fmt.Sprintf("127.0.0.1:%d", test.FreeTCPPort())
 		cm.Connect(peerAddress, did.DID{}, nil)
@@ -133,7 +149,10 @@ func Test_grpcConnectionManager_Connect(t *testing.T) {
 
 	t.Run("no address removes contacts", func(t *testing.T) {
 		p := &TestProtocol{}
-		cm := NewGRPCConnectionManager(NewConfig("", "test"), createKVStore(t), *nodeDID, nil, p).(*grpcConnectionManager)
+		cfg, err := NewConfig("", "test")
+		require.NoError(t, err)
+		cm, err := NewGRPCConnectionManager(cfg, createKVStore(t), *nodeDID, nil, p)
+		require.NoError(t, err)
 		cm.Connect("address", did.MustParseDID("did:nuts:abc"), nil)
 		assert.Len(t, cm.addressBook.contacts, 1)
 
@@ -144,7 +163,10 @@ func Test_grpcConnectionManager_Connect(t *testing.T) {
 }
 
 func Test_grpcConnectionManager_hasActiveConnection(t *testing.T) {
-	cm := NewGRPCConnectionManager(NewConfig("", "test"), createKVStore(t), *nodeDID, nil, &TestProtocol{}).(*grpcConnectionManager)
+	cfg, err := NewConfig("", "test")
+	require.NoError(t, err)
+	cm, err := NewGRPCConnectionManager(cfg, createKVStore(t), *nodeDID, nil, &TestProtocol{})
+	require.NoError(t, err)
 	// add 2 connections
 	ctx := context.Background()
 	bootstrap := transport.Peer{Address: "bootstrap"}
@@ -176,7 +198,8 @@ func Test_grpcConnectionManager_dialerLoop(t *testing.T) {
 	var capturedAddress string
 	timeout := 2 * time.Second // connectLoop ticker takes 1 sec
 
-	cm := NewGRPCConnectionManager(Config{connectionTimeout: 5 * timeout}, createKVStore(t), *nodeDID, dummyAuthenticator{}, &TestProtocol{}).(*grpcConnectionManager)
+	cm, err := NewGRPCConnectionManager(Config{connectionTimeout: 5 * timeout}, createKVStore(t), *nodeDID, dummyAuthenticator{}, &TestProtocol{})
+	require.NoError(t, err)
 	cm.dialer = func(ctx context.Context, target string, _ ...grpc.DialOption) (conn *grpc.ClientConn, err error) {
 		capturedAddress = target
 		<-ctx.Done()
@@ -217,8 +240,9 @@ func Test_grpcConnectionManager_dial(t *testing.T) {
 		defer func() { defaultInterceptors = defaultInterceptors[:0] }()
 
 		// Setup server
-		serverConfig := NewConfig(fmt.Sprintf("localhost:%d", test.FreeTCPPort()), "server")
-		cm := NewGRPCConnectionManager(serverConfig, createKVStore(t), did.DID{}, nil, &TestProtocol{}).(*grpcConnectionManager)
+		serverConfig, err := NewConfig(fmt.Sprintf("localhost:%d", test.FreeTCPPort()), "server")
+		require.NoError(t, err)
+		cm, err := NewGRPCConnectionManager(serverConfig, createKVStore(t), did.DID{}, nil, &TestProtocol{})
 		require.NoError(t, cm.Start())
 		defer cm.Stop()
 
@@ -240,7 +264,8 @@ func Test_grpcConnectionManager_dial(t *testing.T) {
 		backoff := &trackingBackoff{mux: &sync.Mutex{}}
 		peer := transport.Peer{Address: "nuts.nl"}
 		cont := newContact(peer, backoff)
-		cm := NewGRPCConnectionManager(Config{}, createKVStore(t), *nodeDID, dummyAuthenticator{}, &TestProtocol{}).(*grpcConnectionManager)
+		cm, err := NewGRPCConnectionManager(Config{}, createKVStore(t), *nodeDID, dummyAuthenticator{}, &TestProtocol{})
+		require.NoError(t, err)
 		cm.connections.list = append(cm.connections.list, createConnection(cm.ctx, peer)) // add existing connection
 
 		cm.connect(cont)
@@ -256,7 +281,8 @@ func Test_grpcConnectionManager_dial(t *testing.T) {
 		t.Run("dialer context canceled", func(t *testing.T) {
 			backoff := &trackingBackoff{mux: &sync.Mutex{}}
 			cont := newContact(transport.Peer{Address: "nuts.nl"}, backoff)
-			cm := NewGRPCConnectionManager(Config{connectionTimeout: time.Second}, createKVStore(t), *nodeDID, dummyAuthenticator{}, &TestProtocol{}).(*grpcConnectionManager)
+			cm, err := NewGRPCConnectionManager(Config{connectionTimeout: time.Second}, createKVStore(t), *nodeDID, dummyAuthenticator{}, &TestProtocol{})
+			require.NoError(t, err)
 			cm.dialer = func(ctx context.Context, target string, _ ...grpc.DialOption) (conn *grpc.ClientConn, err error) {
 				return nil, status.Error(codes.Canceled, "failed")
 			}
@@ -275,7 +301,8 @@ func Test_grpcConnectionManager_dial(t *testing.T) {
 		t.Run("dialer error", func(t *testing.T) {
 			backoff := &trackingBackoff{mux: &sync.Mutex{}}
 			cont := newContact(transport.Peer{Address: "nuts.nl"}, backoff)
-			cm := NewGRPCConnectionManager(Config{connectionTimeout: time.Second}, createKVStore(t), *nodeDID, dummyAuthenticator{}, &TestProtocol{}).(*grpcConnectionManager)
+			cm, err := NewGRPCConnectionManager(Config{connectionTimeout: time.Second}, createKVStore(t), *nodeDID, dummyAuthenticator{}, &TestProtocol{})
+			require.NoError(t, err)
 			cm.dialer = func(ctx context.Context, target string, _ ...grpc.DialOption) (conn *grpc.ClientConn, err error) {
 				return nil, errors.New("not a context calceled error")
 			}
@@ -300,7 +327,8 @@ func Test_grpcConnectionManager_dial(t *testing.T) {
 
 			// server
 			serverCfg, listener := newBufconnConfig(transport.PeerID(t.Name()))
-			server := NewGRPCConnectionManager(serverCfg, createKVStore(t), *nodeDID, authenticator, &TestProtocol{}).(*grpcConnectionManager)
+			server, err := NewGRPCConnectionManager(serverCfg, createKVStore(t), *nodeDID, authenticator, &TestProtocol{})
+			require.NoError(t, err)
 			if err := server.Start(); err != nil {
 				t.Fatal(err)
 			}
@@ -308,7 +336,8 @@ func Test_grpcConnectionManager_dial(t *testing.T) {
 
 			// client
 			cfg, listener := newBufconnConfig(transport.PeerID(t.Name()), withBufconnDialer(listener))
-			client := NewGRPCConnectionManager(cfg, createKVStore(t), *nodeDID, authenticator, &TestProtocol{}).(*grpcConnectionManager)
+			client, err := NewGRPCConnectionManager(cfg, createKVStore(t), *nodeDID, authenticator, &TestProtocol{})
+			require.NoError(t, err)
 
 			// contact
 			cont := newContact(transport.Peer{Address: "bufnet", NodeDID: *nodeDID}, newTestBackoff())
@@ -342,7 +371,8 @@ func Test_grpcConnectionManager_dial(t *testing.T) {
 		t.Run("error", func(t *testing.T) {
 			//server
 			serverCfg, serverListener := newBufconnConfig("server")
-			server := NewGRPCConnectionManager(serverCfg, nil, *nodeDID, nil).(*grpcConnectionManager)
+			server, err := NewGRPCConnectionManager(serverCfg, nil, *nodeDID, nil)
+			require.NoError(t, err)
 			if err := server.Start(); err != nil {
 				t.Fatal(err)
 			}
@@ -350,7 +380,8 @@ func Test_grpcConnectionManager_dial(t *testing.T) {
 
 			//client
 			clientCfg, _ := newBufconnConfig("client", withBufconnDialer(serverListener))
-			client := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, NewDummyAuthenticator(nil), &TestProtocol{}).(*grpcConnectionManager)
+			client, err := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, NewDummyAuthenticator(nil), &TestProtocol{})
+			require.NoError(t, err)
 
 			// connection
 			backoff := &trackingBackoff{mux: &sync.Mutex{}}
@@ -374,7 +405,8 @@ func Test_grpcConnectionManager_dial(t *testing.T) {
 		})
 		t.Run("wrong DID answered call", func(t *testing.T) {
 			serverCfg, serverListener := newBufconnConfig("server")
-			server := NewGRPCConnectionManager(serverCfg, nil, *nodeDID, nil, &TestProtocol{}).(*grpcConnectionManager)
+			server, err := NewGRPCConnectionManager(serverCfg, nil, *nodeDID, nil, &TestProtocol{})
+			require.NoError(t, err)
 			if err := server.Start(); err != nil {
 				t.Fatal(err)
 			}
@@ -383,7 +415,8 @@ func Test_grpcConnectionManager_dial(t *testing.T) {
 			clientCfg, _ := newBufconnConfig("client", withBufconnDialer(serverListener))
 			ctrl := gomock.NewController(t)
 			authenticator := NewMockAuthenticator(ctrl)
-			client := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, authenticator, &TestProtocol{}).(*grpcConnectionManager)
+			client, err := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, authenticator, &TestProtocol{})
+			require.NoError(t, err)
 			cont := newContact(transport.Peer{Address: "server", NodeDID: did.MustParseDID("did:nuts:remote")}, newTestBackoff())
 
 			// call peer
@@ -411,7 +444,8 @@ func Test_grpcConnectionManager_Peers(t *testing.T) {
 		proto := &TestProtocol{}
 		cfg, listener := newBufconnConfig(transport.PeerID(t.Name()), opts...)
 		db := createKVStore(t)
-		cm := NewGRPCConnectionManager(cfg, db, *nodeDID, authenticator, proto).(*grpcConnectionManager)
+		cm, err := NewGRPCConnectionManager(cfg, db, *nodeDID, authenticator, proto)
+		require.NoError(t, err)
 		if err := cm.Start(); err != nil {
 			t.Fatal(err)
 		}
@@ -499,20 +533,22 @@ func Test_grpcConnectionManager_Start(t *testing.T) {
 	serverCert, _ := tls.LoadX509KeyPair("../../test/certificate-and-key.pem", "../../test/certificate-and-key.pem")
 
 	t.Run("ok - gRPC server not bound", func(t *testing.T) {
-		cm := NewGRPCConnectionManager(Config{}, nil, *nodeDID, nil).(*grpcConnectionManager)
+		cm, err := NewGRPCConnectionManager(Config{}, nil, *nodeDID, nil)
+		require.NoError(t, err)
 		assert.NoError(t, cm.Start())
 		assert.Nil(t, cm.listener)
 	})
 
 	t.Run("ok - gRPC server bound, TLS enabled", func(t *testing.T) {
-		cfg := NewConfig(
+		cfg, err := NewConfig(
 			fmt.Sprintf("127.0.0.1:%d",
 				test.FreeTCPPort()),
 			"foo",
 			WithTLS(serverCert, trustStore),
 		)
-		cm := NewGRPCConnectionManager(cfg, nil, *nodeDID, nil).(*grpcConnectionManager)
-		err := cm.Start()
+		require.NoError(t, err)
+		cm, err := NewGRPCConnectionManager(cfg, nil, *nodeDID, nil)
+		err = cm.Start()
 		require.NoError(t, err)
 		defer cm.Stop()
 
@@ -520,37 +556,40 @@ func Test_grpcConnectionManager_Start(t *testing.T) {
 	})
 
 	t.Run("ok - gRPC server bound, incoming TLS offloaded", func(t *testing.T) {
-		cfg := NewConfig(
+		cfg, err := NewConfig(
 			fmt.Sprintf("127.0.0.1:%d",
 				test.FreeTCPPort()),
 			"foo",
 			WithTLS(serverCert, trustStore),
 			WithTLSOffloading("client-cert"),
 		)
-		cm := NewGRPCConnectionManager(cfg, nil, *nodeDID, nil).(*grpcConnectionManager)
-		err := cm.Start()
+		require.NoError(t, err)
+		cm, err := NewGRPCConnectionManager(cfg, nil, *nodeDID, nil)
+		require.NoError(t, err)
+		err = cm.Start()
 		require.NoError(t, err)
 		defer cm.Stop()
 
 		assert.NotNil(t, cm.listener)
 	})
 	t.Run("ok - gRPC server bound, incoming TLS offloaded (but HTTP client cert name is invalid)", func(t *testing.T) {
-		cfg := NewConfig(
+		_, err := NewConfig(
 			fmt.Sprintf("127.0.0.1:%d",
 				test.FreeTCPPort()),
 			"foo",
 			WithTLS(serverCert, trustStore),
 			WithTLSOffloading(""),
 		)
-		cm := NewGRPCConnectionManager(cfg, nil, *nodeDID, nil).(*grpcConnectionManager)
-		err := cm.Start()
 
 		assert.EqualError(t, err, "tls.certheader must be configured to enable TLS offloading ")
 	})
 
 	t.Run("ok - gRPC server bound, TLS disabled", func(t *testing.T) {
-		cm := NewGRPCConnectionManager(NewConfig(fmt.Sprintf("127.0.0.1:%d", test.FreeTCPPort()), "foo"), nil, *nodeDID, nil).(*grpcConnectionManager)
-		err := cm.Start()
+		cfg, err := NewConfig(fmt.Sprintf("127.0.0.1:%d", test.FreeTCPPort()), "foo")
+		require.NoError(t, err)
+		cm, err := NewGRPCConnectionManager(cfg, nil, *nodeDID, nil)
+		require.NoError(t, err)
+		err = cm.Start()
 		require.NoError(t, err)
 		defer cm.Stop()
 
@@ -568,7 +607,7 @@ func Test_grpcConnectionManager_Start(t *testing.T) {
 			}
 		}).Times(2) // on inbound and outbound TLS config
 
-		cm := NewGRPCConnectionManager(Config{
+		cm, _ := NewGRPCConnectionManager(Config{
 			listenAddress: fmt.Sprintf(":%d", test.FreeTCPPort()),
 			trustStore:    x509.NewCertPool(),
 			serverCert:    &serverCert,
@@ -584,7 +623,8 @@ func Test_grpcConnectionManager_Start(t *testing.T) {
 
 func Test_grpcConnectionManager_Stop(t *testing.T) {
 	t.Run("closes open connections", func(t *testing.T) {
-		cm := NewGRPCConnectionManager(Config{peerID: "12345"}, nil, *nodeDID, nil).(*grpcConnectionManager)
+		cm, err := NewGRPCConnectionManager(Config{peerID: "12345"}, nil, *nodeDID, nil)
+		require.NoError(t, err)
 
 		go cm.handleInboundStream(&TestProtocol{}, newServerStream("1234", ""))
 		test.WaitFor(t, func() (bool, error) {
@@ -598,7 +638,8 @@ func Test_grpcConnectionManager_Stop(t *testing.T) {
 		// This test simulates a slow or unfortunately timed shutdown, where there's an new inbound stream while shutting down.
 		// This previously caused the Connection Manager to deadlock, being blocked by conn.waitUntilDisconnected() which blocks GRPCServer.GracefulStop().
 		// Solved by having the context conn.waitUntilDisconnected() waits for, derive from a parent context supplied by ConnectionManager, which is cancelled when Stop() is called.
-		cm := NewGRPCConnectionManager(Config{peerID: "12345"}, nil, *nodeDID, nil).(*grpcConnectionManager)
+		cm, err := NewGRPCConnectionManager(Config{peerID: "12345"}, nil, *nodeDID, nil)
+		require.NoError(t, err)
 
 		wg := sync.WaitGroup{}
 		wg.Add(2)
@@ -624,12 +665,14 @@ func Test_grpcConnectionManager_Stop(t *testing.T) {
 func Test_grpcConnectionManager_Diagnostics(t *testing.T) {
 	const peerID = "server-peer-id"
 	t.Run("no peers", func(t *testing.T) {
-		cm := NewGRPCConnectionManager(Config{peerID: peerID}, nil, *nodeDID, nil).(*grpcConnectionManager)
+		cm, err := NewGRPCConnectionManager(Config{peerID: peerID}, nil, *nodeDID, nil)
+		require.NoError(t, err)
 		defer cm.Stop()
 		assert.Equal(t, "0", cm.Diagnostics()[1].String()) // assert number_of_peers
 	})
 	t.Run("with peers", func(t *testing.T) {
-		cm := NewGRPCConnectionManager(Config{peerID: peerID}, nil, *nodeDID, nil).(*grpcConnectionManager)
+		cm, err := NewGRPCConnectionManager(Config{peerID: peerID}, nil, *nodeDID, nil)
+		require.NoError(t, err)
 		defer cm.Stop()
 
 		go cm.handleInboundStream(&TestProtocol{}, newServerStream("peer1", ""))
@@ -647,14 +690,16 @@ func Test_grpcConnectionManager_Diagnostics(t *testing.T) {
 func Test_grpcConnectionManager_openOutboundStreams(t *testing.T) {
 	t.Run("client does not support gRPC protocol implementation", func(t *testing.T) {
 		serverCfg, serverListener := newBufconnConfig("server")
-		server := NewGRPCConnectionManager(serverCfg, nil, *nodeDID, nil).(*grpcConnectionManager)
+		server, err := NewGRPCConnectionManager(serverCfg, nil, *nodeDID, nil)
+		require.NoError(t, err)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
 		defer server.Stop()
 
 		clientCfg, _ := newBufconnConfig("client", withBufconnDialer(serverListener))
-		client := NewGRPCConnectionManager(clientCfg, nil, *nodeDID, nil, &TestProtocol{}).(*grpcConnectionManager)
+		client, err := NewGRPCConnectionManager(clientCfg, nil, *nodeDID, nil, &TestProtocol{})
+		require.NoError(t, err)
 
 		connection, _ := client.connections.getOrRegister(context.Background(), transport.Peer{Address: "server"}, false)
 		grpcConn, err := clientCfg.dialer(context.Background(), "server")
@@ -666,14 +711,16 @@ func Test_grpcConnectionManager_openOutboundStreams(t *testing.T) {
 	})
 	t.Run("remote authentication fails", func(t *testing.T) {
 		serverCfg, serverListener := newBufconnConfig("server")
-		server := NewGRPCConnectionManager(serverCfg, nil, did.DID{}, nil, &TestProtocol{}).(*grpcConnectionManager)
+		server, err := NewGRPCConnectionManager(serverCfg, nil, did.DID{}, nil, &TestProtocol{})
+		require.NoError(t, err)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
 		defer server.Stop()
 
 		clientCfg, _ := newBufconnConfig("client", withBufconnDialer(serverListener))
-		client := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, nil, &TestProtocol{}).(*grpcConnectionManager)
+		client, err := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, nil, &TestProtocol{})
+		require.NoError(t, err)
 		c := createConnection(context.Background(), transport.Peer{}).(*conn)
 		c.status.Store(status.New(codes.Unauthenticated, "unauthenticated"))
 		grpcConn, err := clientCfg.dialer(context.Background(), "server")
@@ -706,14 +753,16 @@ func Test_grpcConnectionManager_openOutboundStreams(t *testing.T) {
 		// Bug: peer ID is empty when race condition with disconnect() and notify observers occurs.
 		// See https://github.com/nuts-foundation/nuts-node/issues/978
 		serverCfg, serverListener := newBufconnConfig("server")
-		server := NewGRPCConnectionManager(serverCfg, nil, did.DID{}, nil, &TestProtocol{}).(*grpcConnectionManager)
+		server, err := NewGRPCConnectionManager(serverCfg, nil, did.DID{}, nil, &TestProtocol{})
+		require.NoError(t, err)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
 		defer server.Stop()
 
 		clientCfg, _ := newBufconnConfig("client", withBufconnDialer(serverListener))
-		client := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, nil, &TestProtocol{}).(*grpcConnectionManager)
+		client, err := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, nil, &TestProtocol{})
+		require.NoError(t, err)
 		c := createConnection(context.Background(), transport.Peer{})
 		grpcConn, err := clientCfg.dialer(context.Background(), "server")
 		require.NoError(t, err)
@@ -776,7 +825,7 @@ func Test_grpcConnectionManager_openOutboundStream(t *testing.T) {
 		authenticator := NewMockAuthenticator(ctrl)
 		authenticator.EXPECT().Authenticate(*nodeDID, *grpcPeer, peerInfo).Return(peerInfo, nil)
 
-		cm := NewGRPCConnectionManager(Config{peerID: "server-peer-id"}, nil, *nodeDID, nil).(*grpcConnectionManager)
+		cm, err := NewGRPCConnectionManager(Config{peerID: "server-peer-id"}, nil, *nodeDID, nil)
 		cm.authenticator = authenticator
 
 		defer cm.Stop()
@@ -803,14 +852,16 @@ func Test_grpcConnectionManager_openOutboundStream(t *testing.T) {
 	})
 	t.Run("server did not send ID", func(t *testing.T) {
 		serverCfg, serverListener := newBufconnConfig("")
-		server := NewGRPCConnectionManager(serverCfg, nil, did.DID{}, nil, &TestProtocol{}).(*grpcConnectionManager)
+		server, err := NewGRPCConnectionManager(serverCfg, nil, did.DID{}, nil, &TestProtocol{})
+		require.NoError(t, err)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
 		defer server.Stop()
 
 		clientCfg, _ := newBufconnConfig("client", withBufconnDialer(serverListener))
-		client := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, nil, &TestProtocol{}).(*grpcConnectionManager)
+		client, err := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, nil, &TestProtocol{})
+		require.NoError(t, err)
 		c := createConnection(context.Background(), transport.Peer{})
 		grpcConn, err := clientCfg.dialer(context.Background(), "server")
 		require.NoError(t, err)
@@ -822,14 +873,16 @@ func Test_grpcConnectionManager_openOutboundStream(t *testing.T) {
 	})
 	t.Run("second stream over same connection sends different peer ID", func(t *testing.T) {
 		serverCfg, serverListener := newBufconnConfig("server")
-		server := NewGRPCConnectionManager(serverCfg, nil, did.DID{}, nil, &TestProtocol{}).(*grpcConnectionManager)
+		server, err := NewGRPCConnectionManager(serverCfg, nil, did.DID{}, nil, &TestProtocol{})
+		require.NoError(t, err)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
 		defer server.Stop()
 
 		clientCfg, _ := newBufconnConfig("client", withBufconnDialer(serverListener))
-		client := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, nil, &TestProtocol{}).(*grpcConnectionManager)
+		client, err := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, nil, &TestProtocol{})
+		require.NoError(t, err)
 		c := createConnection(context.Background(), transport.Peer{})
 		grpcConn, err := clientCfg.dialer(context.Background(), "server")
 		require.NoError(t, err)
@@ -848,14 +901,16 @@ func Test_grpcConnectionManager_openOutboundStream(t *testing.T) {
 	})
 	t.Run("already connected (same peer ID)", func(t *testing.T) {
 		serverCfg, serverListener := newBufconnConfig("server")
-		server := NewGRPCConnectionManager(serverCfg, nil, did.DID{}, nil, &TestProtocol{}).(*grpcConnectionManager)
+		server, err := NewGRPCConnectionManager(serverCfg, nil, did.DID{}, nil, &TestProtocol{})
+		require.NoError(t, err)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
 		defer server.Stop()
 
 		clientCfg, _ := newBufconnConfig("client", withBufconnDialer(serverListener))
-		client := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, nil, &TestProtocol{}).(*grpcConnectionManager)
+		client, err := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, nil, &TestProtocol{})
+		require.NoError(t, err)
 		c := createConnection(context.Background(), transport.Peer{})
 		grpcConn, err := clientCfg.dialer(context.Background(), "server")
 		require.NoError(t, err)
@@ -872,7 +927,8 @@ func Test_grpcConnectionManager_openOutboundStream(t *testing.T) {
 	})
 	t.Run("peer authentication fails", func(t *testing.T) {
 		serverCfg, serverListener := newBufconnConfig("server")
-		server := NewGRPCConnectionManager(serverCfg, nil, *nodeDID, nil, &TestProtocol{}).(*grpcConnectionManager)
+		server, err := NewGRPCConnectionManager(serverCfg, nil, *nodeDID, nil, &TestProtocol{})
+		require.NoError(t, err)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
@@ -882,7 +938,8 @@ func Test_grpcConnectionManager_openOutboundStream(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		authenticator := NewMockAuthenticator(ctrl)
 		authenticator.EXPECT().Authenticate(*nodeDID, gomock.Any(), gomock.Any()).Return(transport.Peer{}, ErrNodeDIDAuthFailed)
-		client := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, authenticator, &TestProtocol{}).(*grpcConnectionManager)
+		client, err := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, authenticator, &TestProtocol{})
+		require.NoError(t, err)
 		c := createConnection(context.Background(), transport.Peer{NodeDID: *nodeDID})
 		grpcConn, err := clientCfg.dialer(context.Background(), "server")
 		require.NoError(t, err)
@@ -894,7 +951,8 @@ func Test_grpcConnectionManager_openOutboundStream(t *testing.T) {
 	})
 	t.Run("wrong DID answered call", func(t *testing.T) {
 		serverCfg, serverListener := newBufconnConfig("server")
-		server := NewGRPCConnectionManager(serverCfg, nil, *nodeDID, nil, &TestProtocol{}).(*grpcConnectionManager)
+		server, err := NewGRPCConnectionManager(serverCfg, nil, *nodeDID, nil, &TestProtocol{})
+		require.NoError(t, err)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
@@ -903,7 +961,8 @@ func Test_grpcConnectionManager_openOutboundStream(t *testing.T) {
 		clientCfg, _ := newBufconnConfig("client", withBufconnDialer(serverListener))
 		ctrl := gomock.NewController(t)
 		authenticator := NewMockAuthenticator(ctrl)
-		client := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, authenticator, &TestProtocol{}).(*grpcConnectionManager)
+		client, err := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, authenticator, &TestProtocol{})
+		require.NoError(t, err)
 		c := createConnection(context.Background(), transport.Peer{NodeDID: did.MustParseDID("did:nuts:remote")})
 		grpcConn, err := clientCfg.dialer(context.Background(), "server")
 		require.NoError(t, err)
@@ -915,7 +974,8 @@ func Test_grpcConnectionManager_openOutboundStream(t *testing.T) {
 	})
 	t.Run("peer did not send DID", func(t *testing.T) {
 		serverCfg, serverListener := newBufconnConfig("server")
-		server := NewGRPCConnectionManager(serverCfg, nil, did.DID{}, nil, &TestProtocol{}).(*grpcConnectionManager)
+		server, err := NewGRPCConnectionManager(serverCfg, nil, did.DID{}, nil, &TestProtocol{})
+		require.NoError(t, err)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
@@ -924,7 +984,8 @@ func Test_grpcConnectionManager_openOutboundStream(t *testing.T) {
 		clientCfg, _ := newBufconnConfig("client", withBufconnDialer(serverListener))
 		ctrl := gomock.NewController(t)
 		authenticator := NewMockAuthenticator(ctrl) // is not called
-		client := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, authenticator, &TestProtocol{}).(*grpcConnectionManager)
+		client, err := NewGRPCConnectionManager(clientCfg, nil, did.DID{}, authenticator, &TestProtocol{})
+		require.NoError(t, err)
 		c := createConnection(context.Background(), transport.Peer{NodeDID: did.MustParseDID("did:nuts:remote")})
 		grpcConn, err := clientCfg.dialer(context.Background(), "server")
 		require.NoError(t, err)
@@ -950,7 +1011,8 @@ func Test_grpcConnectionManager_handleInboundStream(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		authenticator := NewMockAuthenticator(ctrl)
 		authenticator.EXPECT().Authenticate(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedPeer, nil)
-		cm := NewGRPCConnectionManager(Config{peerID: "server-peer-id"}, nil, *nodeDID, authenticator).(*grpcConnectionManager)
+		cm, err := NewGRPCConnectionManager(Config{peerID: "server-peer-id"}, nil, *nodeDID, authenticator)
+		require.NoError(t, err)
 		defer cm.Stop()
 
 		handlerExited := &sync.WaitGroup{}
@@ -994,9 +1056,10 @@ func Test_grpcConnectionManager_handleInboundStream(t *testing.T) {
 			Address: "127.0.0.1:9522",
 		}
 		serverStream := newServerStream(expectedPeer.ID, expectedPeer.NodeDID.String())
-		cm := NewGRPCConnectionManager(Config{peerID: "server-peer-id"}, nil, *nodeDID, nil).(*grpcConnectionManager)
+		cm, err := NewGRPCConnectionManager(Config{peerID: "server-peer-id"}, nil, *nodeDID, nil)
+		require.NoError(t, err)
 
-		err := cm.handleInboundStream(protocol, serverStream)
+		err = cm.handleInboundStream(protocol, serverStream)
 		assert.EqualError(t, err, "unable to read peer ID")
 		assert.Empty(t, cm.connections.list)
 	})
@@ -1012,15 +1075,17 @@ func Test_grpcConnectionManager_handleInboundStream(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		authenticator := NewMockAuthenticator(ctrl)
 		authenticator.EXPECT().Authenticate(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedPeer, errors.New("failed"))
-		cm := NewGRPCConnectionManager(Config{peerID: "server-peer-id"}, nil, *nodeDID, authenticator).(*grpcConnectionManager)
+		cm, err := NewGRPCConnectionManager(Config{peerID: "server-peer-id"}, nil, *nodeDID, authenticator)
+		require.NoError(t, err)
 
-		err := cm.handleInboundStream(protocol, serverStream)
+		err = cm.handleInboundStream(protocol, serverStream)
 		assert.Equal(t, err, ErrNodeDIDAuthFailed)
 		assert.Empty(t, cm.connections.list)
 	})
 	t.Run("already connected client", func(t *testing.T) {
-		cm := NewGRPCConnectionManager(Config{peerID: "server-peer-id"}, nil, *nodeDID, nil).(*grpcConnectionManager)
+		cm, err := NewGRPCConnectionManager(Config{peerID: "server-peer-id"}, nil, *nodeDID, nil)
 		defer cm.Stop()
+		require.NoError(t, err)
 
 		go cm.handleInboundStream(protocol, newServerStream("client-peer-id", ""))
 		test.WaitFor(t, func() (bool, error) {
@@ -1028,15 +1093,16 @@ func Test_grpcConnectionManager_handleInboundStream(t *testing.T) {
 		}, 5*time.Second, "time-out while waiting for peer")
 
 		// Second connection with same peer ID is rejected
-		err := cm.handleInboundStream(protocol, newServerStream("client-peer-id", ""))
+		err = cm.handleInboundStream(protocol, newServerStream("client-peer-id", ""))
 		assert.ErrorIs(t, err, ErrAlreadyConnected)
 
 		// Assert only first connection was registered
 		assert.Len(t, cm.connections.list, 1)
 	})
 	t.Run("closing connection removes it from list", func(t *testing.T) {
-		cm := NewGRPCConnectionManager(Config{peerID: "server-peer-id"}, nil, *nodeDID, nil).(*grpcConnectionManager)
+		cm, err := NewGRPCConnectionManager(Config{peerID: "server-peer-id"}, nil, *nodeDID, nil)
 		defer cm.Stop()
+		require.NoError(t, err)
 
 		stream := newServerStream("client-peer-id", "")
 		go cm.handleInboundStream(protocol, stream)

--- a/network/transport/v2/protocol_integration_test.go
+++ b/network/transport/v2/protocol_integration_test.go
@@ -164,7 +164,10 @@ func startNode(t *testing.T, name string, configurers ...func(config *Config)) *
 
 	authenticator := grpc.NewTLSAuthenticator(didservice.NewServiceResolver(&didservice.Resolver{Store: didstore.NewTestStore(t)}))
 	connectionsStore, _ := storageClient.GetProvider("network").GetKVStore("connections", storage.VolatileStorageClass)
-	ctx.connectionManager = grpc.NewGRPCConnectionManager(grpc.NewConfig(listenAddress, peerID), connectionsStore, did.DID{}, authenticator, ctx.protocol)
+	grpcCfg, err := grpc.NewConfig(listenAddress, peerID)
+	require.NoError(t, err)
+	ctx.connectionManager, err = grpc.NewGRPCConnectionManager(grpcCfg, connectionsStore, did.DID{}, authenticator, ctx.protocol)
+	require.NoError(t, err)
 
 	ctx.protocol.Configure(peerID)
 	if err := ctx.connectionManager.Start(); err != nil {


### PR DESCRIPTION
The new CRL validator introduced possible panics during startup. This PR introduces the changes to the connection manager to prevent that.

I'm not sure if the error cases are sufficiently tested