### PR TITLE
Auth: add missing selfsigned fields userRole and username to Access token

### DIFF
--- a/auth/services/oauth/authz_server.go
+++ b/auth/services/oauth/authz_server.go
@@ -552,6 +552,8 @@ func (s *authzServer) buildAccessToken(ctx context.Context, requester did.DID, a
 		accessToken.Prefix = toStrPtr(disclosedAttributeFn(services.PrefixTokenClaim))
 		accessToken.Email = toStrPtr(disclosedAttributeFn(services.EmailTokenClaim))
 		accessToken.AssuranceLevel = toStrPtr(disclosedAttributeFn(services.AssuranceLevelClaim))
+		accessToken.UserRole = toStrPtr(disclosedAttributeFn(services.UserRoleClaim))
+		accessToken.Username = toStrPtr(disclosedAttributeFn(services.UsernameClaim))
 	}
 
 	if len(credentialIDs) > 0 {


### PR DESCRIPTION
Fixes https://github.com/nuts-foundation/nuts-node/issues/2174

Maybe add in e2e test as well?