### PR TITLE
Docs: add proxy_buffering and client_max_body_size to example NGINX config

### DIFF
--- a/docs/pages/deployment/tls-configuration.rst
+++ b/docs/pages/deployment/tls-configuration.rst
@@ -84,7 +84,8 @@ For `NGINX <https://www.nginx.com/>`_ the proxy configuration could look as foll
           ssl_verify_depth          1;
 
           location / {
-            # for large messages
+            # During synchronization of a new Nuts node it is possible that the gRPC stream contains messages larger than NGINX is willing to accept.
+            # The following config disables buffering and increases the max. message a client can send to some sanely large number.
             proxy_buffering off;
             client_max_body_size 128m;
 
@@ -122,11 +123,6 @@ For `NGINX <https://www.nginx.com/>`_ the proxy configuration could look as foll
           }
         }
     }
-
-.. note::
-
-    During synchronization of a new Nuts node it is possible that the gRPC stream contains messages larger than NGINX is willing to accept.
-    To limit these issues add ``proxy_buffering off`` to the gRPC config section, and increase the buffer size to some sanely large number e.g., ``client_max_body_size 128m``.
 
 For `HAProxy <https://www.haproxy.com/>`_ the proxy configuration could look as follows:
 

--- a/docs/pages/deployment/tls-configuration.rst
+++ b/docs/pages/deployment/tls-configuration.rst
@@ -86,6 +86,7 @@ For `NGINX <https://www.nginx.com/>`_ the proxy configuration could look as foll
           location / {
             # During synchronization of a new Nuts node it is possible that the gRPC stream contains messages larger than NGINX is willing to accept.
             # The following config disables buffering and increases the max. message a client can send to some sanely large number.
+            # If not configured, NGINX will drop the connection when syncing lots of transactions at once.
             proxy_buffering off;
             client_max_body_size 128m;
 

--- a/docs/pages/deployment/tls-configuration.rst
+++ b/docs/pages/deployment/tls-configuration.rst
@@ -84,6 +84,10 @@ For `NGINX <https://www.nginx.com/>`_ the proxy configuration could look as foll
           ssl_verify_depth          1;
 
           location / {
+            # for large messages
+            proxy_buffering off;
+            client_max_body_size 128m;
+
             grpc_pass grpc://nuts-node:5555;
             grpc_set_header X-SSL-CERT $ssl_client_escaped_cert;        # add peer's SSL cert
             grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for; # for correct IP logging


### PR DESCRIPTION
Otherwise, bootstrapping nodes are disconnected (gRPC will report `RST_STREAM` error) due to (too) large pages being transmitted.