### PR TITLE
the conversation manager used a timer in its cleanup routine

### DIFF
--- a/network/transport/v2/conversation.go
+++ b/network/transport/v2/conversation.go
@@ -97,7 +97,7 @@ func (cMan *conversationManager) start(ctx context.Context) {
 	done := ctx.Done()
 
 	go func() {
-		timer := time.NewTimer(cMan.validity)
+		timer := time.NewTicker(cMan.validity)
 		for {
 			select {
 			case <-done:


### PR DESCRIPTION
This should cause memory leaks everywhere.