### PR TITLE
Network: add log message when Reprocess has completed

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -775,6 +775,7 @@ func (n *Network) Reprocess(ctx context.Context, contentType string) (*Reprocess
 		return nil, fmt.Errorf("reprocess terminate before completing succesful: %w", ctx.Err())
 	}
 
+	log.Logger().Infof("Successfully completed reprocess of %s", contentType)
 	return new(ReprocessReport), nil
 }
 


### PR DESCRIPTION
The Reprocess API call runs async and there is currently no way to tell if it has finished.

Should this be back ported to other 5.x releases so it is added iff we release any future patches on those versions?