### PR TITLE
Embed test PEM files instead of referencing via paths

### DIFF
--- a/core/tls_test.go
+++ b/core/tls_test.go
@@ -19,9 +19,9 @@
 package core
 
 import (
+	"github.com/nuts-foundation/nuts-node/test/pki"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
 	"testing"
 )
 
@@ -46,8 +46,7 @@ func TestLoadTrustStore(t *testing.T) {
 		assert.Nil(t, store)
 	})
 	t.Run("incomplete chain", func(t *testing.T) {
-		leafCert, err := os.ReadFile("../test/pki/certificate-and-key.pem")
-		cert, err := ParseCertificates(leafCert)
+		cert, err := ParseCertificates(pki.CertificateData)
 		require.NoError(t, err)
 
 		err = validate(&TrustStore{certificates: cert})

--- a/http/engine_test.go
+++ b/http/engine_test.go
@@ -28,6 +28,7 @@ import (
 	"crypto/tls"
 	b64 "encoding/base64"
 	"fmt"
+	"github.com/nuts-foundation/nuts-node/test/pki"
 	"io"
 	"net"
 	"net/http"
@@ -92,9 +93,9 @@ func TestEngine_Configure(t *testing.T) {
 	})
 	t.Run("TLS", func(t *testing.T) {
 		serverCfg := core.NewServerConfig()
-		serverCfg.TLS.CertFile = "../test/pki/certificate-and-key.pem"
-		serverCfg.TLS.CertKeyFile = "../test/pki/certificate-and-key.pem"
-		serverCfg.TLS.TrustStoreFile = "../test/pki/truststore.pem"
+		serverCfg.TLS.CertFile = pki.CertificateFile(t)
+		serverCfg.TLS.CertKeyFile = serverCfg.TLS.CertFile
+		serverCfg.TLS.TrustStoreFile = pki.TruststoreFile(t)
 		tlsConfig, _, _ := serverCfg.TLS.Load()
 
 		t.Run("error - invalid TLS mode", func(t *testing.T) {

--- a/network/transport/grpc/config_test.go
+++ b/network/transport/grpc/config_test.go
@@ -19,12 +19,12 @@
 package grpc
 
 import (
-	"crypto/tls"
 	"crypto/x509"
 	"github.com/golang/mock/gomock"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/network/transport"
 	"github.com/nuts-foundation/nuts-node/pki"
+	testPKI "github.com/nuts-foundation/nuts-node/test/pki"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -36,7 +36,7 @@ func TestConfig_tlsEnabled(t *testing.T) {
 }
 
 func TestNewConfig(t *testing.T) {
-	tlsCert, _ := tls.LoadX509KeyPair(testCertAndKeyFile, testCertAndKeyFile)
+	tlsCert := testPKI.Certificate()
 	x509Cert, _ := x509.ParseCertificates(tlsCert.Certificate[0])
 	ctrl := gomock.NewController(t)
 	pkiMock := pki.NewMockValidator(ctrl)
@@ -74,9 +74,8 @@ func TestNewConfig(t *testing.T) {
 }
 
 func Test_NewClientTLSConfig(t *testing.T) {
-	trustStore, _ := core.LoadTrustStore(testTruststoreFile)
-	clientCert, _ := tls.LoadX509KeyPair(testCertAndKeyFile, testCertAndKeyFile)
-	clientCert.Leaf, _ = x509.ParseCertificate(clientCert.Certificate[0])
+	trustStore, _ := core.ParseTrustStore(testPKI.TruststoreData)
+	clientCert := testPKI.Certificate()
 	pkiMock := pki.NewMockValidator(gomock.NewController(t))
 	pkiMock.EXPECT().SetVerifyPeerCertificateFunc(gomock.Any())
 

--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -20,17 +20,16 @@ package grpc
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/core"
+	testPKI "github.com/nuts-foundation/nuts-node/test/pki"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc/credentials"
 	"hash/crc32"
 	"io"
 	"net"
-	"os"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -56,11 +55,6 @@ import (
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
-)
-
-const (
-	testTruststoreFile = "../../../test/pki/truststore.pem"
-	testCertAndKeyFile = "../../../test/pki/certificate-and-key.pem"
 )
 
 // newBufconnConfig creates a new Config like NewConfig, but configures an in-memory bufconn listener instead of a TCP listener.
@@ -138,8 +132,8 @@ func Test_grpcConnectionManager_Connect(t *testing.T) {
 
 	t.Run("ok - with TLS", func(t *testing.T) {
 		p := &TestProtocol{}
-		ts, _ := core.LoadTrustStore(testTruststoreFile)
-		clientCert, _ := tls.LoadX509KeyPair(testCertAndKeyFile, testCertAndKeyFile)
+		ts, _ := core.ParseTrustStore(testPKI.TruststoreData)
+		clientCert := testPKI.Certificate()
 		ctrl := gomock.NewController(t)
 		pkiMock := pki.NewMockValidator(ctrl)
 		pkiMock.EXPECT().AddTruststore(ts.Certificates())
@@ -558,8 +552,8 @@ func Test_grpcConnectionManager_Peers(t *testing.T) {
 }
 
 func Test_grpcConnectionManager_Start(t *testing.T) {
-	trustStore, _ := core.LoadTrustStore(testTruststoreFile)
-	serverCert, _ := tls.LoadX509KeyPair(testCertAndKeyFile, testCertAndKeyFile)
+	trustStore, _ := core.ParseTrustStore(testPKI.TruststoreData)
+	serverCert := testPKI.Certificate()
 	ctrl := gomock.NewController(t)
 	pkiMock := pki.NewMockValidator(ctrl)
 	pkiMock.EXPECT().AddTruststore(gomock.Any()).AnyTimes()
@@ -1229,11 +1223,7 @@ func Test_grpcConnectionManager_handleInboundStream(t *testing.T) {
 
 func Test_grpcConnectionManager_revalidatePeers(t *testing.T) {
 	mockValidator := pki.NewMockValidator(gomock.NewController(t))
-	clientCertBytes, err := os.ReadFile(testCertAndKeyFile)
-	require.NoError(t, err)
-	certs, err := core.ParseCertificates(clientCertBytes)
-	cert := certs[0]
-	require.NoError(t, err)
+	cert := testPKI.Certificate().Leaf
 
 	t.Run("ok", func(t *testing.T) {
 		mockValidator.EXPECT().Validate([]*x509.Certificate{cert})

--- a/test/node/server.go
+++ b/test/node/server.go
@@ -21,11 +21,10 @@ package node
 import (
 	"context"
 	"fmt"
+	"github.com/nuts-foundation/nuts-node/test/pki"
 	"net/http"
 	"os"
 	"path"
-	"path/filepath"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -72,17 +71,10 @@ func StartServer(t *testing.T, configFunc ...func(httpServerURL string)) (string
 	t.Setenv("NUTS_EVENTS_NATS_PORT", natsPort)
 	t.Setenv("NUTS_EVENTS_NATS_HOSTNAME", "localhost")
 	t.Setenv("NUTS_AUTH_PUBLICURL", httpServerURL)
-
-	// relative paths are defined from the location source 't', find absolute path of current function to fix this
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("Unable to get the current filename")
-	}
-	dirname := filepath.Dir(filename)
-
-	t.Setenv("NUTS_TLS_CERTFILE", fmt.Sprintf("%s/../pki/certificate-and-key.pem", dirname))
-	t.Setenv("NUTS_TLS_CERTKEYFILE", fmt.Sprintf("%s/../pki/certificate-and-key.pem", dirname))
-	t.Setenv("NUTS_TLS_TRUSTSTOREFILE", fmt.Sprintf("%s/../pki/truststore.pem", dirname))
+	certFile := pki.CertificateFile(t)
+	t.Setenv("NUTS_TLS_CERTFILE", certFile)
+	t.Setenv("NUTS_TLS_CERTKEYFILE", certFile)
+	t.Setenv("NUTS_TLS_TRUSTSTOREFILE", pki.TruststoreFile(t))
 
 	for _, fn := range configFunc {
 		fn(httpServerURL)

--- a/test/pki/test.go
+++ b/test/pki/test.go
@@ -24,7 +24,7 @@ func CertificateFile(t *testing.T) string {
 }
 
 func InvalidCertificate() tls.Certificate {
-	cert, err := tls.X509KeyPair(CertificateData, CertificateData)
+	cert, err := tls.X509KeyPair(InvalidCertificateData, InvalidCertificateData)
 	if err != nil {
 		panic(err)
 	}

--- a/test/pki/test.go
+++ b/test/pki/test.go
@@ -1,0 +1,68 @@
+package pki
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	_ "embed"
+	"github.com/nuts-foundation/nuts-node/test/io"
+	"os"
+	"path"
+	"testing"
+)
+
+//go:embed certificate-and-key.pem
+var CertificateData []byte
+
+//go:embed invalid-cert.pem
+var InvalidCertificateData []byte
+
+//go:embed truststore.pem
+var TruststoreData []byte
+
+func CertificateFile(t *testing.T) string {
+	return writeToTemp(t, "certificate.pem", CertificateData)
+}
+
+func InvalidCertificate() tls.Certificate {
+	cert, err := tls.X509KeyPair(CertificateData, CertificateData)
+	if err != nil {
+		panic(err)
+	}
+	cert.Leaf, _ = x509.ParseCertificate(cert.Certificate[0])
+	return cert
+}
+
+func Certificate() tls.Certificate {
+	cert, err := tls.X509KeyPair(CertificateData, CertificateData)
+	if err != nil {
+		panic(err)
+	}
+	cert.Leaf, _ = x509.ParseCertificate(cert.Certificate[0])
+	return cert
+}
+
+func InvalidCertificateFile(t *testing.T) string {
+	return writeToTemp(t, "invalid-cert.pem", InvalidCertificateData)
+}
+
+func TruststoreFile(t *testing.T) string {
+	return writeToTemp(t, "truststore.pem", TruststoreData)
+}
+
+func Truststore() *x509.CertPool {
+	pool := x509.NewCertPool()
+	ok := pool.AppendCertsFromPEM(TruststoreData)
+	if !ok {
+		panic("failed to parse root certificate")
+	}
+	return pool
+}
+
+func writeToTemp(t *testing.T, fileName string, data []byte) string {
+	filePath := path.Join(io.TestDirectory(t), fileName)
+	err := os.WriteFile(filePath, data, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filePath
+}

--- a/test/pki/test.go
+++ b/test/pki/test.go
@@ -58,6 +58,11 @@ func InvalidCertificate() tls.Certificate {
 	return cert
 }
 
+// InvalidCertificateFile returns the path to a file containing an invalid test certificate and its key.
+func InvalidCertificateFile(t *testing.T) string {
+	return writeToTemp(t, "invalid-cert.pem", InvalidCertificateData)
+}
+
 // Certificate returns a valid test certificate.
 func Certificate() tls.Certificate {
 	cert, err := tls.X509KeyPair(CertificateData, CertificateData)

--- a/test/pki/test.go
+++ b/test/pki/test.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package pki
 
 import (
@@ -10,19 +28,27 @@ import (
 	"testing"
 )
 
+// CertificateData contains the PEM-encoded test certificate and its key.
+//
 //go:embed certificate-and-key.pem
 var CertificateData []byte
 
+// InvalidCertificateData contains the PEM-encoded invalid test certificate and its key.
+//
 //go:embed invalid-cert.pem
 var InvalidCertificateData []byte
 
+// TruststoreData contains the PEM-encoded test truststore.
+//
 //go:embed truststore.pem
 var TruststoreData []byte
 
+// CertificateFile returns the path to a file containing a valid test certificate and its key.
 func CertificateFile(t *testing.T) string {
 	return writeToTemp(t, "certificate.pem", CertificateData)
 }
 
+// InvalidCertificate returns an invalid test certificate.
 func InvalidCertificate() tls.Certificate {
 	cert, err := tls.X509KeyPair(InvalidCertificateData, InvalidCertificateData)
 	if err != nil {
@@ -32,6 +58,7 @@ func InvalidCertificate() tls.Certificate {
 	return cert
 }
 
+// Certificate returns a valid test certificate.
 func Certificate() tls.Certificate {
 	cert, err := tls.X509KeyPair(CertificateData, CertificateData)
 	if err != nil {
@@ -41,14 +68,12 @@ func Certificate() tls.Certificate {
 	return cert
 }
 
-func InvalidCertificateFile(t *testing.T) string {
-	return writeToTemp(t, "invalid-cert.pem", InvalidCertificateData)
-}
-
+// TruststoreFile returns the path to a file containing a test truststore.
 func TruststoreFile(t *testing.T) string {
 	return writeToTemp(t, "truststore.pem", TruststoreData)
 }
 
+// Truststore returns a test truststore.
 func Truststore() *x509.CertPool {
 	pool := x509.NewCertPool()
 	ok := pool.AppendCertsFromPEM(TruststoreData)


### PR DESCRIPTION
Easier to read, more resilient to moving files around.