### PR TITLE
make sure username claim is present for dummy, irma and selfsigned

### DIFF
--- a/auth/services/dummy/dummy.go
+++ b/auth/services/dummy/dummy.go
@@ -210,6 +210,7 @@ func (d Dummy) VerifyVP(vp vc.VerifiablePresentation, _ *time.Time) (contract.VP
 			services.PrefixTokenClaim:     proof.Prefix,
 			services.FamilyNameTokenClaim: proof.FamilyName,
 			services.EmailTokenClaim:      proof.Email,
+			services.UsernameClaim:        proof.Email,
 			services.AssuranceLevelClaim:  "low",
 		},
 		contractAttributes: c.Params,

--- a/auth/services/irma/validator.go
+++ b/auth/services/irma/validator.go
@@ -126,6 +126,8 @@ func (I irmaVPVerificationResult) DisclosedAttribute(key string) string {
 		v = I.disclosedAttributes["gemeente.personalData.prefix"]
 	case services.InitialsTokenClaim:
 		v = I.disclosedAttributes["gemeente.personalData.initials"]
+	case services.UsernameClaim:
+		fallthrough
 	case services.EmailTokenClaim:
 		v = I.disclosedAttributes["sidn-pbdf.email.email"]
 	case services.AssuranceLevelClaim:

--- a/auth/services/irma/validator_test.go
+++ b/auth/services/irma/validator_test.go
@@ -117,6 +117,7 @@ func TestIrmaVPVerificationResult(t *testing.T) {
 		assert.Equal(t, "tester", vr.DisclosedAttribute(services.FamilyNameTokenClaim))
 		assert.Equal(t, "von", vr.DisclosedAttribute(services.PrefixTokenClaim))
 		assert.Equal(t, "info@example.com", vr.DisclosedAttribute(services.EmailTokenClaim))
+		assert.Equal(t, "info@example.com", vr.DisclosedAttribute(services.UsernameClaim))
 		assert.Equal(t, "low", vr.DisclosedAttribute(services.AssuranceLevelClaim))
 	})
 

--- a/auth/services/selfsigned/validator_test.go
+++ b/auth/services/selfsigned/validator_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"github.com/nuts-foundation/nuts-node/audit"
+	"github.com/nuts-foundation/nuts-node/auth/services"
 	"github.com/nuts-foundation/nuts-node/auth/services/selfsigned/types"
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/crypto/util"
@@ -112,6 +113,7 @@ func TestValidator_VerifyVP(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, result.Reason())
 		assert.Equal(t, contract.Valid, result.Validity())
+		assert.Equal(t, "user@example.com", result.DisclosedAttribute(services.UsernameClaim))
 	})
 
 	t.Run("technical error on verify", func(t *testing.T) {


### PR DESCRIPTION
closes #2111 

the `username` claim will now always be present in the access token and introspection.
note: not for UZI
note: needs doc update, but waiting for other PR. Added to to #2047 