### PR TITLE
fix typo: credentials_definition -> credential_definition

### DIFF
--- a/vcr/issuer/openid4vci/assets/definitions/NutsAuthorizationCredential.json
+++ b/vcr/issuer/openid4vci/assets/definitions/NutsAuthorizationCredential.json
@@ -3,7 +3,7 @@
   "cryptographic_binding_methods_supported": [
     "did:nuts"
   ],
-  "credentials_definition": {
+  "credential_definition": {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
       "https://www.nuts.nl/credentials/v1"

--- a/vcr/issuer/openid4vci/assets/definitions/NutsOrganizationCredential.json
+++ b/vcr/issuer/openid4vci/assets/definitions/NutsOrganizationCredential.json
@@ -3,7 +3,7 @@
   "cryptographic_binding_methods_supported": [
     "did:nuts"
   ],
-  "credentials_definition": {
+  "credential_definition": {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
       "https://www.nuts.nl/credentials/v1"

--- a/vcr/issuer/openid4vci/issuer_test.go
+++ b/vcr/issuer/openid4vci/issuer_test.go
@@ -89,7 +89,7 @@ func Test_memoryIssuer_Metadata(t *testing.T) {
 		require.Len(t, metadata.CredentialsSupported, 3)
 		assert.Equal(t, "ldp_vc", metadata.CredentialsSupported[0]["format"])
 		require.Len(t, metadata.CredentialsSupported[0]["cryptographic_binding_methods_supported"], 1)
-		assert.Equal(t, metadata.CredentialsSupported[0]["credentials_definition"],
+		assert.Equal(t, metadata.CredentialsSupported[0]["credential_definition"],
 			map[string]interface{}{
 				"@context": []interface{}{"https://www.w3.org/2018/credentials/v1", "https://www.nuts.nl/credentials/v1"},
 				"type":     []interface{}{"VerifiableCredential", "NutsAuthorizationCredential"},

--- a/vcr/issuer/openid4vci/test/valid/ExampleCredential.json
+++ b/vcr/issuer/openid4vci/test/valid/ExampleCredential.json
@@ -3,7 +3,7 @@
   "cryptographic_binding_methods_supported": [
     "did:nuts"
   ],
-  "credentials_definition": {
+  "credential_definition": {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
       "https://www.nuts.nl/credentials/v1"


### PR DESCRIPTION
[spec says credential_definition](https://openid.bitbucket.io/connect/editors-draft/openid-4-verifiable-credential-issuance-1_0.html#name-credential-issuer-metadata-3)