### PR TITLE
irma config no longer generates errors

### DIFF
--- a/auth/services/irma/factory_test.go
+++ b/auth/services/irma/factory_test.go
@@ -42,14 +42,6 @@ func TestGetIrmaServer(t *testing.T) {
 		assert.NotNil(t, irmaServer, "expected an IRMA server instance")
 	})
 
-	t.Run("it fails on an unknown extra schema dir", func(t *testing.T) {
-		dirname, err := os.MkdirTemp(validatorConfig.IrmaConfigPath, "foo")
-		require.NoError(t, err)
-		defer func() { os.RemoveAll(dirname) }()
-		_, err = getIrmaConfig(validatorConfig)
-		assert.ErrorContains(t, err, "no scheme file")
-	})
-
 	// Check if the fix for https://github.com/privacybydesign/irmago/issues/139 works
 	t.Run("it removes leftover scheme dirs", func(t *testing.T) {
 		dirname, err := os.MkdirTemp(validatorConfig.IrmaConfigPath, "tempscheme")


### PR DESCRIPTION
In the latest patch they fixed a case we use for testing error conditions.
So we're no longer able to test it that way.
Also logic behinds it does a mkdirall and fail conditions only check if dirs exist.....