### PR TITLE
OpenID4VCI: Re-use http.Client for connection re-use

### DIFF
--- a/vcr/holder/openid_test.go
+++ b/vcr/holder/openid_test.go
@@ -42,12 +42,12 @@ var holderDID = did.MustParseDID("did:nuts:holder")
 var issuerDID = did.MustParseDID("did:nuts:issuer")
 
 func TestNewOIDCWallet(t *testing.T) {
-	w := NewOpenIDHandler(openid4vci.ClientConfig{}, holderDID, "https://holder.example.com", nil, nil, nil)
+	w := NewOpenIDHandler(holderDID, "https://holder.example.com", &http.Client{}, nil, nil, nil)
 	assert.NotNil(t, w)
 }
 
 func Test_wallet_Metadata(t *testing.T) {
-	w := NewOpenIDHandler(openid4vci.ClientConfig{}, holderDID, "https://holder.example.com", nil, nil, nil)
+	w := NewOpenIDHandler(holderDID, "https://holder.example.com", &http.Client{}, nil, nil, nil)
 
 	metadata := w.Metadata()
 
@@ -104,7 +104,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 			return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 		}
 
-		w := NewOpenIDHandler(openid4vci.ClientConfig{}, holderDID, "https://holder.example.com", credentialStore, jwtSigner, keyResolver).(*openidHandler)
+		w := NewOpenIDHandler(holderDID, "https://holder.example.com", &http.Client{}, credentialStore, jwtSigner, keyResolver).(*openidHandler)
 		w.issuerClientCreator = func(_ context.Context, httpClient core.HTTPRequestDoer, credentialIssuerIdentifier string) (openid4vci.IssuerAPIClient, error) {
 			return issuerAPIClient, nil
 		}
@@ -116,7 +116,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("pre-authorized code grant", func(t *testing.T) {
-		w := NewOpenIDHandler(openid4vci.ClientConfig{}, holderDID, "https://holder.example.com", nil, nil, nil).(*openidHandler)
+		w := NewOpenIDHandler(holderDID, "https://holder.example.com", &http.Client{}, nil, nil, nil).(*openidHandler)
 		t.Run("no grants", func(t *testing.T) {
 			offer := openid4vci.CredentialOffer{Credentials: offeredCredential()}
 			err := w.HandleCredentialOffer(audit.TestContext(), offer)
@@ -146,7 +146,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 		})
 	})
 	t.Run("error - too many credentials in offer", func(t *testing.T) {
-		w := NewOpenIDHandler(openid4vci.ClientConfig{}, holderDID, "https://holder.example.com", nil, nil, nil)
+		w := NewOpenIDHandler(holderDID, "https://holder.example.com", &http.Client{}, nil, nil, nil)
 
 		offer := openid4vci.CredentialOffer{
 			Credentials: []openid4vci.OfferedCredential{
@@ -164,7 +164,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 		issuerAPIClient := openid4vci.NewMockIssuerAPIClient(ctrl)
 		issuerAPIClient.EXPECT().RequestAccessToken(gomock.Any(), gomock.Any()).Return(nil, errors.New("request failed"))
 
-		w := NewOpenIDHandler(openid4vci.ClientConfig{}, holderDID, "https://holder.example.com", nil, nil, nil).(*openidHandler)
+		w := NewOpenIDHandler(holderDID, "https://holder.example.com", &http.Client{}, nil, nil, nil).(*openidHandler)
 		w.issuerClientCreator = func(_ context.Context, httpClient core.HTTPRequestDoer, credentialIssuerIdentifier string) (openid4vci.IssuerAPIClient, error) {
 			return issuerAPIClient, nil
 		}
@@ -178,7 +178,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 		issuerAPIClient := openid4vci.NewMockIssuerAPIClient(ctrl)
 		issuerAPIClient.EXPECT().RequestAccessToken(gomock.Any(), gomock.Any()).Return(&openid4vci.TokenResponse{}, nil)
 
-		w := NewOpenIDHandler(openid4vci.ClientConfig{}, holderDID, "https://holder.example.com", nil, nil, nil).(*openidHandler)
+		w := NewOpenIDHandler(holderDID, "https://holder.example.com", &http.Client{}, nil, nil, nil).(*openidHandler)
 		w.issuerClientCreator = func(_ context.Context, httpClient core.HTTPRequestDoer, credentialIssuerIdentifier string) (openid4vci.IssuerAPIClient, error) {
 			return issuerAPIClient, nil
 		}
@@ -192,7 +192,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 		issuerAPIClient := openid4vci.NewMockIssuerAPIClient(ctrl)
 		issuerAPIClient.EXPECT().RequestAccessToken(gomock.Any(), gomock.Any()).Return(&openid4vci.TokenResponse{AccessToken: "foo"}, nil)
 
-		w := NewOpenIDHandler(openid4vci.ClientConfig{}, holderDID, "https://holder.example.com", nil, nil, nil).(*openidHandler)
+		w := NewOpenIDHandler(holderDID, "https://holder.example.com", &http.Client{}, nil, nil, nil).(*openidHandler)
 		w.issuerClientCreator = func(_ context.Context, httpClient core.HTTPRequestDoer, credentialIssuerIdentifier string) (openid4vci.IssuerAPIClient, error) {
 			return issuerAPIClient, nil
 		}
@@ -202,7 +202,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 		require.EqualError(t, err, "invalid_token - c_nonce is missing")
 	})
 	t.Run("error - no credentials in offer", func(t *testing.T) {
-		w := NewOpenIDHandler(openid4vci.ClientConfig{}, holderDID, "https://holder.example.com", nil, nil, nil)
+		w := NewOpenIDHandler(holderDID, "https://holder.example.com", &http.Client{}, nil, nil, nil)
 
 		err := w.HandleCredentialOffer(audit.TestContext(), openid4vci.CredentialOffer{}).(openid4vci.Error)
 
@@ -210,7 +210,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, err.StatusCode)
 	})
 	t.Run("error - can't issuer client (metadata can't be loaded)", func(t *testing.T) {
-		w := NewOpenIDHandler(openid4vci.ClientConfig{}, holderDID, "https://holder.example.com", nil, nil, nil)
+		w := NewOpenIDHandler(holderDID, "https://holder.example.com", &http.Client{}, nil, nil, nil)
 
 		err := w.HandleCredentialOffer(audit.TestContext(), openid4vci.CredentialOffer{
 			CredentialIssuer: "http://localhost:87632",
@@ -240,7 +240,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 		keyResolver := vdrTypes.NewMockKeyResolver(ctrl)
 		keyResolver.EXPECT().ResolveSigningKeyID(holderDID, nil)
 
-		w := NewOpenIDHandler(openid4vci.ClientConfig{}, holderDID, "https://holder.example.com", nil, jwtSigner, keyResolver).(*openidHandler)
+		w := NewOpenIDHandler(holderDID, "https://holder.example.com", &http.Client{}, nil, jwtSigner, keyResolver).(*openidHandler)
 		w.issuerClientCreator = func(_ context.Context, _ core.HTTPRequestDoer, _ string) (openid4vci.IssuerAPIClient, error) {
 			return issuerAPIClient, nil
 		}
@@ -250,7 +250,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 		require.EqualError(t, err, "invalid_request - received credential does not match offer: credential does not match credential_definition: type mismatch")
 	})
 	t.Run("error - unsupported format", func(t *testing.T) {
-		w := NewOpenIDHandler(openid4vci.ClientConfig{}, holderDID, "https://holder.example.com", nil, nil, nil)
+		w := NewOpenIDHandler(holderDID, "https://holder.example.com", &http.Client{}, nil, nil, nil)
 
 		err := w.HandleCredentialOffer(audit.TestContext(), openid4vci.CredentialOffer{
 			Credentials: []openid4vci.OfferedCredential{{Format: "not supported"}},
@@ -260,7 +260,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, err.StatusCode)
 	})
 	t.Run("error - credentialSubject not allowed in offer", func(t *testing.T) {
-		w := NewOpenIDHandler(openid4vci.ClientConfig{}, holderDID, "https://holder.example.com", nil, nil, nil)
+		w := NewOpenIDHandler(holderDID, "https://holder.example.com", &http.Client{}, nil, nil, nil)
 		credentials := offeredCredential()
 		credentials[0].CredentialDefinition.CredentialSubject = new(map[string]interface{})
 

--- a/vcr/issuer/openid_test.go
+++ b/vcr/issuer/openid_test.go
@@ -65,21 +65,21 @@ var issuedVC = vc.VerifiableCredential{
 
 func TestNew(t *testing.T) {
 	t.Run("custom definitions", func(t *testing.T) {
-		iss, err := NewOpenIDHandler(issuerDID, issuerIdentifier, "./test/valid", openid4vci.ClientConfig{}, nil, NewOpenIDMemoryStore())
+		iss, err := NewOpenIDHandler(issuerDID, issuerIdentifier, "./test/valid", nil, nil, NewOpenIDMemoryStore())
 
 		require.NoError(t, err)
 		assert.Len(t, iss.(*openidHandler).credentialsSupported, 3)
 	})
 
 	t.Run("error - invalid json", func(t *testing.T) {
-		_, err := NewOpenIDHandler(issuerDID, issuerIdentifier, "./test/invalid", openid4vci.ClientConfig{}, nil, NewOpenIDMemoryStore())
+		_, err := NewOpenIDHandler(issuerDID, issuerIdentifier, "./test/invalid", nil, nil, NewOpenIDMemoryStore())
 
 		require.Error(t, err)
 		assert.EqualError(t, err, "failed to parse credential definition from test/invalid/invalid.json: unexpected end of JSON input")
 	})
 
 	t.Run("error - invalid directory", func(t *testing.T) {
-		_, err := NewOpenIDHandler(issuerDID, issuerIdentifier, "./test/non_existing", openid4vci.ClientConfig{}, nil, NewOpenIDMemoryStore())
+		_, err := NewOpenIDHandler(issuerDID, issuerIdentifier, "./test/non_existing", nil, nil, NewOpenIDMemoryStore())
 
 		require.Error(t, err)
 		assert.EqualError(t, err, "failed to load credential definitions: lstat ./test/non_existing: no such file or directory")
@@ -397,12 +397,12 @@ func Test_memoryIssuer_HandleAccessTokenRequest(t *testing.T) {
 	})
 	t.Run("pre-authorized code issued by other issuer", func(t *testing.T) {
 		store := NewOpenIDMemoryStore()
-		service, err := NewOpenIDHandler(issuerDID, issuerIdentifier, definitionsDIR, openid4vci.ClientConfig{}, nil, store)
+		service, err := NewOpenIDHandler(issuerDID, issuerIdentifier, definitionsDIR, &http.Client{}, nil, store)
 		require.NoError(t, err)
 		_, err = service.(*openidHandler).createOffer(ctx, issuedVC, "code")
 		require.NoError(t, err)
 
-		otherService, err := NewOpenIDHandler(did.MustParseDID("did:nuts:other"), "http://example.com/other", definitionsDIR, openid4vci.ClientConfig{}, nil, store)
+		otherService, err := NewOpenIDHandler(did.MustParseDID("did:nuts:other"), "http://example.com/other", definitionsDIR, &http.Client{}, nil, store)
 		require.NoError(t, err)
 		accessToken, _, err := otherService.HandleAccessTokenRequest(audit.TestContext(), "code")
 
@@ -435,7 +435,7 @@ func assertProtocolError(t *testing.T, err error, statusCode int, message string
 }
 
 func requireNewTestHandler(t *testing.T, keyResolver types.KeyResolver) *openidHandler {
-	service, err := NewOpenIDHandler(issuerDID, issuerIdentifier, definitionsDIR, openid4vci.ClientConfig{}, keyResolver, NewOpenIDMemoryStore())
+	service, err := NewOpenIDHandler(issuerDID, issuerIdentifier, definitionsDIR, &http.Client{}, keyResolver, NewOpenIDMemoryStore())
 	require.NoError(t, err)
 	return service.(*openidHandler)
 }

--- a/vcr/openid4vci/types.go
+++ b/vcr/openid4vci/types.go
@@ -21,7 +21,6 @@
 package openid4vci
 
 import (
-	"crypto/tls"
 	ssi "github.com/nuts-foundation/go-did"
 	"time"
 )
@@ -178,11 +177,4 @@ type Config struct {
 	Enabled bool `koanf:"enabled"`
 	// Timeout defines the timeout for HTTP client operations
 	Timeout time.Duration `koanf:"timeout"`
-}
-
-// ClientConfig holds openid4vci client configuration
-type ClientConfig struct {
-	Timeout   time.Duration
-	TLS       *tls.Config
-	HTTPSOnly bool
 }

--- a/vcr/openid4vci/wallet_client.go
+++ b/vcr/openid4vci/wallet_client.go
@@ -54,8 +54,6 @@ func NewWalletAPIClient(ctx context.Context, httpClient core.HTTPRequestDoer, wa
 	}, nil
 }
 
-var _ WalletAPIClient = (*defaultWalletAPIClient)(nil)
-
 type defaultWalletAPIClient struct {
 	metadata   OAuth2ClientMetadata
 	httpClient core.HTTPRequestDoer

--- a/vcr/test/openid4vci_integration_test.go
+++ b/vcr/test/openid4vci_integration_test.go
@@ -21,7 +21,6 @@ package test
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"github.com/nuts-foundation/nuts-node/core"
 	httpModule "github.com/nuts-foundation/nuts-node/http"
 	"github.com/nuts-foundation/nuts-node/network/log"
@@ -121,7 +120,7 @@ func TestOpenID4VCIConnectionReuse(t *testing.T) {
 		},
 	}
 
-	const numCreds = 10
+	const numCreds = 4
 	errChan := make(chan error, numCreds)
 	wg := sync.WaitGroup{}
 	for i := 0; i < numCreds; i++ {
@@ -149,8 +148,11 @@ func TestOpenID4VCIConnectionReuse(t *testing.T) {
 		errs = append(errs, err.Error())
 	}
 	assert.Empty(t, errs, "error issuing credential")
-	println(fmt.Sprintf("newConns: %+v", newConns))
-	//assert.LessOrEqualf(t, newConns.Load(), int32(expectedConnsCount), "number of created HTTP connections should be at most %d", expectedConnsCount)
+	connsTotal := 0
+	for _, v := range newConns {
+		connsTotal += v
+	}
+	assert.LessOrEqualf(t, connsTotal, expectedConnsCount, "number of created HTTP connections should be at most %d", expectedConnsCount)
 }
 
 // TestOpenID4VCI_Metadata tests resolving OpenID4VCI metadata, while the party hasn't registered its base URL.


### PR DESCRIPTION
Fixes https://github.com/nuts-foundation/nuts-node/issues/2315

We should probably test this using the performance test?