### PR TITLE
OpenID4VCI: Move OAuth2 paths out of openid4vci subpath

### DIFF
--- a/docs/_static/vcr/openid4vci_v0.yaml
+++ b/docs/_static/vcr/openid4vci_v0.yaml
@@ -3,8 +3,8 @@ info:
   title: OpenID4VCI Issuer API
   version: 0.0.0
   description: >
-    This API is EXPERIMENTAL and implements a draft version of OpenID 4 Verifiable Credential Issuance.
-    It is subject to change and should not be used in production.
+    This API implements OpenID 4 Verifiable Credential Issuance.
+    The specification is in draft and may change, thus this API might change as well.
 servers:
   - url: "http://localhost:1323"
 paths:

--- a/docs/_static/vcr/openid4vci_v0.yaml
+++ b/docs/_static/vcr/openid4vci_v0.yaml
@@ -110,7 +110,7 @@ paths:
               schema:
                 type: string
                 example: application/json
-  "/n2n/identity/{did}/oidc/token":
+  "/n2n/identity/{did}/token":
     post:
       tags:
         - Issuer
@@ -160,7 +160,7 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
-  "/n2n/identity/{did}/issuer/openid4vci/credential":
+  "/n2n/identity/{did}/openid4vci/credential":
     post:
       tags:
         - Issuer
@@ -220,7 +220,7 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
-  "/n2n/identity/{did}/wallet/openid4vci/credential_offer":
+  "/n2n/identity/{did}/openid4vci/credential_offer":
     get:
       tags:
         - Wallet

--- a/vcr/api/openid4vci/v0/generated.go
+++ b/vcr/api/openid4vci/v0/generated.go
@@ -51,13 +51,13 @@ type ServerInterface interface {
 	// (GET /n2n/identity/{did}/.well-known/openid-credential-wallet)
 	GetOAuth2ClientMetadata(ctx echo.Context, did string) error
 	// Used by the wallet to request credentials
-	// (POST /n2n/identity/{did}/issuer/openid4vci/credential)
+	// (POST /n2n/identity/{did}/openid4vci/credential)
 	RequestCredential(ctx echo.Context, did string, params RequestCredentialParams) error
 	// Used by the wallet to request an access token
-	// (POST /n2n/identity/{did}/oidc/token)
+	// (POST /n2n/identity/{did}/token)
 	RequestAccessToken(ctx echo.Context, did string) error
 	// Used by the issuer to offer credentials to the wallet
-	// (GET /n2n/identity/{did}/wallet/openid4vci/credential_offer)
+	// (GET /n2n/identity/{did}/openid4vci/credential_offer)
 	HandleCredentialOffer(ctx echo.Context, did string, params HandleCredentialOfferParams) error
 }
 
@@ -239,9 +239,9 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.GET(baseURL+"/n2n/identity/:did/.well-known/openid-credential-issuer", wrapper.GetOpenID4VCIIssuerMetadata)
 	router.HEAD(baseURL+"/n2n/identity/:did/.well-known/openid-credential-issuer", wrapper.GetOpenID4VCIIssuerMetadataHeaders)
 	router.GET(baseURL+"/n2n/identity/:did/.well-known/openid-credential-wallet", wrapper.GetOAuth2ClientMetadata)
-	router.POST(baseURL+"/n2n/identity/:did/issuer/openid4vci/credential", wrapper.RequestCredential)
-	router.POST(baseURL+"/n2n/identity/:did/oidc/token", wrapper.RequestAccessToken)
-	router.GET(baseURL+"/n2n/identity/:did/wallet/openid4vci/credential_offer", wrapper.HandleCredentialOffer)
+	router.POST(baseURL+"/n2n/identity/:did/openid4vci/credential", wrapper.RequestCredential)
+	router.POST(baseURL+"/n2n/identity/:did/token", wrapper.RequestAccessToken)
+	router.GET(baseURL+"/n2n/identity/:did/openid4vci/credential_offer", wrapper.HandleCredentialOffer)
 
 }
 
@@ -489,13 +489,13 @@ type StrictServerInterface interface {
 	// (GET /n2n/identity/{did}/.well-known/openid-credential-wallet)
 	GetOAuth2ClientMetadata(ctx context.Context, request GetOAuth2ClientMetadataRequestObject) (GetOAuth2ClientMetadataResponseObject, error)
 	// Used by the wallet to request credentials
-	// (POST /n2n/identity/{did}/issuer/openid4vci/credential)
+	// (POST /n2n/identity/{did}/openid4vci/credential)
 	RequestCredential(ctx context.Context, request RequestCredentialRequestObject) (RequestCredentialResponseObject, error)
 	// Used by the wallet to request an access token
-	// (POST /n2n/identity/{did}/oidc/token)
+	// (POST /n2n/identity/{did}/token)
 	RequestAccessToken(ctx context.Context, request RequestAccessTokenRequestObject) (RequestAccessTokenResponseObject, error)
 	// Used by the issuer to offer credentials to the wallet
-	// (GET /n2n/identity/{did}/wallet/openid4vci/credential_offer)
+	// (GET /n2n/identity/{did}/openid4vci/credential_offer)
 	HandleCredentialOffer(ctx context.Context, request HandleCredentialOfferRequestObject) (HandleCredentialOfferResponseObject, error)
 }
 

--- a/vcr/holder/openid.go
+++ b/vcr/holder/openid.go
@@ -75,7 +75,7 @@ type openidHandler struct {
 
 func (h *openidHandler) Metadata() openid4vci.OAuth2ClientMetadata {
 	return openid4vci.OAuth2ClientMetadata{
-		CredentialOfferEndpoint: core.JoinURLPaths(h.identifier, "/wallet/openid4vci/credential_offer"),
+		CredentialOfferEndpoint: core.JoinURLPaths(h.identifier, "/openid4vci/credential_offer"),
 	}
 }
 

--- a/vcr/holder/openid_test.go
+++ b/vcr/holder/openid_test.go
@@ -52,7 +52,7 @@ func Test_wallet_Metadata(t *testing.T) {
 	metadata := w.Metadata()
 
 	assert.Equal(t, openid4vci.OAuth2ClientMetadata{
-		CredentialOfferEndpoint: "https://holder.example.com/wallet/openid4vci/credential_offer",
+		CredentialOfferEndpoint: "https://holder.example.com/openid4vci/credential_offer",
 	}, metadata)
 }
 

--- a/vcr/issuer/openid.go
+++ b/vcr/issuer/openid.go
@@ -135,7 +135,7 @@ type openidHandler struct {
 func (i *openidHandler) Metadata() openid4vci.CredentialIssuerMetadata {
 	metadata := openid4vci.CredentialIssuerMetadata{
 		CredentialIssuer:   i.issuerIdentifierURL,
-		CredentialEndpoint: core.JoinURLPaths(i.issuerIdentifierURL, "/issuer/openid4vci/credential"),
+		CredentialEndpoint: core.JoinURLPaths(i.issuerIdentifierURL, "/openid4vci/credential"),
 	}
 
 	// deepcopy the i.credentialsSupported slice to prevent concurrent access to the slice.
@@ -147,7 +147,7 @@ func (i *openidHandler) Metadata() openid4vci.CredentialIssuerMetadata {
 func (i *openidHandler) ProviderMetadata() openid4vci.ProviderMetadata {
 	return openid4vci.ProviderMetadata{
 		Issuer:        i.issuerIdentifierURL,
-		TokenEndpoint: core.JoinURLPaths(i.issuerIdentifierURL, "oidc/token"),
+		TokenEndpoint: core.JoinURLPaths(i.issuerIdentifierURL, "token"),
 		// TODO: Anonymous access (no client_id) is OK as long as PKIoverheid Private is used,
 		// if that requirement is dropped we need to authenticate wallets using client_id.
 		// See https://github.com/nuts-foundation/nuts-node/issues/2032

--- a/vcr/issuer/openid_test.go
+++ b/vcr/issuer/openid_test.go
@@ -93,7 +93,7 @@ func Test_memoryIssuer_Metadata(t *testing.T) {
 		metadata := issuer.Metadata()
 
 		assert.Equal(t, "https://example.com/did:nuts:issuer", metadata.CredentialIssuer)
-		assert.Equal(t, "https://example.com/did:nuts:issuer/issuer/openid4vci/credential", metadata.CredentialEndpoint)
+		assert.Equal(t, "https://example.com/did:nuts:issuer/openid4vci/credential", metadata.CredentialEndpoint)
 		require.Len(t, metadata.CredentialsSupported, 3)
 		assert.Equal(t, "ldp_vc", metadata.CredentialsSupported[0]["format"])
 		require.Len(t, metadata.CredentialsSupported[0]["cryptographic_binding_methods_supported"], 1)
@@ -110,7 +110,7 @@ func Test_memoryIssuer_ProviderMetadata(t *testing.T) {
 
 	assert.Equal(t, openid4vci.ProviderMetadata{
 		Issuer:        "https://example.com/did:nuts:issuer",
-		TokenEndpoint: "https://example.com/did:nuts:issuer/oidc/token",
+		TokenEndpoint: "https://example.com/did:nuts:issuer/token",
 		PreAuthorizedGrantAnonymousAccessSupported: true,
 	}, metadata)
 }


### PR DESCRIPTION
Make paths simpler;
- OAuth2 endpoints should be directly under the DID (`/token`)
- We don't need the `/issuer` and `/wallet` prefixes for openid4vci endpoints, since they don't overlap