### PR TITLE
Docs: move tls.crl.maxvaliditydays release note to 5.3.0

### DIFF
--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -4,6 +4,16 @@ Release notes
 #############
 
 ************************
+Hazelnut update (v5.3.0)
+************************
+
+Release date: **DRAFT**
+
+- The ``tls.crl.maxvaliditydays`` config flag has been deprecated. CRLs are now updated more frequently, making this option obsolete.
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v5.2.0...v5.3.0
+
+************************
 Hazelnut update (v5.2.0)
 ************************
 
@@ -15,7 +25,6 @@ Release date: **DRAFT**
 - ``network.connections.outbound_connectors`` on ``/status/diagnostics`` has been moved to ``/internal/network/v1/addressbook``.
   Previously it showed only failing connections, now it shows all addresses it will try to connect to (regardless it's already connected to them or not).
 - Added support for encrypting documents using the JWE standard (for DIDComm support).
-- The ``tls.crl.maxvaliditydays`` config flag has been deprecated. CRLs are now updated more frequently, making this option obsolete.
 
 **Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v5.1.0...v5.2.0
 


### PR DESCRIPTION
5.2 was tagged on a commit before the introduction of this feature