### PR TITLE
Allow literal \n in trustedsigner

### DIFF
--- a/pki/denylist.go
+++ b/pki/denylist.go
@@ -135,6 +135,7 @@ func (b *denylistImpl) ValidateCert(cert *x509.Certificate) error {
 			logger().WithError(err).
 				WithField("Issuer", issuer).
 				WithField("S/N", serialNumber).
+				WithField("Thumbprint", thumbprint).
 				Error("Cert validation failed because the denylist cannot be downloaded")
 
 			// Return an error indicating the denylist cannot be retrieved
@@ -156,10 +157,22 @@ func (b *denylistImpl) ValidateCert(cert *x509.Certificate) error {
 	for _, entry := range *entriesPtr {
 		// Check for this issuer and serial number combination
 		if entry.Issuer == issuer && entry.SerialNumber == serialNumber && entry.JWKThumbprint == thumbprint {
+			logger().
+				WithField("Issuer", issuer).
+				WithField("S/N", serialNumber).
+				WithField("Thumbprint", thumbprint).
+				Debug("Rejecting banned certificate")
 			// Return an error indicating the certificate has been denylisted
 			return fmt.Errorf("%w: %s", ErrCertBanned, entry.Reason)
 		}
 	}
+
+	// Log a message about the cert being validated
+	logger().
+		WithField("Issuer", issuer).
+		WithField("S/N", serialNumber).
+		WithField("Thumbprint", thumbprint).
+		Debug("Validated certificate")
 
 	// Return a nil error as the certificate hasn't been denylisted
 	return nil
@@ -206,6 +219,9 @@ func (b *denylistImpl) Update() error {
 
 	// Track when the denylist was last updated
 	b.lastUpdated = time.Now()
+
+	// Log when the denylist is updated
+	logger().Debug("Denylist updated successfully")
 
 	// Return a nil error as the denylist was successfully updated
 	return nil

--- a/pki/denylist.go
+++ b/pki/denylist.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -97,8 +98,11 @@ func NewDenylist(config DenylistConfig) (Denylist, error) {
 		}, nil
 	}
 
+	// Convert any literal '\n' in the PEM to an actual newline character
+	trustedSigner := strings.ReplaceAll(config.TrustedSigner, "\\n", "\n")
+
 	// Parse the trusted key
-	key, err := jwk.ParseKey([]byte(config.TrustedSigner), jwk.WithPEM(true))
+	key, err := jwk.ParseKey([]byte(trustedSigner), jwk.WithPEM(true))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse key: %w", err)
 	}

--- a/pki/denylist_test.go
+++ b/pki/denylist_test.go
@@ -205,6 +205,29 @@ func TestNewDenylist(t *testing.T) {
 	})
 }
 
+// TestBackslashNInKey ensures a denylist is correctly downloaded
+func TestBackslashNInKey(t *testing.T) {
+	// Get the trusted denylist
+	denylistJSON := trustedDenylist(t)
+
+	// Setup a denylist server
+	testServer := denylistTestServer(denylistJSON)
+	defer testServer.Close()
+
+	// Trusted signer as PEM with literal \n sequences instead of newlines
+	trustedSigner := `-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAB262IB4Bg7CzZ/kap8gU+16vD9x/mom7WEjIZsBz+LY=\n-----END PUBLIC KEY-----`
+
+	// Use the server in a new denylist
+	denylist, err := NewDenylist(DenylistConfig{URL: testServer.URL, TrustedSigner: trustedSigner})
+	require.NoError(t, err)
+	require.NotNil(t, denylist)
+
+	// Download the denylist data and ensure it is correct
+	bytes, err := denylist.(*denylistImpl).download()
+	assert.NoError(t, err)
+	assert.Equal(t, string(bytes), denylistJSON)
+}
+
 // TestDownloadDenylist ensures a denylist is correctly downloaded
 func TestDownloadDenylist(t *testing.T) {
 	// Get the trusted denylist
@@ -442,3 +465,4 @@ func TestRSACertificateJWKThumbprint(t *testing.T) {
 	keyID := certKeyJWKThumbprint(cert)
 	assert.Equal(t, "PVOjk-5d4Lb-FGxurW-fNMUv3rYZZBWF3gGaP5s1UVQ", keyID)
 }
+


### PR DESCRIPTION
This change makes configuring the denylist a lot simpler