### PR TITLE
only enable latest tag for docker if build tag equals latest github tag

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -26,11 +26,18 @@ jobs:
           echo "::set-output name=git_branch::$(echo ${GITHUB_REF#refs/heads/})"
           echo "::set-output name=git_version::$(git name-rev --tags --name-only $(git rev-parse HEAD))"
 
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get-latest-tag
+        with:
+          semver_only: true
+
       - name: Print version params
         run: |
           echo "Commit: ${{ steps.version.outputs.git_commit }}"
           echo "Branch: ${{ steps.version.outputs.git_branch }}"
           echo "Version: ${{ steps.version.outputs.git_version }}"
+          echo "Latest tag: ${{ steps.get-latest-tag.outputs.tag }}"
+          echo "This tag: ${{ github.ref }}"
 
       - name: Docker meta
         id: docker_meta
@@ -45,7 +52,7 @@ jobs:
             # generate v5 tag
             type=semver,pattern={{major}}
           flavor: |
-            latest=auto
+            latest=auto,enable=${{ github.ref == steps.get-latest-tag.outputs.tag }}
             prefix=v,onlatest=false
 
       - name: Set up QEMU

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -52,7 +52,7 @@ jobs:
             # generate v5 tag
             type=semver,pattern={{major}}
           flavor: |
-            latest=auto,enable=${{ github.ref == steps.get-latest-tag.outputs.tag }}
+            latest=${{ github.ref == steps.get-latest-tag.outputs.tag }}
             prefix=v,onlatest=false
 
       - name: Set up QEMU


### PR DESCRIPTION
fixes #2167 

`latest` was always created, now it's only enabled if the tag being build is the latest github tag.