### PR TITLE
Configure backup shelves for credentials and revocations

### DIFF
--- a/docs/pages/deployment/backup-restore.rst
+++ b/docs/pages/deployment/backup-restore.rst
@@ -64,28 +64,11 @@ To restore a backup, follow the following steps:
 
 1. shutdown the node
 2. remove the following directories from the ``datadir``: ``events``, ``network``, ``vcr``, and ``vdr``
-3. keep node offline by removing ``network.bootstrapnodes`` and ``network.grpcaddr`` from the config file and set ``network.enablediscovery`` to ``false``
-4. follow the restore procedure for your storage (BBolt, Redis, Hashicorp Vault)
-5. restore the ``vcr/trusted_issuers.yaml`` file inside ``datadir``
-6. start your node
-7. make empty POST calls to
-
-.. code-block:: http
-
-    POST <node-address>/internal/network/v1/reprocess?type=application/vc+json
-    POST <node-address>/internal/network/v1/reprocess?type=application/ld+json;type=revocation
-
-.. note::
-
-    When making the API calls, make sure you use the proper URL escaping (``%2B`` for ``+`` and ``%3B`` for ``;``).
-    Reprocess calls return immediately and will do the work in the background.
-
-8. wait until the reprocess operations are complete
-9. shutdown the node
-10. undo the configuration changes in step 3
-11. start the node
+3. follow the restore procedure for your storage (BBolt, Redis, Hashicorp Vault)
+4. restore the ``vcr/trusted_issuers.yaml`` file inside ``datadir``
+5. start your node
 
 BBolt
 =====
 
-In step 4, copy ``network/data.db``, ``vcr/backup-issued-credentials.db`` and ``vdr/didstore.db`` from your backup to the ``datadir`` (keep the directory structure).
+In step 3, copy ``network/data.db``, ``vcr/backup-credentials.db``, ``vcr/backup-issued-credentials.db``, ``vcr/backup-revoked-credentials.db`` and ``vdr/didstore.db`` from your backup to the ``datadir`` (keep the directory structure).

--- a/vcr/issuer/leia_store.go
+++ b/vcr/issuer/leia_store.go
@@ -44,7 +44,6 @@ type leiaIssuerStore struct {
 	issuedCredentials  leia.Collection
 	revokedCredentials leia.Collection
 	store              storage.KVBackedLeiaStore
-	backupStore        stoabs.KVStore
 }
 
 // NewLeiaIssuerStore creates a new instance of leiaIssuerStore which implements the Store interface.
@@ -53,7 +52,7 @@ func NewLeiaIssuerStore(dbPath string, backupStore stoabs.KVStore) (Store, error
 	if err != nil {
 		return nil, fmt.Errorf("failed to create leiaIssuerStore: %w", err)
 	}
-	// add wraper
+	// add backup wrapper
 	kvBackedStore, err := storage.NewKVBackedLeiaStore(store, backupStore)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create KV backed issuer store: %w", err)
@@ -81,7 +80,6 @@ func NewLeiaIssuerStore(dbPath string, backupStore stoabs.KVStore) (Store, error
 		issuedCredentials:  issuedCollection,
 		revokedCredentials: revokedCollection,
 		store:              kvBackedStore,
-		backupStore:        backupStore,
 	}
 
 	// initialize indices, this is required for handleRestore. Without the index metadata it can't iterate and detect data entries.

--- a/vcr/test.go
+++ b/vcr/test.go
@@ -103,6 +103,28 @@ func NewTestVCRInstance(t *testing.T) *vcr {
 	return newInstance
 }
 
+func NewTestVCRInstanceInDir(t *testing.T, testDirectory string) *vcr {
+	// give network a subdirectory to avoid duplicate networks in tests
+	newInstance := NewVCRInstance(
+		nil,
+		nil,
+		network.NewTestNetworkInstance(t),
+		jsonld.NewTestJSONLDManager(t),
+		events.NewTestManager(t),
+		storage.NewTestStorageEngine(testDirectory),
+		nil, nil,
+	).(*vcr)
+
+	if err := newInstance.Configure(core.TestServerConfig(core.ServerConfig{Datadir: testDirectory})); err != nil {
+		t.Fatal(err)
+	}
+	if err := newInstance.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	return newInstance
+}
+
 type mockContext struct {
 	ctrl            *gomock.Controller
 	tx              *network.MockTransactions

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -229,6 +229,10 @@ func (c *vcr) Configure(config core.ServerConfig) error {
 
 	c.holder = holder.New(c.keyResolver, c.keyStore, c.verifier, c.jsonldManager)
 
+	if err = c.store.HandleRestore(); err != nil {
+		return err
+	}
+
 	return c.trustConfig.Load()
 }
 
@@ -256,7 +260,7 @@ func (c *vcr) createCredentialsStore() error {
 		CollectionName: "credentials",
 		CollectionType: leia.JSONLDCollection,
 		BackupShelf:    credentialsBackupShelf,
-		SearchQuery:    leia.NewIRIPath("id"),
+		SearchQuery:    leia.NewIRIPath(),
 	})
 
 	// init indices

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -51,6 +51,13 @@ import (
 )
 
 func TestVCR_Configure(t *testing.T) {
+	t.Run("error - creating issuer store", func(t *testing.T) {
+		testDirectory := io.TestDirectory(t)
+		instance := NewVCRInstance(nil, nil, nil, jsonld.NewTestJSONLDManager(t), nil, storage.NewTestStorageEngine(testDirectory), nil, nil).(*vcr)
+
+		err := instance.Configure(core.TestServerConfig(core.ServerConfig{Datadir: "test"}))
+		assert.EqualError(t, err, "failed to create leiaIssuerStore: mkdir test/vcr: not a directory")
+	})
 	t.Run("openid4vci", func(t *testing.T) {
 		testDirectory := io.TestDirectory(t)
 		ctrl := gomock.NewController(t)
@@ -93,15 +100,6 @@ func TestVCR_Configure(t *testing.T) {
 }
 
 func TestVCR_Start(t *testing.T) {
-
-	t.Run("error - creating db", func(t *testing.T) {
-		testDirectory := io.TestDirectory(t)
-		instance := NewVCRInstance(nil, nil, nil, jsonld.NewTestJSONLDManager(t), nil, storage.NewTestStorageEngine(testDirectory), nil, nil).(*vcr)
-
-		_ = instance.Configure(core.TestServerConfig(core.ServerConfig{Datadir: "test"}))
-		err := instance.Start()
-		assert.EqualError(t, err, "mkdir test/vcr: not a directory")
-	})
 
 	t.Run("ok", func(t *testing.T) {
 		instance := NewTestVCRInstance(t)

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -21,14 +21,18 @@ package vcr
 
 import (
 	"context"
+	"crypto/sha1"
 	"encoding/json"
 	"errors"
 	"github.com/nuts-foundation/go-leia/v4"
+	"github.com/nuts-foundation/go-stoabs"
+	bbolt2 "github.com/nuts-foundation/go-stoabs/bbolt"
 	"github.com/nuts-foundation/nuts-node/pki"
 	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/nuts-foundation/nuts-node/vcr/openid4vci"
 	"github.com/stretchr/testify/require"
 	"os"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -379,6 +383,28 @@ func TestVcr_Untrusted(t *testing.T) {
 			return instance.Untrusted(issuer)
 		}, 0)
 	})
+}
+
+func TestVcr_restoreFromShelf(t *testing.T) {
+	testVC := vc.VerifiableCredential{}
+	_ = json.Unmarshal([]byte(jsonld.TestOrganizationCredential), &testVC)
+	testDir := io.TestDirectory(t)
+	backupStorePath := path.Join(testDir, "data", "vcr", "backup-credentials.db")
+	backupStore, err := bbolt2.CreateBBoltStore(backupStorePath)
+	require.NoError(t, err)
+	bytes := []byte(jsonld.TestOrganizationCredential)
+	ref := sha1.Sum(bytes)
+	_ = backupStore.WriteShelf(context.Background(), credentialsBackupShelf, func(writer stoabs.Writer) error {
+		return writer.Put(stoabs.BytesKey(ref[:]), bytes)
+	})
+	_ = backupStore.Close(context.Background())
+
+	store := NewTestVCRInstanceInDir(t, testDir)
+	_ = store.Trust(testVC.Type[0], testVC.Issuer)
+	require.NoError(t, err)
+	result, err := store.Resolve(*testVC.ID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, testVC, *result)
 }
 
 func confirmUntrustedStatus(t *testing.T, fn func(issuer ssi.URI) ([]ssi.URI, error), numUntrusted int) {

--- a/vcr/verifier/leia_store_test.go
+++ b/vcr/verifier/leia_store_test.go
@@ -19,6 +19,9 @@
 package verifier
 
 import (
+	"context"
+	"github.com/nuts-foundation/go-stoabs"
+	"go.uber.org/mock/gomock"
 	"path"
 	"testing"
 
@@ -29,17 +32,19 @@ import (
 )
 
 func TestNewLeiaVerifierStore(t *testing.T) {
+	backupStore := newMockKVStore(t)
+
 	t.Run("ok", func(t *testing.T) {
 		testDir := io.TestDirectory(t)
 		verifierStorePath := path.Join(testDir, "vcr", "verifier-store.db")
-		sut, err := NewLeiaVerifierStore(verifierStorePath)
+		sut, err := NewLeiaVerifierStore(verifierStorePath, backupStore)
 
 		assert.NoError(t, err)
 		assert.IsType(t, &leiaVerifierStore{}, sut)
 	})
 
 	t.Run("error", func(t *testing.T) {
-		sut, err := NewLeiaVerifierStore("/")
+		sut, err := NewLeiaVerifierStore("/", nil)
 
 		assert.Contains(t, err.Error(), "failed to create leiaVerifierStore:")
 		assert.Nil(t, sut)
@@ -49,7 +54,8 @@ func TestNewLeiaVerifierStore(t *testing.T) {
 func TestLeiaStore_Close(t *testing.T) {
 	testDir := io.TestDirectory(t)
 	verifierStorePath := path.Join(testDir, "vcr", "verifier-store.db")
-	sut, _ := NewLeiaVerifierStore(verifierStorePath)
+	backupStore := newMockKVStore(t)
+	sut, _ := NewLeiaVerifierStore(verifierStorePath, backupStore)
 	err := sut.Close()
 	assert.NoError(t, err)
 }
@@ -57,7 +63,8 @@ func TestLeiaStore_Close(t *testing.T) {
 func Test_leiaVerifierStore_StoreRevocation(t *testing.T) {
 	testDir := io.TestDirectory(t)
 	verifierStorePath := path.Join(testDir, "vcr", "verifier-store.db")
-	sut, _ := NewLeiaVerifierStore(verifierStorePath)
+	backupStore := newMockKVStore(t)
+	sut, _ := NewLeiaVerifierStore(verifierStorePath, backupStore)
 
 	t.Run("it stores a revocation and can find it back", func(t *testing.T) {
 		subjectID := ssi.MustParseURI("did:nuts:123#ab-c")
@@ -73,7 +80,8 @@ func Test_leiaVerifierStore_StoreRevocation(t *testing.T) {
 func Test_leiaVerifierStore_GetRevocation(t *testing.T) {
 	testDir := io.TestDirectory(t)
 	verifierStorePath := path.Join(testDir, "vcr", "verifier-store.db")
-	sut, _ := NewLeiaVerifierStore(verifierStorePath)
+	backupStore := newMockKVStore(t)
+	sut, _ := NewLeiaVerifierStore(verifierStorePath, backupStore)
 	subjectID := ssi.MustParseURI("did:nuts:123#ab-c")
 	revocation := &credential.Revocation{Subject: subjectID}
 	assert.NoError(t, sut.StoreRevocation(*revocation))
@@ -93,10 +101,11 @@ func Test_leiaVerifierStore_GetRevocation(t *testing.T) {
 }
 
 func Test_leiaVerifierStore_Diagnostics(t *testing.T) {
+	backupStore := newMockKVStore(t)
 	t.Run("empty", func(t *testing.T) {
 		testDir := io.TestDirectory(t)
 		verifierStorePath := path.Join(testDir, "vcr", "verifier-store.db")
-		sut, _ := NewLeiaVerifierStore(verifierStorePath)
+		sut, _ := NewLeiaVerifierStore(verifierStorePath, backupStore)
 
 		actual := sut.Diagnostics()
 		assert.Len(t, actual, 1)
@@ -106,7 +115,7 @@ func Test_leiaVerifierStore_Diagnostics(t *testing.T) {
 	t.Run("not empty", func(t *testing.T) {
 		testDir := io.TestDirectory(t)
 		verifierStorePath := path.Join(testDir, "vcr", "verifier-store.db")
-		sut, _ := NewLeiaVerifierStore(verifierStorePath)
+		sut, _ := NewLeiaVerifierStore(verifierStorePath, backupStore)
 
 		subjectID := ssi.MustParseURI("did:nuts:123#ab-c")
 		revocation := &credential.Revocation{Subject: subjectID}
@@ -116,4 +125,17 @@ func Test_leiaVerifierStore_Diagnostics(t *testing.T) {
 		assert.Len(t, actual, 1)
 		assert.Equal(t, 1, actual[0].Result())
 	})
+}
+
+// newMockKVStore create a mockStore with contents
+func newMockKVStore(t *testing.T) stoabs.KVStore {
+	ctrl := gomock.NewController(t)
+	backupStore := stoabs.NewMockKVStore(ctrl)
+	mockReader := stoabs.NewMockReader(ctrl)
+	mockReader.EXPECT().Empty().Return(false, nil).AnyTimes()
+	mockReader.EXPECT().Iterate(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	backupStore.EXPECT().ReadShelf(context.Background(), revocationBackupShelf, gomock.Any()).Do(func(arg0 context.Context, arg1 string, arg2 func(reader stoabs.Reader) error) error {
+		return arg2(mockReader)
+	}).AnyTimes()
+	return backupStore
 }


### PR DESCRIPTION
Supposed to be part of #2317. #2323 only migrated issuer store to use new wrapper.

This PR adds the backup for the wallet and the revocations. This also eliminates a large part of the restore procedure.