### PR TITLE
rewrite github docker action set-output

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -22,9 +22,9 @@ jobs:
         id: version
         shell: bash
         run: |
-          echo "::set-output name=git_commit::$(echo ${GITHUB_SHA})"
-          echo "::set-output name=git_branch::$(echo ${GITHUB_REF#refs/heads/})"
-          echo "::set-output name=git_version::$(git name-rev --tags --name-only $(git rev-parse HEAD))"
+          echo "git_commit=$(echo ${GITHUB_SHA})" >> $GITHUB_OUTPUT
+          echo "git_branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+          echo "git_version=$(git name-rev --tags --name-only $(git rev-parse HEAD))" >> $GITHUB_OUTPUT
 
       - name: Print version params
         run: |


### PR DESCRIPTION
fixes #2250
 
as stated by https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/