### PR TITLE
gossip manager now uses Peer.Key instead of peerId

### DIFF
--- a/network/transport/grpc/predicate.go
+++ b/network/transport/grpc/predicate.go
@@ -28,6 +28,19 @@ type Predicate interface {
 	Match(conn Connection) bool
 }
 
+type peerPredicate struct {
+	peer transport.Peer
+}
+
+// ByPeer filters the connection on the Peer Key (peerID + NodeDID + address)
+func ByPeer(peer transport.Peer) Predicate {
+	return peerPredicate{peer: peer}
+}
+
+func (predicate peerPredicate) Match(conn Connection) bool {
+	return conn.Peer().Key() == predicate.peer.Key()
+}
+
 type peerIDPredicate struct {
 	peerID transport.PeerID
 }

--- a/network/transport/v2/gossip/mock.go
+++ b/network/transport/v2/gossip/mock.go
@@ -36,9 +36,9 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // GossipReceived mocks base method.
-func (m *MockManager) GossipReceived(id transport.PeerID, refs ...hash.SHA256Hash) {
+func (m *MockManager) GossipReceived(peer transport.Peer, refs ...hash.SHA256Hash) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{id}
+	varargs := []interface{}{peer}
 	for _, a := range refs {
 		varargs = append(varargs, a)
 	}
@@ -46,9 +46,9 @@ func (m *MockManager) GossipReceived(id transport.PeerID, refs ...hash.SHA256Has
 }
 
 // GossipReceived indicates an expected call of GossipReceived.
-func (mr *MockManagerMockRecorder) GossipReceived(id interface{}, refs ...interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) GossipReceived(peer interface{}, refs ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{id}, refs...)
+	varargs := append([]interface{}{peer}, refs...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GossipReceived", reflect.TypeOf((*MockManager)(nil).GossipReceived), varargs...)
 }
 

--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -273,7 +273,7 @@ func (p *protocol) handleGossip(ctx context.Context, connection grpc.Connection,
 		refs[i] = hash.FromSlice(bytes)
 	}
 	if len(refs) > 0 {
-		p.gManager.GossipReceived(connection.Peer().ID, refs...)
+		p.gManager.GossipReceived(connection.Peer(), refs...)
 	}
 
 	// filter for unknown transactions

--- a/network/transport/v2/handlers_test.go
+++ b/network/transport/v2/handlers_test.go
@@ -251,7 +251,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
 		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
 		mocks.State.EXPECT().IsPresent(gomock.Any(), xorPeer).Return(false, nil)
-		mocks.Gossip.EXPECT().GossipReceived(connection.ID(), xorPeer)
+		mocks.Gossip.EXPECT().GossipReceived(peer, xorPeer)
 		mocks.Sender.EXPECT().sendTransactionListQuery(connection, []hash.SHA256Hash{xorPeer}).Return(nil)
 
 		err := p.handleGossip(ctx, connection, envelope)
@@ -263,7 +263,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
 		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockPeer+1)
 		mocks.State.EXPECT().IsPresent(gomock.Any(), xorPeer).Return(false, nil)
-		mocks.Gossip.EXPECT().GossipReceived(connection.ID(), xorPeer)
+		mocks.Gossip.EXPECT().GossipReceived(peer, xorPeer)
 		mocks.Sender.EXPECT().sendTransactionListQuery(connection, []hash.SHA256Hash{xorPeer}).Return(nil)
 
 		err := p.handleGossip(ctx, connection, envelope)
@@ -277,7 +277,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
 		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockPeer+1)
 		mocks.State.EXPECT().IsPresent(gomock.Any(), xorPeer).Return(true, nil)
-		mocks.Gossip.EXPECT().GossipReceived(connection.ID(), xorPeer)
+		mocks.Gossip.EXPECT().GossipReceived(peer, xorPeer)
 		mocks.Sender.EXPECT().sendState(connection, xorLocal, clockPeer+1)
 
 		err := p.handleGossip(ctx, connection, envelope)
@@ -290,7 +290,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
 		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
 		mocks.State.EXPECT().IsPresent(gomock.Any(), xorPeer).Return(false, nil)
-		mocks.Gossip.EXPECT().GossipReceived(connection.ID(), xorPeer)
+		mocks.Gossip.EXPECT().GossipReceived(peer, xorPeer)
 		mocks.Sender.EXPECT().sendState(connection, xorLocal, clockLocal).Return(nil)
 
 		err := p.handleGossip(ctx, connection, envelope)
@@ -316,7 +316,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
 		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
 		mocks.State.EXPECT().IsPresent(gomock.Any(), xorLocal).Return(true, nil)
-		mocks.Gossip.EXPECT().GossipReceived(connection.ID(), xorLocal)
+		mocks.Gossip.EXPECT().GossipReceived(peer, xorLocal)
 		mocks.Sender.EXPECT().sendState(connection, xorLocal, clockLocal).Return(nil)
 
 		err := p.handleGossip(ctx, connection, envelope)
@@ -332,7 +332,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
 		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
 		mocks.State.EXPECT().IsPresent(gomock.Any(), xorPeer).Return(false, nil)
-		mocks.Gossip.EXPECT().GossipReceived(connection.ID(), xorPeer)
+		mocks.Gossip.EXPECT().GossipReceived(peer, xorPeer)
 
 		mocks.Sender.EXPECT().sendTransactionListQuery(connection, []hash.SHA256Hash{xorPeer}).Return(errors.New("custom"))
 
@@ -345,7 +345,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
 		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
 		mocks.State.EXPECT().IsPresent(gomock.Any(), xorPeer).Return(false, errors.New("custom"))
-		mocks.Gossip.EXPECT().GossipReceived(connection.ID(), xorPeer)
+		mocks.Gossip.EXPECT().GossipReceived(peer, xorPeer)
 
 		err := p.handleGossip(ctx, connection, envelope)
 

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -235,8 +235,8 @@ func (p *protocol) gossipTransaction(event dag.Event) (bool, error) {
 	return true, nil
 }
 
-func (p *protocol) sendGossip(id transport.PeerID, refs []hash.SHA256Hash, xor hash.SHA256Hash, clock uint32) bool {
-	conn := p.connectionList.Get(grpc.ByConnected(), grpc.ByPeerID(id))
+func (p *protocol) sendGossip(transportPeer transport.Peer, refs []hash.SHA256Hash, xor hash.SHA256Hash, clock uint32) bool {
+	conn := p.connectionList.Get(grpc.ByConnected(), grpc.ByPeer(transportPeer))
 	var err error
 
 	if conn == nil {
@@ -248,7 +248,7 @@ func (p *protocol) sendGossip(id transport.PeerID, refs []hash.SHA256Hash, xor h
 	if err != nil {
 		log.Logger().
 			WithError(err).
-			WithField(core.LogFieldPeerID, id.String()).
+			WithField(core.LogFieldPeerID, transportPeer.ID.String()).
 			Error("failed to send Gossip message")
 		return false
 	}


### PR DESCRIPTION
fixes #1950 

2nd part of phasing out peerID