### PR TITLE
Docs: update deprecated NGINX http2 directive

### DIFF
--- a/docs/pages/deployment/tls-configuration.rst
+++ b/docs/pages/deployment/tls-configuration.rst
@@ -76,7 +76,8 @@ For `NGINX <https://www.nginx.com/>`_ the proxy configuration could look as foll
     http {
         server {
           server_name nuts-grpc;
-          listen                    5555 ssl http2;
+          listen                    5555 ssl;
+          http2                     on;
           ssl_certificate           /etc/nginx/ssl/server.pem;
           ssl_certificate_key       /etc/nginx/ssl/key.pem;
           ssl_client_certificate    /etc/nginx/ssl/truststore.pem;

--- a/e2e-tests/nuts-network/ssl-offloading/nginx/docker-compose.yml
+++ b/e2e-tests/nuts-network/ssl-offloading/nginx/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     healthcheck:
       interval: 1s # Make test run quicker by checking health status more often
   nodeA:
-    image: nginx:1.23
+    image: nginx:1.25.1
     volumes:
       - "./node-A/nginx.conf:/etc/nginx/nginx.conf:ro"
       - "../../../tls-certs/nodeA-certificate.pem:/etc/nginx/ssl/server.pem:ro"

--- a/e2e-tests/nuts-network/ssl-offloading/nginx/node-A/nginx.conf
+++ b/e2e-tests/nuts-network/ssl-offloading/nginx/node-A/nginx.conf
@@ -35,7 +35,8 @@ http {
 
     server {
       server_name nodeA;
-      listen                    443 ssl http2;
+      listen                    443 ssl;
+      http2                     on;
       ssl_certificate           /etc/nginx/ssl/server.pem;
       ssl_certificate_key       /etc/nginx/ssl/key.pem;
       ssl_client_certificate    /etc/nginx/ssl/truststore.pem;

--- a/e2e-tests/oauth-flow/docker-compose.yml
+++ b/e2e-tests/oauth-flow/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     healthcheck:
       interval: 1s # Make test run quicker by checking health status more often
   nodeA:
-    image: nginx:1.18
+    image: nginx:1.25.1
     ports:
       - "10443:443"
     volumes:

--- a/e2e-tests/oauth-flow/node-A/nginx.conf
+++ b/e2e-tests/oauth-flow/node-A/nginx.conf
@@ -30,7 +30,8 @@ http {
 
     server {
       server_name nodeA;
-      listen                    443 ssl http2;
+      listen                    443 ssl;
+      http2                     on;
       ssl_certificate           /etc/nginx/ssl/server.pem;
       ssl_certificate_key       /etc/nginx/ssl/key.pem;
       ssl_client_certificate    /etc/nginx/ssl/truststore.pem;


### PR DESCRIPTION
Not sure if we should already fix this.
The [http2 directive](https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2) is introduced in v1.25.1 that was released on 2023-06-13. Updating this now might be causing more issues with older versions than it is fixing.