### PR TITLE
Network: add maximum connection lifetime

### DIFF
--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -1040,7 +1040,7 @@ func TestNetworkIntegration_TLSOffloading(t *testing.T) {
 
 			// Assert connection is rejected
 			msg, err := result.Recv()
-			assert.EqualError(t, err, "rpc error: code = Unauthenticated desc = TLS client certificate authentication failed")
+			assert.EqualError(t, err, "rpc error: code = Unauthenticated desc = TLS client certificate validation failed")
 			assert.Nil(t, msg)
 		})
 	})

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -410,7 +410,7 @@ func TestNetworkIntegration_NodesConnectToEachOther(t *testing.T) {
 		testDirectory := io.TestDirectory(t)
 		resetIntegrationTest(t)
 
-		grpc.SetServerKeepaliveParams(t) // server disconnects after 1 sec
+		grpc.SetServerKeepaliveParamsForTest(t) // server disconnects after 1 sec
 		// Start 2 nodes: node1 and node2, where each connects to the other
 		node1 := startNode(t, "node1", testDirectory, func(_ *core.ServerConfig, cfg *Config) {
 			cfg.NodeDID = "did:nuts:node1"
@@ -438,7 +438,7 @@ func TestNetworkIntegration_NodesConnectToEachOther(t *testing.T) {
 		testDirectory := io.TestDirectory(t)
 		resetIntegrationTest(t)
 
-		grpc.SetClientKeepaliveParams(t) // client disconnects after 1 sec
+		grpc.SetClientKeepaliveParamsForTest(t) // client disconnects after 1 sec
 		// Start 2 nodes: node1 and node2, where each connects to the other
 		node1 := startNode(t, "node1", testDirectory, func(_ *core.ServerConfig, cfg *Config) {
 			cfg.NodeDID = "did:nuts:node1"

--- a/network/transport/grpc/test.go
+++ b/network/transport/grpc/test.go
@@ -161,8 +161,8 @@ func SetPeerID(t *testing.T, manager transport.ConnectionManager, id transport.P
 	cm.config.peerID = id
 }
 
-// SetServerKeepaliveParams sets the MaxConnectionAge to 1 sec and MaxConnectionAgeGrace to 1 nSec on the keepalive.ServerParameters and restores the default during cleanup.
-func SetServerKeepaliveParams(t *testing.T) {
+// SetServerKeepaliveParamsForTest sets the MaxConnectionAge to 1 sec and MaxConnectionAgeGrace to 1 nSec on the keepalive.ServerParameters and restores the default during cleanup.
+func SetServerKeepaliveParamsForTest(t *testing.T) {
 	defaultAge := serverKeepaliveParams
 	serverKeepaliveParams = keepalive.ServerParameters{
 		MaxConnectionAge:      time.Second,
@@ -173,8 +173,8 @@ func SetServerKeepaliveParams(t *testing.T) {
 	})
 }
 
-// SetClientKeepaliveParams sets the clientMaxConnectionAge to 1 sec and restores the default during cleanup.
-func SetClientKeepaliveParams(t *testing.T) {
+// SetClientKeepaliveParamsForTest sets the clientMaxConnectionAge to 1 sec and restores the default during cleanup.
+func SetClientKeepaliveParamsForTest(t *testing.T) {
 	defaultAge := clientMaxConnectionAge
 	clientMaxConnectionAge = time.Second
 	t.Cleanup(func() {

--- a/network/transport/grpc/test.go
+++ b/network/transport/grpc/test.go
@@ -21,8 +21,10 @@ package grpc
 import (
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/network/transport"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 	"testing"
+	"time"
 )
 
 // StubConnectionList is a stub implementation of the transport.ConnectionList interface
@@ -157,4 +159,25 @@ func SetPeerID(t *testing.T, manager transport.ConnectionManager, id transport.P
 		t.Fatalf("expected manager to be of type *grpcConnectionManager, but got %T", manager)
 	}
 	cm.config.peerID = id
+}
+
+// SetServerKeepaliveParams sets the MaxConnectionAge to 1 sec and MaxConnectionAgeGrace to 1 nSec on the keepalive.ServerParameters and restores the default during cleanup.
+func SetServerKeepaliveParams(t *testing.T) {
+	defaultAge := serverKeepaliveParams
+	serverKeepaliveParams = keepalive.ServerParameters{
+		MaxConnectionAge:      time.Second,
+		MaxConnectionAgeGrace: time.Nanosecond,
+	}
+	t.Cleanup(func() {
+		serverKeepaliveParams = defaultAge
+	})
+}
+
+// SetClientKeepaliveParams sets the clientMaxConnectionAge to 1 sec and restores the default during cleanup.
+func SetClientKeepaliveParams(t *testing.T) {
+	defaultAge := clientMaxConnectionAge
+	clientMaxConnectionAge = time.Second
+	t.Cleanup(func() {
+		clientMaxConnectionAge = defaultAge
+	})
 }

--- a/network/transport/grpc/tls_offloading.go
+++ b/network/transport/grpc/tls_offloading.go
@@ -43,13 +43,14 @@ func newAuthenticationInterceptor(clientCertHeaderName string, pkiValidator pki.
 	return (&tlsOffloadingAuthenticator{clientCertHeaderName: clientCertHeaderName, pkiValidator: pkiValidator}).intercept
 }
 
+// tlsOffloadingAuthenticator get the TLS certificate from the 'clientCertHeaderName' header and set it on the grpc.peer.
 type tlsOffloadingAuthenticator struct {
 	clientCertHeaderName string
 	pkiValidator         pki.Validator
 }
 
 func (t *tlsOffloadingAuthenticator) intercept(srv interface{}, serverStream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-	// Det certificate from header
+	// Get certificate from header
 	certificates, err := t.authenticate(serverStream)
 	if err != nil {
 		log.Logger().

--- a/pki/pki_test.go
+++ b/pki/pki_test.go
@@ -102,8 +102,7 @@ func TestPKI_CheckHealth(t *testing.T) {
 	require.NoError(t, e.validator.AddTruststore(store.Certificates()))
 
 	// Add Denylist
-	testServer := denylistTestServer("")
-	defer testServer.Close()
+	testServer := denylistTestServer(t, "")
 	e.denylist, err = testDenylist(testServer.URL, publicKeyDoNotUse)
 	require.NoError(t, err)
 	require.NotNil(t, e.denylist)

--- a/pki/test.go
+++ b/pki/test.go
@@ -1,0 +1,32 @@
+package pki
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+)
+
+// TestDenylistWithCert sets a new Denylist on the Validator and adds the certificate.
+// This is useful in integrations tests etc.
+func TestDenylistWithCert(t *testing.T, val Validator, cert *x509.Certificate) {
+	dl := &denylistImpl{
+		url:         "some-url",
+		lastUpdated: time.Now(),
+	}
+	dl.entries.Store(&[]denylistEntry{
+		{
+			Issuer:        cert.Issuer.String(),
+			SerialNumber:  cert.SerialNumber.String(),
+			JWKThumbprint: certKeyJWKThumbprint(cert),
+			Reason:        `testing purposes`,
+		},
+	})
+	switch v := val.(type) {
+	case *PKI:
+		v.denylist = dl
+	case *validator:
+		v.denylist = dl
+	default:
+		t.Fatal("cannot set Denylist on val")
+	}
+}

--- a/pki/validator_test.go
+++ b/pki/validator_test.go
@@ -136,16 +136,14 @@ func TestValidator_Validate(t *testing.T) {
 		testSoftHard(t, val, validCertA, nil, ErrCRLExpired)
 	})
 	t.Run("blocked cert", func(t *testing.T) {
-		ts := denylistTestServer(trustedDenylist(t))
-		defer ts.Close()
+		ts := denylistTestServer(t, trustedDenylist(t))
 		val.denylist, err = testDenylist(ts.URL, publicKeyDoNotUse)
 		require.NoError(t, err)
 
 		testSoftHard(t, val, bannedCert, ErrCertBanned, ErrCertBanned)
 	})
 	t.Run("denylist missing", func(t *testing.T) {
-		ts := denylistTestServer("")
-		defer ts.Close()
+		ts := denylistTestServer(t, "")
 		val.denylist, err = testDenylist(ts.URL, publicKeyDoNotUse)
 		require.NoError(t, err)
 


### PR DESCRIPTION
closes #2018 
Closing a connection once the used certificate is revoked/deny listed as proposed in the issue adds a lot of complexity. 

The current solution sets a maximum lifetime before the connection will be closed on the server side (15min) and client side (20 min). Since the network was designed to have connections open all the time, there are some race conditions in the disconnect vs sending of messages. The server side has a graceful closure using gRPC to wrap-up any ongoing communication resulting in less issues. We need to test how big of an issue this really is.

Also added some integration tests