### PR TITLE
Network: add revoked/denied cert to health check

### DIFF
--- a/network/transport/grpc/config.go
+++ b/network/transport/grpc/config.go
@@ -136,7 +136,7 @@ func (cfg Config) tlsEnabled() bool {
 }
 
 func newServerTLSConfig(config Config) (*tls.Config, error) {
-	tlsConfig, err := newTLSConfig(config)
+	tlsConfig, err := baseTLSConfig(config)
 	if err != nil {
 		return nil, err
 	}
@@ -148,8 +148,17 @@ func newServerTLSConfig(config Config) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
+// NewClientTLSConfig returns the network grpc client tls.Config
+func NewClientTLSConfig(clientCert *tls.Certificate, trustStore *x509.CertPool, pkiValidator pki.Validator) (*tls.Config, error) {
+	return newClientTLSConfig(Config{
+		clientCert:   clientCert,
+		trustStore:   trustStore,
+		pkiValidator: pkiValidator,
+	})
+}
+
 func newClientTLSConfig(config Config) (*tls.Config, error) {
-	tlsConfig, err := newTLSConfig(config)
+	tlsConfig, err := baseTLSConfig(config)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +169,7 @@ func newClientTLSConfig(config Config) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-func newTLSConfig(config Config) (*tls.Config, error) {
+func baseTLSConfig(config Config) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		MinVersion: core.MinTLSVersion,
 	}


### PR DESCRIPTION
this health check is performed on both `network.tls` where it uses the configured certificate, and `network.auth_config` where it validates the received certificate as part of the self-connect check.

```
{
    "details": {
        "crypto.filesystem": {
            "status": "UP"
        },
        "network.auth_config": {
            "details": "cannot connect to own NutsComm grpc://nuts-dev.snaauw.com:5555: certificate is banned: gerard can tell you: subject=CN=nuts-dev.snaauw.com, S/N=14349442077069222814, issuer=CN=Nuts Development Network Root CA",
            "status": "UNKNOWN"
        },
        "network.tls": {
            "details": "certificate is banned: gerard can tell you: subject=CN=nuts-dev.snaauw.com, S/N=14349442077069222814, issuer=CN=Nuts Development Network Root CA",
            "status": "DOWN"
        },
        "pki.crl": {
            "status": "UP"
        }
    },
    "status": "DOWN"
}
```

test denylist is hosted at: https://gist.githubusercontent.com/beardedfoo/44d6dbc2d0d08c5a94626b612464f47b/raw/cbd780b267fc9f4f7368f7e41cd8cd2cc75136a3/gistfile1.txt