### PR TITLE
Helm: do not set new chart as latest release

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
+        with:
+          mark_as_latest: false
         env:
           CR_CHARTS_DIR: charts
           CR_PAGES_BRANCH: gh-pages


### PR DESCRIPTION
The action sets the newest chart as the latest release on GitHub by default