### PR TITLE
did:web resolver

### DIFF
--- a/vcr/config_test.go
+++ b/vcr/config_test.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package vcr
 
 import (

--- a/vdr/didweb/resolver.go
+++ b/vdr/didweb/resolver.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package didweb
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/vdr/types"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+var _ types.DIDResolver = (*Resolver)(nil)
+
+// Resolver is a DID resolver for the did:web method.
+type Resolver struct {
+	HttpClient *http.Client
+}
+
+// NewResolver creates a new Resolver with default TLS configuration.
+func NewResolver() *Resolver {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	return &Resolver{
+		HttpClient: &http.Client{
+			Transport: transport,
+			Timeout:   5 * time.Second,
+		},
+	}
+}
+
+// Resolve implements the DIDResolver interface.
+func (w Resolver) Resolve(id did.DID, _ *types.ResolveMetadata) (*did.Document, *types.DocumentMetadata, error) {
+	if id.Method != "web" {
+		return nil, nil, errors.New("only did:web is supported")
+	}
+
+	var baseID = id.ID
+	var path string
+	subpathIdx := strings.Index(id.ID, ":")
+	if subpathIdx == -1 {
+		path = "/.well-known/did.json"
+	} else {
+		// subpaths are encoded as / -> :
+		baseID = id.ID[:subpathIdx]
+		path = id.ID[subpathIdx:]
+		path = strings.ReplaceAll(path, ":", "/") + "/did.json"
+	}
+
+	unescapedID, err := url.PathUnescape(baseID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid did:web: %w", err)
+	}
+	targetURL := "https://" + unescapedID + path
+
+	// TODO: Support DNS over HTTPS (DOH), https://www.rfc-editor.org/rfc/rfc8484
+	httpResponse, err := w.HttpClient.Get(targetURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("did:web HTTP error: %w", err)
+	}
+	defer httpResponse.Body.Close()
+	if !(httpResponse.StatusCode >= 200 && httpResponse.StatusCode < 300) {
+		return nil, nil, fmt.Errorf("did:web non-ok HTTP status: %s", httpResponse.Status)
+	}
+
+	ct := httpResponse.Header.Get("Content-Type")
+	switch ct {
+	case "application/did+ld+json":
+		// TODO: Should we perform JSON-LD processing here, as stated by the spec?
+		fallthrough
+	case "application/json":
+		fallthrough
+	case "application/did+json":
+		// This is OK
+	default:
+		return nil, nil, fmt.Errorf("did:web unsupported content-type: %s", ct)
+	}
+
+	// Read document
+	data, err := io.ReadAll(httpResponse.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("did:web HTTP response read error: %w", err)
+	}
+	var document did.Document
+	err = document.UnmarshalJSON(data)
+	if err != nil {
+		return nil, nil, fmt.Errorf("did:web JSON unmarshal error: %w", err)
+	}
+
+	if !document.ID.Equals(id.WithoutURL()) {
+		return nil, nil, fmt.Errorf("did:web document ID mismatch: %s != %s", document.ID, id.WithoutURL())
+	}
+
+	return &document, &types.DocumentMetadata{}, nil
+}

--- a/vdr/didweb/resolver_test.go
+++ b/vdr/didweb/resolver_test.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package didweb
+
+import (
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+const didDocTemplate = `
+{
+  "context": "https://www.w3.org/ns/did/v1",
+  "id": "<did>",
+  "capabilityInvocation": ["<did>#aQgahRFAhdStcQyD6R25fFYslo4JZXuqYUySTtXB_Lo"],
+  "verificationMethod": [
+    {
+      "controller": "<did>",
+      "id": "<did>#aQgahRFAhdStcQyD6R25fFYslo4JZXuqYUySTtXB_Lo",
+      "publicKeyJwk": {
+        "crv": "P-256",
+        "kid": "<did>#aQgahRFAhdStcQyD6R25fFYslo4JZXuqYUySTtXB_Lo",
+        "kty": "EC",
+        "x": "iCpv6AGDpdYVZjniwklkL8A4DGNhBK/DngbpdDjjBlo=",
+        "y": "27/qwElvfxhXtG2TDSO5LwReuFRwR+qydBdpQqu6H5M="
+      },
+      "type": "JsonWebKey2020"
+    }
+  ]
+}`
+
+func TestResolver_Resolve(t *testing.T) {
+	var baseDID did.DID
+	tlsServer := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/.well-known/did.json":
+			writer.Header().Add("Content-Type", "application/did+json")
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write([]byte(strings.ReplaceAll(didDocTemplate, "<did>", baseDID.String())))
+			return
+		case "/json-ld/did.json":
+			writer.Header().Add("Content-Type", "application/did+ld+json")
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write([]byte(strings.ReplaceAll(didDocTemplate, "<did>", baseDID.String()+":json-ld")))
+			return
+		case "/json/did.json":
+			writer.Header().Add("Content-Type", "application/json")
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write([]byte(strings.ReplaceAll(didDocTemplate, "<did>", baseDID.String()+":json")))
+			return
+		case "/unsupported-content-type/did.json":
+			writer.Header().Add("Content-Type", "text/plain")
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write([]byte(strings.ReplaceAll(didDocTemplate, "<did>", baseDID.String())))
+			return
+		case "/invalid-id-in-document/did.json":
+			writer.Header().Add("Content-Type", "application/did+json")
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write([]byte(strings.ReplaceAll(didDocTemplate, "<did>", "did:example:123")))
+			return
+		default:
+			writer.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer tlsServer.Close()
+	resolver := &Resolver{
+		HttpClient: tlsServer.Client(),
+	}
+
+	baseDIDString := url.QueryEscape(strings.TrimPrefix(tlsServer.URL, "https://"))
+	baseDID = did.MustParseDID("did:web:" + baseDIDString)
+
+	t.Run("resolve base DID - did+json", func(t *testing.T) {
+		doc, md, err := resolver.Resolve(baseDID, nil)
+
+		require.NoError(t, err)
+		assert.NotNil(t, md)
+		require.NotNil(t, doc)
+		assert.Equal(t, baseDID, doc.ID)
+	})
+	t.Run("resolve base DID - json-ld", func(t *testing.T) {
+		doc, md, err := resolver.Resolve(did.MustParseDID(baseDID.String()+":json-ld"), nil)
+
+		require.NoError(t, err)
+		assert.NotNil(t, md)
+		assert.NotNil(t, doc)
+	})
+	t.Run("resolve base DID - json", func(t *testing.T) {
+		doc, md, err := resolver.Resolve(did.MustParseDID(baseDID.String()+":json"), nil)
+
+		require.NoError(t, err)
+		assert.NotNil(t, md)
+		assert.NotNil(t, doc)
+	})
+	t.Run("resolve DID with path", func(t *testing.T) {
+		id := did.MustParseDIDURL(baseDID.String() + "/some/path")
+		doc, md, err := resolver.Resolve(id, nil)
+
+		require.NoError(t, err)
+		assert.NotNil(t, md)
+		require.NotNil(t, doc)
+		assert.Equal(t, baseDID, doc.ID)
+	})
+	t.Run("not found", func(t *testing.T) {
+		id := did.MustParseDIDURL(baseDID.String() + ":not-found")
+		doc, md, err := resolver.Resolve(id, nil)
+
+		require.EqualError(t, err, "did:web non-ok HTTP status: 404 Not Found")
+		assert.Nil(t, md)
+		assert.Nil(t, doc)
+	})
+	t.Run("unsupported content-type", func(t *testing.T) {
+		id := did.MustParseDIDURL(baseDID.String() + ":unsupported-content-type")
+		doc, md, err := resolver.Resolve(id, nil)
+
+		require.EqualError(t, err, "did:web unsupported content-type: text/plain")
+		assert.Nil(t, md)
+		assert.Nil(t, doc)
+	})
+	t.Run("ID in document does not match DID being resolved", func(t *testing.T) {
+		id := did.MustParseDIDURL(baseDID.String() + ":invalid-id-in-document")
+		doc, md, err := resolver.Resolve(id, nil)
+
+		require.ErrorContains(t, err, "did:web document ID mismatch")
+		assert.Nil(t, md)
+		assert.Nil(t, doc)
+	})
+}


### PR DESCRIPTION
Builds on https://github.com/nuts-foundation/nuts-node/pull/2352

TODO: 
- [x] The method spec states consumer should also accept `application/json`: https://w3c-ccg.github.io/did-method-web/#key-material-and-document-handling

This to discuss:
- [ ] Should be apply JSON-LD processing for JSON-LD DID documents, as stated by the spec? Or only support JSON for now (and produce JSON, instead of JSON-LD)?