### PR TITLE
Network: re-validate peers after denylist update

### DIFF
--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -966,7 +966,7 @@ func TestNetworkIntegration_TLSOffloading(t *testing.T) {
 			require.NoError(t, err)
 			cert, err := core.ParseCertificates(clientCertBytes)
 			require.NoError(t, err)
-			pki.TestDenylistWithCert(t, node1.network.pkiValidator, cert[0])
+			pki.SetNewDenylistWithCert(t, node1.network.pkiValidator, cert[0])
 
 			// Create client (node2) that connects to server node
 			grpcConn, err := grpcLib.Dial(nameToAddress(t, "node1"), grpcLib.WithTransportCredentials(insecure.NewCredentials()))

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -213,6 +213,7 @@ func TestNetwork_Configure(t *testing.T) {
 		ctx.protocol.EXPECT().Configure(gomock.Any())
 		ctx.pkiValidator.EXPECT().AddTruststore(gomock.Any())
 		ctx.pkiValidator.EXPECT().SetVerifyPeerCertificateFunc(gomock.Any()).Times(2) // tls.Configs: client, selfTestDialer
+		ctx.pkiValidator.EXPECT().SubscribeDenied(gomock.Any())
 		ctx.network.connectionManager = nil
 
 		cfg := *core.NewServerConfig()

--- a/network/transport/grpc/authenticator.go
+++ b/network/transport/grpc/authenticator.go
@@ -19,6 +19,7 @@
 package grpc
 
 import (
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/go-did/did"
@@ -83,6 +84,7 @@ func (t tlsAuthenticator) Authenticate(nodeDID did.DID, grpcPeer grpcPeer.Peer, 
 		Debug("Connection successfully authenticated")
 	peer.NodeDID = nodeDID
 	peer.Authenticated = true
+	peer.Certificate = peerCertificate
 	return peer, nil
 }
 
@@ -96,5 +98,6 @@ type dummyAuthenticator struct{}
 func (d dummyAuthenticator) Authenticate(nodeDID did.DID, _ grpcPeer.Peer, peer transport.Peer) (transport.Peer, error) {
 	peer.NodeDID = nodeDID
 	peer.Authenticated = true
+	peer.Certificate = &x509.Certificate{}
 	return peer, nil
 }

--- a/network/transport/grpc/authenticator_test.go
+++ b/network/transport/grpc/authenticator_test.go
@@ -54,6 +54,7 @@ func Test_tlsAuthenticator_Authenticate(t *testing.T) {
 	expectedPeer := transport.Peer{
 		NodeDID:       nodeDID,
 		Authenticated: true,
+		Certificate:   cert,
 	}
 
 	t.Run("ok", func(t *testing.T) {
@@ -89,6 +90,11 @@ func Test_tlsAuthenticator_Authenticate(t *testing.T) {
 					PeerCertificates: []*x509.Certificate{wildcardCert},
 				},
 			},
+		}
+		expectedPeer := transport.Peer{
+			NodeDID:       nodeDID,
+			Authenticated: true,
+			Certificate:   wildcardCert,
 		}
 
 		authenticatedPeer, err := authenticator.Authenticate(nodeDID, grpcPeer, transport.Peer{})

--- a/network/transport/grpc/connection.go
+++ b/network/transport/grpc/connection.go
@@ -221,13 +221,10 @@ func (mc *conn) startReceiving(protocol Protocol, stream Stream) {
 		defer atomic.AddInt32(activeGoroutines, -1)
 		for {
 			message := protocol.CreateEnvelope()
-			err := stream.RecvMsg(message)
-			select {
-			case <-mc.ctx.Done():
-				// disconnect: drop message and stop receiving
+			err := stream.RecvMsg(message) // blocking
+			if mc.ctx.Err() != nil {
+				// connection has been closed: drop message and stop receiving
 				return
-			default:
-				//non-blocking
 			}
 			if err != nil {
 				errStatus, isStatusError := status.FromError(err)

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -552,6 +552,7 @@ func (s *grpcConnectionManager) revalidatePeers() {
 		if nowFunc().After(peerCert.NotAfter) {
 			log.Logger().WithError(errors.New("certificate expired while in use")).WithFields(conn.Peer().ToFields()).Info("Disconnected peer")
 			conn.disconnect()
+			return
 		}
 		err = s.config.pkiValidator.Validate([]*x509.Certificate{peerCert})
 		if err != nil {

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -396,7 +396,7 @@ func (s *grpcConnectionManager) Contacts() []transport.Contact {
 func (s *grpcConnectionManager) Diagnostics() []core.DiagnosticResult {
 	return append(
 		[]core.DiagnosticResult{
-			lastCertificateValidation{*s.lastCertificateValidation.Load()},
+			lastCertificateValidationStatistic{*s.lastCertificateValidation.Load()},
 			ownPeerIDStatistic{s.config.peerID},
 		},
 		s.connections.Diagnostics()...)

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -124,10 +124,9 @@ func NewGRPCConnectionManager(config Config, connectionStore stoabs.KVStore, nod
 	cm.addressBook = newAddressBook(connectionStore, config.backoffCreator)
 	cm.registerPrometheusMetrics()
 	cm.ctx, cm.ctxCancel = context.WithCancel(context.Background())
+	cm.lastCertificateValidation.Store(&time.Time{})
 	if config.tlsEnabled() {
 		config.pkiValidator.SubscribeDenied(cm.revalidatePeers)
-		now := nowFunc()
-		cm.lastCertificateValidation.Store(&now)
 	}
 	return cm, nil
 }

--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -20,10 +20,12 @@ package grpc
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/nuts-foundation/go-did/did"
@@ -36,7 +38,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	grpcPeer "google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
@@ -123,6 +124,9 @@ func NewGRPCConnectionManager(config Config, connectionStore stoabs.KVStore, nod
 	cm.addressBook = newAddressBook(connectionStore, config.backoffCreator)
 	cm.registerPrometheusMetrics()
 	cm.ctx, cm.ctxCancel = context.WithCancel(context.Background())
+	if config.tlsEnabled() {
+		config.pkiValidator.SubscribeDenied(cm.revalidatePeers)
+	}
 
 	return cm, nil
 }
@@ -145,10 +149,11 @@ type grpcConnectionManager struct {
 	addressBook *addressBook
 
 	dialer
-	connectLoopWG     sync.WaitGroup
-	dialOptions       []grpc.DialOption
-	connectionTimeout time.Duration
-	connections       *connectionList
+	connectLoopWG             sync.WaitGroup
+	dialOptions               []grpc.DialOption
+	connectionTimeout         time.Duration
+	connections               *connectionList
+	lastCertificateValidation atomic.Int64
 }
 
 // newGrpcServer configures a new grpc.Server
@@ -182,18 +187,6 @@ func newGrpcServer(config Config) (*grpc.Server, error) {
 	// Chain interceptors. ipInterceptor is added last, so it processes the stream first.
 	serverInterceptors = append(serverInterceptors, ipInterceptor)
 	serverOpts = append(serverOpts, grpc.ChainStreamInterceptor(serverInterceptors...))
-
-	// Define the keepalive policy for the grpc server in such a way that connections are not long-lived.
-	// By blocking long-lived connections we ensure that connections are periodically reauthorized, namely
-	// so that a remote host which was authorized at the time of connection can become unauthorized and
-	// this is correctly enforced.
-	//
-	// Configured per https://github.com/grpc/grpc-go/blob/c9d3ea5673252d212c69f3d3c10ce1d7b287a86b/examples/features/keepalive/server/main.go#L43
-	keepaliveParams := keepalive.ServerParameters{
-		MaxConnectionAge:      15 * time.Minute, // If any connection is alive for too long, send a GOAWAY
-		MaxConnectionAgeGrace: 15 * time.Second, // Allow time for pending RPCs to complete before forcibly closing connections
-	}
-	serverOpts = append(serverOpts, grpc.KeepaliveParams(keepaliveParams))
 
 	// Create gRPC server for inbound connectionList and associate it with the protocols
 	return grpc.NewServer(serverOpts...), nil
@@ -401,7 +394,7 @@ func (s *grpcConnectionManager) Contacts() []transport.Contact {
 }
 
 func (s *grpcConnectionManager) Diagnostics() []core.DiagnosticResult {
-	return append(append([]core.DiagnosticResult{ownPeerIDStatistic{s.config.peerID}}, s.connections.Diagnostics()...))
+	return append([]core.DiagnosticResult{lastCertificateValidation{time.Unix(s.lastCertificateValidation.Load(), 0).UTC()}, ownPeerIDStatistic{s.config.peerID}}, s.connections.Diagnostics()...)
 }
 
 // RegisterService implements grpc.ServiceRegistrar to register the gRPC services protocols expose.
@@ -542,6 +535,24 @@ func (s *grpcConnectionManager) authenticate(nodeDID did.DID, peer transport.Pee
 		}
 	}
 	return peer, nil
+}
+
+// revalidatePeers verifies for all peers the x509.Certificate provided during TLS handshake is still valid.
+func (s *grpcConnectionManager) revalidatePeers() {
+	var err error
+	s.lastCertificateValidation.Store(nowFunc().UTC().Unix())
+	s.connections.forEach(func(conn Connection) {
+		peerCert := conn.Peer().Certificate
+		if nowFunc().After(peerCert.NotAfter) {
+			log.Logger().WithError(errors.New("certificate expired while in use")).WithFields(conn.Peer().ToFields()).Info("Disconnected peer")
+			conn.disconnect()
+		}
+		err = s.config.pkiValidator.Validate([]*x509.Certificate{peerCert})
+		if err != nil {
+			log.Logger().WithError(err).WithFields(conn.Peer().ToFields()).Warn("Disconnected peer")
+			conn.disconnect()
+		}
+	})
 }
 
 func (s *grpcConnectionManager) handleInboundStream(protocol Protocol, inboundStream grpc.ServerStream) error {

--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -704,12 +704,12 @@ func Test_grpcConnectionManager_Stop(t *testing.T) {
 
 func Test_grpcConnectionManager_Diagnostics(t *testing.T) {
 	const peerID = "server-peer-id"
-	testTime := time.Now().UTC().Truncate(time.Second)
+	testTime := time.Now()
 	t.Run("no peers", func(t *testing.T) {
 		cm, err := NewGRPCConnectionManager(Config{peerID: peerID}, nil, *nodeDID, nil)
 		require.NoError(t, err)
 		defer cm.Stop()
-		cm.lastCertificateValidation.Store(testTime.Unix())
+		cm.lastCertificateValidation.Store(&testTime)
 
 		diag := cm.Diagnostics()
 
@@ -722,7 +722,7 @@ func Test_grpcConnectionManager_Diagnostics(t *testing.T) {
 		cm, err := NewGRPCConnectionManager(Config{peerID: peerID}, nil, *nodeDID, nil)
 		require.NoError(t, err)
 		defer cm.Stop()
-		cm.lastCertificateValidation.Store(testTime.Unix())
+		cm.lastCertificateValidation.Store(&testTime)
 
 		go cm.handleInboundStream(&TestProtocol{}, newServerStream("peer1", ""))
 		go cm.handleInboundStream(&TestProtocol{}, newServerStream("peer2", ""))

--- a/network/transport/grpc/connection_mock.go
+++ b/network/transport/grpc/connection_mock.go
@@ -63,20 +63,6 @@ func (mr *MockConnectionMockRecorder) IsConnected() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConnected", reflect.TypeOf((*MockConnection)(nil).IsConnected))
 }
 
-// IsProtocolConnected mocks base method.
-func (m *MockConnection) IsProtocolConnected(protocol Protocol) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsProtocolConnected", protocol)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsProtocolConnected indicates an expected call of IsProtocolConnected.
-func (mr *MockConnectionMockRecorder) IsProtocolConnected(protocol interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsProtocolConnected", reflect.TypeOf((*MockConnection)(nil).IsProtocolConnected), protocol)
-}
-
 // Peer mocks base method.
 func (m *MockConnection) Peer() transport.Peer {
 	m.ctrl.T.Helper()

--- a/network/transport/grpc/stats.go
+++ b/network/transport/grpc/stats.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"sort"
 	"strings"
+	"time"
 )
 
 // numberOfPeersStatistic contains node's number of peers it's connected to.
@@ -90,6 +91,25 @@ func (o ownPeerIDStatistic) Name() string {
 // String returns the statistic as string.
 func (o ownPeerIDStatistic) String() string {
 	return o.peerID.String()
+}
+
+// lastCertificateValidation contains the Unix timestamp of the most recent certificate validation of all peers.
+type lastCertificateValidation struct {
+	lastCheck time.Time
+}
+
+func (o lastCertificateValidation) Result() interface{} {
+	return o.lastCheck
+}
+
+// Name returns the name of the statistic.
+func (o lastCertificateValidation) Name() string {
+	return "certificates_last_validated"
+}
+
+// String returns the statistic as string.
+func (o lastCertificateValidation) String() string {
+	return o.lastCheck.String()
 }
 
 type prometheusStreamWrapper struct {

--- a/network/transport/grpc/stats.go
+++ b/network/transport/grpc/stats.go
@@ -93,22 +93,22 @@ func (o ownPeerIDStatistic) String() string {
 	return o.peerID.String()
 }
 
-// lastCertificateValidation contains the Unix timestamp of the most recent certificate validation of all peers.
-type lastCertificateValidation struct {
+// lastCertificateValidationStatistic contains the timestamp of the most recent certificate validation of all peers.
+type lastCertificateValidationStatistic struct {
 	lastCheck time.Time
 }
 
-func (o lastCertificateValidation) Result() interface{} {
+func (o lastCertificateValidationStatistic) Result() interface{} {
 	return o.lastCheck
 }
 
 // Name returns the name of the statistic.
-func (o lastCertificateValidation) Name() string {
+func (o lastCertificateValidationStatistic) Name() string {
 	return "certificates_last_validated"
 }
 
 // String returns the statistic as string.
-func (o lastCertificateValidation) String() string {
+func (o lastCertificateValidationStatistic) String() string {
 	return o.lastCheck.String()
 }
 

--- a/network/transport/grpc/test.go
+++ b/network/transport/grpc/test.go
@@ -19,6 +19,7 @@
 package grpc
 
 import (
+	"crypto/x509"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/network/transport"
 	"google.golang.org/grpc/status"
@@ -69,12 +70,14 @@ var _ Connection = (*StubConnection)(nil)
 
 // StubConnection is a stub implementation of the Connection interface
 type StubConnection struct {
-	Open          bool
-	NodeDID       did.DID
-	SentMsgs      []interface{}
-	PeerID        transport.PeerID
-	Authenticated bool
-	Address       string
+	Open            bool
+	NodeDID         did.DID
+	SentMsgs        []interface{}
+	PeerID          transport.PeerID
+	Authenticated   bool
+	Address         string
+	Certificate     *x509.Certificate
+	disconnectCalls int
 }
 
 func NewStubConnection(peer transport.Peer) *StubConnection {
@@ -83,7 +86,8 @@ func NewStubConnection(peer transport.Peer) *StubConnection {
 		PeerID:        peer.ID,
 		NodeDID:       peer.NodeDID,
 		Authenticated: peer.Authenticated,
-		Address:       peer.Address}
+		Address:       peer.Address,
+		Certificate:   peer.Certificate}
 }
 
 func (s *StubConnection) ID() transport.PeerID {
@@ -104,6 +108,7 @@ func (s *StubConnection) Peer() transport.Peer {
 		NodeDID:       s.NodeDID,
 		Authenticated: s.Authenticated,
 		Address:       s.Address,
+		Certificate:   s.Certificate,
 	}
 }
 
@@ -131,7 +136,7 @@ func (s *StubConnection) SetErrorStatus(_ *status.Status) {
 }
 
 func (s *StubConnection) disconnect() {
-	panic("implement me")
+	s.disconnectCalls++
 }
 
 func (s *StubConnection) waitUntilDisconnected() {

--- a/network/transport/types.go
+++ b/network/transport/types.go
@@ -53,7 +53,7 @@ type Peer struct {
 	// Authenticated is true when NodeDID is set and authentication is successful.
 	Authenticated bool `json:"authenticated"`
 	// Certificate presented by peer during TLS handshake.
-	Certificate *x509.Certificate `json:"certificate,omitempty"`
+	Certificate *x509.Certificate `json:"-" yaml:"-"`
 }
 
 // ToFields returns the peer as a map of fields, to be used when logging the peer details.

--- a/network/transport/types.go
+++ b/network/transport/types.go
@@ -19,6 +19,7 @@
 package transport
 
 import (
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -51,6 +52,8 @@ type Peer struct {
 	NodeDID did.DID `json:"nodedid"`
 	// Authenticated is true when NodeDID is set and authentication is successful.
 	Authenticated bool `json:"authenticated"`
+	// Certificate presented by peer during TLS handshake.
+	Certificate *x509.Certificate `json:"certificate,omitempty"`
 }
 
 // ToFields returns the peer as a map of fields, to be used when logging the peer details.

--- a/pki/denylist_test.go
+++ b/pki/denylist_test.go
@@ -288,9 +288,14 @@ func TestUpdateValidDenylist(t *testing.T) {
 	// Ensure the new denylist update time is zero
 	assert.True(t, denylist.LastUpdated().IsZero())
 
+	// Ensure that subscribers are notified
+	var iscalled bool
+	denylist.Subscribe(func() { iscalled = true })
+
 	// Update the denylist data and ensure there are no errors
 	err = denylist.Update()
 	require.NoError(t, err)
+	assert.True(t, iscalled)
 
 	// Ensure the entries are present as expected in the denylist structure
 	entriesPtr := denylist.(*denylistImpl).entries.Load()
@@ -465,4 +470,3 @@ func TestRSACertificateJWKThumbprint(t *testing.T) {
 	keyID := certKeyJWKThumbprint(cert)
 	assert.Equal(t, "PVOjk-5d4Lb-FGxurW-fNMUv3rYZZBWF3gGaP5s1UVQ", keyID)
 }
-

--- a/pki/interface.go
+++ b/pki/interface.go
@@ -53,7 +53,7 @@ type Denylist interface {
 	// ValidateCert returns an error if a certificate should not be used
 	ValidateCert(cert *x509.Certificate) error
 
-	// Subscribe calls all subscribers when the denylist is updated
+	// Subscribe registers a callback that is triggered everytime the denylist is updated
 	Subscribe(f func())
 }
 

--- a/pki/interface.go
+++ b/pki/interface.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"github.com/nuts-foundation/nuts-node/core"
+	"time"
 )
 
 // errors
@@ -31,7 +32,30 @@ var (
 	ErrCRLExpired    = errors.New("crl has expired")
 	ErrCertRevoked   = errors.New("certificate is revoked")
 	ErrCertUntrusted = errors.New("certificate's issuer is not trusted")
+	// ErrDenylistMissing occurs when the denylist cannot be downloaded
+	ErrDenylistMissing = errors.New("denylist cannot be retrieved")
+
+	// ErrCertBanned means the certificate was banned by a denylist rather than revoked by a CRL
+	ErrCertBanned = errors.New("certificate is banned")
 )
+
+// Denylist implements a global certificate rejection
+type Denylist interface {
+	// LastUpdated provides the time at which the denylist was last retrieved
+	LastUpdated() time.Time
+
+	// Update fetches a new copy of the denylist
+	Update() error
+
+	// URL returns the URL of the denylist
+	URL() string
+
+	// ValidateCert returns an error if a certificate should not be used
+	ValidateCert(cert *x509.Certificate) error
+
+	// Subscribe calls all subscribers when the denylist is updated
+	Subscribe(f func())
+}
 
 type Validator interface {
 	// Validate returns an error if any of the certificates in the chain has been revoked, or if the request cannot be processed.
@@ -48,6 +72,10 @@ type Validator interface {
 	// AddTruststore adds all CAs to the truststore for validation of CRL signatures. It also adds all CRL Distribution Endpoints found in the chain.
 	// CRL Distribution Points encountered during operation, such as on end user certificates, are only added to the monitored CRLs if their issuer is in the truststore.
 	AddTruststore(chain []*x509.Certificate) error
+
+	// SubscribeDenied registers a callback that is triggered everytime the denylist is updated.
+	// This can be used to revalidate all certificates on long-lasting connections by calling Validate on them again.
+	SubscribeDenied(f func())
 }
 
 // Provider is an interface for providing PKI services (e.g. TLS configuration, certificate validation).

--- a/pki/mock.go
+++ b/pki/mock.go
@@ -8,10 +8,102 @@ import (
 	tls "crypto/tls"
 	x509 "crypto/x509"
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	core "github.com/nuts-foundation/nuts-node/core"
 )
+
+// MockDenylist is a mock of Denylist interface.
+type MockDenylist struct {
+	ctrl     *gomock.Controller
+	recorder *MockDenylistMockRecorder
+}
+
+// MockDenylistMockRecorder is the mock recorder for MockDenylist.
+type MockDenylistMockRecorder struct {
+	mock *MockDenylist
+}
+
+// NewMockDenylist creates a new mock instance.
+func NewMockDenylist(ctrl *gomock.Controller) *MockDenylist {
+	mock := &MockDenylist{ctrl: ctrl}
+	mock.recorder = &MockDenylistMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockDenylist) EXPECT() *MockDenylistMockRecorder {
+	return m.recorder
+}
+
+// LastUpdated mocks base method.
+func (m *MockDenylist) LastUpdated() time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LastUpdated")
+	ret0, _ := ret[0].(time.Time)
+	return ret0
+}
+
+// LastUpdated indicates an expected call of LastUpdated.
+func (mr *MockDenylistMockRecorder) LastUpdated() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastUpdated", reflect.TypeOf((*MockDenylist)(nil).LastUpdated))
+}
+
+// Subscribe mocks base method.
+func (m *MockDenylist) Subscribe(f func()) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Subscribe", f)
+}
+
+// Subscribe indicates an expected call of Subscribe.
+func (mr *MockDenylistMockRecorder) Subscribe(f interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockDenylist)(nil).Subscribe), f)
+}
+
+// URL mocks base method.
+func (m *MockDenylist) URL() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "URL")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// URL indicates an expected call of URL.
+func (mr *MockDenylistMockRecorder) URL() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URL", reflect.TypeOf((*MockDenylist)(nil).URL))
+}
+
+// Update mocks base method.
+func (m *MockDenylist) Update() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockDenylistMockRecorder) Update() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockDenylist)(nil).Update))
+}
+
+// ValidateCert mocks base method.
+func (m *MockDenylist) ValidateCert(cert *x509.Certificate) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateCert", cert)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateCert indicates an expected call of ValidateCert.
+func (mr *MockDenylistMockRecorder) ValidateCert(cert interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateCert", reflect.TypeOf((*MockDenylist)(nil).ValidateCert), cert)
+}
 
 // MockValidator is a mock of Validator interface.
 type MockValidator struct {
@@ -62,6 +154,18 @@ func (m *MockValidator) SetVerifyPeerCertificateFunc(config *tls.Config) error {
 func (mr *MockValidatorMockRecorder) SetVerifyPeerCertificateFunc(config interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVerifyPeerCertificateFunc", reflect.TypeOf((*MockValidator)(nil).SetVerifyPeerCertificateFunc), config)
+}
+
+// SubscribeDenied mocks base method.
+func (m *MockValidator) SubscribeDenied(f func()) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SubscribeDenied", f)
+}
+
+// SubscribeDenied indicates an expected call of SubscribeDenied.
+func (mr *MockValidatorMockRecorder) SubscribeDenied(f interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeDenied", reflect.TypeOf((*MockValidator)(nil).SubscribeDenied), f)
 }
 
 // Validate mocks base method.
@@ -142,6 +246,18 @@ func (m *MockProvider) SetVerifyPeerCertificateFunc(config *tls.Config) error {
 func (mr *MockProviderMockRecorder) SetVerifyPeerCertificateFunc(config interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVerifyPeerCertificateFunc", reflect.TypeOf((*MockProvider)(nil).SetVerifyPeerCertificateFunc), config)
+}
+
+// SubscribeDenied mocks base method.
+func (m *MockProvider) SubscribeDenied(f func()) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SubscribeDenied", f)
+}
+
+// SubscribeDenied indicates an expected call of SubscribeDenied.
+func (mr *MockProviderMockRecorder) SubscribeDenied(f interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeDenied", reflect.TypeOf((*MockProvider)(nil).SubscribeDenied), f)
 }
 
 // Validate mocks base method.

--- a/pki/test.go
+++ b/pki/test.go
@@ -1,0 +1,32 @@
+package pki
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+)
+
+// TestDenylistWithCert sets a new Denylist on the Validator and adds the certificate.
+// This is useful in integrations tests etc.
+func TestDenylistWithCert(t *testing.T, val Validator, cert *x509.Certificate) {
+	dl := &denylistImpl{
+		url:         "some-url",
+		lastUpdated: time.Now(),
+	}
+	dl.entries.Store(&[]denylistEntry{
+		{
+			Issuer:        cert.Issuer.String(),
+			SerialNumber:  cert.SerialNumber.String(),
+			JWKThumbprint: certKeyJWKThumbprint(cert),
+			Reason:        `testing purposes`,
+		},
+	})
+	switch v := val.(type) {
+	case *PKI:
+		v.denylist = dl
+	case *validator:
+		v.denylist = dl
+	default:
+		t.Fatal("cannot set Denylist on val")
+	}
+}

--- a/pki/test.go
+++ b/pki/test.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package pki
 
 import (
@@ -6,9 +24,9 @@ import (
 	"time"
 )
 
-// TestDenylistWithCert sets a new Denylist on the Validator and adds the certificate.
+// SetNewDenylistWithCert sets a new Denylist on the Validator and adds the certificate.
 // This is useful in integrations tests etc.
-func TestDenylistWithCert(t *testing.T, val Validator, cert *x509.Certificate) {
+func SetNewDenylistWithCert(t *testing.T, val Validator, cert *x509.Certificate) {
 	dl := &denylistImpl{
 		url:         "some-url",
 		lastUpdated: time.Now(),

--- a/pki/validator.go
+++ b/pki/validator.go
@@ -258,6 +258,10 @@ func (v *validator) AddTruststore(chain []*x509.Certificate) error {
 	return nil
 }
 
+func (v *validator) SubscribeDenied(f func()) {
+	v.denylist.Subscribe(f)
+}
+
 func (v *validator) getCert(subject string) (*x509.Certificate, bool) {
 	issuer, ok := v.truststore.Load(subject)
 	if !ok {

--- a/pki/validator_test.go
+++ b/pki/validator_test.go
@@ -27,6 +27,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"github.com/golang/mock/gomock"
 	"github.com/nuts-foundation/nuts-node/core"
 	"go.uber.org/goleak"
 	"math/big"
@@ -221,6 +222,17 @@ func TestValidator_AddTruststore(t *testing.T) {
 			assert.ErrorContains(t, err, "certificate's issuer is not in the trust store")
 		})
 	})
+}
+
+func TestValidator_SubscribeDenied(t *testing.T) {
+	mockDenylist := NewMockDenylist(gomock.NewController(t))
+	mockDenylist.EXPECT().Subscribe(gomock.Any())
+
+	val, err := newValidator(DefaultConfig())
+	require.NoError(t, err)
+	val.denylist = mockDenylist
+
+	val.SubscribeDenied(func() { _ = "functions handles cannot be tested for equality" })
 }
 
 func Test_NewValidator(t *testing.T) {


### PR DESCRIPTION
closes #2018  alternative solution to #2235 

DenyList.Subscribers get pinged when the Denylist is updated (revalidation is not performed when Denylist is not configured). What to do with this information is determined by the subscriber. The connection manager verifies the certificate of all peers and disconnects those that are no longer valid.

diagnostics also show the last time the certificate was updated, which is zero if the denylist is not used
```
network:
    connections:
        certificates_last_validated: 0001-01-01T00:00:00Z
        connected_peers:
            - id: ...
```