### PR TITLE
OIDC: Rename invalid proof error codes

### DIFF
--- a/docs/_static/vcr/oidc4vci_v0.yaml
+++ b/docs/_static/vcr/oidc4vci_v0.yaml
@@ -182,7 +182,7 @@ paths:
                 "$ref": "#/components/schemas/ErrorResponse"
         "400":
           description: >
-            Invalid request. Code can be "invalid_request", "unsupported_credential_type", "unsupported_credential_format" or "invalid_or_missing_proof".
+            Invalid request. Code can be "invalid_request", "unsupported_credential_type", "unsupported_credential_format" or "invalid_proof".
             Specified by https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-error-response
           content:
             application/json:

--- a/vcr/issuer/openid4vci/issuer.go
+++ b/vcr/issuer/openid4vci/issuer.go
@@ -225,14 +225,14 @@ func (i *issuer) validateProof(request oidc4vci.CredentialRequest, issuer did.DI
 	if request.Proof == nil {
 		return oidc4vci.Error{
 			Err:        errors.New("missing proof"),
-			Code:       oidc4vci.InvalidOrMissingProof,
+			Code:       oidc4vci.InvalidProof,
 			StatusCode: http.StatusBadRequest,
 		}
 	}
 	if request.Proof.ProofType != oidc4vci.ProofTypeJWT {
 		return oidc4vci.Error{
 			Err:        errors.New("proof type not supported"),
-			Code:       oidc4vci.InvalidOrMissingProof,
+			Code:       oidc4vci.InvalidProof,
 			StatusCode: http.StatusBadRequest,
 		}
 	}
@@ -244,7 +244,7 @@ func (i *issuer) validateProof(request oidc4vci.CredentialRequest, issuer did.DI
 	if err != nil {
 		return oidc4vci.Error{
 			Err:        err,
-			Code:       oidc4vci.InvalidOrMissingProof,
+			Code:       oidc4vci.InvalidProof,
 			StatusCode: http.StatusBadRequest,
 		}
 	}
@@ -253,7 +253,7 @@ func (i *issuer) validateProof(request oidc4vci.CredentialRequest, issuer did.DI
 	if signerDID, err := didservice.GetDIDFromURL(signingKeyID); err != nil || signerDID.String() != wallet.String() {
 		return oidc4vci.Error{
 			Err:        fmt.Errorf("credential offer was signed by other DID than intended wallet: %s", signingKeyID),
-			Code:       oidc4vci.InvalidOrMissingProof,
+			Code:       oidc4vci.InvalidProof,
 			StatusCode: http.StatusBadRequest,
 		}
 	}
@@ -269,7 +269,7 @@ func (i *issuer) validateProof(request oidc4vci.CredentialRequest, issuer did.DI
 	if !audienceMatches {
 		return oidc4vci.Error{
 			Err:        fmt.Errorf("audience doesn't match credential issuer (aud=%s)", token.Audience()),
-			Code:       oidc4vci.InvalidOrMissingProof,
+			Code:       oidc4vci.InvalidProof,
 			StatusCode: http.StatusBadRequest,
 		}
 	}
@@ -289,14 +289,14 @@ func (i *issuer) validateProof(request oidc4vci.CredentialRequest, issuer did.DI
 	if typ == "" {
 		return oidc4vci.Error{
 			Err:        errors.New("missing typ header"),
-			Code:       oidc4vci.InvalidOrMissingProof,
+			Code:       oidc4vci.InvalidProof,
 			StatusCode: http.StatusBadRequest,
 		}
 	}
 	if typ != oidc4vci.JWTTypeOpenID4VCIProof {
 		return oidc4vci.Error{
 			Err:        fmt.Errorf("invalid typ claim (expected: %s): %s", oidc4vci.JWTTypeOpenID4VCIProof, typ),
-			Code:       oidc4vci.InvalidOrMissingProof,
+			Code:       oidc4vci.InvalidProof,
 			StatusCode: http.StatusBadRequest,
 		}
 	}

--- a/vcr/issuer/openid4vci/issuer_test.go
+++ b/vcr/issuer/openid4vci/issuer_test.go
@@ -133,7 +133,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 			response, err := service.HandleCredentialRequest(ctx, issuerDID, invalidRequest, accessToken)
 
-			assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - proof type not supported")
+			assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - proof type not supported")
 			assert.Nil(t, response)
 		})
 		t.Run("jwt", func(t *testing.T) {
@@ -143,7 +143,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, issuerDID, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - missing proof")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - missing proof")
 				assert.Nil(t, response)
 			})
 			t.Run("invalid JWT", func(t *testing.T) {
@@ -152,7 +152,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, issuerDID, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - invalid compact serialization format: invalid number of segments")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - invalid compact serialization format: invalid number of segments")
 				assert.Nil(t, response)
 			})
 			t.Run("not signed by intended wallet (DID differs)", func(t *testing.T) {
@@ -175,7 +175,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, issuerDID, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - credential offer was signed by other DID than intended wallet: did:nuts:holder#1")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - credential offer was signed by other DID than intended wallet: did:nuts:holder#1")
 				assert.Nil(t, response)
 			})
 			t.Run("signing key is unknown", func(t *testing.T) {
@@ -191,7 +191,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, issuerDID, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - key not found in DID document")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - key not found in DID document")
 				assert.Nil(t, response)
 			})
 			t.Run("typ header missing", func(t *testing.T) {
@@ -201,7 +201,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, issuerDID, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - missing typ header")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - missing typ header")
 				assert.Nil(t, response)
 			})
 			t.Run("typ header invalid", func(t *testing.T) {
@@ -211,7 +211,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, issuerDID, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - invalid typ claim (expected: openid4vci-proof+jwt): JWT")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - invalid typ claim (expected: openid4vci-proof+jwt): JWT")
 				assert.Nil(t, response)
 			})
 			t.Run("aud header doesn't match issuer identifier", func(t *testing.T) {
@@ -221,7 +221,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, issuerDID, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - audience doesn't match credential issuer (aud=[https://example.com/someone-else])")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - audience doesn't match credential issuer (aud=[https://example.com/someone-else])")
 				assert.Nil(t, response)
 			})
 		})

--- a/vcr/oidc4vci/error.go
+++ b/vcr/oidc4vci/error.go
@@ -45,9 +45,9 @@ const (
 	UnsupportedCredentialType ErrorCode = "unsupported_credential_type"
 	// UnsupportedCredentialFormat is returned when the credential issuer does not support the requested credential format.
 	UnsupportedCredentialFormat ErrorCode = "unsupported_credential_format"
-	// InvalidOrMissingProof is returned when the Credential Request did not contain a proof,
+	// InvalidProof is returned when the Credential Request did not contain a proof,
 	// or proof was invalid, i.e. it was not bound to a Credential Issuer provided nonce
-	InvalidOrMissingProof ErrorCode = "invalid_or_missing_proof"
+	InvalidProof ErrorCode = "invalid_proof"
 )
 
 // Error is an error that signals the error was (probably) caused by the client (e.g. bad request),


### PR DESCRIPTION
`invalid_or_missing_proof` has been renamed to `invalid_proof`. This is the only change to the error codes to date.