### PR TITLE
generate and check c_nonce for credential request

### DIFF
--- a/docs/_static/vcr/oidc4vci_v0.yaml
+++ b/docs/_static/vcr/oidc4vci_v0.yaml
@@ -424,9 +424,17 @@ components:
         - error
       properties:
         error:
-            type: string
-            description: Code identifying the error that occurred.
-            example: "invalid_request"
+          type: string
+          description: Code identifying the error that occurred.
+          example: "invalid_request"
+        c_nonce:
+          type: string
+          description: a string containing a new nonce value to be used for subsequent requests.
+          example: "tZignsnFbp"
+        c_nonce_expires_in:
+          type: integer
+          description: The lifetime in seconds of the nonce value.
+          example: 900
     CredentialResponse:
       type: object
       required:

--- a/vcr/api/oidc4vci/v0/issuer_test.go
+++ b/vcr/api/oidc4vci/v0/issuer_test.go
@@ -100,7 +100,7 @@ func TestWrapper_RequestAccessToken(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		oidcIssuer := issuer.NewMockOpenIDHandler(ctrl)
-		oidcIssuer.EXPECT().HandleAccessTokenRequest(gomock.Any(), "code").Return("access-token", nil)
+		oidcIssuer.EXPECT().HandleAccessTokenRequest(gomock.Any(), "code").Return("access-token", "c_nonce", nil)
 		documentOwner := types.NewMockDocumentOwner(ctrl)
 		documentOwner.EXPECT().IsOwner(gomock.Any(), gomock.Any()).Return(true, nil)
 		service := vcr.NewMockVCR(ctrl)
@@ -116,6 +116,7 @@ func TestWrapper_RequestAccessToken(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, "access-token", response.(RequestAccessToken200JSONResponse).AccessToken)
+		assert.Equal(t, "c_nonce", response.(RequestAccessToken200JSONResponse).CNonce)
 	})
 	t.Run("unknown tenant", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/vcr/holder/openid.go
+++ b/vcr/holder/openid.go
@@ -138,7 +138,7 @@ func (h openidHandler) HandleCredentialOffer(ctx context.Context, offer oidc4vci
 		}
 	}
 
-	if accessTokenResponse.CNonce == nil {
+	if accessTokenResponse.CNonce == "" {
 		return oidc4vci.Error{
 			Err:        errors.New("c_nonce is missing"),
 			Code:       oidc4vci.InvalidToken,
@@ -237,7 +237,7 @@ func (h openidHandler) retrieveCredential(ctx context.Context, issuerClient oidc
 	claims := map[string]interface{}{
 		"aud":   issuerClient.Metadata().CredentialIssuer,
 		"iat":   nowFunc().Unix(),
-		"nonce": *tokenResponse.CNonce,
+		"nonce": tokenResponse.CNonce,
 	}
 
 	proof, err := h.signer.SignJWT(ctx, claims, headers, keyID)

--- a/vcr/holder/openid_test.go
+++ b/vcr/holder/openid_test.go
@@ -93,8 +93,8 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 			"pre-authorized_code": "code",
 		}).Return(&oidc4vci.TokenResponse{
 			AccessToken: "access-token",
-			CNonce:      &nonce,
-			ExpiresIn:   new(int),
+			CNonce:      nonce,
+			ExpiresIn:   0,
 			TokenType:   "bearer",
 		}, nil)
 		issuerAPIClient.EXPECT().RequestCredential(gomock.Any(), gomock.Any(), "access-token").
@@ -258,7 +258,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		issuerAPIClient := oidc4vci.NewMockIssuerAPIClient(ctrl)
 		issuerAPIClient.EXPECT().Metadata().Return(metadata)
-		issuerAPIClient.EXPECT().RequestAccessToken(gomock.Any(), gomock.Any()).Return(&oidc4vci.TokenResponse{AccessToken: "access-token", CNonce: new(string)}, nil)
+		issuerAPIClient.EXPECT().RequestAccessToken(gomock.Any(), gomock.Any()).Return(&oidc4vci.TokenResponse{AccessToken: "access-token", CNonce: "c_nonce"}, nil)
 		issuerAPIClient.EXPECT().RequestCredential(gomock.Any(), gomock.Any(), gomock.Any()).Return(&vc.VerifiableCredential{
 			Context: []ssi.URI{ssi.MustParseURI("https://www.w3.org/2018/credentials/v1")},
 			Type:    []ssi.URI{ssi.MustParseURI("VerifiableCredential")},

--- a/vcr/issuer/issuer_test.go
+++ b/vcr/issuer/issuer_test.go
@@ -300,8 +300,8 @@ func Test_issuer_Issue(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			walletResolver := oidc4vci.NewMockIdentifierResolver(ctrl)
 			walletResolver.EXPECT().Resolve(holderDID).AnyTimes().Return(walletIdentifier, nil)
-			openidIsser := NewMockOpenIDHandler(ctrl)
-			openidIsser.EXPECT().OfferCredential(gomock.Any(), gomock.Any(), walletIdentifier)
+			openidIssuer := NewMockOpenIDHandler(ctrl)
+			openidIssuer.EXPECT().OfferCredential(gomock.Any(), gomock.Any(), walletIdentifier)
 			vcrStore := vcr.NewMockWriter(ctrl)
 			vcrStore.EXPECT().StoreCredential(gomock.Any(), gomock.Any())
 			keyResolver := NewMockkeyResolver(ctrl)
@@ -317,7 +317,7 @@ func Test_issuer_Issue(t *testing.T) {
 				walletResolver: walletResolver,
 				openidHandlerFn: func(ctx context.Context, id did.DID) (OpenIDHandler, error) {
 					if id.Equals(issuerDID) {
-						return openidIsser, nil
+						return openidIssuer, nil
 					}
 					return nil, nil
 				},

--- a/vcr/issuer/openid.go
+++ b/vcr/issuer/openid.go
@@ -95,6 +95,7 @@ type OpenIDHandler interface {
 	// ProviderMetadata returns the OpenID Connect provider metadata.
 	ProviderMetadata() oidc4vci.ProviderMetadata
 	// HandleAccessTokenRequest handles an OAuth2 access token request for the given issuer and pre-authorized code.
+	// It returns the access token and a c_nonce.
 	HandleAccessTokenRequest(ctx context.Context, preAuthorizedCode string) (string, string, error)
 	// Metadata returns the OpenID4VCI credential issuer metadata for the given issuer.
 	Metadata() oidc4vci.CredentialIssuerMetadata

--- a/vcr/issuer/openid_mock.go
+++ b/vcr/issuer/openid_mock.go
@@ -37,12 +37,13 @@ func (m *MockOpenIDHandler) EXPECT() *MockOpenIDHandlerMockRecorder {
 }
 
 // HandleAccessTokenRequest mocks base method.
-func (m *MockOpenIDHandler) HandleAccessTokenRequest(ctx context.Context, preAuthorizedCode string) (string, error) {
+func (m *MockOpenIDHandler) HandleAccessTokenRequest(ctx context.Context, preAuthorizedCode string) (string, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleAccessTokenRequest", ctx, preAuthorizedCode)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // HandleAccessTokenRequest indicates an expected call of HandleAccessTokenRequest.

--- a/vcr/issuer/openid_test.go
+++ b/vcr/issuer/openid_test.go
@@ -183,7 +183,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 				invalidRequest := createRequest(createHeaders(), createClaims(""))
 				invalidRequest.Proof = nil
 
-				_, err := service.HandleCredentialRequest(ctx, issuerDID, invalidRequest, accessToken)
+				_, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
 				require.ErrorAs(t, err, new(oidc4vci.Error))
 				cNonce := err.(oidc4vci.Error).CNonce

--- a/vcr/issuer/openid_test.go
+++ b/vcr/issuer/openid_test.go
@@ -122,10 +122,11 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 			"kid": keyID,
 		}
 	}
-	createClaims := func() map[string]interface{} {
+	createClaims := func(nonce string) map[string]interface{} {
 		return map[string]interface{}{
-			"aud": issuerIdentifier,
-			"iat": time.Now().Unix(),
+			"aud":   issuerIdentifier,
+			"iat":   time.Now().Unix(),
+			"nonce": nonce,
 		}
 	}
 	createRequest := func(headers, claims map[string]interface{}) oidc4vci.CredentialRequest {
@@ -139,15 +140,15 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 			},
 		}
 	}
-	validRequest := createRequest(createHeaders(), createClaims())
 
 	const preAuthCode = "some-secret-code"
 
 	service := requireNewTestHandler(t, keyResolver)
 	_, err := service.createOffer(ctx, issuedVC, preAuthCode)
 	require.NoError(t, err)
-	accessToken, err := service.HandleAccessTokenRequest(ctx, preAuthCode)
+	accessToken, cNonce, err := service.HandleAccessTokenRequest(ctx, preAuthCode)
 	require.NoError(t, err)
+	validRequest := createRequest(createHeaders(), createClaims(cNonce))
 
 	t.Run("ok", func(t *testing.T) {
 		auditLogs := audit.CaptureLogs(t)
@@ -160,7 +161,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 	})
 	t.Run("proof validation", func(t *testing.T) {
 		t.Run("unsupported proof type", func(t *testing.T) {
-			invalidRequest := createRequest(createHeaders(), createClaims())
+			invalidRequest := createRequest(createHeaders(), createClaims(""))
 			invalidRequest.Proof.ProofType = "not-supported"
 
 			response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
@@ -170,7 +171,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 		})
 		t.Run("jwt", func(t *testing.T) {
 			t.Run("missing proof", func(t *testing.T) {
-				invalidRequest := createRequest(createHeaders(), createClaims())
+				invalidRequest := createRequest(createHeaders(), createClaims(""))
 				invalidRequest.Proof = nil
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
@@ -179,7 +180,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 				assert.Nil(t, response)
 			})
 			t.Run("invalid JWT", func(t *testing.T) {
-				invalidRequest := createRequest(createHeaders(), createClaims())
+				invalidRequest := createRequest(createHeaders(), createClaims(""))
 				invalidRequest.Proof.Jwt = "not a JWT"
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
@@ -200,10 +201,10 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 				service := requireNewTestHandler(t, keyResolver)
 				_, err := service.createOffer(ctx, otherIssuedVC, preAuthCode)
 				require.NoError(t, err)
-				accessToken, err := service.HandleAccessTokenRequest(ctx, preAuthCode)
+				accessToken, _, err := service.HandleAccessTokenRequest(ctx, preAuthCode)
 				require.NoError(t, err)
 
-				invalidRequest := createRequest(createHeaders(), createClaims())
+				invalidRequest := createRequest(createHeaders(), createClaims(""))
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
@@ -216,10 +217,10 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 				service := requireNewTestHandler(t, keyResolver)
 				_, err := service.createOffer(ctx, issuedVC, preAuthCode)
 				require.NoError(t, err)
-				accessToken, err := service.HandleAccessTokenRequest(ctx, preAuthCode)
+				accessToken, _, err := service.HandleAccessTokenRequest(ctx, preAuthCode)
 				require.NoError(t, err)
 
-				invalidRequest := createRequest(createHeaders(), createClaims())
+				invalidRequest := createRequest(createHeaders(), createClaims(""))
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
@@ -229,7 +230,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 			t.Run("typ header missing", func(t *testing.T) {
 				headers := createHeaders()
 				headers["typ"] = ""
-				invalidRequest := createRequest(headers, createClaims())
+				invalidRequest := createRequest(headers, createClaims(""))
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
@@ -239,7 +240,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 			t.Run("typ header invalid", func(t *testing.T) {
 				headers := createHeaders()
 				delete(headers, "typ") // causes JWT library to set it to default ("JWT")
-				invalidRequest := createRequest(headers, createClaims())
+				invalidRequest := createRequest(headers, createClaims(""))
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
@@ -247,7 +248,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 				assert.Nil(t, response)
 			})
 			t.Run("aud header doesn't match issuer identifier", func(t *testing.T) {
-				claims := createClaims()
+				claims := createClaims("")
 				claims["aud"] = "https://example.com/someone-else"
 				invalidRequest := createRequest(createHeaders(), claims)
 
@@ -256,6 +257,26 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - audience doesn't match credential issuer (aud=[https://example.com/someone-else])")
 				assert.Nil(t, response)
 			})
+		})
+		t.Run("unknown nonce", func(t *testing.T) {
+			invalidRequest := createRequest(createHeaders(), createClaims("other"))
+
+			response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
+
+			assertProtocolError(t, err, http.StatusBadRequest, "invalid_token - unknown nonce")
+			assert.Nil(t, response)
+		})
+		t.Run("wrong nonce", func(t *testing.T) {
+			_, err := service.createOffer(ctx, issuedVC, "other")
+			require.NoError(t, err)
+			_, cNonce, err := service.HandleAccessTokenRequest(ctx, "other")
+			require.NoError(t, err)
+			invalidRequest := createRequest(createHeaders(), createClaims(cNonce))
+
+			response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
+
+			assertProtocolError(t, err, http.StatusBadRequest, "invalid_token - nonce not valid for access token")
+			assert.Nil(t, response)
 		})
 	})
 
@@ -306,21 +327,21 @@ func Test_memoryIssuer_HandleAccessTokenRequest(t *testing.T) {
 		_, err := service.createOffer(ctx, issuedVC, "code")
 		require.NoError(t, err)
 
-		accessToken, err := service.HandleAccessTokenRequest(audit.TestContext(), "code")
+		accessToken, _, err := service.HandleAccessTokenRequest(audit.TestContext(), "code")
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, accessToken)
 	})
 	t.Run("pre-authorized code issued by other issuer", func(t *testing.T) {
 		store := NewOpenIDMemoryStore()
-		service, err := NewOpenIDHandler(issuerDID, issuerIdentifier,  definitionsDIR, oidc4vci.ClientConfig{}, nil, store)
+		service, err := NewOpenIDHandler(issuerDID, issuerIdentifier, definitionsDIR, oidc4vci.ClientConfig{}, nil, store)
 		require.NoError(t, err)
 		_, err = service.(*openidHandler).createOffer(ctx, issuedVC, "code")
 		require.NoError(t, err)
 
 		otherService, err := NewOpenIDHandler(did.MustParseDID("did:nuts:other"), "http://example.com/other", definitionsDIR, oidc4vci.ClientConfig{}, nil, store)
 		require.NoError(t, err)
-		accessToken, err := otherService.HandleAccessTokenRequest(audit.TestContext(), "code")
+		accessToken, _, err := otherService.HandleAccessTokenRequest(audit.TestContext(), "code")
 
 		var protocolError oidc4vci.Error
 		require.ErrorAs(t, err, &protocolError)
@@ -333,7 +354,7 @@ func Test_memoryIssuer_HandleAccessTokenRequest(t *testing.T) {
 		_, err := service.createOffer(ctx, issuedVC, "some-other-code")
 		require.NoError(t, err)
 
-		accessToken, err := service.HandleAccessTokenRequest(audit.TestContext(), "code")
+		accessToken, _, err := service.HandleAccessTokenRequest(audit.TestContext(), "code")
 
 		var protocolError oidc4vci.Error
 		require.ErrorAs(t, err, &protocolError)

--- a/vcr/oidc4vci/error.go
+++ b/vcr/oidc4vci/error.go
@@ -52,7 +52,12 @@ const (
 
 // Error is an error that signals the error was (probably) caused by the client (e.g. bad request),
 // or that the client can recover from the error (e.g. retry). Errors are specified by the OpenID4VCI specification.
+// Invalid proof errors may also add a new c_nonce that the client must use in the next credential request.
 type Error struct {
+	// CNonce is a random string that the client must send in the next credential request.
+	CNonce *string `json:"c_nonce,omitempty"`
+	// CNonceExpiresIn is the number of seconds until the c_nonce expires.
+	CNonceExpiresIn *int `json:"c_nonce_expires_in,omitempty"`
 	// Code is the error code as defined by the OpenID4VCI spec.
 	Code ErrorCode `json:"error"`
 	// Err is the underlying error, may be omitted. It is not intended to be returned to the client.

--- a/vcr/oidc4vci/types.go
+++ b/vcr/oidc4vci/types.go
@@ -138,11 +138,14 @@ type TokenResponse struct {
 	// AccessToken defines the access token issued by the authorization server.
 	AccessToken string `json:"access_token"`
 
-	// CNonce defines the JSON string containing a nonce to be used to create a proof of possession of key material when requesting a Credential. When received, the WalletAPIClient MUST use this nonce value for its subsequent credential requests until the Credential Issuer provides a fresh nonce.
-	CNonce *string `json:"c_nonce,omitempty"`
+	// CNonce defines the JSON string containing a nonce to be used to create a proof of possession of key material when requesting a Credential.
+	// When received, the WalletAPIClient MUST use this nonce value for its subsequent credential requests until the Credential Issuer provides a fresh nonce.
+	// Although optional in the spec, we use a concrete value since we always fill it.
+	CNonce string `json:"c_nonce,omitempty"`
 
 	// ExpiresIn defines the lifetime in seconds of the access token.
-	ExpiresIn *int `json:"expires_in,omitempty"`
+	// Although optional in the spec, we use a concrete value since we always fill it.
+	ExpiresIn int `json:"expires_in,omitempty"`
 
 	// TokenType defines the type of the token issued as described in [RFC6749].
 	TokenType string `json:"token_type"`


### PR DESCRIPTION
closes #2233

c_nonce is now filled with actual value. The c_nonce must match the same flow as the access token is bound to.
changed it from `*string` type to `string` type in `TokenResponse` struct since we always fill it.