### PR TITLE
OID$VCI: rename types to type

### DIFF
--- a/docs/_static/vcr/oidc4vci_v0.yaml
+++ b/docs/_static/vcr/oidc4vci_v0.yaml
@@ -272,7 +272,7 @@ components:
                   "https://www.w3.org/2018/credentials/v1",
                   "https://nuts.nl/credentials/v1"
                 ],
-                "types": [
+                "type": [
                   "VerifiableCredential",
                   "NutsAuthorizationCredential"
                 ],
@@ -392,7 +392,7 @@ components:
               "https://www.w3.org/2018/credentials/v1",
               "https://nuts.nl/credentials/v1"
             ],
-            "types": [
+            "type": [
               "VerifiableCredential",
               "NutsAuthorizationCredential"
             ],
@@ -479,7 +479,7 @@ components:
                   "https://www.w3.org/2018/credentials/v1",
                   "https://nuts.nl/credentials/v1"
                 ],
-                "types": [
+                "type": [
                   "VerifiableCredential",
                   "NutsAuthorizationCredential"
                 ]

--- a/vcr/api/oidc4vci/v0/wallet_test.go
+++ b/vcr/api/oidc4vci/v0/wallet_test.go
@@ -85,7 +85,7 @@ func TestWrapper_HandleCredentialOffer(t *testing.T) {
 					"format": oidc4vci.VerifiableCredentialJSONLDFormat,
 					"credential_definition": map[string]interface{}{
 						"@context": []string{"a", "b"},
-						"types":    []string{"VerifiableCredential", "HumanCredential"},
+						"type":     []string{"VerifiableCredential", "HumanCredential"},
 					},
 				},
 			},

--- a/vcr/holder/oidc4vci_wallet_test.go
+++ b/vcr/holder/oidc4vci_wallet_test.go
@@ -62,7 +62,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 				"format": oidc4vci.VerifiableCredentialJSONLDFormat,
 				"credential_definition": map[string]interface{}{
 					"@context": []string{"a", "b"},
-					"types":    []string{"VerifiableCredential", "HumanCredential"},
+					"type":     []string{"VerifiableCredential", "HumanCredential"},
 				},
 			},
 		},
@@ -157,14 +157,14 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 					"format": oidc4vci.VerifiableCredentialJSONLDFormat,
 					"credential_definition": map[string]interface{}{
 						"@context": []string{"a", "b"},
-						"types":    []string{"VerifiableCredential", "HumanCredential"},
+						"type":     []string{"VerifiableCredential", "HumanCredential"},
 					},
 				},
 				{
 					"format": oidc4vci.VerifiableCredentialJSONLDFormat,
 					"credential_definition": map[string]interface{}{
 						"@context": []string{"a", "b"},
-						"types":    []string{"VerifiableCredential", "HumanCredential"},
+						"type":     []string{"VerifiableCredential", "HumanCredential"},
 					},
 				},
 			},

--- a/vcr/issuer/openid4vci/issuer.go
+++ b/vcr/issuer/openid4vci/issuer.go
@@ -317,7 +317,7 @@ func (i *issuer) createOffer(ctx context.Context, credential vc.VerifiableCreden
 			"format": oidc4vci.VerifiableCredentialJSONLDFormat,
 			"credential_definition": map[string]interface{}{
 				"@context": credential.Context,
-				"types":    credential.Type,
+				"type":     credential.Type,
 			},
 		}},
 		Grants: map[string]interface{}{

--- a/vcr/oidc4vci/docs/README.md
+++ b/vcr/oidc4vci/docs/README.md
@@ -40,7 +40,7 @@ Step described in [OIDC4VCI 4.1. Credential Offer]( https://openid.net/specs/ope
           "https://www.w3.org/2018/credentials/v1",
           "https://nuts.nl/credentials/v1"
         ],
-        "types": [
+        "type": [
           "VerifiableCredential",
           "NutsAuthorizationCredential"
         ]
@@ -119,7 +119,7 @@ The issuer responds with the metadata (`application/json`):
         "https://www.w3.org/2018/credentials/v1",
         "https://nuts.nl/credentials/v1"
       ],
-      "types": [
+      "type": [
         "VerifiableCredential",
         "NutsAuthorizationCredential"
       ],
@@ -174,7 +174,7 @@ POST https://issuer.example/credential
          "https://www.w3.org/2018/credentials/v1",
          "https://nuts.nl/credentials/v1"
       ],
-      "types": [
+      "type": [
          "VerifiableCredential",
          "NutsAuthorizationCredential"
       ],


### PR DESCRIPTION
in the editors draft (v13) `types` has been renamed to `type` to match to json-ld reserved name
part of #2281