### PR TITLE
Didman: added UpdateEndpoint and UpdateCompoundService

### DIFF
--- a/didman/api/v1/api.go
+++ b/didman/api/v1/api.go
@@ -127,6 +127,10 @@ func (w *Wrapper) AddEndpoint(ctx context.Context, request AddEndpointRequestObj
 // UpdateEndpoint handles calls to update a service. It only checks params and sets the correct return status code.
 // didman.UpdateEndpoint does the heavy lifting.
 func (w *Wrapper) UpdateEndpoint(ctx context.Context, request UpdateEndpointRequestObject) (UpdateEndpointResponseObject, error) {
+	if request.Body.Type != "" && request.Body.Type != request.Type {
+		return nil, core.InvalidInputError("updating endpoint type is not supported")
+	}
+	request.Body.Type = request.Type
 	endpoint, err := w.addOrUpdateEndpoint(ctx, request.Did, *request.Body, w.Didman.UpdateEndpoint)
 	if err != nil {
 		return nil, err
@@ -219,7 +223,11 @@ func (w *Wrapper) AddCompoundService(ctx context.Context, request AddCompoundSer
 
 // UpdateCompoundService handles calls to update a compound service.
 func (w *Wrapper) UpdateCompoundService(ctx context.Context, request UpdateCompoundServiceRequestObject) (UpdateCompoundServiceResponseObject, error) {
-	service, err := w.addOrUpdateCompoundService(ctx, request.Did, *request.Body, w.Didman.AddCompoundService)
+	if request.Body.Type != "" && request.Body.Type != request.Type {
+		return nil, core.InvalidInputError("updating compound service type is not supported")
+	}
+	request.Body.Type = request.Type
+	service, err := w.addOrUpdateCompoundService(ctx, request.Did, *request.Body, w.Didman.UpdateCompoundService)
 	if err != nil {
 		return nil, err
 	}

--- a/didman/api/v1/api_test.go
+++ b/didman/api/v1/api_test.go
@@ -51,7 +51,6 @@ func TestWrapper_AddEndpoint(t *testing.T) {
 		Body: &service,
 	}
 	ctx := audit.TestContext()
-	wrapper := &Wrapper{}
 
 	t.Run("ok", func(t *testing.T) {
 		test := newMockContext(t)
@@ -68,7 +67,8 @@ func TestWrapper_AddEndpoint(t *testing.T) {
 	})
 
 	t.Run("error - incorrect type", func(t *testing.T) {
-		response, err := wrapper.AddEndpoint(ctx, AddEndpointRequestObject{
+		test := newMockContext(t)
+		response, err := test.wrapper.AddEndpoint(ctx, AddEndpointRequestObject{
 			Did: targetDID.String(),
 			Body: &EndpointProperties{
 				Endpoint: serviceEndpoint.String(),
@@ -80,7 +80,8 @@ func TestWrapper_AddEndpoint(t *testing.T) {
 	})
 
 	t.Run("error - incorrect endpoint", func(t *testing.T) {
-		response, err := wrapper.AddEndpoint(ctx, AddEndpointRequestObject{
+		test := newMockContext(t)
+		response, err := test.wrapper.AddEndpoint(ctx, AddEndpointRequestObject{
 			Did: targetDID.String(),
 			Body: &EndpointProperties{
 				Type:     service.Type,
@@ -93,7 +94,8 @@ func TestWrapper_AddEndpoint(t *testing.T) {
 	})
 
 	t.Run("error - incorrect did", func(t *testing.T) {
-		response, err := wrapper.AddEndpoint(ctx, AddEndpointRequestObject{
+		test := newMockContext(t)
+		response, err := test.wrapper.AddEndpoint(ctx, AddEndpointRequestObject{
 			Body: &EndpointProperties{
 				Type:     service.Type,
 				Endpoint: serviceEndpoint.String(),
@@ -101,7 +103,7 @@ func TestWrapper_AddEndpoint(t *testing.T) {
 		})
 
 		assert.ErrorIs(t, err, did.ErrInvalidDID)
-		assert.Equal(t, http.StatusBadRequest, wrapper.ResolveStatusCode(err))
+		assert.Equal(t, http.StatusBadRequest, test.wrapper.ResolveStatusCode(err))
 		assert.Nil(t, response)
 	})
 
@@ -293,7 +295,7 @@ func TestWrapper_AddCompoundService(t *testing.T) {
 
 	t.Run("error - incorrect did", func(t *testing.T) {
 		test := newMockContext(t)
-		response, err := test.wrapper.AddCompoundService(ctx, AddCompoundServiceRequestObject{Did: "not a did"})
+		response, err := test.wrapper.AddCompoundService(ctx, AddCompoundServiceRequestObject{Did: "not a did", Body: &CompoundServiceProperties{}})
 
 		assert.ErrorIs(t, err, did.ErrInvalidDID)
 		assert.Equal(t, http.StatusBadRequest, test.wrapper.ResolveStatusCode(err))

--- a/didman/api/v1/generated.go
+++ b/didman/api/v1/generated.go
@@ -160,13 +160,13 @@ type ClientInterface interface {
 
 	AddCompoundService(ctx context.Context, did string, body AddCompoundServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// UpdateCompoundService request with any body
-	UpdateCompoundServiceWithBody(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	UpdateCompoundService(ctx context.Context, did string, body UpdateCompoundServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
-
 	// GetCompoundServiceEndpoint request
 	GetCompoundServiceEndpoint(ctx context.Context, did string, compoundServiceType string, endpointType string, params *GetCompoundServiceEndpointParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateCompoundService request with any body
+	UpdateCompoundServiceWithBody(ctx context.Context, did string, pType string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateCompoundService(ctx context.Context, did string, pType string, body UpdateCompoundServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetContactInformation request
 	GetContactInformation(ctx context.Context, did string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -181,13 +181,13 @@ type ClientInterface interface {
 
 	AddEndpoint(ctx context.Context, did string, body AddEndpointJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// UpdateEndpoint request with any body
-	UpdateEndpointWithBody(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	UpdateEndpoint(ctx context.Context, did string, body UpdateEndpointJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
-
 	// DeleteEndpointsByType request
 	DeleteEndpointsByType(ctx context.Context, did string, pType string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateEndpoint request with any body
+	UpdateEndpointWithBody(ctx context.Context, did string, pType string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateEndpoint(ctx context.Context, did string, pType string, body UpdateEndpointJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SearchOrganizations request
 	SearchOrganizations(ctx context.Context, params *SearchOrganizationsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -232,32 +232,32 @@ func (c *Client) AddCompoundService(ctx context.Context, did string, body AddCom
 	return c.Client.Do(req)
 }
 
-func (c *Client) UpdateCompoundServiceWithBody(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateCompoundServiceRequestWithBody(c.Server, did, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) UpdateCompoundService(ctx context.Context, did string, body UpdateCompoundServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateCompoundServiceRequest(c.Server, did, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
 func (c *Client) GetCompoundServiceEndpoint(ctx context.Context, did string, compoundServiceType string, endpointType string, params *GetCompoundServiceEndpointParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetCompoundServiceEndpointRequest(c.Server, did, compoundServiceType, endpointType, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateCompoundServiceWithBody(ctx context.Context, did string, pType string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateCompoundServiceRequestWithBody(c.Server, did, pType, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateCompoundService(ctx context.Context, did string, pType string, body UpdateCompoundServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateCompoundServiceRequest(c.Server, did, pType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -328,32 +328,32 @@ func (c *Client) AddEndpoint(ctx context.Context, did string, body AddEndpointJS
 	return c.Client.Do(req)
 }
 
-func (c *Client) UpdateEndpointWithBody(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateEndpointRequestWithBody(c.Server, did, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) UpdateEndpoint(ctx context.Context, did string, body UpdateEndpointJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateEndpointRequest(c.Server, did, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
 func (c *Client) DeleteEndpointsByType(ctx context.Context, did string, pType string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewDeleteEndpointsByTypeRequest(c.Server, did, pType)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateEndpointWithBody(ctx context.Context, did string, pType string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateEndpointRequestWithBody(c.Server, did, pType, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateEndpoint(ctx context.Context, did string, pType string, body UpdateEndpointJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateEndpointRequest(c.Server, did, pType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -469,53 +469,6 @@ func NewAddCompoundServiceRequestWithBody(server string, did string, contentType
 	return req, nil
 }
 
-// NewUpdateCompoundServiceRequest calls the generic UpdateCompoundService builder with application/json body
-func NewUpdateCompoundServiceRequest(server string, did string, body UpdateCompoundServiceJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewUpdateCompoundServiceRequestWithBody(server, did, "application/json", bodyReader)
-}
-
-// NewUpdateCompoundServiceRequestWithBody generates requests for UpdateCompoundService with any type of body
-func NewUpdateCompoundServiceRequestWithBody(server string, did string, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "did", runtime.ParamLocationPath, did)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/internal/didman/v1/did/%s/compoundservice", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("PUT", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
 // NewGetCompoundServiceEndpointRequest generates requests for GetCompoundServiceEndpoint
 func NewGetCompoundServiceEndpointRequest(server string, did string, compoundServiceType string, endpointType string, params *GetCompoundServiceEndpointParams) (*http.Request, error) {
 	var err error
@@ -591,6 +544,60 @@ func NewGetCompoundServiceEndpointRequest(server string, did string, compoundSer
 
 		req.Header.Set("accept", headerParam0)
 	}
+
+	return req, nil
+}
+
+// NewUpdateCompoundServiceRequest calls the generic UpdateCompoundService builder with application/json body
+func NewUpdateCompoundServiceRequest(server string, did string, pType string, body UpdateCompoundServiceJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateCompoundServiceRequestWithBody(server, did, pType, "application/json", bodyReader)
+}
+
+// NewUpdateCompoundServiceRequestWithBody generates requests for UpdateCompoundService with any type of body
+func NewUpdateCompoundServiceRequestWithBody(server string, did string, pType string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "did", runtime.ParamLocationPath, did)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "type", runtime.ParamLocationPath, pType)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/internal/didman/v1/did/%s/compoundservice/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -723,53 +730,6 @@ func NewAddEndpointRequestWithBody(server string, did string, contentType string
 	return req, nil
 }
 
-// NewUpdateEndpointRequest calls the generic UpdateEndpoint builder with application/json body
-func NewUpdateEndpointRequest(server string, did string, body UpdateEndpointJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewUpdateEndpointRequestWithBody(server, did, "application/json", bodyReader)
-}
-
-// NewUpdateEndpointRequestWithBody generates requests for UpdateEndpoint with any type of body
-func NewUpdateEndpointRequestWithBody(server string, did string, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "did", runtime.ParamLocationPath, did)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/internal/didman/v1/did/%s/endpoint", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("PUT", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
 // NewDeleteEndpointsByTypeRequest generates requests for DeleteEndpointsByType
 func NewDeleteEndpointsByTypeRequest(server string, did string, pType string) (*http.Request, error) {
 	var err error
@@ -807,6 +767,60 @@ func NewDeleteEndpointsByTypeRequest(server string, did string, pType string) (*
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewUpdateEndpointRequest calls the generic UpdateEndpoint builder with application/json body
+func NewUpdateEndpointRequest(server string, did string, pType string, body UpdateEndpointJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateEndpointRequestWithBody(server, did, pType, "application/json", bodyReader)
+}
+
+// NewUpdateEndpointRequestWithBody generates requests for UpdateEndpoint with any type of body
+func NewUpdateEndpointRequestWithBody(server string, did string, pType string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "did", runtime.ParamLocationPath, did)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "type", runtime.ParamLocationPath, pType)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/internal/didman/v1/did/%s/endpoint/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -955,13 +969,13 @@ type ClientWithResponsesInterface interface {
 
 	AddCompoundServiceWithResponse(ctx context.Context, did string, body AddCompoundServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*AddCompoundServiceResponse, error)
 
-	// UpdateCompoundService request with any body
-	UpdateCompoundServiceWithBodyWithResponse(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateCompoundServiceResponse, error)
-
-	UpdateCompoundServiceWithResponse(ctx context.Context, did string, body UpdateCompoundServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateCompoundServiceResponse, error)
-
 	// GetCompoundServiceEndpoint request
 	GetCompoundServiceEndpointWithResponse(ctx context.Context, did string, compoundServiceType string, endpointType string, params *GetCompoundServiceEndpointParams, reqEditors ...RequestEditorFn) (*GetCompoundServiceEndpointResponse, error)
+
+	// UpdateCompoundService request with any body
+	UpdateCompoundServiceWithBodyWithResponse(ctx context.Context, did string, pType string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateCompoundServiceResponse, error)
+
+	UpdateCompoundServiceWithResponse(ctx context.Context, did string, pType string, body UpdateCompoundServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateCompoundServiceResponse, error)
 
 	// GetContactInformation request
 	GetContactInformationWithResponse(ctx context.Context, did string, reqEditors ...RequestEditorFn) (*GetContactInformationResponse, error)
@@ -976,13 +990,13 @@ type ClientWithResponsesInterface interface {
 
 	AddEndpointWithResponse(ctx context.Context, did string, body AddEndpointJSONRequestBody, reqEditors ...RequestEditorFn) (*AddEndpointResponse, error)
 
-	// UpdateEndpoint request with any body
-	UpdateEndpointWithBodyWithResponse(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateEndpointResponse, error)
-
-	UpdateEndpointWithResponse(ctx context.Context, did string, body UpdateEndpointJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateEndpointResponse, error)
-
 	// DeleteEndpointsByType request
 	DeleteEndpointsByTypeWithResponse(ctx context.Context, did string, pType string, reqEditors ...RequestEditorFn) (*DeleteEndpointsByTypeResponse, error)
+
+	// UpdateEndpoint request with any body
+	UpdateEndpointWithBodyWithResponse(ctx context.Context, did string, pType string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateEndpointResponse, error)
+
+	UpdateEndpointWithResponse(ctx context.Context, did string, pType string, body UpdateEndpointJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateEndpointResponse, error)
 
 	// SearchOrganizations request
 	SearchOrganizationsWithResponse(ctx context.Context, params *SearchOrganizationsParams, reqEditors ...RequestEditorFn) (*SearchOrganizationsResponse, error)
@@ -1055,38 +1069,6 @@ func (r AddCompoundServiceResponse) StatusCode() int {
 	return 0
 }
 
-type UpdateCompoundServiceResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *CompoundService
-	JSONDefault  *struct {
-		// Detail A human-readable explanation specific to this occurrence of the problem.
-		Detail string `json:"detail"`
-
-		// Status HTTP statuscode
-		Status float32 `json:"status"`
-
-		// Title A short, human-readable summary of the problem type.
-		Title string `json:"title"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r UpdateCompoundServiceResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r UpdateCompoundServiceResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
 type GetCompoundServiceEndpointResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -1113,6 +1095,38 @@ func (r GetCompoundServiceEndpointResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetCompoundServiceEndpointResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateCompoundServiceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CompoundService
+	JSONDefault  *struct {
+		// Detail A human-readable explanation specific to this occurrence of the problem.
+		Detail string `json:"detail"`
+
+		// Status HTTP statuscode
+		Status float32 `json:"status"`
+
+		// Title A short, human-readable summary of the problem type.
+		Title string `json:"title"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateCompoundServiceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateCompoundServiceResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1215,6 +1229,37 @@ func (r AddEndpointResponse) StatusCode() int {
 	return 0
 }
 
+type DeleteEndpointsByTypeResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSONDefault  *struct {
+		// Detail A human-readable explanation specific to this occurrence of the problem.
+		Detail string `json:"detail"`
+
+		// Status HTTP statuscode
+		Status float32 `json:"status"`
+
+		// Title A short, human-readable summary of the problem type.
+		Title string `json:"title"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteEndpointsByTypeResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteEndpointsByTypeResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UpdateEndpointResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -1241,37 +1286,6 @@ func (r UpdateEndpointResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UpdateEndpointResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type DeleteEndpointsByTypeResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSONDefault  *struct {
-		// Detail A human-readable explanation specific to this occurrence of the problem.
-		Detail string `json:"detail"`
-
-		// Status HTTP statuscode
-		Status float32 `json:"status"`
-
-		// Title A short, human-readable summary of the problem type.
-		Title string `json:"title"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r DeleteEndpointsByTypeResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r DeleteEndpointsByTypeResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1367,23 +1381,6 @@ func (c *ClientWithResponses) AddCompoundServiceWithResponse(ctx context.Context
 	return ParseAddCompoundServiceResponse(rsp)
 }
 
-// UpdateCompoundServiceWithBodyWithResponse request with arbitrary body returning *UpdateCompoundServiceResponse
-func (c *ClientWithResponses) UpdateCompoundServiceWithBodyWithResponse(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateCompoundServiceResponse, error) {
-	rsp, err := c.UpdateCompoundServiceWithBody(ctx, did, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseUpdateCompoundServiceResponse(rsp)
-}
-
-func (c *ClientWithResponses) UpdateCompoundServiceWithResponse(ctx context.Context, did string, body UpdateCompoundServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateCompoundServiceResponse, error) {
-	rsp, err := c.UpdateCompoundService(ctx, did, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseUpdateCompoundServiceResponse(rsp)
-}
-
 // GetCompoundServiceEndpointWithResponse request returning *GetCompoundServiceEndpointResponse
 func (c *ClientWithResponses) GetCompoundServiceEndpointWithResponse(ctx context.Context, did string, compoundServiceType string, endpointType string, params *GetCompoundServiceEndpointParams, reqEditors ...RequestEditorFn) (*GetCompoundServiceEndpointResponse, error) {
 	rsp, err := c.GetCompoundServiceEndpoint(ctx, did, compoundServiceType, endpointType, params, reqEditors...)
@@ -1391,6 +1388,23 @@ func (c *ClientWithResponses) GetCompoundServiceEndpointWithResponse(ctx context
 		return nil, err
 	}
 	return ParseGetCompoundServiceEndpointResponse(rsp)
+}
+
+// UpdateCompoundServiceWithBodyWithResponse request with arbitrary body returning *UpdateCompoundServiceResponse
+func (c *ClientWithResponses) UpdateCompoundServiceWithBodyWithResponse(ctx context.Context, did string, pType string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateCompoundServiceResponse, error) {
+	rsp, err := c.UpdateCompoundServiceWithBody(ctx, did, pType, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateCompoundServiceResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateCompoundServiceWithResponse(ctx context.Context, did string, pType string, body UpdateCompoundServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateCompoundServiceResponse, error) {
+	rsp, err := c.UpdateCompoundService(ctx, did, pType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateCompoundServiceResponse(rsp)
 }
 
 // GetContactInformationWithResponse request returning *GetContactInformationResponse
@@ -1436,23 +1450,6 @@ func (c *ClientWithResponses) AddEndpointWithResponse(ctx context.Context, did s
 	return ParseAddEndpointResponse(rsp)
 }
 
-// UpdateEndpointWithBodyWithResponse request with arbitrary body returning *UpdateEndpointResponse
-func (c *ClientWithResponses) UpdateEndpointWithBodyWithResponse(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateEndpointResponse, error) {
-	rsp, err := c.UpdateEndpointWithBody(ctx, did, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseUpdateEndpointResponse(rsp)
-}
-
-func (c *ClientWithResponses) UpdateEndpointWithResponse(ctx context.Context, did string, body UpdateEndpointJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateEndpointResponse, error) {
-	rsp, err := c.UpdateEndpoint(ctx, did, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseUpdateEndpointResponse(rsp)
-}
-
 // DeleteEndpointsByTypeWithResponse request returning *DeleteEndpointsByTypeResponse
 func (c *ClientWithResponses) DeleteEndpointsByTypeWithResponse(ctx context.Context, did string, pType string, reqEditors ...RequestEditorFn) (*DeleteEndpointsByTypeResponse, error) {
 	rsp, err := c.DeleteEndpointsByType(ctx, did, pType, reqEditors...)
@@ -1460,6 +1457,23 @@ func (c *ClientWithResponses) DeleteEndpointsByTypeWithResponse(ctx context.Cont
 		return nil, err
 	}
 	return ParseDeleteEndpointsByTypeResponse(rsp)
+}
+
+// UpdateEndpointWithBodyWithResponse request with arbitrary body returning *UpdateEndpointResponse
+func (c *ClientWithResponses) UpdateEndpointWithBodyWithResponse(ctx context.Context, did string, pType string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateEndpointResponse, error) {
+	rsp, err := c.UpdateEndpointWithBody(ctx, did, pType, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateEndpointResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateEndpointWithResponse(ctx context.Context, did string, pType string, body UpdateEndpointJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateEndpointResponse, error) {
+	rsp, err := c.UpdateEndpoint(ctx, did, pType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateEndpointResponse(rsp)
 }
 
 // SearchOrganizationsWithResponse request returning *SearchOrganizationsResponse
@@ -1564,48 +1578,6 @@ func ParseAddCompoundServiceResponse(rsp *http.Response) (*AddCompoundServiceRes
 	return response, nil
 }
 
-// ParseUpdateCompoundServiceResponse parses an HTTP response from a UpdateCompoundServiceWithResponse call
-func ParseUpdateCompoundServiceResponse(rsp *http.Response) (*UpdateCompoundServiceResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &UpdateCompoundServiceResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest CompoundService
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest struct {
-			// Detail A human-readable explanation specific to this occurrence of the problem.
-			Detail string `json:"detail"`
-
-			// Status HTTP statuscode
-			Status float32 `json:"status"`
-
-			// Title A short, human-readable summary of the problem type.
-			Title string `json:"title"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
 // ParseGetCompoundServiceEndpointResponse parses an HTTP response from a GetCompoundServiceEndpointWithResponse call
 func ParseGetCompoundServiceEndpointResponse(rsp *http.Response) (*GetCompoundServiceEndpointResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -1645,6 +1617,48 @@ func ParseGetCompoundServiceEndpointResponse(rsp *http.Response) (*GetCompoundSe
 
 	case rsp.StatusCode == 200:
 		// Content-type (text/plain) unsupported
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateCompoundServiceResponse parses an HTTP response from a UpdateCompoundServiceWithResponse call
+func ParseUpdateCompoundServiceResponse(rsp *http.Response) (*UpdateCompoundServiceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateCompoundServiceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CompoundService
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest struct {
+			// Detail A human-readable explanation specific to this occurrence of the problem.
+			Detail string `json:"detail"`
+
+			// Status HTTP statuscode
+			Status float32 `json:"status"`
+
+			// Title A short, human-readable summary of the problem type.
+			Title string `json:"title"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
 
 	}
 
@@ -1777,27 +1791,20 @@ func ParseAddEndpointResponse(rsp *http.Response) (*AddEndpointResponse, error) 
 	return response, nil
 }
 
-// ParseUpdateEndpointResponse parses an HTTP response from a UpdateEndpointWithResponse call
-func ParseUpdateEndpointResponse(rsp *http.Response) (*UpdateEndpointResponse, error) {
+// ParseDeleteEndpointsByTypeResponse parses an HTTP response from a DeleteEndpointsByTypeWithResponse call
+func ParseDeleteEndpointsByTypeResponse(rsp *http.Response) (*DeleteEndpointsByTypeResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &UpdateEndpointResponse{
+	response := &DeleteEndpointsByTypeResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Endpoint
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest struct {
 			// Detail A human-readable explanation specific to this occurrence of the problem.
@@ -1819,20 +1826,27 @@ func ParseUpdateEndpointResponse(rsp *http.Response) (*UpdateEndpointResponse, e
 	return response, nil
 }
 
-// ParseDeleteEndpointsByTypeResponse parses an HTTP response from a DeleteEndpointsByTypeWithResponse call
-func ParseDeleteEndpointsByTypeResponse(rsp *http.Response) (*DeleteEndpointsByTypeResponse, error) {
+// ParseUpdateEndpointResponse parses an HTTP response from a UpdateEndpointWithResponse call
+func ParseUpdateEndpointResponse(rsp *http.Response) (*UpdateEndpointResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &DeleteEndpointsByTypeResponse{
+	response := &UpdateEndpointResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Endpoint
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest struct {
 			// Detail A human-readable explanation specific to this occurrence of the problem.
@@ -1943,12 +1957,12 @@ type ServerInterface interface {
 	// Add a compound service to a DID Document.
 	// (POST /internal/didman/v1/did/{did}/compoundservice)
 	AddCompoundService(ctx echo.Context, did string) error
-	// Update a compound service.
-	// (PUT /internal/didman/v1/did/{did}/compoundservice)
-	UpdateCompoundService(ctx echo.Context, did string) error
 	// Retrieves the endpoint with the specified endpointType from the specified compound service.
 	// (GET /internal/didman/v1/did/{did}/compoundservice/{compoundServiceType}/endpoint/{endpointType})
 	GetCompoundServiceEndpoint(ctx echo.Context, did string, compoundServiceType string, endpointType string, params GetCompoundServiceEndpointParams) error
+	// Update a compound service.
+	// (PUT /internal/didman/v1/did/{did}/compoundservice/{type})
+	UpdateCompoundService(ctx echo.Context, did string, pType string) error
 
 	// (GET /internal/didman/v1/did/{did}/contactinfo)
 	GetContactInformation(ctx echo.Context, did string) error
@@ -1958,12 +1972,12 @@ type ServerInterface interface {
 	// Add a service endpoint or a reference to a service.
 	// (POST /internal/didman/v1/did/{did}/endpoint)
 	AddEndpoint(ctx echo.Context, did string) error
-	// Update a service endpoint or a reference to a service.
-	// (PUT /internal/didman/v1/did/{did}/endpoint)
-	UpdateEndpoint(ctx echo.Context, did string) error
 
 	// (DELETE /internal/didman/v1/did/{did}/endpoint/{type})
 	DeleteEndpointsByType(ctx echo.Context, did string, pType string) error
+	// Update a service endpoint or a reference to a service.
+	// (PUT /internal/didman/v1/did/{did}/endpoint/{type})
+	UpdateEndpoint(ctx echo.Context, did string, pType string) error
 
 	// (GET /internal/didman/v1/search/organizations)
 	SearchOrganizations(ctx echo.Context, params SearchOrganizationsParams) error
@@ -2010,24 +2024,6 @@ func (w *ServerInterfaceWrapper) AddCompoundService(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.AddCompoundService(ctx, did)
-	return err
-}
-
-// UpdateCompoundService converts echo context to params.
-func (w *ServerInterfaceWrapper) UpdateCompoundService(ctx echo.Context) error {
-	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
-
-	err = runtime.BindStyledParameterWithLocation("simple", false, "did", runtime.ParamLocationPath, ctx.Param("did"), &did)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter did: %s", err))
-	}
-
-	ctx.Set(JwtBearerAuthScopes, []string{""})
-
-	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.UpdateCompoundService(ctx, did)
 	return err
 }
 
@@ -2091,6 +2087,32 @@ func (w *ServerInterfaceWrapper) GetCompoundServiceEndpoint(ctx echo.Context) er
 	return err
 }
 
+// UpdateCompoundService converts echo context to params.
+func (w *ServerInterfaceWrapper) UpdateCompoundService(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "did" -------------
+	var did string
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "did", runtime.ParamLocationPath, ctx.Param("did"), &did)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter did: %s", err))
+	}
+
+	// ------------- Path parameter "type" -------------
+	var pType string
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "type", runtime.ParamLocationPath, ctx.Param("type"), &pType)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter type: %s", err))
+	}
+
+	ctx.Set(JwtBearerAuthScopes, []string{""})
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.UpdateCompoundService(ctx, did, pType)
+	return err
+}
+
 // GetContactInformation converts echo context to params.
 func (w *ServerInterfaceWrapper) GetContactInformation(ctx echo.Context) error {
 	var err error
@@ -2145,24 +2167,6 @@ func (w *ServerInterfaceWrapper) AddEndpoint(ctx echo.Context) error {
 	return err
 }
 
-// UpdateEndpoint converts echo context to params.
-func (w *ServerInterfaceWrapper) UpdateEndpoint(ctx echo.Context) error {
-	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
-
-	err = runtime.BindStyledParameterWithLocation("simple", false, "did", runtime.ParamLocationPath, ctx.Param("did"), &did)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter did: %s", err))
-	}
-
-	ctx.Set(JwtBearerAuthScopes, []string{""})
-
-	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.UpdateEndpoint(ctx, did)
-	return err
-}
-
 // DeleteEndpointsByType converts echo context to params.
 func (w *ServerInterfaceWrapper) DeleteEndpointsByType(ctx echo.Context) error {
 	var err error
@@ -2186,6 +2190,32 @@ func (w *ServerInterfaceWrapper) DeleteEndpointsByType(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.DeleteEndpointsByType(ctx, did, pType)
+	return err
+}
+
+// UpdateEndpoint converts echo context to params.
+func (w *ServerInterfaceWrapper) UpdateEndpoint(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "did" -------------
+	var did string
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "did", runtime.ParamLocationPath, ctx.Param("did"), &did)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter did: %s", err))
+	}
+
+	// ------------- Path parameter "type" -------------
+	var pType string
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "type", runtime.ParamLocationPath, ctx.Param("type"), &pType)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter type: %s", err))
+	}
+
+	ctx.Set(JwtBearerAuthScopes, []string{""})
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.UpdateEndpoint(ctx, did, pType)
 	return err
 }
 
@@ -2264,13 +2294,13 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 
 	router.GET(baseURL+"/internal/didman/v1/did/:did/compoundservice", wrapper.GetCompoundServices)
 	router.POST(baseURL+"/internal/didman/v1/did/:did/compoundservice", wrapper.AddCompoundService)
-	router.PUT(baseURL+"/internal/didman/v1/did/:did/compoundservice", wrapper.UpdateCompoundService)
 	router.GET(baseURL+"/internal/didman/v1/did/:did/compoundservice/:compoundServiceType/endpoint/:endpointType", wrapper.GetCompoundServiceEndpoint)
+	router.PUT(baseURL+"/internal/didman/v1/did/:did/compoundservice/:type", wrapper.UpdateCompoundService)
 	router.GET(baseURL+"/internal/didman/v1/did/:did/contactinfo", wrapper.GetContactInformation)
 	router.PUT(baseURL+"/internal/didman/v1/did/:did/contactinfo", wrapper.UpdateContactInformation)
 	router.POST(baseURL+"/internal/didman/v1/did/:did/endpoint", wrapper.AddEndpoint)
-	router.PUT(baseURL+"/internal/didman/v1/did/:did/endpoint", wrapper.UpdateEndpoint)
 	router.DELETE(baseURL+"/internal/didman/v1/did/:did/endpoint/:type", wrapper.DeleteEndpointsByType)
+	router.PUT(baseURL+"/internal/didman/v1/did/:did/endpoint/:type", wrapper.UpdateEndpoint)
 	router.GET(baseURL+"/internal/didman/v1/search/organizations", wrapper.SearchOrganizations)
 	router.DELETE(baseURL+"/internal/didman/v1/service/:id", wrapper.DeleteService)
 
@@ -2353,45 +2383,6 @@ func (response AddCompoundServicedefaultJSONResponse) VisitAddCompoundServiceRes
 	return json.NewEncoder(w).Encode(response.Body)
 }
 
-type UpdateCompoundServiceRequestObject struct {
-	Did  string `json:"did"`
-	Body *UpdateCompoundServiceJSONRequestBody
-}
-
-type UpdateCompoundServiceResponseObject interface {
-	VisitUpdateCompoundServiceResponse(w http.ResponseWriter) error
-}
-
-type UpdateCompoundService200JSONResponse CompoundService
-
-func (response UpdateCompoundService200JSONResponse) VisitUpdateCompoundServiceResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
-type UpdateCompoundServicedefaultJSONResponse struct {
-	Body struct {
-		// Detail A human-readable explanation specific to this occurrence of the problem.
-		Detail string `json:"detail"`
-
-		// Status HTTP statuscode
-		Status float32 `json:"status"`
-
-		// Title A short, human-readable summary of the problem type.
-		Title string `json:"title"`
-	}
-	StatusCode int
-}
-
-func (response UpdateCompoundServicedefaultJSONResponse) VisitUpdateCompoundServiceResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(response.StatusCode)
-
-	return json.NewEncoder(w).Encode(response.Body)
-}
-
 type GetCompoundServiceEndpointRequestObject struct {
 	Did                 string `json:"did"`
 	CompoundServiceType string `json:"compoundServiceType"`
@@ -2437,6 +2428,46 @@ type GetCompoundServiceEndpointdefaultJSONResponse struct {
 }
 
 func (response GetCompoundServiceEndpointdefaultJSONResponse) VisitGetCompoundServiceEndpointResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(response.StatusCode)
+
+	return json.NewEncoder(w).Encode(response.Body)
+}
+
+type UpdateCompoundServiceRequestObject struct {
+	Did  string `json:"did"`
+	Type string `json:"type"`
+	Body *UpdateCompoundServiceJSONRequestBody
+}
+
+type UpdateCompoundServiceResponseObject interface {
+	VisitUpdateCompoundServiceResponse(w http.ResponseWriter) error
+}
+
+type UpdateCompoundService200JSONResponse CompoundService
+
+func (response UpdateCompoundService200JSONResponse) VisitUpdateCompoundServiceResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateCompoundServicedefaultJSONResponse struct {
+	Body struct {
+		// Detail A human-readable explanation specific to this occurrence of the problem.
+		Detail string `json:"detail"`
+
+		// Status HTTP statuscode
+		Status float32 `json:"status"`
+
+		// Title A short, human-readable summary of the problem type.
+		Title string `json:"title"`
+	}
+	StatusCode int
+}
+
+func (response UpdateCompoundServicedefaultJSONResponse) VisitUpdateCompoundServiceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(response.StatusCode)
 
@@ -2559,45 +2590,6 @@ func (response AddEndpointdefaultJSONResponse) VisitAddEndpointResponse(w http.R
 	return json.NewEncoder(w).Encode(response.Body)
 }
 
-type UpdateEndpointRequestObject struct {
-	Did  string `json:"did"`
-	Body *UpdateEndpointJSONRequestBody
-}
-
-type UpdateEndpointResponseObject interface {
-	VisitUpdateEndpointResponse(w http.ResponseWriter) error
-}
-
-type UpdateEndpoint200JSONResponse Endpoint
-
-func (response UpdateEndpoint200JSONResponse) VisitUpdateEndpointResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
-type UpdateEndpointdefaultJSONResponse struct {
-	Body struct {
-		// Detail A human-readable explanation specific to this occurrence of the problem.
-		Detail string `json:"detail"`
-
-		// Status HTTP statuscode
-		Status float32 `json:"status"`
-
-		// Title A short, human-readable summary of the problem type.
-		Title string `json:"title"`
-	}
-	StatusCode int
-}
-
-func (response UpdateEndpointdefaultJSONResponse) VisitUpdateEndpointResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(response.StatusCode)
-
-	return json.NewEncoder(w).Encode(response.Body)
-}
-
 type DeleteEndpointsByTypeRequestObject struct {
 	Did  string `json:"did"`
 	Type string `json:"type"`
@@ -2630,6 +2622,46 @@ type DeleteEndpointsByTypedefaultJSONResponse struct {
 }
 
 func (response DeleteEndpointsByTypedefaultJSONResponse) VisitDeleteEndpointsByTypeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(response.StatusCode)
+
+	return json.NewEncoder(w).Encode(response.Body)
+}
+
+type UpdateEndpointRequestObject struct {
+	Did  string `json:"did"`
+	Type string `json:"type"`
+	Body *UpdateEndpointJSONRequestBody
+}
+
+type UpdateEndpointResponseObject interface {
+	VisitUpdateEndpointResponse(w http.ResponseWriter) error
+}
+
+type UpdateEndpoint200JSONResponse Endpoint
+
+func (response UpdateEndpoint200JSONResponse) VisitUpdateEndpointResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateEndpointdefaultJSONResponse struct {
+	Body struct {
+		// Detail A human-readable explanation specific to this occurrence of the problem.
+		Detail string `json:"detail"`
+
+		// Status HTTP statuscode
+		Status float32 `json:"status"`
+
+		// Title A short, human-readable summary of the problem type.
+		Title string `json:"title"`
+	}
+	StatusCode int
+}
+
+func (response UpdateEndpointdefaultJSONResponse) VisitUpdateEndpointResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(response.StatusCode)
 
@@ -2723,12 +2755,12 @@ type StrictServerInterface interface {
 	// Add a compound service to a DID Document.
 	// (POST /internal/didman/v1/did/{did}/compoundservice)
 	AddCompoundService(ctx context.Context, request AddCompoundServiceRequestObject) (AddCompoundServiceResponseObject, error)
-	// Update a compound service.
-	// (PUT /internal/didman/v1/did/{did}/compoundservice)
-	UpdateCompoundService(ctx context.Context, request UpdateCompoundServiceRequestObject) (UpdateCompoundServiceResponseObject, error)
 	// Retrieves the endpoint with the specified endpointType from the specified compound service.
 	// (GET /internal/didman/v1/did/{did}/compoundservice/{compoundServiceType}/endpoint/{endpointType})
 	GetCompoundServiceEndpoint(ctx context.Context, request GetCompoundServiceEndpointRequestObject) (GetCompoundServiceEndpointResponseObject, error)
+	// Update a compound service.
+	// (PUT /internal/didman/v1/did/{did}/compoundservice/{type})
+	UpdateCompoundService(ctx context.Context, request UpdateCompoundServiceRequestObject) (UpdateCompoundServiceResponseObject, error)
 
 	// (GET /internal/didman/v1/did/{did}/contactinfo)
 	GetContactInformation(ctx context.Context, request GetContactInformationRequestObject) (GetContactInformationResponseObject, error)
@@ -2738,12 +2770,12 @@ type StrictServerInterface interface {
 	// Add a service endpoint or a reference to a service.
 	// (POST /internal/didman/v1/did/{did}/endpoint)
 	AddEndpoint(ctx context.Context, request AddEndpointRequestObject) (AddEndpointResponseObject, error)
-	// Update a service endpoint or a reference to a service.
-	// (PUT /internal/didman/v1/did/{did}/endpoint)
-	UpdateEndpoint(ctx context.Context, request UpdateEndpointRequestObject) (UpdateEndpointResponseObject, error)
 
 	// (DELETE /internal/didman/v1/did/{did}/endpoint/{type})
 	DeleteEndpointsByType(ctx context.Context, request DeleteEndpointsByTypeRequestObject) (DeleteEndpointsByTypeResponseObject, error)
+	// Update a service endpoint or a reference to a service.
+	// (PUT /internal/didman/v1/did/{did}/endpoint/{type})
+	UpdateEndpoint(ctx context.Context, request UpdateEndpointRequestObject) (UpdateEndpointResponseObject, error)
 
 	// (GET /internal/didman/v1/search/organizations)
 	SearchOrganizations(ctx context.Context, request SearchOrganizationsRequestObject) (SearchOrganizationsResponseObject, error)
@@ -2821,37 +2853,6 @@ func (sh *strictHandler) AddCompoundService(ctx echo.Context, did string) error 
 	return nil
 }
 
-// UpdateCompoundService operation middleware
-func (sh *strictHandler) UpdateCompoundService(ctx echo.Context, did string) error {
-	var request UpdateCompoundServiceRequestObject
-
-	request.Did = did
-
-	var body UpdateCompoundServiceJSONRequestBody
-	if err := ctx.Bind(&body); err != nil {
-		return err
-	}
-	request.Body = &body
-
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.UpdateCompoundService(ctx.Request().Context(), request.(UpdateCompoundServiceRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UpdateCompoundService")
-	}
-
-	response, err := handler(ctx, request)
-
-	if err != nil {
-		return err
-	} else if validResponse, ok := response.(UpdateCompoundServiceResponseObject); ok {
-		return validResponse.VisitUpdateCompoundServiceResponse(ctx.Response())
-	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
-	}
-	return nil
-}
-
 // GetCompoundServiceEndpoint operation middleware
 func (sh *strictHandler) GetCompoundServiceEndpoint(ctx echo.Context, did string, compoundServiceType string, endpointType string, params GetCompoundServiceEndpointParams) error {
 	var request GetCompoundServiceEndpointRequestObject
@@ -2874,6 +2875,38 @@ func (sh *strictHandler) GetCompoundServiceEndpoint(ctx echo.Context, did string
 		return err
 	} else if validResponse, ok := response.(GetCompoundServiceEndpointResponseObject); ok {
 		return validResponse.VisitGetCompoundServiceEndpointResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("Unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// UpdateCompoundService operation middleware
+func (sh *strictHandler) UpdateCompoundService(ctx echo.Context, did string, pType string) error {
+	var request UpdateCompoundServiceRequestObject
+
+	request.Did = did
+	request.Type = pType
+
+	var body UpdateCompoundServiceJSONRequestBody
+	if err := ctx.Bind(&body); err != nil {
+		return err
+	}
+	request.Body = &body
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.UpdateCompoundService(ctx.Request().Context(), request.(UpdateCompoundServiceRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "UpdateCompoundService")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(UpdateCompoundServiceResponseObject); ok {
+		return validResponse.VisitUpdateCompoundServiceResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("Unexpected response type: %T", response)
 	}
@@ -2967,37 +3000,6 @@ func (sh *strictHandler) AddEndpoint(ctx echo.Context, did string) error {
 	return nil
 }
 
-// UpdateEndpoint operation middleware
-func (sh *strictHandler) UpdateEndpoint(ctx echo.Context, did string) error {
-	var request UpdateEndpointRequestObject
-
-	request.Did = did
-
-	var body UpdateEndpointJSONRequestBody
-	if err := ctx.Bind(&body); err != nil {
-		return err
-	}
-	request.Body = &body
-
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.UpdateEndpoint(ctx.Request().Context(), request.(UpdateEndpointRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UpdateEndpoint")
-	}
-
-	response, err := handler(ctx, request)
-
-	if err != nil {
-		return err
-	} else if validResponse, ok := response.(UpdateEndpointResponseObject); ok {
-		return validResponse.VisitUpdateEndpointResponse(ctx.Response())
-	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
-	}
-	return nil
-}
-
 // DeleteEndpointsByType operation middleware
 func (sh *strictHandler) DeleteEndpointsByType(ctx echo.Context, did string, pType string) error {
 	var request DeleteEndpointsByTypeRequestObject
@@ -3018,6 +3020,38 @@ func (sh *strictHandler) DeleteEndpointsByType(ctx echo.Context, did string, pTy
 		return err
 	} else if validResponse, ok := response.(DeleteEndpointsByTypeResponseObject); ok {
 		return validResponse.VisitDeleteEndpointsByTypeResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("Unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// UpdateEndpoint operation middleware
+func (sh *strictHandler) UpdateEndpoint(ctx echo.Context, did string, pType string) error {
+	var request UpdateEndpointRequestObject
+
+	request.Did = did
+	request.Type = pType
+
+	var body UpdateEndpointJSONRequestBody
+	if err := ctx.Bind(&body); err != nil {
+		return err
+	}
+	request.Body = &body
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.UpdateEndpoint(ctx.Request().Context(), request.(UpdateEndpointRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "UpdateEndpoint")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(UpdateEndpointResponseObject); ok {
+		return validResponse.VisitUpdateEndpointResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("Unexpected response type: %T", response)
 	}

--- a/didman/didman.go
+++ b/didman/didman.go
@@ -114,22 +114,42 @@ func (d *didman) Name() string {
 	return ModuleName
 }
 
-func (d *didman) AddEndpoint(ctx context.Context, id did.DID, serviceType string, u url.URL) (*did.Service, error) {
+func (d *didman) AddEndpoint(ctx context.Context, id did.DID, serviceType string, endpoint url.URL) (*did.Service, error) {
 	unlockFn := d.callSerializer.Lock(id.String())
 	defer unlockFn()
 
 	log.Logger().
 		WithField(core.LogFieldDID, id.String()).
 		WithField(core.LogFieldServiceType, serviceType).
-		WithField(core.LogFieldServiceEndpoint, u.String()).
+		WithField(core.LogFieldServiceEndpoint, endpoint.String()).
 		Debug("Adding endpoint")
-	service, err := d.addService(ctx, id, serviceType, u.String(), nil)
+	service, err := d.addService(ctx, id, serviceType, endpoint.String(), nil)
 	if err == nil {
 		log.Logger().
 			WithField(core.LogFieldDID, id.String()).
 			WithField(core.LogFieldServiceType, serviceType).
-			WithField(core.LogFieldServiceEndpoint, u.String()).
+			WithField(core.LogFieldServiceEndpoint, endpoint.String()).
 			Info("Endpoint added")
+	}
+	return service, err
+}
+
+func (d *didman) UpdateEndpoint(ctx context.Context, id did.DID, serviceType string, endpoint url.URL) (*did.Service, error) {
+	unlockFn := d.callSerializer.Lock(id.String())
+	defer unlockFn()
+
+	log.Logger().
+		WithField(core.LogFieldDID, id.String()).
+		WithField(core.LogFieldServiceType, serviceType).
+		WithField(core.LogFieldServiceEndpoint, endpoint.String()).
+		Debug("Updating endpoint")
+	service, err := d.updateService(ctx, id, serviceType, endpoint.String())
+	if err == nil {
+		log.Logger().
+			WithField(core.LogFieldDID, id.String()).
+			WithField(core.LogFieldServiceType, serviceType).
+			WithField(core.LogFieldServiceEndpoint, endpoint.String()).
+			Info("Endpoint updated")
 	}
 	return service, err
 }
@@ -190,6 +210,34 @@ func (d *didman) AddCompoundService(ctx context.Context, id did.DID, serviceType
 			WithField(core.LogFieldServiceType, serviceType).
 			WithField(core.LogFieldServiceEndpoint, endpoints).
 			Info("Compound service added")
+	}
+
+	return service, err
+}
+
+func (d *didman) UpdateCompoundService(ctx context.Context, id did.DID, serviceType string, endpoints map[string]ssi.URI) (*did.Service, error) {
+	unlockFn := d.callSerializer.Lock(id.String())
+	defer unlockFn()
+
+	log.Logger().
+		WithField(core.LogFieldDID, id.String()).
+		WithField(core.LogFieldServiceType, serviceType).
+		WithField(core.LogFieldServiceEndpoint, endpoints).
+		Debug("Adding compound updated")
+
+	// transform service references to map[string]interface{}
+	serviceEndpoint := map[string]interface{}{}
+	for k, v := range endpoints {
+		serviceEndpoint[k] = v.String()
+	}
+
+	service, err := d.updateService(ctx, id, serviceType, serviceEndpoint)
+	if err == nil {
+		log.Logger().
+			WithField(core.LogFieldDID, id.String()).
+			WithField(core.LogFieldServiceType, serviceType).
+			WithField(core.LogFieldServiceEndpoint, endpoints).
+			Info("Compound service updated")
 	}
 
 	return service, err
@@ -518,6 +566,33 @@ func (d *didman) addService(ctx context.Context, id did.DID, serviceType string,
 
 	// Add on DID Document and update
 	doc.Service = append(doc.Service, *service)
+	if err = d.vdr.Update(ctx, id, *doc); err != nil {
+		return nil, err
+	}
+	return service, nil
+}
+
+func (d *didman) updateService(ctx context.Context, id did.DID, serviceType string, serviceEndpoint interface{}) (*did.Service, error) {
+	doc, _, err := d.docResolver.Resolve(id, nil)
+	if err != nil {
+		return nil, err
+	}
+	service := &did.Service{
+		Type:            serviceType,
+		ServiceEndpoint: serviceEndpoint,
+	}
+	service.ID = generateIDForService(id, *service)
+
+	serviceFound := false
+	for i, s := range doc.Service {
+		if s.Type == serviceType {
+			doc.Service[i] = *service
+			serviceFound = true
+		}
+	}
+	if !serviceFound {
+		return nil, types.ErrServiceNotFound
+	}
 	if err = d.vdr.Update(ctx, id, *doc); err != nil {
 		return nil, err
 	}

--- a/didman/didman.go
+++ b/didman/didman.go
@@ -223,7 +223,7 @@ func (d *didman) UpdateCompoundService(ctx context.Context, id did.DID, serviceT
 		WithField(core.LogFieldDID, id.String()).
 		WithField(core.LogFieldServiceType, serviceType).
 		WithField(core.LogFieldServiceEndpoint, endpoints).
-		Debug("Adding compound updated")
+		Debug("Updating compound service")
 
 	// transform service references to map[string]interface{}
 	serviceEndpoint := map[string]interface{}{}
@@ -583,14 +583,14 @@ func (d *didman) updateService(ctx context.Context, id did.DID, serviceType stri
 	}
 	service.ID = generateIDForService(id, *service)
 
-	serviceFound := false
+	serviceToBeUpdatedFound := false
 	for i, s := range doc.Service {
 		if s.Type == serviceType {
 			doc.Service[i] = *service
-			serviceFound = true
+			serviceToBeUpdatedFound = true
 		}
 	}
-	if !serviceFound {
+	if !serviceToBeUpdatedFound {
 		return nil, types.ErrServiceNotFound
 	}
 	if err = d.vdr.Update(ctx, id, *doc); err != nil {

--- a/didman/mock.go
+++ b/didman/mock.go
@@ -53,18 +53,18 @@ func (mr *MockDidmanMockRecorder) AddCompoundService(ctx, id, serviceType, endpo
 }
 
 // AddEndpoint mocks base method.
-func (m *MockDidman) AddEndpoint(ctx context.Context, id did.DID, serviceType string, u url.URL) (*did.Service, error) {
+func (m *MockDidman) AddEndpoint(ctx context.Context, id did.DID, serviceType string, endpoint url.URL) (*did.Service, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddEndpoint", ctx, id, serviceType, u)
+	ret := m.ctrl.Call(m, "AddEndpoint", ctx, id, serviceType, endpoint)
 	ret0, _ := ret[0].(*did.Service)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddEndpoint indicates an expected call of AddEndpoint.
-func (mr *MockDidmanMockRecorder) AddEndpoint(ctx, id, serviceType, u interface{}) *gomock.Call {
+func (mr *MockDidmanMockRecorder) AddEndpoint(ctx, id, serviceType, endpoint interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEndpoint", reflect.TypeOf((*MockDidman)(nil).AddEndpoint), ctx, id, serviceType, u)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEndpoint", reflect.TypeOf((*MockDidman)(nil).AddEndpoint), ctx, id, serviceType, endpoint)
 }
 
 // DeleteEndpointsByType mocks base method.
@@ -155,6 +155,21 @@ func (mr *MockDidmanMockRecorder) SearchOrganizations(ctx, query, didServiceType
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchOrganizations", reflect.TypeOf((*MockDidman)(nil).SearchOrganizations), ctx, query, didServiceType)
 }
 
+// UpdateCompoundService mocks base method.
+func (m *MockDidman) UpdateCompoundService(ctx context.Context, id did.DID, serviceType string, endpoints map[string]go_did.URI) (*did.Service, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateCompoundService", ctx, id, serviceType, endpoints)
+	ret0, _ := ret[0].(*did.Service)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateCompoundService indicates an expected call of UpdateCompoundService.
+func (mr *MockDidmanMockRecorder) UpdateCompoundService(ctx, id, serviceType, endpoints interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCompoundService", reflect.TypeOf((*MockDidman)(nil).UpdateCompoundService), ctx, id, serviceType, endpoints)
+}
+
 // UpdateContactInformation mocks base method.
 func (m *MockDidman) UpdateContactInformation(ctx context.Context, id did.DID, information ContactInformation) (*ContactInformation, error) {
 	m.ctrl.T.Helper()
@@ -168,6 +183,21 @@ func (m *MockDidman) UpdateContactInformation(ctx context.Context, id did.DID, i
 func (mr *MockDidmanMockRecorder) UpdateContactInformation(ctx, id, information interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContactInformation", reflect.TypeOf((*MockDidman)(nil).UpdateContactInformation), ctx, id, information)
+}
+
+// UpdateEndpoint mocks base method.
+func (m *MockDidman) UpdateEndpoint(ctx context.Context, id did.DID, serviceType string, endpoint url.URL) (*did.Service, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateEndpoint", ctx, id, serviceType, endpoint)
+	ret0, _ := ret[0].(*did.Service)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateEndpoint indicates an expected call of UpdateEndpoint.
+func (mr *MockDidmanMockRecorder) UpdateEndpoint(ctx, id, serviceType, endpoint interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEndpoint", reflect.TypeOf((*MockDidman)(nil).UpdateEndpoint), ctx, id, serviceType, endpoint)
 }
 
 // MockCompoundServiceResolver is a mock of CompoundServiceResolver interface.

--- a/didman/types.go
+++ b/didman/types.go
@@ -36,7 +36,11 @@ type Didman interface {
 	// AddEndpoint adds a service to a DID Document. The serviceEndpoint is set to the given URL.
 	// It returns ErrDuplicateService if a service with the given type already exists.
 	// It can also return various errors from DocResolver.Resolve and VDR.Update
-	AddEndpoint(ctx context.Context, id did.DID, serviceType string, u url.URL) (*did.Service, error)
+	AddEndpoint(ctx context.Context, id did.DID, serviceType string, endpoint url.URL) (*did.Service, error)
+
+	// UpdateEndpoint updates the serviceEndpoint of a service in a DID Document. The serviceEndpoint is set to the given URL.
+	// It can return various errors from DocResolver.Resolve and VDR.Update.
+	UpdateEndpoint(ctx context.Context, id did.DID, serviceType string, endpoint url.URL) (*did.Service, error)
 
 	// DeleteEndpointsByType takes a did and type and removes all endpoint with the type from the DID Document.
 	// It returns ErrServiceNotFound if no services with the given type can't be found in the DID Document.
@@ -56,6 +60,12 @@ type Didman interface {
 	// It returns ErrReferencedServiceNotAnEndpoint if one of the references does not resolve to a single endpoint URL.
 	// It can also return various errors from DocResolver.Resolve and VDR.Update
 	AddCompoundService(ctx context.Context, id did.DID, serviceType string, endpoints map[string]ssi.URI) (*did.Service, error)
+
+	// UpdateCompoundService updates a compound endpoint in a DID Document.
+	// It returns didservice.DIDServiceQueryError if one of the service references is invalid.
+	// It returns ErrReferencedServiceNotAnEndpoint if one of the references does not resolve to a single endpoint URL.
+	// It can also return various errors from DocResolver.Resolve and VDR.Update
+	UpdateCompoundService(ctx context.Context, id did.DID, serviceType string, endpoints map[string]ssi.URI) (*did.Service, error)
 
 	// UpdateContactInformation adds or updates the compoundService with type equal to node-contact-info with provided
 	// contact information to the DID Document.

--- a/docs/_static/didman/v1.yaml
+++ b/docs/_static/didman/v1.yaml
@@ -97,12 +97,28 @@ paths:
                 $ref: '#/components/schemas/Endpoint'
         default:
           $ref: '../common/error_response.yaml'
+  /internal/didman/v1/did/{did}/endpoint/{type}:
+    parameters:
+      - name: did
+        in: path
+        description: URL encoded DID.
+        required: true
+        example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
+        schema:
+          type: string
+      - name: type
+        in: path
+        description: Type of the service
+        required: true
+        example: oauth
+        schema:
+          type: string
     put:
       operationId: "updateEndpoint"
       summary: Update a service endpoint or a reference to a service.
       description: |
         Update an endpoint's URL or reference in a DID document. The endpoint to be updated is selected by type.
-        The URL can either be an Endpoint or a reference to another service.
+        The URL can either be an Endpoint or a reference to another service. Updating the type is not supported.
 
         error returns:
         * 400 - incorrect input
@@ -124,22 +140,6 @@ paths:
                 $ref: '#/components/schemas/Endpoint'
         default:
           $ref: '../common/error_response.yaml'
-  /internal/didman/v1/did/{did}/endpoint/{type}:
-    parameters:
-      - name: did
-        in: path
-        description: URL encoded DID.
-        required: true
-        example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
-        schema:
-          type: string
-      - name: type
-        in: path
-        description: Type of the service
-        required: true
-        example: oauth
-        schema:
-          type: string
     delete:
       operationId: deleteEndpointsByType
       description: |
@@ -220,11 +220,27 @@ paths:
                 $ref: '#/components/schemas/CompoundService'
         default:
           $ref: '../common/error_response.yaml'
+  /internal/didman/v1/did/{did}/compoundservice/{type}:
+    parameters:
+      - name: did
+        in: path
+        description: URL encoded DID.
+        required: true
+        example: did:nuts:EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
+        schema:
+          type: string
+      - name: type
+        in: path
+        description: Type of the compound service
+        required: true
+        example: eOverdracht-sender
+        schema:
+          type: string
     put:
       summary: Update a compound service.
       description: |
         Update a compound service in a DID Document. It follows the same requirements as when adding a compound service.
-        It updates all endpoints of the compound service (no partial updates).
+        It updates all endpoints of the compound service (no partial updates). Updating the type is not supported.
 
         error returns:
         * 400 - incorrect input

--- a/docs/_static/didman/v1.yaml
+++ b/docs/_static/didman/v1.yaml
@@ -97,6 +97,33 @@ paths:
                 $ref: '#/components/schemas/Endpoint'
         default:
           $ref: '../common/error_response.yaml'
+    put:
+      operationId: "updateEndpoint"
+      summary: Update a service endpoint or a reference to a service.
+      description: |
+        Update an endpoint's URL or reference in a DID document. The endpoint to be updated is selected by type.
+        The URL can either be an Endpoint or a reference to another service.
+
+        error returns:
+        * 400 - incorrect input
+        * 404 - unknown DID or service with this type
+      tags:
+        - services
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EndpointProperties'
+      responses:
+        "200":
+          description: The endpoint which has been updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Endpoint'
+        default:
+          $ref: '../common/error_response.yaml'
   /internal/didman/v1/did/{did}/endpoint/{type}:
     parameters:
       - name: did
@@ -187,6 +214,33 @@ paths:
       responses:
         "200":
           description: The compound service has been added to the DID Document
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompoundService'
+        default:
+          $ref: '../common/error_response.yaml'
+    put:
+      summary: Update a compound service.
+      description: |
+        Update a compound service in a DID Document. It follows the same requirements as when adding a compound service.
+        It updates all endpoints of the compound service (no partial updates).
+
+        error returns:
+        * 400 - incorrect input
+        * 404 - unknown DID or service with this type
+      operationId: "updateCompoundService"
+      tags:
+        - services
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompoundServiceProperties'
+      responses:
+        "200":
+          description: The compound service has been updated
           content:
             application/json:
               schema:


### PR DESCRIPTION
Given https://github.com/nuts-foundation/nuts-node/issues/2131, it becomes very unpractical to update an absolute endpoint (service with a URL) when it's referenced by other services: it would mean parties have to:

1. delete all references first,
2. then delete the service itself,
3. then create the service with the updated endpoint,
4. finally recreate all references.

That it didn't hurt much up until now is because the "is being referenced"-check was always broken (at least for references from other documents), but it still applies to for references within the same document.

Furthermore, each hackaton people are asking how to update a service so having an API for that really helps.