### PR TITLE
PKI: add denylist Key and URL

### DIFF
--- a/network/transport/grpc/connection_manager.go
+++ b/network/transport/grpc/connection_manager.go
@@ -561,6 +561,11 @@ func (s *grpcConnectionManager) revalidatePeers() {
 	s.lastCertificateValidation.Store(&now)
 	s.connections.forEach(func(conn Connection) {
 		peerCert := conn.Peer().Certificate
+		if peerCert == nil {
+			// This can happen when the denylist is updated while the node is trying to set up an outbound connection.
+			// See https://github.com/nuts-foundation/nuts-node/issues/2333
+			return
+		}
 		if nowFunc().After(peerCert.NotAfter) {
 			log.Logger().WithError(errors.New("certificate expired while in use")).WithFields(conn.Peer().ToFields()).Info("Disconnected peer")
 			conn.disconnect()

--- a/pki/cmd.go
+++ b/pki/cmd.go
@@ -31,9 +31,7 @@ func FlagSet() *pflag.FlagSet {
 	// Flags for denylist features
 	flagSet.Int("pki.maxupdatefailhours", defs.MaxUpdateFailHours, "Maximum number of hours that a denylist update can fail")
 	flagSet.Bool("pki.softfail", defs.Softfail, "Do not reject certificates if their revocation status cannot be established when softfail is true")
-	// TODO: Choose a default trusted signer key
 	flagSet.String("pki.denylist.trustedsigner", defs.Denylist.TrustedSigner, "Ed25519 public key (in PEM format) of the trusted signer for denylists")
-	// TODO: Choose a default denylist URL
 	flagSet.String("pki.denylist.url", defs.Denylist.URL, "URL of PKI denylist (set to empty string to disable)")
 
 	// Changing these config values is not recommended, and they are expected to almost always be the same value, so

--- a/pki/config.go
+++ b/pki/config.go
@@ -22,7 +22,7 @@ package pki
 func DefaultConfig() Config {
 	return Config{
 		Denylist: DenylistConfig{
-			URL:           "https://cdn.jsdelivr.net/gh/nuts-foundation/denylist@main/denylist-out/denylist.jws",
+			URL:           "https://cdn.jsdelivr.net/gh/nuts-foundation/denylist@main/denylist/denylist.jws",
 			TrustedSigner: "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAmKjcSOrKOJR2cYd6UNbemNeusvjs930Y4nCIZ1R2zCI=\n-----END PUBLIC KEY-----",
 		},
 		MaxUpdateFailHours: 4,

--- a/pki/config.go
+++ b/pki/config.go
@@ -22,8 +22,8 @@ package pki
 func DefaultConfig() Config {
 	return Config{
 		Denylist: DenylistConfig{
-			URL:           "",
-			TrustedSigner: "",
+			URL:           "https://cdn.jsdelivr.net/gh/nuts-foundation/denylist@main/denylist-out/denylist.jws",
+			TrustedSigner: "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAmKjcSOrKOJR2cYd6UNbemNeusvjs930Y4nCIZ1R2zCI=\n-----END PUBLIC KEY-----",
 		},
 		MaxUpdateFailHours: 4,
 		Softfail:           true,

--- a/pki/config_test.go
+++ b/pki/config_test.go
@@ -30,6 +30,6 @@ func Test_DefaultConfig(t *testing.T) {
 	assert.Equal(t, 4, cfg.MaxUpdateFailHours)
 	assert.True(t, cfg.Softfail)
 	require.NotNil(t, cfg.Denylist)
-	assert.Empty(t, cfg.Denylist.TrustedSigner)
-	assert.Empty(t, cfg.Denylist.URL)
+	assert.NotEmpty(t, cfg.Denylist.TrustedSigner)
+	assert.NotEmpty(t, cfg.Denylist.URL)
 }

--- a/pki/test.go
+++ b/pki/test.go
@@ -24,6 +24,15 @@ import (
 	"time"
 )
 
+// TestConfig is the same as DefaultConfig without a denylist URL set.
+func TestConfig(t *testing.T) Config {
+	return Config{
+		Denylist:           DenylistConfig{},
+		MaxUpdateFailHours: 4,
+		Softfail:           true,
+	}
+}
+
 // SetNewDenylistWithCert sets a new Denylist on the Validator and adds the certificate.
 // This is useful in integrations tests etc.
 func SetNewDenylistWithCert(t *testing.T, val Validator, cert *x509.Certificate) {

--- a/pki/test.go
+++ b/pki/test.go
@@ -21,7 +21,6 @@ package pki
 import (
 	"crypto/x509"
 	"testing"
-	"time"
 )
 
 // TestConfig is the same as DefaultConfig without a denylist URL set.
@@ -37,9 +36,10 @@ func TestConfig(t *testing.T) Config {
 // This is useful in integrations tests etc.
 func SetNewDenylistWithCert(t *testing.T, val Validator, cert *x509.Certificate) {
 	dl := &denylistImpl{
-		url:         "some-url",
-		lastUpdated: time.Now(),
+		url: "some-url",
 	}
+	now := nowFunc()
+	dl.lastUpdated.Store(&now)
 	dl.entries.Store(&[]denylistEntry{
 		{
 			Issuer:        cert.Issuer.String(),

--- a/pki/validator_test.go
+++ b/pki/validator_test.go
@@ -62,7 +62,7 @@ func TestValidator_Start(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	val, err := newValidatorWithHTTPClient(DefaultConfig(), newClient())
+	val, err := newValidatorWithHTTPClient(TestConfig(t), newClient())
 	require.NoError(t, err)
 	require.NoError(t, val.AddTruststore(store.Certificates()))
 
@@ -197,7 +197,7 @@ func TestValidator_AddTruststore(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("ok", func(t *testing.T) {
-		val, err := newValidator(DefaultConfig())
+		val, err := newValidator(TestConfig(t))
 		require.NoError(t, err)
 
 		err = val.AddTruststore(store.Certificates())

--- a/pki/validator_test.go
+++ b/pki/validator_test.go
@@ -228,7 +228,7 @@ func TestValidator_SubscribeDenied(t *testing.T) {
 	mockDenylist := NewMockDenylist(gomock.NewController(t))
 	mockDenylist.EXPECT().Subscribe(gomock.Any())
 
-	val, err := newValidator(DefaultConfig())
+	val, err := newValidator(TestConfig(t))
 	require.NoError(t, err)
 	val.denylist = mockDenylist
 


### PR DESCRIPTION
This PR adds default config values for the denylist.URL and denylist.TrustedSigner. This will cause the nuts-node to periodically download the denylist hosted at https://github.com/nuts-foundation/denylis. An e2e test will be added after this is merged