### PR TITLE
VCR: remove duplicate and conflicting constants

### DIFF
--- a/vcr/issuer/network_publisher.go
+++ b/vcr/issuer/network_publisher.go
@@ -43,12 +43,6 @@ type networkPublisher struct {
 	keyResolver     keyResolver
 }
 
-// VcDocumentType holds the content type used in network documents which contain Verifiable Credentials
-const VcDocumentType = "application/vc+json"
-
-// RevocationDocumentType holds the content type used in network documents which contain a credential revocation
-const RevocationDocumentType = "application/vc+json;type=revocation"
-
 // NewNetworkPublisher creates a new networkPublisher which implements the Publisher interface.
 // It is the default implementation to use for issuers to publish credentials and revocations to the Nuts network.
 func NewNetworkPublisher(networkTx network.Transactions, docResolver vdr.DocResolver, keyResolver crypto.KeyResolver) Publisher {
@@ -94,7 +88,7 @@ func (p networkPublisher) PublishCredential(ctx context.Context, verifiableCrede
 	}
 
 	payload, _ := json.Marshal(verifiableCredential)
-	tx := network.TransactionTemplate(VcDocumentType, payload, key).
+	tx := network.TransactionTemplate(types.VcDocumentType, payload, key).
 		WithTimestamp(verifiableCredential.IssuanceDate).
 		WithAdditionalPrevs(meta.SourceTransactions).
 		WithPrivate(participants)

--- a/vcr/issuer/network_publisher_test.go
+++ b/vcr/issuer/network_publisher_test.go
@@ -119,7 +119,7 @@ func Test_networkPublisher_PublishCredential(t *testing.T) {
 		expectedTemplate := network.Template{
 			Key:             testKey,
 			Payload:         payload,
-			Type:            VcDocumentType,
+			Type:            types.VcDocumentType,
 			AttachKey:       false,
 			Timestamp:       time.Time{},
 			AdditionalPrevs: nil,
@@ -164,7 +164,7 @@ func Test_networkPublisher_PublishCredential(t *testing.T) {
 		expectedTemplate := network.Template{
 			Key:             testKey,
 			Payload:         payload,
-			Type:            VcDocumentType,
+			Type:            types.VcDocumentType,
 			AttachKey:       false,
 			Timestamp:       time.Time{},
 			AdditionalPrevs: nil,
@@ -272,7 +272,7 @@ func Test_networkPublisher_PublishCredential(t *testing.T) {
 			expectedTemplate := network.Template{
 				Key:             testKey,
 				Payload:         payload,
-				Type:            VcDocumentType,
+				Type:            types.VcDocumentType,
 				AttachKey:       false,
 				Timestamp:       time.Time{},
 				AdditionalPrevs: nil,


### PR DESCRIPTION
Removing these constants since they are both also declared in types

mainly needs to be removed to prevent accidental usage since
`RevocationDocumentTye =  "application/vc+json;type=revocation"` is unused but very similar to 
`RevocationLDDocumentType = "application/ld+json;type=revocation"` from types