### PR TITLE
Update circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     parallelism: 8
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.20
     steps:
       - checkout
 
@@ -36,7 +36,7 @@ jobs:
 
   report:
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.20
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/earthly-config.yml
+++ b/.circleci/earthly-config.yml
@@ -1,5 +1,0 @@
-global:
-  buildkit_additional_config: |
-    [registry."localhost:5000"]
-      http = true
-      insecure = true


### PR DESCRIPTION
#2202 needs go version 1.20, and testing using earthly has been removed last year