### PR TITLE
add xor tree repair loop

### DIFF
--- a/network/dag/consistency.go
+++ b/network/dag/consistency.go
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package dag
+
+import (
+	"context"
+	"github.com/nuts-foundation/go-stoabs"
+	"github.com/nuts-foundation/nuts-node/network/dag/tree"
+	"github.com/nuts-foundation/nuts-node/network/log"
+	"sync"
+	"time"
+)
+
+type circuit int
+
+const (
+	circuitGreen circuit = iota
+	circuitYellow
+	circuitRed
+)
+
+// xorTreeRepair is responsible for repairing the XOR tree. Its loop is triggered when the network layer detects differences in XOR values with all other nodes.
+// It will loop over all pages of the XOR tree and recalculates the XOR value with the transactions in the database.
+// This repair is needed because current networks have nodes that have a wrong XOR value. How this happens is not yet known, it could be due to DB failures of due to failures in older versions.
+// The fact is that we can fix the state relatively easy.
+// The loop checks a page (512 LC values) per 10 seconds and continues looping until the network layer signals all is ok again.
+type xorTreeRepair struct {
+	ctx          context.Context
+	cancel       context.CancelFunc
+	ticker       *time.Ticker
+	currentPage  uint32
+	state        *state
+	circuitState circuit
+	mutex        sync.Mutex
+}
+
+func newXorTreeRepair(state *state) *xorTreeRepair {
+	return &xorTreeRepair{
+		state:  state,
+		ticker: time.NewTicker(10 * time.Second),
+	}
+}
+
+func (f *xorTreeRepair) start() {
+	f.ctx, f.cancel = context.WithCancel(context.Background())
+	go f.loop()
+}
+
+func (f *xorTreeRepair) shutdown() {
+	if f.cancel != nil {
+		f.cancel()
+	}
+}
+
+func (f *xorTreeRepair) loop() {
+	for {
+		select {
+		case <-f.ctx.Done():
+			return
+		case <-f.ticker.C:
+			f.checkPage()
+		}
+	}
+}
+
+func (f *xorTreeRepair) checkPage() {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	// ignore run if circuit is not red
+	if f.circuitState < circuitRed {
+		return
+	}
+
+	currentLC := f.state.lamportClockHigh.Load()
+	lcStart := f.currentPage * PageSize
+	lcEnd := lcStart + PageSize
+
+	// initialize an XOR tree
+	calculatedXorTree := tree.New(tree.NewXor(), PageSize)
+
+	// acquire global lock
+	err := f.state.graph.db.Write(context.Background(), func(txn stoabs.WriteTx) error {
+		txs, err := f.state.graph.findBetweenLC(txn, lcStart, lcEnd)
+		if err != nil {
+			return err
+		}
+		for _, tx := range txs {
+			calculatedXorTree.Insert(tx.Ref(), tx.Clock())
+		}
+
+		// Get XOR leaf from current XOR tree
+		xorTillEnd, _ := f.state.xorTree.getZeroTo(lcEnd - 1)
+		if lcStart != 0 {
+			xorTillStart, _ := f.state.xorTree.getZeroTo(lcStart - 1)
+			_ = xorTillEnd.Subtract(xorTillStart)
+		}
+
+		// Subtract the calculated tree, should be empty if the trees are equal
+		_ = xorTillEnd.Subtract(calculatedXorTree.Root())
+		if !xorTillEnd.Empty() {
+			// it's not empty, so replace the leaf in the current XOR tree with the calculated one
+			err = f.state.xorTree.tree.Replace(lcStart, calculatedXorTree.Root())
+			if err != nil {
+				return err
+			}
+			log.Logger().Warnf("detected XOR tree mismatch for page %d, fixed using recalculated values", f.currentPage)
+		}
+
+		// Now we do the same for the IBLT tree as stated in
+		// https://github.com/nuts-foundation/nuts-node/issues/2295
+		// we skip the iblt tree for now, since the chance for it to become corrupt is incredibly low.
+		// there can only be a problem with duplicate entries, not with missing entries.
+		// the xor tree already has an effect when it's missing entries.
+		// fixing the iblt tree is a copy of the code above (but with ibltTree instead of xorTree).
+
+		return nil
+	})
+	if err != nil {
+		log.Logger().Warnf("failed to run xorTreeRepair check: %s", err)
+	}
+
+	if lcEnd > currentLC {
+		// start over when end is reached for next run
+		f.currentPage = 0
+	} else {
+		// increment page so on the next round we check a different page.
+		f.currentPage++
+	}
+}
+
+func (f *xorTreeRepair) stateOK() {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	f.circuitState = circuitGreen
+	f.currentPage = 0
+}
+
+func (f *xorTreeRepair) incrementCount() {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	f.circuitState++
+}

--- a/network/dag/consistency.go
+++ b/network/dag/consistency.go
@@ -58,24 +58,23 @@ func newXorTreeRepair(state *state) *xorTreeRepair {
 }
 
 func (f *xorTreeRepair) start() {
-	f.ctx, f.cancel = context.WithCancel(context.Background())
-	go f.loop()
+	var ctx context.Context
+	ctx, f.cancel = context.WithCancel(context.Background())
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-f.ticker.C:
+				f.checkPage()
+			}
+		}
+	}()
 }
 
 func (f *xorTreeRepair) shutdown() {
 	if f.cancel != nil {
 		f.cancel()
-	}
-}
-
-func (f *xorTreeRepair) loop() {
-	for {
-		select {
-		case <-f.ctx.Done():
-			return
-		case <-f.ticker.C:
-			f.checkPage()
-		}
 	}
 }
 

--- a/network/dag/consistency_test.go
+++ b/network/dag/consistency_test.go
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package dag
+
+import (
+	"context"
+	"encoding/binary"
+	"github.com/magiconair/properties/assert"
+	"github.com/nuts-foundation/go-stoabs"
+	"github.com/nuts-foundation/go-stoabs/bbolt"
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	"github.com/nuts-foundation/nuts-node/network/dag/tree"
+	"github.com/nuts-foundation/nuts-node/test"
+	"github.com/nuts-foundation/nuts-node/test/io"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestXorTreeRepair(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	tx, _, _ := CreateTestTransaction(1)
+	t.Run("xor tree repaired after 2 signals", func(t *testing.T) {
+		txState := createXorTreeRepairState(t, tx)
+		require.NoError(t, txState.Start())
+		txState.xorTree = newTreeStore(xorShelf, tree.New(tree.NewXor(), PageSize))
+
+		// twice to set circuit to red
+		txState.IncorrectStateDetected()
+		txState.IncorrectStateDetected()
+
+		// await for XOR to change
+		test.WaitFor(t, func() (bool, error) {
+			xorRoot := txState.xorTree.tree.Root()
+			hashRoot := xorRoot.(*tree.Xor).Hash()
+			return hashRoot.Equals(tx.Ref()), nil
+		}, time.Second, "xorTree not updated within wait period")
+	})
+	t.Run("checkPage executed after 2 signals", func(t *testing.T) {
+		txState := createXorTreeRepairState(t, tx)
+		txState.xorTree = newTreeStore(xorShelf, tree.New(tree.NewXor(), PageSize))
+
+		// twice to set circuit to red
+		txState.IncorrectStateDetected()
+		txState.IncorrectStateDetected()
+		txState.xorTreeRepair.checkPage()
+
+		assert.Equal(t, tx.Ref(), xorRootDate(txState))
+	})
+	t.Run("checkPage not executed after 1 signal", func(t *testing.T) {
+		txState := createXorTreeRepairState(t, tx)
+		txState.xorTree = newTreeStore(xorShelf, tree.New(tree.NewXor(), PageSize))
+
+		// twice to set circuit to yellow
+		txState.IncorrectStateDetected()
+		txState.xorTreeRepair.checkPage()
+
+		assert.Equal(t, hash.EmptyHash(), xorRootDate(txState))
+	})
+	t.Run("checkPage not executed after okState", func(t *testing.T) {
+		txState := createXorTreeRepairState(t, tx)
+		txState.xorTree = newTreeStore(xorShelf, tree.New(tree.NewXor(), PageSize))
+
+		// twice to set circuit to red
+		txState.IncorrectStateDetected()
+		txState.IncorrectStateDetected()
+		// back to green
+		txState.CorrectStateDetected()
+		txState.xorTreeRepair.checkPage()
+
+		assert.Equal(t, hash.EmptyHash(), xorRootDate(txState))
+	})
+	t.Run("checkPage executed for multiple pages", func(t *testing.T) {
+		txState := createXorTreeRepairState(t, tx)
+		prev := tx
+		expectedHash := tx.Ref()
+		for i := uint32(1); i < 600; i++ {
+			tx2, _, _ := CreateTestTransaction(i, prev)
+			payload := make([]byte, 4)
+			binary.BigEndian.PutUint32(payload, i)
+			_ = txState.Add(context.Background(), tx2, payload)
+			prev = tx2
+			expectedHash = expectedHash.Xor(tx2.Ref())
+		}
+		require.NoError(t, txState.Start())
+		txState.xorTree = newTreeStore(xorShelf, tree.New(tree.NewXor(), PageSize))
+
+		// twice to set circuit to red
+		txState.IncorrectStateDetected()
+		txState.IncorrectStateDetected()
+
+		// await for XOR to change
+		test.WaitFor(t, func() (bool, error) {
+			xorRoot := txState.xorTree.tree.Root()
+			hashRoot := xorRoot.(*tree.Xor).Hash()
+			return hashRoot.Equals(expectedHash), nil
+		}, 5*time.Second, "xorTree not updated within wait period")
+	})
+}
+
+func xorRootDate(s *state) hash.SHA256Hash {
+	return s.xorTree.tree.Root().(*tree.Xor).Hash()
+}
+
+func createXorTreeRepairState(t testing.TB, tx Transaction) *state {
+	txState := createStoppedState(t)
+	txState.xorTreeRepair.ticker = time.NewTicker(5 * time.Millisecond)
+	payload := []byte{0, 0, 0, 1}
+	txState.Add(context.Background(), tx, payload)
+	return txState
+}
+
+func createStoppedState(t testing.TB) *state {
+	testDir := io.TestDirectory(t)
+	bboltStore, err := bbolt.CreateBBoltStore(filepath.Join(testDir, "test_state"), stoabs.WithNoSync())
+	if err != nil {
+		t.Fatal("failed to create store: ", err)
+	}
+	s, err := NewState(bboltStore)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		s.Shutdown()
+	})
+	return s.(*state)
+}

--- a/network/dag/consistency_test.go
+++ b/network/dag/consistency_test.go
@@ -52,6 +52,9 @@ func TestXorTreeRepair(t *testing.T) {
 
 		// await for XOR to change
 		test.WaitFor(t, func() (bool, error) {
+			txState.xorTreeRepair.mutex.Lock()
+			defer txState.xorTreeRepair.mutex.Unlock()
+
 			xorRoot := txState.xorTree.tree.Root()
 			hashRoot := xorRoot.(*tree.Xor).Hash()
 			return hashRoot.Equals(tx.Ref()), nil
@@ -112,6 +115,9 @@ func TestXorTreeRepair(t *testing.T) {
 
 		// await for XOR to change
 		test.WaitFor(t, func() (bool, error) {
+			txState.xorTreeRepair.mutex.Lock()
+			defer txState.xorTreeRepair.mutex.Unlock()
+
 			xorRoot := txState.xorTree.tree.Root()
 			hashRoot := xorRoot.(*tree.Xor).Hash()
 			return hashRoot.Equals(expectedHash), nil

--- a/network/dag/interface.go
+++ b/network/dag/interface.go
@@ -93,6 +93,11 @@ type State interface {
 	//	- highest lamport clock in the DAG
 	// A requested clock of math.MaxUint32 will return the iblt of the entire DAG
 	IBLT(reqClock uint32) (tree.Iblt, uint32)
+
+	// IncorrectStateDetected is called when the xor and LC value from a gossip message do NOT match the local state.
+	IncorrectStateDetected()
+	// CorrectStateDetected is called when the xor and LC value from a gossip message match the local state.
+	CorrectStateDetected()
 }
 
 // Statistics holds data about the current state of the DAG.

--- a/network/dag/mock.go
+++ b/network/dag/mock.go
@@ -52,6 +52,18 @@ func (mr *MockStateMockRecorder) Add(ctx, transactions, payload interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockState)(nil).Add), ctx, transactions, payload)
 }
 
+// CorrectStateDetected mocks base method.
+func (m *MockState) CorrectStateDetected() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CorrectStateDetected")
+}
+
+// CorrectStateDetected indicates an expected call of CorrectStateDetected.
+func (mr *MockStateMockRecorder) CorrectStateDetected() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CorrectStateDetected", reflect.TypeOf((*MockState)(nil).CorrectStateDetected))
+}
+
 // Diagnostics mocks base method.
 func (m *MockState) Diagnostics() []core.DiagnosticResult {
 	m.ctrl.T.Helper()
@@ -124,6 +136,18 @@ func (m *MockState) IBLT(reqClock uint32) (tree.Iblt, uint32) {
 func (mr *MockStateMockRecorder) IBLT(reqClock interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IBLT", reflect.TypeOf((*MockState)(nil).IBLT), reqClock)
+}
+
+// IncorrectStateDetected mocks base method.
+func (m *MockState) IncorrectStateDetected() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "IncorrectStateDetected")
+}
+
+// IncorrectStateDetected indicates an expected call of IncorrectStateDetected.
+func (mr *MockStateMockRecorder) IncorrectStateDetected() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncorrectStateDetected", reflect.TypeOf((*MockState)(nil).IncorrectStateDetected))
 }
 
 // IsPayloadPresent mocks base method.

--- a/network/dag/tree/tree.go
+++ b/network/dag/tree/tree.go
@@ -287,10 +287,6 @@ func (t *tree) Root() Data {
 }
 
 func (t *tree) ZeroTo(clock uint32) (Data, uint32) {
-	if clock < 0 {
-		return t.prototype.New(), 0
-	}
-
 	data := t.root.data.Clone()
 	next := t.root
 	for {

--- a/network/dag/tree/tree.go
+++ b/network/dag/tree/tree.go
@@ -20,6 +20,7 @@ package tree
 
 import (
 	"encoding"
+	"errors"
 	"sort"
 
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
@@ -70,6 +71,9 @@ type Tree interface {
 	// Load builds a tree from binary leaf data. The keys in leaves correspond to a node's split value.
 	// All consecutive leaves must be present. Gaps must be filled with zero value of the corresponding Data implementation.
 	Load(leaves map[uint32][]byte) error
+	// Replace replaces the Data at the leaf starting with the given clock value with the given Data.
+	// It adds the leaf to the dirtyLeaves map.
+	Replace(clock uint32, data Data) error
 }
 
 /*
@@ -191,6 +195,28 @@ func (t *tree) Delete(ref hash.SHA256Hash, clock uint32) {
 	})
 }
 
+func (t *tree) Replace(clock uint32, data Data) error {
+	var current *node
+	next := t.root
+	for next != nil {
+		current = next
+		if current.isLeaf() {
+			if clock >= current.limitLC {
+				t.reRoot()
+				next = t.root
+				continue
+			}
+			current.data = data
+			t.dirtyLeaves[current.splitLC] = current
+
+			// recalculate all upper leaves
+			return t.rebuild()
+		}
+		next = t.getNextNode(current, clock)
+	}
+	return errors.New("unknown leaf")
+}
+
 // updateOrCreatePath calls fn on all nodes on the path from the root to leaf containing the clock value.
 // If the path/leaf does not exist it will be created.
 // The leaf is marked dirty.
@@ -230,6 +256,15 @@ func (t *tree) reRoot() {
 	t.treeSize *= 2
 }
 
+func (t *tree) rebuild() error {
+	root, err := t.root.rebuild()
+	if err != nil {
+		return err
+	}
+	*t.root = root
+	return nil
+}
+
 // getNextNode retrieves the next node based on the clock value. If the node does not exist it is created.
 func (t *tree) getNextNode(n *node, clock uint32) *node {
 	// return nil if n is a leaf
@@ -252,6 +287,10 @@ func (t *tree) Root() Data {
 }
 
 func (t *tree) ZeroTo(clock uint32) (Data, uint32) {
+	if clock < 0 {
+		return t.prototype.New(), 0
+	}
+
 	data := t.root.data.Clone()
 	next := t.root
 	for {
@@ -381,4 +420,25 @@ func newNode(splitLC, limitLC uint32, data Data) *node {
 
 func (n node) isLeaf() bool {
 	return n.left == nil
+}
+
+// reBuild rebuilds the node from left and right.
+func (n node) rebuild() (node, error) {
+	var err error
+	if n.isLeaf() {
+		return n, nil
+	}
+	*n.left, err = n.left.rebuild()
+	if err != nil {
+		return n, err
+	}
+	n.data = n.left.data.Clone()
+	if n.right != nil {
+		*n.right, err = n.right.rebuild()
+		if err != nil {
+			return n, err
+		}
+		return n, n.data.Add(n.right.data)
+	}
+	return n, nil
 }

--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -264,6 +264,8 @@ func (p *protocol) handleGossip(ctx context.Context, connection grpc.Connection,
 	xor, clock := p.state.XOR(dag.MaxLamportClock)
 	peerXor := hash.FromSlice(msg.XOR)
 	if xor.Equals(peerXor) {
+		// open circuit on fixer
+
 		return nil
 	}
 
@@ -300,6 +302,7 @@ func (p *protocol) handleGossip(ctx context.Context, connection grpc.Connection,
 	// If the XORs are not equal and the peer is behind, still request the missing refs if there are any.
 	tempXor := xor.Xor(refs...)
 	if tempXor.Equals(peerXor) || (msg.LC < clock && len(refs) > 0) {
+		p.state.CorrectStateDetected()
 		return p.sender.sendTransactionListQuery(connection, refs)
 	}
 
@@ -308,11 +311,20 @@ func (p *protocol) handleGossip(ctx context.Context, connection grpc.Connection,
 		log.Logger().
 			WithFields(connection.Peer().ToFields()).
 			Debug("XOR is different from peer but Gossip contained no new transactions")
+
+		// if LCs are the same and XOR differs, something is probably broken in our node or the other node.
+		// If it's this node then all messages from all peers will trigger the incorrect state detection.
+		// This node will then start to loop over pages of tx until the state is fixed.
+		if msg.LC == clock {
+			p.state.IncorrectStateDetected()
+		}
+
 	} else {
 		log.Logger().
 			WithFields(connection.Peer().ToFields()).
 			Debug("XOR is different from peer and peer's clock is equal or higher")
 	}
+
 	return p.sender.sendState(connection, xor, clock)
 }
 

--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -264,8 +264,7 @@ func (p *protocol) handleGossip(ctx context.Context, connection grpc.Connection,
 	xor, clock := p.state.XOR(dag.MaxLamportClock)
 	peerXor := hash.FromSlice(msg.XOR)
 	if xor.Equals(peerXor) {
-		// open circuit on fixer
-
+		p.state.CorrectStateDetected()
 		return nil
 	}
 

--- a/network/transport/v2/handlers_test.go
+++ b/network/transport/v2/handlers_test.go
@@ -303,6 +303,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 
 		p, mocks := newTestProtocol(t, nil)
 		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
+		mocks.State.EXPECT().IncorrectStateDetected()
 		mocks.Sender.EXPECT().sendState(connection, xorLocal, clockLocal).Return(nil)
 
 		err := p.handleGossip(ctx, connection, envelope)
@@ -316,6 +317,7 @@ func TestProtocol_handleGossip(t *testing.T) {
 		p, mocks := newTestProtocol(t, nil)
 		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(xorLocal, clockLocal)
 		mocks.State.EXPECT().IsPresent(gomock.Any(), xorLocal).Return(true, nil)
+		mocks.State.EXPECT().IncorrectStateDetected()
 		mocks.Gossip.EXPECT().GossipReceived(peer, xorLocal)
 		mocks.Sender.EXPECT().sendState(connection, xorLocal, clockLocal).Return(nil)
 

--- a/network/transport/v2/protocol_integration_test.go
+++ b/network/transport/v2/protocol_integration_test.go
@@ -175,6 +175,7 @@ func startNode(t *testing.T, name string, configurers ...func(config *Config)) *
 	}
 	ctx.protocol.Start()
 	t.Cleanup(func() {
+		_ = ctx.state.Shutdown()
 		ctx.protocol.Stop()
 		ctx.connectionManager.Stop()
 	})

--- a/network/transport/v2/protocol_test.go
+++ b/network/transport/v2/protocol_test.go
@@ -98,6 +98,9 @@ func newTestProtocol(t *testing.T, nodeDID *did.DID) (*protocol, protocolMocks) 
 	proto.sender = sender
 	proto.listHandler = newTransactionListHandler(context.Background(), proto.handleTransactionList)
 
+	// called whenever XOR values match up
+	state.EXPECT().CorrectStateDetected().AnyTimes()
+
 	return proto, protocolMocks{
 		Controller:       ctrl,
 		State:            state,


### PR DESCRIPTION
closes #2295 

The dag state now starts a go routine that loops over parts of the dag when triggered. The trigger is a multiple XOR comparison failure detected from gossip messages. All connected nodes will need to have a different XOR before it's triggered. When triggered it handles a page of TX per 10 seconds.

The fix does not run as migration on startup. Although performance is good enough (20k tx/s), it exposes healthy nodes to an alternate code path which was previously not present. With this solution only nodes with a broken xor tree will be exposed to this code, reducing the risk of introducing new bugs for healthy nodes.

iblt trees are not repaired as discussed in #2295 