### PR TITLE
Cleanup: remove old network.tls properties from e2e tests

### DIFF
--- a/e2e-tests/nuts-network/direct-wan/node-A/nuts.yaml
+++ b/e2e-tests/nuts-network/direct-wan/node-A/nuts.yaml
@@ -13,9 +13,6 @@ crypto:
   storage: fs
 network:
   grpcaddr:	:5555
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem
 tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem

--- a/e2e-tests/nuts-network/direct-wan/node-B/nuts.yaml
+++ b/e2e-tests/nuts-network/direct-wan/node-B/nuts.yaml
@@ -14,9 +14,6 @@ crypto:
 network:
   bootstrapnodes: nodeA:5555
   grpcaddr:	:5555
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem
 tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem

--- a/e2e-tests/nuts-network/private-transactions/node-A/nuts.yaml
+++ b/e2e-tests/nuts-network/private-transactions/node-A/nuts.yaml
@@ -23,6 +23,3 @@ network:
   grpcaddr:	:5555
   v2:
     gossipinterval: 500
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem

--- a/e2e-tests/nuts-network/private-transactions/node-B/nuts.yaml
+++ b/e2e-tests/nuts-network/private-transactions/node-B/nuts.yaml
@@ -24,6 +24,3 @@ network:
   grpcaddr:	:5555
   v2:
     gossipinterval: 450
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem

--- a/e2e-tests/nuts-network/ssl-offloading/haproxy/node-A/nuts.yaml
+++ b/e2e-tests/nuts-network/ssl-offloading/haproxy/node-A/nuts.yaml
@@ -18,6 +18,3 @@ network:
   grpcaddr:	:5555
   v2:
     gossipinterval: 250
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem

--- a/e2e-tests/nuts-network/ssl-offloading/haproxy/node-B/nuts.yaml
+++ b/e2e-tests/nuts-network/ssl-offloading/haproxy/node-B/nuts.yaml
@@ -19,6 +19,3 @@ network:
   grpcaddr:	:5555
   v2:
     gossipinterval: 250
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem

--- a/e2e-tests/nuts-network/ssl-offloading/nginx/node-A/nuts.yaml
+++ b/e2e-tests/nuts-network/ssl-offloading/nginx/node-A/nuts.yaml
@@ -18,6 +18,3 @@ network:
   grpcaddr:	:5555
   v2:
     gossipinterval: 250
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem

--- a/e2e-tests/nuts-network/ssl-offloading/nginx/node-B/nuts.yaml
+++ b/e2e-tests/nuts-network/ssl-offloading/nginx/node-B/nuts.yaml
@@ -15,9 +15,6 @@ tls:
   offload: incoming
   certheader: X-SSL-CERT
 network:
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem
   bootstrapnodes: nodeA:443
   grpcaddr:	:5555
   v2:

--- a/e2e-tests/nuts-network/ssl-pass-through/node-A/nuts.yaml
+++ b/e2e-tests/nuts-network/ssl-pass-through/node-A/nuts.yaml
@@ -11,9 +11,6 @@ network:
   grpcaddr:	:5555
   v2:
     gossipinterval: 250
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem
 tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem

--- a/e2e-tests/nuts-network/ssl-pass-through/node-B/nuts.yaml
+++ b/e2e-tests/nuts-network/ssl-pass-through/node-B/nuts.yaml
@@ -12,9 +12,6 @@ network:
   grpcaddr:	:5555
   v2:
     gossipinterval: 250
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem
 tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem

--- a/e2e-tests/oauth-flow/node-A/nuts.yaml
+++ b/e2e-tests/oauth-flow/node-A/nuts.yaml
@@ -18,6 +18,3 @@ tls:
 network:
   v2:
     gossipinterval: 500
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem

--- a/e2e-tests/oauth-flow/node-B/nuts.yaml
+++ b/e2e-tests/oauth-flow/node-B/nuts.yaml
@@ -20,6 +20,3 @@ network:
   bootstrapnodes: nodeA-backend:5555
   v2:
     gossipinterval: 400
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem

--- a/e2e-tests/openid4vci/issuer-initiated/node-A/nuts.yaml
+++ b/e2e-tests/openid4vci/issuer-initiated/node-A/nuts.yaml
@@ -30,6 +30,3 @@ network:
   grpcaddr:	:5555
   v2:
     gossipinterval: 500
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem

--- a/e2e-tests/openid4vci/issuer-initiated/node-B/nuts.yaml
+++ b/e2e-tests/openid4vci/issuer-initiated/node-B/nuts.yaml
@@ -31,6 +31,3 @@ network:
   grpcaddr:	:5555
   v2:
     gossipinterval: 450
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem

--- a/e2e-tests/ops/key-rotation/node-A/nuts.yaml
+++ b/e2e-tests/ops/key-rotation/node-A/nuts.yaml
@@ -11,9 +11,6 @@ auth:
     autoupdateschemas: false
 network:
   grpcaddr:	:5555
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem
 tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem

--- a/e2e-tests/ops/key-rotation/node-B/nuts.yaml
+++ b/e2e-tests/ops/key-rotation/node-B/nuts.yaml
@@ -12,9 +12,6 @@ auth:
 network:
   bootstrapnodes: nodeA:5555
   grpcaddr:	:5555
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem
 tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem

--- a/e2e-tests/storage/backup-restore/node-A/nuts.yaml
+++ b/e2e-tests/storage/backup-restore/node-A/nuts.yaml
@@ -16,6 +16,3 @@ storage:
       directory: /backup
 network:
   grpcaddr:	:5555
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem

--- a/e2e-tests/storage/redis/node-A/nuts.yaml
+++ b/e2e-tests/storage/redis/node-A/nuts.yaml
@@ -13,9 +13,6 @@ crypto:
   storage: fs
 network:
   grpcaddr:	:5555
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem
 tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem

--- a/e2e-tests/storage/redis/node-B/nuts.yaml
+++ b/e2e-tests/storage/redis/node-B/nuts.yaml
@@ -14,9 +14,6 @@ crypto:
 network:
   bootstrapnodes: nodeA:5555
   grpcaddr:	:5555
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem
 tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem

--- a/e2e-tests/storage/vault/nuts.yaml
+++ b/e2e-tests/storage/vault/nuts.yaml
@@ -15,9 +15,6 @@ crypto:
     address: http://vault-adapter:8210
 network:
   grpcaddr:	:5555
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
-  truststorefile: /opt/nuts/truststore.pem
 tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem


### PR DESCRIPTION
Replaced by `tls` root props.