### PR TITLE
fix key resolving when multiple keys exist

### DIFF
--- a/vdr/didservice/resolvers.go
+++ b/vdr/didservice/resolvers.go
@@ -168,18 +168,14 @@ func (r KeyResolver) ResolveRelationKey(keyID string, validAt *time.Time, relati
 	if err != nil {
 		return "", err
 	}
-	var result *did.VerificationRelationship
 	relationships, _ := resolveRelationships(doc, relationType)
 
 	for _, rel := range relationships {
 		if rel.ID.String() == keyID {
-			result = &rel
+			return rel.PublicKey()
 		}
 	}
-	if result == nil {
-		return "", types.ErrKeyNotFound
-	}
-	return result.PublicKey()
+	return "", types.ErrKeyNotFound
 }
 
 func resolveRelationships(doc *did.Document, relationType types.RelationType) (relationships did.VerificationRelationships, err error) {

--- a/vdr/didservice/resolvers_test.go
+++ b/vdr/didservice/resolvers_test.go
@@ -41,6 +41,11 @@ func TestResolveSigningKey(t *testing.T) {
 	keyCreator := newMockKeyCreator()
 	docCreator := Creator{KeyStore: keyCreator}
 	doc, _, _ := docCreator.Create(nil, DefaultCreationOptions())
+	// add a second key to the document
+	methodID := doc.ID
+	methodID.Fragment = "key2"
+	newMethod := &did.VerificationMethod{ID: methodID}
+	doc.AddAssertionMethod(newMethod)
 
 	t.Run("ok", func(t *testing.T) {
 		store.EXPECT().Resolve(testDID, gomock.Any()).Return(doc, nil, nil)


### PR DESCRIPTION
A range loop reuses the memory address of the variable. Therefore the last key from the list will be 'found' even if the `if` doesn't match.

Backport to V5.2