### PR TITLE
VCR Search: don't log each individual invalid search result

### DIFF
--- a/vcr/search.go
+++ b/vcr/search.go
@@ -115,6 +115,6 @@ func formatFilteredVCsLogMessage(verifyErrors map[string]int) string {
 		sort.Strings(parts)
 		numFiltered += count
 	}
-	msg := fmt.Sprintf("Filtered %d invalid VCs from search results (more info on TRACE): %s", len(verifyErrors), strings.Join(parts, ", "))
+	msg := fmt.Sprintf("Filtered %d invalid VCs from search results (more info on TRACE): %s", numFiltered, strings.Join(parts, ", "))
 	return msg
 }

--- a/vcr/search.go
+++ b/vcr/search.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/vcr/log"
+	"github.com/sirupsen/logrus"
 	"reflect"
 	"sort"
 	"strings"
@@ -100,7 +101,7 @@ func (c *vcr) Search(ctx context.Context, searchTerms []SearchTerm, allowUntrust
 	}
 
 	// Print debug log if we found invalid credentials, make a distinction between different errors
-	if len(verifyErrors) > 0 {
+	if len(verifyErrors) > 0 && log.Logger().Level >= logrus.DebugLevel {
 		log.Logger().Debug(formatFilteredVCsLogMessage(verifyErrors))
 	}
 

--- a/vcr/search.go
+++ b/vcr/search.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/vcr/log"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -79,6 +80,7 @@ func (c *vcr) Search(ctx context.Context, searchTerms []SearchTerm, allowUntrust
 	if err != nil {
 		return nil, err
 	}
+	verifyErrors := make(map[string]int, 0)
 	for _, doc := range docs {
 		foundCredential := vc.VerifiableCredential{}
 		err = json.Unmarshal(doc, &foundCredential)
@@ -92,9 +94,27 @@ func (c *vcr) Search(ctx context.Context, searchTerms []SearchTerm, allowUntrust
 			log.Logger().
 				WithError(err).
 				WithField(core.LogFieldCredentialID, foundCredential.ID).
-				Debug("Encountered invalid VC, omitting from search results.")
+				Trace("Encountered invalid VC, omitting from search results.")
+			verifyErrors[err.Error()]++
 		}
 	}
 
+	// Print debug log if we found invalid credentials, make a distinction between different errors
+	if len(verifyErrors) > 0 {
+		log.Logger().Debug(formatFilteredVCsLogMessage(verifyErrors))
+	}
+
 	return VCs, nil
+}
+
+func formatFilteredVCsLogMessage(verifyErrors map[string]int) string {
+	parts := make([]string, 0, len(verifyErrors))
+	numFiltered := 0
+	for err, count := range verifyErrors {
+		parts = append(parts, fmt.Sprintf("'%s' (%d times)", err, count))
+		sort.Strings(parts)
+		numFiltered += count
+	}
+	msg := fmt.Sprintf("Filtered %d invalid VCs from search results (more info on TRACE): %s", len(verifyErrors), strings.Join(parts, ", "))
+	return msg
 }

--- a/vcr/search_test.go
+++ b/vcr/search_test.go
@@ -22,6 +22,7 @@ package vcr
 import (
 	"context"
 	"github.com/stretchr/testify/require"
+	"io"
 	"testing"
 	"time"
 
@@ -160,4 +161,14 @@ func TestVCR_Search(t *testing.T) {
 
 		assert.Len(t, creds, 0)
 	})
+}
+
+func Test_formatFilteredVCsLogMessage(t *testing.T) {
+	input := map[string]int{
+		types.ErrRevoked.Error():   2,
+		types.ErrUntrusted.Error(): 10,
+		io.EOF.Error():             1,
+	}
+	msg := formatFilteredVCsLogMessage(input)
+	assert.Equal(t, "Filtered 3 invalid VCs from search results (more info on TRACE): 'EOF' (1 times), 'credential is revoked' (2 times), 'credential issuer is untrusted' (10 times)", msg)
 }

--- a/vcr/search_test.go
+++ b/vcr/search_test.go
@@ -170,5 +170,5 @@ func Test_formatFilteredVCsLogMessage(t *testing.T) {
 		io.EOF.Error():             1,
 	}
 	msg := formatFilteredVCsLogMessage(input)
-	assert.Equal(t, "Filtered 3 invalid VCs from search results (more info on TRACE): 'EOF' (1 times), 'credential is revoked' (2 times), 'credential issuer is untrusted' (10 times)", msg)
+	assert.Equal(t, "Filtered 13 invalid VCs from search results (more info on TRACE): 'EOF' (1 times), 'credential is revoked' (2 times), 'credential issuer is untrusted' (10 times)", msg)
 }


### PR DESCRIPTION
Right now it logs a line for every invalid VCs, which might also be a revoked credential. Or untrusted. We're probably not interested in revoked credentials, _maybe_ in untrusted credentials (to find out why you can't find a certain VC). So best option to both keep the errors but also declutter the DEBUG log is to just log the error counts, individual errors on TRACE.

Example DEBUG log:

```
Filtered 13 invalid VCs from search results (more info on TRACE): 'EOF' (1 times), 'credential is revoked' (2 times), 'credential issuer is untrusted' (10 times)
```