### PR TITLE
Network: log incoming auth failures on debug

### DIFF
--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -536,7 +536,7 @@ func (s *grpcConnectionManager) authenticate(nodeDID did.DID, peer transport.Pee
 				WithError(err).
 				WithFields(peer.ToFields()).
 				WithField(core.LogFieldDID, nodeDID).
-				Warn("Peer node DID could not be authenticated")
+				Debug("Peer node DID could not be authenticated")
 			// Error message is spec'd by RFC017, because it is returned to the peer
 			return transport.Peer{}, ErrNodeDIDAuthFailed
 		}


### PR DESCRIPTION
Properly updated/behaving nodes backoff when outbound authentication fails, but there are some that don't, causing log spam. It extremely annoys me and causes Hackaton participants to have a hard time reading their logs.

I think we can safely put it on debug, since it's the connecting party (remote) that must observe it can't connect and has to fix it.