### PR TITLE
VCR: Distinguish VP/VC not valid at given time errors

### DIFF
--- a/vcr/types/constants.go
+++ b/vcr/types/constants.go
@@ -38,8 +38,11 @@ var ErrUntrusted = errors.New("credential issuer is untrusted")
 // ErrInvalidCredential is returned when validation failed
 var ErrInvalidCredential = errors.New("invalid credential")
 
-// ErrInvalidPeriod is returned when the credential is not valid at the given time.
-var ErrInvalidPeriod = errors.New("credential not valid at given time")
+// ErrCredentialNotValidAtTime is returned when the credential is not valid at the given time.
+var ErrCredentialNotValidAtTime = errors.New("credential not valid at given time")
+
+// ErrPresentationNotValidAtTime is returned when the presentation is not valid at the given time.
+var ErrPresentationNotValidAtTime = errors.New("presentation not valid at given time")
 
 // VcDocumentType holds the content type used in network documents which contain Verifiable Credentials
 const VcDocumentType = "application/vc+json"

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -174,7 +174,7 @@ func TestVCR_Resolve(t *testing.T) {
 		ctx.vcr.trustConfig.AddTrust(ssi.MustParseURI("NutsOrganizationCredential"), testVC.Issuer)
 
 		_, err := ctx.vcr.Resolve(*testVC.ID, &time.Time{})
-		assert.Equal(t, vcrTypes.ErrInvalidPeriod, err)
+		assert.Equal(t, vcrTypes.ErrCredentialNotValidAtTime, err)
 	})
 
 	t.Run("error - no longer valid", func(t *testing.T) {
@@ -183,7 +183,7 @@ func TestVCR_Resolve(t *testing.T) {
 		ctx.vcr.trustConfig.AddTrust(ssi.MustParseURI("NutsOrganizationCredential"), testVC.Issuer)
 
 		_, err := ctx.vcr.Resolve(*testVC.ID, &nextYear)
-		assert.Equal(t, vcrTypes.ErrInvalidPeriod, err)
+		assert.Equal(t, vcrTypes.ErrCredentialNotValidAtTime, err)
 	})
 
 	t.Run("ok - revoked", func(t *testing.T) {

--- a/vcr/verifier/verifier_test.go
+++ b/vcr/verifier/verifier_test.go
@@ -358,8 +358,8 @@ func Test_verifier_validateAtTime(t *testing.T) {
 		t.Run("credential is valid", func(t *testing.T) {
 			sut := verifier{}
 			credentialToTest := testCredential(t)
-			validationErr := sut.validateAtTime(credentialToTest.IssuanceDate, credentialToTest.ExpirationDate, timeToCheck)
-			assert.NoError(t, validationErr)
+			valid := sut.validateAtTime(credentialToTest.IssuanceDate, credentialToTest.ExpirationDate, timeToCheck)
+			assert.True(t, valid)
 		})
 	})
 
@@ -369,8 +369,8 @@ func Test_verifier_validateAtTime(t *testing.T) {
 			timeToCheck = &now
 			sut := verifier{}
 			credentialToTest := testCredential(t)
-			validationErr := sut.validateAtTime(credentialToTest.IssuanceDate, credentialToTest.ExpirationDate, timeToCheck)
-			assert.NoError(t, validationErr)
+			valid := sut.validateAtTime(credentialToTest.IssuanceDate, credentialToTest.ExpirationDate, timeToCheck)
+			assert.True(t, valid)
 		})
 
 		t.Run("credential is invalid when timeAt is before issuance", func(t *testing.T) {
@@ -379,8 +379,8 @@ func Test_verifier_validateAtTime(t *testing.T) {
 			timeToCheck = &beforeIssuance
 			sut := verifier{}
 			credentialToTest := testCredential(t)
-			validationErr := sut.validateAtTime(credentialToTest.IssuanceDate, credentialToTest.ExpirationDate, timeToCheck)
-			assert.EqualError(t, validationErr, "credential not valid at given time")
+			valid := sut.validateAtTime(credentialToTest.IssuanceDate, credentialToTest.ExpirationDate, timeToCheck)
+			assert.False(t, valid)
 		})
 
 		t.Run("credential is invalid when timeAt is after expiration", func(t *testing.T) {
@@ -392,8 +392,8 @@ func Test_verifier_validateAtTime(t *testing.T) {
 			credentialToTest := testCredential(t)
 			// Set expirationDate since the testCredential does not have one
 			credentialToTest.ExpirationDate = &expireTime
-			validationErr := sut.validateAtTime(credentialToTest.IssuanceDate, credentialToTest.ExpirationDate, timeToCheck)
-			assert.EqualError(t, validationErr, "credential not valid at given time")
+			valid := sut.validateAtTime(credentialToTest.IssuanceDate, credentialToTest.ExpirationDate, timeToCheck)
+			assert.False(t, valid)
 		})
 
 	})
@@ -558,7 +558,7 @@ func TestVerifier_VerifyVP(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, vcs, 1)
 	})
-	t.Run("error - VC verification fails (not valid at time)", func(t *testing.T) {
+	t.Run("error - VP verification fails (not valid at time)", func(t *testing.T) {
 		_ = json.Unmarshal([]byte(rawVP), &vp)
 
 		var validAt time.Time
@@ -569,7 +569,7 @@ func TestVerifier_VerifyVP(t *testing.T) {
 
 		vcs, err := ctx.verifier.doVerifyVP(mockVerifier, vp, true, &validAt)
 
-		assert.EqualError(t, err, "verification error: credential not valid at given time")
+		assert.EqualError(t, err, "verification error: presentation not valid at given time")
 		assert.Empty(t, vcs)
 	})
 	t.Run("error - VC verification fails", func(t *testing.T) {


### PR DESCRIPTION
Earlier, they had the same errors message, which is confusing.