### PR TITLE
OpenID4VCI: fix unknown nonce error

### DIFF
--- a/vcr/issuer/openid.go
+++ b/vcr/issuer/openid.go
@@ -387,14 +387,14 @@ func (i *openidHandler) validateProof(ctx context.Context, flow *Flow, request o
 	if flowFromNonce == nil {
 		return oidc4vci.Error{
 			Err:        errors.New("unknown nonce"),
-			Code:       oidc4vci.InvalidToken,
+			Code:       oidc4vci.InvalidProof,
 			StatusCode: http.StatusBadRequest,
 		}
 	}
 	if flowFromNonce.ID != flow.ID {
 		return oidc4vci.Error{
 			Err:        errors.New("nonce not valid for access token"),
-			Code:       oidc4vci.InvalidToken,
+			Code:       oidc4vci.InvalidProof,
 			StatusCode: http.StatusBadRequest,
 		}
 	}

--- a/vcr/issuer/openid_test.go
+++ b/vcr/issuer/openid_test.go
@@ -166,7 +166,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 			response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-			assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - proof type not supported")
+			assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - proof type not supported")
 			assert.Nil(t, response)
 		})
 		t.Run("jwt", func(t *testing.T) {
@@ -176,7 +176,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - missing proof")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - missing proof")
 				assert.Nil(t, response)
 			})
 			t.Run("missing proof returns error with new c_nonce", func(t *testing.T) {
@@ -200,7 +200,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - invalid compact serialization format: invalid number of segments")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - invalid compact serialization format: invalid number of segments")
 				assert.Nil(t, response)
 			})
 			t.Run("not signed by intended wallet (DID differs)", func(t *testing.T) {
@@ -223,7 +223,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - credential offer was signed by other DID than intended wallet: did:nuts:holder#1")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - credential offer was signed by other DID than intended wallet: did:nuts:holder#1")
 				assert.Nil(t, response)
 			})
 			t.Run("signing key is unknown", func(t *testing.T) {
@@ -239,7 +239,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - key not found in DID document")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - key not found in DID document")
 				assert.Nil(t, response)
 			})
 			t.Run("typ header missing", func(t *testing.T) {
@@ -249,7 +249,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - missing typ header")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - missing typ header")
 				assert.Nil(t, response)
 			})
 			t.Run("typ header invalid", func(t *testing.T) {
@@ -259,7 +259,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - invalid typ claim (expected: openid4vci-proof+jwt): JWT")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - invalid typ claim (expected: openid4vci-proof+jwt): JWT")
 				assert.Nil(t, response)
 			})
 			t.Run("aud header doesn't match issuer identifier", func(t *testing.T) {
@@ -269,7 +269,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - audience doesn't match credential issuer (aud=[https://example.com/someone-else])")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - audience doesn't match credential issuer (aud=[https://example.com/someone-else])")
 				assert.Nil(t, response)
 			})
 		})
@@ -278,7 +278,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 			response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-			assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - unknown nonce")
+			assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - unknown nonce")
 			assert.Nil(t, response)
 		})
 		t.Run("wrong nonce", func(t *testing.T) {
@@ -290,7 +290,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 			response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-			assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - nonce not valid for access token")
+			assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - nonce not valid for access token")
 			assert.Nil(t, response)
 		})
 	})

--- a/vcr/issuer/openid_test.go
+++ b/vcr/issuer/openid_test.go
@@ -166,7 +166,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 			response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-			assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - proof type not supported")
+			assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - proof type not supported")
 			assert.Nil(t, response)
 		})
 		t.Run("jwt", func(t *testing.T) {
@@ -176,7 +176,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - missing proof")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - missing proof")
 				assert.Nil(t, response)
 			})
 			t.Run("missing proof returns error with new c_nonce", func(t *testing.T) {
@@ -200,7 +200,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - invalid compact serialization format: invalid number of segments")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - invalid compact serialization format: invalid number of segments")
 				assert.Nil(t, response)
 			})
 			t.Run("not signed by intended wallet (DID differs)", func(t *testing.T) {
@@ -223,7 +223,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - credential offer was signed by other DID than intended wallet: did:nuts:holder#1")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - credential offer was signed by other DID than intended wallet: did:nuts:holder#1")
 				assert.Nil(t, response)
 			})
 			t.Run("signing key is unknown", func(t *testing.T) {
@@ -239,7 +239,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - key not found in DID document")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - key not found in DID document")
 				assert.Nil(t, response)
 			})
 			t.Run("typ header missing", func(t *testing.T) {
@@ -249,7 +249,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - missing typ header")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - missing typ header")
 				assert.Nil(t, response)
 			})
 			t.Run("typ header invalid", func(t *testing.T) {
@@ -259,7 +259,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - invalid typ claim (expected: openid4vci-proof+jwt): JWT")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - invalid typ claim (expected: openid4vci-proof+jwt): JWT")
 				assert.Nil(t, response)
 			})
 			t.Run("aud header doesn't match issuer identifier", func(t *testing.T) {
@@ -269,7 +269,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 				response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-				assertProtocolError(t, err, http.StatusBadRequest, "invalid_proof - audience doesn't match credential issuer (aud=[https://example.com/someone-else])")
+				assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - audience doesn't match credential issuer (aud=[https://example.com/someone-else])")
 				assert.Nil(t, response)
 			})
 		})
@@ -278,7 +278,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 			response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-			assertProtocolError(t, err, http.StatusBadRequest, "invalid_token - unknown nonce")
+			assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - unknown nonce")
 			assert.Nil(t, response)
 		})
 		t.Run("wrong nonce", func(t *testing.T) {
@@ -290,7 +290,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 
 			response, err := service.HandleCredentialRequest(ctx, invalidRequest, accessToken)
 
-			assertProtocolError(t, err, http.StatusBadRequest, "invalid_token - nonce not valid for access token")
+			assertProtocolError(t, err, http.StatusBadRequest, "invalid_or_missing_proof - nonce not valid for access token")
 			assert.Nil(t, response)
 		})
 	})

--- a/vcr/oidc4vci/error.go
+++ b/vcr/oidc4vci/error.go
@@ -47,7 +47,7 @@ const (
 	UnsupportedCredentialFormat ErrorCode = "unsupported_credential_format"
 	// InvalidProof is returned when the Credential Request did not contain a proof,
 	// or proof was invalid, i.e. it was not bound to a Credential Issuer provided nonce
-	InvalidProof ErrorCode = "invalid_proof"
+	InvalidProof ErrorCode = "invalid_or_missing_proof"
 )
 
 // Error is an error that signals the error was (probably) caused by the client (e.g. bad request),

--- a/vcr/oidc4vci/error.go
+++ b/vcr/oidc4vci/error.go
@@ -47,7 +47,7 @@ const (
 	UnsupportedCredentialFormat ErrorCode = "unsupported_credential_format"
 	// InvalidProof is returned when the Credential Request did not contain a proof,
 	// or proof was invalid, i.e. it was not bound to a Credential Issuer provided nonce
-	InvalidProof ErrorCode = "invalid_or_missing_proof"
+	InvalidProof ErrorCode = "invalid_proof"
 )
 
 // Error is an error that signals the error was (probably) caused by the client (e.g. bad request),


### PR DESCRIPTION
Should be `invalid_or_missing_proof` according to https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-error-response