### PR TITLE
removed dead diagnostics code

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -77,17 +77,6 @@ func (system *System) Load(flags *pflag.FlagSet) error {
 	})
 }
 
-// Diagnostics returns the compound diagnostics for all engines.
-func (system *System) Diagnostics() []DiagnosticResult {
-	result := make([]DiagnosticResult, 0)
-	system.VisitEngines(func(engine Engine) {
-		if m, ok := engine.(Diagnosable); ok {
-			result = append(result, m.Diagnostics()...)
-		}
-	})
-	return result
-}
-
 // Start starts all engines in the system.
 func (system *System) Start() error {
 	var err error

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -153,18 +153,6 @@ func TestSystem_Migrate(t *testing.T) {
 	})
 }
 
-func TestSystem_Diagnostics(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	r := NewMockDiagnosable(ctrl)
-	r.EXPECT().Diagnostics().Return([]DiagnosticResult{&GenericDiagnosticResult{Title: "Result"}})
-
-	system := NewSystem()
-	system.RegisterEngine(TestEngine{})
-	system.RegisterEngine(r)
-	assert.Len(t, system.Diagnostics(), 1)
-}
-
 func TestSystem_RegisterEngine(t *testing.T) {
 	t.Run("adds an engine to the list", func(t *testing.T) {
 		ctl := System{


### PR DESCRIPTION
removed `Diagnostics()` from `System`, wasn't used.