### PR TITLE
Fix service deletion

### DIFF
--- a/didman/didman.go
+++ b/didman/didman.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strings"
 	"sync"
 
 	ssi "github.com/nuts-foundation/go-did"
@@ -326,16 +325,9 @@ func (d *didman) deleteService(ctx context.Context, serviceID ssi.URI) error {
 		return types.ErrServiceNotFound
 	}
 
-	// check for existing use
-	if err = d.store.Iterate(func(itDoc did.Document, metadata types.DocumentMetadata) error {
-		// itDoc contains the iterator document
-		// doc is the document that contains the service to be deleted
-		if referencesService(itDoc, doc.ID.String(), service.Type) {
-			return ErrServiceInUse
-		}
-		return nil
-	}); err != nil {
-		return err
+	// check for existing use on this document
+	if referencedService(doc, didservice.MakeServiceReference(doc.ID, service.Type).String()) {
+		return ErrServiceInUse
 	}
 
 	// remove service
@@ -619,24 +611,27 @@ func generateIDForService(id did.DID, service did.Service) ssi.URI {
 	return d
 }
 
-func referencesService(doc did.Document, serviceDID, serviceType string) bool {
+// referencedService checks if serviceRef occurs in doc's services.
+// serviceRef is in the form: did:nuts:123/serviceEndpoint?type=oauth_prod
+func referencedService(doc *did.Document, serviceRef string) bool {
 	for _, s := range doc.Service {
-		cs := types.CompoundService{}
-		// ignore structures that can not be parsed to compound endpoints
-		if err := s.UnmarshalServiceEndpoint(&cs); err == nil {
+		switch s.ServiceEndpoint.(type) {
+		case map[string]interface{}: // compound service
+			cs := types.CompoundService{}
+			_ = s.UnmarshalServiceEndpoint(&cs)
 			for _, ref := range cs {
-				// the reference is in the form: did:nuts:123/serviceEndpoint?type=oauth_prod
-				// we need the baseDID and the serviceType
-				parts := strings.Split(ref, "/serviceEndpoint?type=")
-				if len(parts) == 2 {
-					baseDID := parts[0]
-					sType := parts[1]
-
-					if sType == serviceType && baseDID == serviceDID {
-						return true
-					}
+				if ref == serviceRef {
+					return true
 				}
 			}
+		case interface{}: // service endpoint
+			var serviceEndpoint string
+			_ = s.UnmarshalServiceEndpoint(&serviceEndpoint)
+			if serviceEndpoint == serviceRef {
+				return true
+			}
+		default: // sets are not supported
+			// Should this do anything?
 		}
 	}
 	return false

--- a/vdr/didstore/store.go
+++ b/vdr/didstore/store.go
@@ -164,7 +164,7 @@ func (tl *store) Resolve(id did.DID, resolveMetadata *vdr.ResolveMetadata) (retu
 }
 
 func (tl *store) Iterate(fn vdr.DocIterator) error {
-	err := tl.db.Read(context.Background(), func(tx stoabs.ReadTx) error {
+	return tl.db.Read(context.Background(), func(tx stoabs.ReadTx) error {
 		latestReader := tx.GetShelfReader(latestShelf)
 
 		return latestReader.Iterate(func(didKey stoabs.Key, metadataRecordRef []byte) error {
@@ -182,10 +182,6 @@ func (tl *store) Iterate(fn vdr.DocIterator) error {
 			return fn(document, metadata.asVDRMetadata())
 		}, stoabs.BytesKey{})
 	})
-	if err != nil {
-		return fmt.Errorf("iterate: database error on Read: %w", err)
-	}
-	return nil
 }
 
 func (tl *store) Conflicted(fn vdr.DocIterator) error {

--- a/vdr/integration_test.go
+++ b/vdr/integration_test.go
@@ -146,13 +146,13 @@ func TestVDRIntegration_Test(t *testing.T) {
 
 	// try to deactivate the document again
 	err = docUpdater.Deactivate(ctx.audit, docB.ID)
-	assert.EqualError(t, err, "the DID document has been deactivated",
+	assert.ErrorIs(t, err, types.ErrDeactivated,
 		"expected an error when trying to deactivate an already deactivated document")
 
 	// try to update document A should fail since it no longer has an active controller
 	docA.Service = docA.Service[1:]
 	err = ctx.vdr.Update(ctx.audit, docAID, *docA)
-	assert.EqualError(t, err, "could not find any controllers for document")
+	assert.EqualError(t, err, "update DID document: could not find any controllers for document")
 }
 
 func TestVDRIntegration_ConcurrencyTest(t *testing.T) {

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -258,7 +258,7 @@ func (r *VDR) Update(ctx context.Context, id did.DID, next did.Document) error {
 
 	// Validate document. No more changes should be made to the document after this point.
 	if err = ManagedDocumentValidator(didservice.NewServiceResolver(r.didDocResolver)).Validate(next); err != nil {
-		return err
+		return fmt.Errorf("could not update DID document, validation failed: %w", err)
 	}
 
 	payload, err := json.Marshal(next)

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -119,7 +119,7 @@ func TestVDR_Update(t *testing.T) {
 		resolvedMetadata := types.DocumentMetadata{}
 		test.mockStore.EXPECT().Resolve(*id, expectedResolverMetadata).Return(&currentDIDDocument, &resolvedMetadata, nil)
 		err := test.vdr.Update(test.ctx, *id, nextDIDDocument)
-		assert.EqualError(t, err, "DID Document validation failed: invalid context")
+		assert.EqualError(t, err, "update DID document: DID Document validation failed: invalid context")
 	})
 
 	t.Run("error - no controller for document", func(t *testing.T) {
@@ -133,7 +133,7 @@ func TestVDR_Update(t *testing.T) {
 		resolvedMetadata := types.DocumentMetadata{}
 		test.mockStore.EXPECT().Resolve(*id, expectedResolverMetadata).Return(&document, &resolvedMetadata, nil)
 		err := test.vdr.Update(test.ctx, *id, document)
-		assert.EqualError(t, err, "the DID document has been deactivated")
+		assert.EqualError(t, err, "update DID document: the DID document has been deactivated")
 	})
 	t.Run("error - could not resolve current document", func(t *testing.T) {
 		test := newVDRTestCtx(t)
@@ -143,7 +143,7 @@ func TestVDR_Update(t *testing.T) {
 		}
 		test.mockStore.EXPECT().Resolve(*id, expectedResolverMetadata).Return(nil, nil, types.ErrNotFound)
 		err := test.vdr.Update(test.ctx, *id, nextDIDDocument)
-		assert.EqualError(t, err, "unable to find the DID document")
+		assert.EqualError(t, err, "update DID document: unable to find the DID document")
 	})
 
 	t.Run("error - document not managed by this node", func(t *testing.T) {
@@ -158,7 +158,8 @@ func TestVDR_Update(t *testing.T) {
 		err := test.vdr.Update(test.ctx, *id, nextDIDDocument)
 
 		assert.Error(t, err)
-		assert.EqualError(t, err, "DID document not managed by this node")
+		assert.EqualError(t, err, "update DID document: DID document not managed by this node")
+		assert.ErrorIs(t, err, types.ErrDIDNotManagedByThisNode)
 		assert.True(t, errors.Is(err, types.ErrDIDNotManagedByThisNode),
 			"expected ErrDIDNotManagedByThisNode error when the document is not managed by this node")
 	})


### PR DESCRIPTION
Fix #2131.

This is WIP, needs tests and cleanup.

## The bug:
Given a service with id `did:nuts:123#abc` of type `oauth`.
During a DIDMan `deleteService` call it is checked if the service is in use.
Instead of the following reference format: `did:nuts:123/serviceEndpoint?type=oauth`
The following was used `did:nuts:123#abc` in the check.
Which always returned false
Then DIDMan removes the service from the DID Document and tries to update the DID Document.
Then the Updater performs a validation step on the DID Document which fails because there is a compound service with a reference to a service that does not exists.