### PR TITLE
only allow openid4vci calls over https when strictmode is enabled

### DIFF
--- a/core/http_client.go
+++ b/core/http_client.go
@@ -139,8 +139,8 @@ func newEmptyTokenGenerator() AuthorizationTokenGenerator {
 	}
 }
 
-// StrictHTTPClient creates a HTTPRequestDoer that only allows HTTPS calls when strictmode is enabled.
-func StrictHTTPClient(strictmode bool, client *http.Client) HTTPRequestDoer {
+// NewStrictHTTPClient creates a HTTPRequestDoer that only allows HTTPS calls when strictmode is enabled.
+func NewStrictHTTPClient(strictmode bool, client *http.Client) HTTPRequestDoer {
 	return &strictHTTPClient{
 		client:     client,
 		strictmode: strictmode,

--- a/core/http_client_test.go
+++ b/core/http_client_test.go
@@ -87,6 +87,17 @@ func TestHTTPClient(t *testing.T) {
 	})
 }
 
+func TestStrictHTTPClient_Do(t *testing.T) {
+	t.Run("error on HTTP call when strictmode is enabled", func(t *testing.T) {
+		client := StrictHTTPClient(true, &stdHttp.Client{})
+		httpRequest, _ := stdHttp.NewRequest("GET", "http://example.com", nil)
+
+		_, err := client.Do(httpRequest)
+
+		assert.Error(t, err)
+	})
+}
+
 func TestUserAgentRequestEditor(t *testing.T) {
 	GitVersion = ""
 	req := &stdHttp.Request{Header: map[string][]string{}}

--- a/core/http_client_test.go
+++ b/core/http_client_test.go
@@ -89,7 +89,7 @@ func TestHTTPClient(t *testing.T) {
 
 func TestStrictHTTPClient_Do(t *testing.T) {
 	t.Run("error on HTTP call when strictmode is enabled", func(t *testing.T) {
-		client := StrictHTTPClient(true, &stdHttp.Client{})
+		client := NewStrictHTTPClient(true, &stdHttp.Client{})
 		httpRequest, _ := stdHttp.NewRequest("GET", "http://example.com", nil)
 
 		_, err := client.Do(httpRequest)

--- a/vcr/config.go
+++ b/vcr/config.go
@@ -30,6 +30,8 @@ type Config struct {
 	OIDC4VCI OIDC4VCIConfig `koanf:"oidc4vci"`
 	// datadir holds the location the VCR files are stored
 	datadir string
+	// strictmode holds a copy of the core.ServerConfig.Strictmode value
+	strictmode bool
 }
 
 // OIDC4VCIConfig holds the config for the OIDC4VCI credential issuer and wallet

--- a/vcr/config.go
+++ b/vcr/config.go
@@ -28,10 +28,6 @@ const ModuleName = "VCR"
 type Config struct {
 	// OIDC4VCI holds the config for the OIDC4VCI credential issuer and wallet
 	OIDC4VCI OIDC4VCIConfig `koanf:"oidc4vci"`
-	// datadir holds the location the VCR files are stored
-	datadir string
-	// strictmode holds a copy of the core.ServerConfig.Strictmode value
-	strictmode bool
 }
 
 // OIDC4VCIConfig holds the config for the OIDC4VCI credential issuer and wallet

--- a/vcr/holder/oidc4vci_wallet.go
+++ b/vcr/holder/oidc4vci_wallet.go
@@ -105,9 +105,9 @@ func (h wallet) HandleCredentialOffer(ctx context.Context, offer oidc4vci.Creden
 	}
 
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
-	httpTransport.TLSClientConfig = h.config.ClientTLSConfig
-	httpClient := core.NewStrictHTTPClient(h.config.Strictmode, &http.Client{
-		Timeout:   h.config.ClientTimeout,
+	httpTransport.TLSClientConfig = h.config.TLS
+	httpClient := core.NewStrictHTTPClient(h.config.HTTPSOnly, &http.Client{
+		Timeout:   h.config.Timeout,
 		Transport: httpTransport,
 	})
 	issuerClient, err := h.issuerClientCreator(ctx, httpClient, offer.CredentialIssuer)
@@ -147,7 +147,7 @@ func (h wallet) HandleCredentialOffer(ctx context.Context, offer oidc4vci.Creden
 	}
 
 	retrieveCtx := audit.Context(ctx, "app-oidc4vci", "VCR/OIDC4VCI", "RetrieveCredential")
-	retrieveCtx, cancel := context.WithTimeout(retrieveCtx, h.config.ClientTimeout)
+	retrieveCtx, cancel := context.WithTimeout(retrieveCtx, h.config.Timeout)
 	defer cancel()
 	credential, err := h.retrieveCredential(retrieveCtx, issuerClient, offer, accessTokenResponse)
 	if err != nil {

--- a/vcr/holder/oidc4vci_wallet.go
+++ b/vcr/holder/oidc4vci_wallet.go
@@ -106,7 +106,7 @@ func (h wallet) HandleCredentialOffer(ctx context.Context, offer oidc4vci.Creden
 
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
 	httpTransport.TLSClientConfig = h.config.ClientTLSConfig
-	httpClient := core.StrictHTTPClient(h.config.Strictmode, &http.Client{
+	httpClient := core.NewStrictHTTPClient(h.config.Strictmode, &http.Client{
 		Timeout:   h.config.ClientTimeout,
 		Transport: httpTransport,
 	})

--- a/vcr/issuer/openid4vci/issuer.go
+++ b/vcr/issuer/openid4vci/issuer.go
@@ -156,9 +156,9 @@ func (i *issuer) OfferCredential(ctx context.Context, credential vc.VerifiableCr
 		Infof("Offering credential using OIDC4VCI (client-metadata-url=%s)", clientMetadataURL)
 
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
-	httpTransport.TLSClientConfig = i.config.ClientTLSConfig
-	httpClient := core.NewStrictHTTPClient(i.config.Strictmode, &http.Client{
-		Timeout:   i.config.ClientTimeout,
+	httpTransport.TLSClientConfig = i.config.TLS
+	httpClient := core.NewStrictHTTPClient(i.config.HTTPSOnly, &http.Client{
+		Timeout:   i.config.Timeout,
 		Transport: httpTransport,
 	})
 	client, err := i.walletClientCreator(ctx, httpClient, clientMetadataURL)

--- a/vcr/issuer/openid4vci/issuer.go
+++ b/vcr/issuer/openid4vci/issuer.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	crypt "crypto"
 	"crypto/rand"
-	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -71,13 +70,12 @@ type Issuer interface {
 }
 
 // New creates a new Issuer instance. The identifier is the Credential Issuer Identifier, e.g. https://example.com/issuer/
-func New(baseURL string, clientTLSConfig *tls.Config, clientTimeout time.Duration, keyResolver types.KeyResolver, store Store) Issuer {
+func New(baseURL string, config oidc4vci.ClientConfig, keyResolver types.KeyResolver, store Store) Issuer {
 	return &issuer{
 		baseURL:             baseURL,
 		keyResolver:         keyResolver,
 		walletClientCreator: oidc4vci.NewWalletAPIClient,
-		clientTimeout:       clientTimeout,
-		clientTLSConfig:     clientTLSConfig,
+		config:              config,
 		store:               store,
 	}
 }
@@ -86,9 +84,8 @@ type issuer struct {
 	baseURL             string
 	keyResolver         types.KeyResolver
 	store               Store
-	walletClientCreator func(ctx context.Context, httpClient *http.Client, walletMetadataURL string) (oidc4vci.WalletAPIClient, error)
-	clientTLSConfig     *tls.Config
-	clientTimeout       time.Duration
+	walletClientCreator func(ctx context.Context, httpClient core.HTTPRequestDoer, walletMetadataURL string) (oidc4vci.WalletAPIClient, error)
+	config              oidc4vci.ClientConfig
 }
 
 func (i *issuer) Metadata(issuer did.DID) (oidc4vci.CredentialIssuerMetadata, error) {
@@ -159,11 +156,11 @@ func (i *issuer) OfferCredential(ctx context.Context, credential vc.VerifiableCr
 		Infof("Offering credential using OIDC4VCI (client-metadata-url=%s)", clientMetadataURL)
 
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
-	httpTransport.TLSClientConfig = i.clientTLSConfig
-	httpClient := &http.Client{
-		Timeout:   i.clientTimeout,
+	httpTransport.TLSClientConfig = i.config.ClientTLSConfig
+	httpClient := core.StrictHTTPClient(i.config.Strictmode, &http.Client{
+		Timeout:   i.config.ClientTimeout,
 		Transport: httpTransport,
-	}
+	})
 	client, err := i.walletClientCreator(ctx, httpClient, clientMetadataURL)
 	if err != nil {
 		return err

--- a/vcr/issuer/openid4vci/issuer.go
+++ b/vcr/issuer/openid4vci/issuer.go
@@ -157,7 +157,7 @@ func (i *issuer) OfferCredential(ctx context.Context, credential vc.VerifiableCr
 
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
 	httpTransport.TLSClientConfig = i.config.ClientTLSConfig
-	httpClient := core.StrictHTTPClient(i.config.Strictmode, &http.Client{
+	httpClient := core.NewStrictHTTPClient(i.config.Strictmode, &http.Client{
 		Timeout:   i.config.ClientTimeout,
 		Transport: httpTransport,
 	})

--- a/vcr/oidc4vci/config.go
+++ b/vcr/oidc4vci/config.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package oidc4vci
+
+import (
+	"crypto/tls"
+	"time"
+)
+
+// ClientConfig holds openid4vci client configuration
+type ClientConfig struct {
+	ClientTimeout   time.Duration
+	ClientTLSConfig *tls.Config
+	Strictmode      bool
+}

--- a/vcr/oidc4vci/config.go
+++ b/vcr/oidc4vci/config.go
@@ -25,7 +25,7 @@ import (
 
 // ClientConfig holds openid4vci client configuration
 type ClientConfig struct {
-	ClientTimeout   time.Duration
-	ClientTLSConfig *tls.Config
-	Strictmode      bool
+	Timeout   time.Duration
+	TLS       *tls.Config
+	HTTPSOnly bool
 }

--- a/vcr/oidc4vci/wallet_client.go
+++ b/vcr/oidc4vci/wallet_client.go
@@ -48,8 +48,6 @@ func NewWalletAPIClient(ctx context.Context, httpClient core.HTTPRequestDoer, wa
 		return nil, fmt.Errorf("unable to load OAuth2 credential client metadata (url=%s): %w", walletMetadataURL, err)
 	}
 
-	// TODO: check for https in strictmode
-
 	return &defaultWalletAPIClient{
 		httpClient: httpClient,
 		metadata:   *metadata,

--- a/vcr/oidc4vci/wallet_client.go
+++ b/vcr/oidc4vci/wallet_client.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
+	"github.com/nuts-foundation/nuts-node/core"
 	"net/url"
 )
 
@@ -38,7 +38,7 @@ type WalletAPIClient interface {
 var _ WalletAPIClient = (*defaultWalletAPIClient)(nil)
 
 // NewWalletAPIClient resolves the OAuth2 credential client metadata from the given URL.
-func NewWalletAPIClient(ctx context.Context, httpClient *http.Client, walletMetadataURL string) (WalletAPIClient, error) {
+func NewWalletAPIClient(ctx context.Context, httpClient core.HTTPRequestDoer, walletMetadataURL string) (WalletAPIClient, error) {
 	if walletMetadataURL == "" {
 		return nil, errors.New("empty wallet metadata URL")
 	}
@@ -47,6 +47,8 @@ func NewWalletAPIClient(ctx context.Context, httpClient *http.Client, walletMeta
 	if err != nil {
 		return nil, fmt.Errorf("unable to load OAuth2 credential client metadata (url=%s): %w", walletMetadataURL, err)
 	}
+
+	// TODO: check for https in strictmode
 
 	return &defaultWalletAPIClient{
 		httpClient: httpClient,
@@ -58,7 +60,7 @@ var _ WalletAPIClient = (*defaultWalletAPIClient)(nil)
 
 type defaultWalletAPIClient struct {
 	metadata   OAuth2ClientMetadata
-	httpClient *http.Client
+	httpClient core.HTTPRequestDoer
 }
 
 func (c *defaultWalletAPIClient) Metadata() OAuth2ClientMetadata {
@@ -82,7 +84,7 @@ func (c *defaultWalletAPIClient) OfferCredential(ctx context.Context, offer Cred
 	return nil
 }
 
-func loadOAuth2CredentialsClientMetadata(ctx context.Context, metadataURL string, httpClient *http.Client) (*OAuth2ClientMetadata, error) {
+func loadOAuth2CredentialsClientMetadata(ctx context.Context, metadataURL string, httpClient core.HTTPRequestDoer) (*OAuth2ClientMetadata, error) {
 	// TODO: Support HTTPS (which truststore?)
 	//       See https://github.com/nuts-foundation/nuts-node/issues/2032
 	// TODO: what about caching?


### PR DESCRIPTION
closes #2061 

I added a `StrictHTTPClient` to `core.http_client` which returns a `HTTPRequestDoer`. It wraps an `http.Client` and the `strictmode` config to make sure an error is returned when a non-HTTPS address is called when in strictmode.

Due to the additional passing of `strictmode`, I created a `oidc4vci.ClientConfig` to pass `strictmode`, `TLS.Config` and `ClientTimeout` and reduce the amount of parameters.