### PR TITLE
Docs: add .readthedocs.yaml to fix failing build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
Our read the docs builds have been failing since last week. This is caused by a dependency update, but since we do not fix all dependencies it's not obvious which one caused it. 

The dep update no longer accepts the outdated version of (open)ssl that is apparently used by default in the build environment. The simplest fix appears to be forcing RTD to use a newer version of python (now uses 3.7, version 3.10+ require the supported version of openssl) which is easily managed by this default config.

I've added a hidden page to RTD to test if this works
https://nuts-node.readthedocs.io/en/docs-readthedocs-yaml/