### PR TITLE
helm chart improvements:

### DIFF
--- a/charts/nuts-node/Chart.yaml
+++ b/charts/nuts-node/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nuts-node/templates/_helpers.tpl
+++ b/charts/nuts-node/templates/_helpers.tpl
@@ -71,3 +71,47 @@ NUTS Port helpers
 {{- default 5555}}
 {{- end }}
 {{- end }}
+
+{{/*
+Get the password secret.
+*/}}
+{{- define "redis.secretName" -}}
+{{- if .Values.storage.redis.existingSecret -}}
+{{- printf "%s" (tpl .Values.storage.redis.existingSecret $) -}}
+{{- else -}}
+{{- printf "%s" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the password key to be retrieved from Redis&reg; secret.
+*/}}
+{{- define "redis.secretPasswordKey" -}}
+{{- if and .Values.storage.redis.existingSecret .Values.storage.redis.existingSecretPasswordKey -}}
+{{- printf "%s" .Values.storage.redis.existingSecretPasswordKey -}}
+{{- else -}}
+{{- printf "redis-password" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the password secret.
+*/}}
+{{- define "redis.sentinel.secretName" -}}
+{{- if .Values.storage.redis.sentinel.existingSecret -}}
+{{- printf "%s" (tpl .Values.storage.redis.sentinel.existingSecret $) -}}
+{{- else -}}
+{{- printf "%s" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the password key to be retrieved from Redis&reg; secret.
+*/}}
+{{- define "redis.sentinel.secretPasswordKey" -}}
+{{- if and .Values.storage.redis.sentinel.existingSecret .Values.storage.redis.sentinel.existingSecretPasswordKey -}}
+{{- printf "%s" .Values.storage.redis.sentinel.existingSecretPasswordKey -}}
+{{- else -}}
+{{- printf "redis-password" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/nuts-node/templates/deployment.yaml
+++ b/charts/nuts-node/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
             secretName: nuts-ssl-secret
         - name: nuts-data-pv
           persistentVolumeClaim:
-            claimName: nuts-data-pvc
+            claimName: {{ .Release.Namespace }}-{{ .Release.Name }}-data-pvc
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -46,6 +46,26 @@ spec:
           env:
             - name: NUTS_CONFIGFILE
               value: "/opt/nuts/nuts.yaml"
+        {{- if .Values.storage}}
+          {{- if .Values.storage.redis }}
+            {{- if .Values.storage.redis.existingSecret }}
+            - name: NUTS_STORAGE_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "redis.secretName" . }}
+                  key: {{ template "redis.secretPasswordKey" . }}
+            {{- end }}
+          {{- if .Values.storage.redis.sentinel}}
+            {{- if .Values.storage.redis.sentinel.existingSecret }}
+            - name: NUTS_STORAGE_REDIS_SENTINEL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "redis.sentinel.secretName" . }}
+                  key: {{ template "redis.sentinel.secretPasswordKey" . }}
+            {{- end }}
+          {{- end  }}
+          {{- end }}
+        {{- end }}
           volumeMounts:
             - name: nuts-config
               mountPath: /opt/nuts/nuts.yaml

--- a/charts/nuts-node/templates/nuts-data-pv.yaml
+++ b/charts/nuts-node/templates/nuts-data-pv.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: nuts-data-pv
+  name: {{ .Release.Namespace }}-{{ .Release.Name }}-data-pv
   labels:
     type: local
   annotations:
@@ -21,7 +21,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: nuts-data-pvc
+  name: {{ .Release.Namespace }}-{{ .Release.Name }}-data-pvc
   annotations:
     "helm.sh/resource-policy": keep
 spec:

--- a/charts/nuts-node/values.yaml
+++ b/charts/nuts-node/values.yaml
@@ -82,8 +82,18 @@ tolerations: []
 
 affinity: {}
 
+# if you want to use an existing secret for the redis password, uncomment below
+#storage:
+#  redis: # for normal redis password
+#    existingSecret: nuts-node-redis-auth
+#    existingSecretPasswordKey: redis-password
+#    sentinel: # for redis sentinel password
+#      existingSecret: nuts-node-redis-auth
+#      existingSecretPasswordKey: redis-password
+
 nuts:
   config:
+    strictmode: false
     # Everything below `nuts.config` will be placed into the `nuts.yaml` config file of the Pods
     datadir: /opt/nuts/data
     http:
@@ -98,6 +108,9 @@ nuts:
       certkeyfile: /opt/nuts/ssl/node.nuts.local.key
       enabletls: false
       grpcaddr: :5555
+    #storage:
+    #  redis:
+    #    address: nuts-node-redis-master.nuts-dev.svc.cluster.local
 
   # Config for the NUTS data mount inside Kubernetes
   data:


### PR DESCRIPTION
1.  added option to use existingSecret for redis/sentinel 
2. using releasename and namespace for pv and pvc so it can be deployed on the same cluster in different namespaces 
3. disabled strictmode in default values.yaml as tls is also disabled in the default values.yaml
4. updated chart version