### PR TITLE
VDR: Remove specific KeyResolver funcs in favor of generic ResolveKey

### DIFF
--- a/auth/services/notary/notary.go
+++ b/auth/services/notary/notary.go
@@ -107,14 +107,14 @@ func NewNotary(config Config, vcr vcr.VCR, keyResolver types.KeyResolver, keySto
 // If the duration is 0 than the default duration is used.
 func (n *notary) DrawUpContract(ctx context.Context, template contract.Template, orgID did.DID, validFrom time.Time, validDuration time.Duration, organizationCredential *vc.VerifiableCredential) (*contract.Contract, error) {
 	// Test if the org in managed by this node:
-	signingKeyID, err := n.keyResolver.ResolveSigningKeyID(orgID, &validFrom)
+	signingKeyID, _, err := n.keyResolver.ResolveKey(orgID, &validFrom, types.NutsSigningKeyType)
 	if errors.Is(err, types.ErrNotFound) {
 		return nil, services.InvalidContractRequestError{Message: "no valid organization credential at provided validFrom date"}
 	} else if err != nil {
 		return nil, fmt.Errorf("could not draw up contract: %w", err)
 	}
 
-	if !n.privateKeyStore.Exists(ctx, signingKeyID) {
+	if !n.privateKeyStore.Exists(ctx, signingKeyID.String()) {
 		return nil, services.InvalidContractRequestError{Message: fmt.Errorf("organization is not managed by this node: %w", ErrMissingOrganizationKey)}
 	}
 

--- a/auth/services/notary/notary_test.go
+++ b/auth/services/notary/notary_test.go
@@ -54,7 +54,7 @@ func TestContract_DrawUpContract(t *testing.T) {
 	duration := 10 * time.Minute
 
 	// Create DID document for org
-	keyID := orgID
+	keyID := orgID.URI()
 	keyID.Fragment = "key-1"
 
 	searchTerms := []vcr.SearchTerm{
@@ -69,7 +69,7 @@ func TestContract_DrawUpContract(t *testing.T) {
 	t.Run("draw up valid contract", func(t *testing.T) {
 		test := buildContext(t)
 
-		test.keyResolver.EXPECT().ResolveSigningKeyID(orgID, gomock.Any()).Return(keyID.String(), nil)
+		test.keyResolver.EXPECT().ResolveKey(orgID, &validFrom, types.NutsSigningKeyType).Return(keyID, nil, nil)
 		test.keyStore.EXPECT().Exists(ctx, keyID.String()).Return(true)
 		test.vcr.EXPECT().Search(context.Background(), searchTerms, false, nil).Return([]vc.VerifiableCredential{testCredential}, nil)
 
@@ -84,7 +84,7 @@ func TestContract_DrawUpContract(t *testing.T) {
 		test := buildContext(t)
 		defer test.ctrl.Finish()
 
-		test.keyResolver.EXPECT().ResolveSigningKeyID(orgID, gomock.Any()).Return(keyID.String(), nil)
+		test.keyResolver.EXPECT().ResolveKey(orgID, gomock.Any(), types.NutsSigningKeyType).Return(keyID, nil, nil)
 		test.keyStore.EXPECT().Exists(ctx, keyID.String()).Return(true)
 
 		drawnUpContract, err := test.notary.DrawUpContract(ctx, template, orgID, validFrom, duration, &testCredential)
@@ -97,7 +97,7 @@ func TestContract_DrawUpContract(t *testing.T) {
 	t.Run("no given duration uses default", func(t *testing.T) {
 		test := buildContext(t)
 
-		test.keyResolver.EXPECT().ResolveSigningKeyID(orgID, gomock.Any()).Return(keyID.String(), nil)
+		test.keyResolver.EXPECT().ResolveKey(orgID, &validFrom, gomock.Any()).Return(keyID, nil, nil)
 		test.keyStore.EXPECT().Exists(ctx, keyID.String()).Return(true)
 		test.vcr.EXPECT().Search(context.Background(), searchTerms, false, nil).Return([]vc.VerifiableCredential{testCredential}, nil)
 
@@ -111,7 +111,7 @@ func TestContract_DrawUpContract(t *testing.T) {
 	t.Run("no given time uses time.Now()", func(t *testing.T) {
 		test := buildContext(t)
 
-		test.keyResolver.EXPECT().ResolveSigningKeyID(orgID, gomock.Any()).Return(keyID.String(), nil)
+		test.keyResolver.EXPECT().ResolveKey(orgID, &time.Time{}, gomock.Any()).Return(keyID, nil, nil)
 		test.keyStore.EXPECT().Exists(ctx, keyID.String()).Return(true)
 		test.vcr.EXPECT().Search(context.Background(), searchTerms, false, nil).Return([]vc.VerifiableCredential{testCredential}, nil)
 
@@ -129,7 +129,7 @@ func TestContract_DrawUpContract(t *testing.T) {
 	t.Run("nok - unknown organization", func(t *testing.T) {
 		test := buildContext(t)
 
-		test.keyResolver.EXPECT().ResolveSigningKeyID(orgID, gomock.Any()).Return("", types.ErrNotFound)
+		test.keyResolver.EXPECT().ResolveKey(orgID, &validFrom, gomock.Any()).Return(ssi.URI{}, nil, types.ErrNotFound)
 
 		drawnUpContract, err := test.notary.DrawUpContract(ctx, template, orgID, validFrom, duration, nil)
 
@@ -140,7 +140,7 @@ func TestContract_DrawUpContract(t *testing.T) {
 	t.Run("nok - unknown private key", func(t *testing.T) {
 		test := buildContext(t)
 
-		test.keyResolver.EXPECT().ResolveSigningKeyID(orgID, gomock.Any()).Return(keyID.String(), nil)
+		test.keyResolver.EXPECT().ResolveKey(orgID, &validFrom, gomock.Any()).Return(keyID, nil, nil)
 		test.keyStore.EXPECT().Exists(ctx, keyID.String()).Return(false)
 
 		drawnUpContract, err := test.notary.DrawUpContract(ctx, template, orgID, validFrom, duration, nil)
@@ -152,7 +152,7 @@ func TestContract_DrawUpContract(t *testing.T) {
 	t.Run("nok - other DID resolver error", func(t *testing.T) {
 		test := buildContext(t)
 
-		test.keyResolver.EXPECT().ResolveSigningKeyID(orgID, gomock.Any()).Return("", errors.New("error occurred"))
+		test.keyResolver.EXPECT().ResolveKey(orgID, &validFrom, gomock.Any()).Return(ssi.URI{}, nil, errors.New("error occurred"))
 
 		drawnUpContract, err := test.notary.DrawUpContract(ctx, template, orgID, validFrom, duration, nil)
 
@@ -163,7 +163,7 @@ func TestContract_DrawUpContract(t *testing.T) {
 	t.Run("nok - could not find credential", func(t *testing.T) {
 		test := buildContext(t)
 
-		test.keyResolver.EXPECT().ResolveSigningKeyID(orgID, gomock.Any()).Return(keyID.String(), nil)
+		test.keyResolver.EXPECT().ResolveKey(orgID, &validFrom, gomock.Any()).Return(keyID, nil, nil)
 		test.keyStore.EXPECT().Exists(ctx, keyID.String()).Return(true)
 		test.vcr.EXPECT().Search(context.Background(), searchTerms, false, nil).Return(nil, errors.New("error occurred"))
 
@@ -176,7 +176,7 @@ func TestContract_DrawUpContract(t *testing.T) {
 	t.Run("nok - render error", func(t *testing.T) {
 		test := buildContext(t)
 
-		test.keyResolver.EXPECT().ResolveSigningKeyID(orgID, gomock.Any()).Return(keyID.String(), nil)
+		test.keyResolver.EXPECT().ResolveKey(orgID, &validFrom, gomock.Any()).Return(keyID, nil, nil)
 		test.keyStore.EXPECT().Exists(ctx, keyID.String()).Return(true)
 		test.vcr.EXPECT().Search(context.Background(), searchTerms, false, nil).Return([]vc.VerifiableCredential{testCredential}, nil)
 
@@ -193,7 +193,7 @@ func TestContract_DrawUpContract(t *testing.T) {
 	t.Run("ok - multiple (matching) VCs", func(t *testing.T) {
 		test := buildContext(t)
 
-		test.keyResolver.EXPECT().ResolveSigningKeyID(orgID, gomock.Any()).Return(keyID.String(), nil)
+		test.keyResolver.EXPECT().ResolveKey(orgID, &validFrom, gomock.Any()).Return(keyID, nil, nil)
 		test.keyStore.EXPECT().Exists(ctx, keyID.String()).Return(true)
 		test.vcr.EXPECT().Search(context.Background(), searchTerms, false, nil).Return([]vc.VerifiableCredential{testCredential, testCredential}, nil)
 
@@ -210,7 +210,7 @@ func TestContract_DrawUpContract(t *testing.T) {
 		testCredential2 := vc.VerifiableCredential{}
 		_ = json.Unmarshal([]byte(jsonld.TestCredential), &testCredential2)
 
-		test.keyResolver.EXPECT().ResolveSigningKeyID(orgID, gomock.Any()).Return(keyID.String(), nil)
+		test.keyResolver.EXPECT().ResolveKey(orgID, &validFrom, gomock.Any()).Return(keyID, nil, nil)
 		test.keyStore.EXPECT().Exists(ctx, keyID.String()).Return(true)
 		test.vcr.EXPECT().Search(context.Background(), searchTerms, false, nil).Return([]vc.VerifiableCredential{testCredential, testCredential2}, nil)
 
@@ -223,7 +223,7 @@ func TestContract_DrawUpContract(t *testing.T) {
 	t.Run("nok - given VC does not contain organization name", func(t *testing.T) {
 		test := buildContext(t)
 
-		test.keyResolver.EXPECT().ResolveSigningKeyID(orgID, gomock.Any()).Return(keyID.String(), nil)
+		test.keyResolver.EXPECT().ResolveKey(orgID, &validFrom, gomock.Any()).Return(keyID, nil, nil)
 		test.keyStore.EXPECT().Exists(ctx, keyID.String()).Return(true)
 
 		drawnUpContract, err := test.notary.DrawUpContract(ctx, template, orgID, validFrom, duration, &vc.VerifiableCredential{})

--- a/auth/services/oauth/authz_server_test.go
+++ b/auth/services/oauth/authz_server_test.go
@@ -125,8 +125,8 @@ func TestAuth_CreateAccessToken(t *testing.T) {
 
 		ctx.nameResolver.EXPECT().Search(context.Background(), searchTerms, false, gomock.Any()).Return([]vc.VerifiableCredential{testCredential}, nil)
 		ctx.contractNotary.EXPECT().VerifyVP(gomock.Any(), nil).Return(nil, errors.New("identity validation failed"))
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(requesterSigningKey.Public(), nil)
-		ctx.keyResolver.EXPECT().ResolveSigningKeyID(authorizerDID, gomock.Any()).MinTimes(1).Return(authorizerSigningKeyID.String(), nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(requesterSigningKey.Public(), nil)
+		ctx.keyResolver.EXPECT().ResolveKey(authorizerDID, gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(authorizerSigningKeyID, authorizerSigningKey, nil)
 		ctx.keyStore.EXPECT().Exists(ctx.audit, authorizerSigningKeyID.String()).Return(true)
 		tokenCtx := validContext()
 		signToken(tokenCtx)
@@ -140,7 +140,7 @@ func TestAuth_CreateAccessToken(t *testing.T) {
 	t.Run("JWT validity too long", func(t *testing.T) {
 		ctx := createContext(t)
 
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(requesterSigningKey.Public(), nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), nil, types.NutsSigningKeyType).MinTimes(1).Return(requesterSigningKey.Public(), nil)
 
 		tokenCtx := validContext()
 		tokenCtx.jwtBearerToken.Set(jwt.ExpirationKey, time.Now().Add(10*time.Second))
@@ -157,8 +157,8 @@ func TestAuth_CreateAccessToken(t *testing.T) {
 
 		ctx.nameResolver.EXPECT().Search(context.Background(), searchTerms, false, gomock.Any()).Return([]vc.VerifiableCredential{testCredential}, nil)
 		ctx.keyStore.EXPECT().Exists(ctx.audit, authorizerSigningKeyID.String()).Return(true)
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(requesterSigningKey.Public(), nil)
-		ctx.keyResolver.EXPECT().ResolveSigningKeyID(authorizerDID, gomock.Any()).MinTimes(1).Return(authorizerSigningKeyID.String(), nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(requesterSigningKey.Public(), nil)
+		ctx.keyResolver.EXPECT().ResolveKey(authorizerDID, gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(authorizerSigningKeyID, authorizerSigningKey, nil)
 		ctx.contractNotary.EXPECT().VerifyVP(gomock.Any(), nil).Return(services.TestVPVerificationResult{Val: contract.Invalid, FailureReason: "because of reasons"}, nil)
 
 		tokenCtx := validContext()
@@ -172,8 +172,8 @@ func TestAuth_CreateAccessToken(t *testing.T) {
 
 	t.Run("error detail masking", func(t *testing.T) {
 		setup := func(ctx *testContext) *testContext {
-			ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(requesterSigningKey.Public(), nil).AnyTimes()
-			ctx.keyResolver.EXPECT().ResolveSigningKeyID(authorizerDID, gomock.Any()).MinTimes(1).Return(authorizerSigningKeyID.String(), nil).AnyTimes()
+			ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(requesterSigningKey.Public(), nil).AnyTimes()
+			ctx.keyResolver.EXPECT().ResolveKey(authorizerDID, gomock.Any(), gomock.Any()).MinTimes(1).Return(authorizerSigningKeyID, authorizerSigningKey, nil).AnyTimes()
 			ctx.nameResolver.EXPECT().Search(context.Background(), searchTerms, false, gomock.Any()).Return([]vc.VerifiableCredential{testCredential}, nil).AnyTimes()
 			ctx.didResolver.EXPECT().Resolve(authorizerDID, gomock.Any()).Return(getAuthorizerDIDDocument(), nil, nil).AnyTimes()
 			ctx.serviceResolver.EXPECT().GetCompoundServiceEndpoint(authorizerDID, expectedService, services.OAuthEndpointType, true).Return(expectedAudience, nil).AnyTimes()
@@ -218,8 +218,8 @@ func TestAuth_CreateAccessToken(t *testing.T) {
 	t.Run("valid - without user identity", func(t *testing.T) {
 		testCtx := createContext(t)
 
-		testCtx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(requesterSigningKey.Public(), nil)
-		testCtx.keyResolver.EXPECT().ResolveSigningKeyID(authorizerDID, gomock.Any()).MinTimes(1).Return(authorizerSigningKeyID.String(), nil)
+		testCtx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(requesterSigningKey.Public(), nil)
+		testCtx.keyResolver.EXPECT().ResolveKey(authorizerDID, gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(authorizerSigningKeyID, authorizerSigningKey, nil)
 		testCtx.nameResolver.EXPECT().Search(context.Background(), searchTerms, false, gomock.Any()).Return([]vc.VerifiableCredential{testCredential}, nil)
 		testCtx.didResolver.EXPECT().Resolve(authorizerDID, gomock.Any()).Return(getAuthorizerDIDDocument(), nil, nil).AnyTimes()
 		testCtx.serviceResolver.EXPECT().GetCompoundServiceEndpoint(authorizerDID, expectedService, services.OAuthEndpointType, true).Return(expectedAudience, nil)
@@ -240,8 +240,8 @@ func TestAuth_CreateAccessToken(t *testing.T) {
 	t.Run("valid - all fields", func(t *testing.T) {
 		ctx := createContext(t)
 
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(requesterSigningKey.Public(), nil)
-		ctx.keyResolver.EXPECT().ResolveSigningKeyID(authorizerDID, gomock.Any()).MinTimes(1).Return(authorizerSigningKeyID.String(), nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(requesterSigningKey.Public(), nil)
+		ctx.keyResolver.EXPECT().ResolveKey(authorizerDID, gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(authorizerSigningKeyID, authorizerSigningKey, nil)
 		ctx.nameResolver.EXPECT().Search(context.Background(), searchTerms, false, gomock.Any()).Return([]vc.VerifiableCredential{testCredential}, nil)
 		ctx.didResolver.EXPECT().Resolve(authorizerDID, gomock.Any()).Return(getAuthorizerDIDDocument(), nil, nil).AnyTimes()
 		ctx.serviceResolver.EXPECT().GetCompoundServiceEndpoint(authorizerDID, expectedService, services.OAuthEndpointType, true).Return(expectedAudience, nil)
@@ -265,7 +265,7 @@ func TestAuth_CreateAccessToken(t *testing.T) {
 	t.Run("missing organization credential", func(t *testing.T) {
 		ctx := createContext(t)
 
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(requesterSigningKey.Public(), nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(requesterSigningKey.Public(), nil)
 		ctx.nameResolver.EXPECT().Search(context.Background(), searchTerms, false, gomock.Any()).Return([]vc.VerifiableCredential{}, nil)
 		ctx.didResolver.EXPECT().Resolve(authorizerDID, gomock.Any()).Return(getAuthorizerDIDDocument(), nil, nil).AnyTimes()
 
@@ -290,7 +290,7 @@ func TestService_validateIssuer(t *testing.T) {
 		ctx := createContext(t)
 
 		tokenCtx := validContext()
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(requesterSigningKey.Public(), nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(requesterSigningKey.Public(), nil)
 		ctx.nameResolver.EXPECT().Search(context.Background(), searchTerms, false, gomock.Any()).Return([]vc.VerifiableCredential{testCredential}, nil)
 
 		err := ctx.oauthService.validateIssuer(tokenCtx)
@@ -302,7 +302,7 @@ func TestService_validateIssuer(t *testing.T) {
 		ctx := createContext(t)
 
 		tokenCtx := validContext()
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(requesterSigningKey.Public(), nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(requesterSigningKey.Public(), nil)
 		ctx.nameResolver.EXPECT().Search(context.Background(), searchTerms, false, gomock.Any()).Return([]vc.VerifiableCredential{testCredential, testCredential}, nil)
 
 		err := ctx.oauthService.validateIssuer(tokenCtx)
@@ -322,7 +322,7 @@ func TestService_validateIssuer(t *testing.T) {
 		ctx := createContext(t)
 
 		tokenCtx := validContext()
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).Return(requesterSigningKey.Public(), nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), gomock.Any(), types.NutsSigningKeyType).Return(requesterSigningKey.Public(), nil)
 		ctx.nameResolver.EXPECT().Search(context.Background(), searchTerms, false, gomock.Any()).Return(nil, errors.New("error occurred"))
 
 		err := ctx.oauthService.validateIssuer(tokenCtx)
@@ -332,7 +332,7 @@ func TestService_validateIssuer(t *testing.T) {
 		ctx := createContext(t)
 
 		tokenCtx := validContext()
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).Return(requesterSigningKey.Public(), nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), gomock.Any(), types.NutsSigningKeyType).Return(requesterSigningKey.Public(), nil)
 		ctx.nameResolver.EXPECT().Search(context.Background(), searchTerms, false, gomock.Any()).Return([]vc.VerifiableCredential{}, nil)
 
 		err := ctx.oauthService.validateIssuer(tokenCtx)
@@ -343,7 +343,7 @@ func TestService_validateIssuer(t *testing.T) {
 
 		tokenCtx := validContext()
 
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(nil, fmt.Errorf("not found"))
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(nil, fmt.Errorf("not found"))
 
 		err := ctx.oauthService.validateIssuer(tokenCtx)
 		assert.EqualError(t, err, "invalid jwt.issuer key ID: not found")
@@ -357,7 +357,7 @@ func TestService_validateSubject(t *testing.T) {
 		tokenCtx := validContext()
 		tokenCtx.jwtBearerToken.Set(jwt.SubjectKey, authorizerDID.String())
 
-		ctx.keyResolver.EXPECT().ResolveSigningKeyID(authorizerDID, gomock.Any()).MinTimes(1).Return(authorizerSigningKeyID.String(), nil)
+		ctx.keyResolver.EXPECT().ResolveKey(authorizerDID, gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(authorizerSigningKeyID, authorizerSigningKey, nil)
 		ctx.keyStore.EXPECT().Exists(ctx.audit, authorizerSigningKeyID.String()).Return(true)
 
 		err := ctx.oauthService.validateSubject(ctx.audit, tokenCtx)
@@ -387,7 +387,7 @@ func TestService_validateSubject(t *testing.T) {
 		tokenCtx := validContext()
 		tokenCtx.jwtBearerToken.Set(jwt.SubjectKey, authorizerDID.String())
 
-		ctx.keyResolver.EXPECT().ResolveSigningKeyID(authorizerDID, gomock.Any()).MinTimes(1).Return(authorizerSigningKeyID.String(), nil)
+		ctx.keyResolver.EXPECT().ResolveKey(authorizerDID, gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(authorizerSigningKeyID, authorizerSigningKey, nil)
 		ctx.keyStore.EXPECT().Exists(ctx.audit, authorizerSigningKeyID.String()).Return(false)
 
 		err := ctx.oauthService.validateSubject(ctx.audit, tokenCtx)
@@ -587,7 +587,7 @@ func TestService_parseAndValidateJwtBearerToken(t *testing.T) {
 
 		keyID := "did:nuts:somedid#key-id"
 
-		ctx.keyResolver.EXPECT().ResolveSigningKey(keyID, gomock.Any()).Return(privateKey.Public(), nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(keyID, nil, types.NutsSigningKeyType).Return(privateKey.Public(), nil)
 
 		// alg: RS256
 		token := jwt.New()
@@ -608,7 +608,7 @@ func TestService_parseAndValidateJwtBearerToken(t *testing.T) {
 		tokenCtx := validContext()
 		signToken(tokenCtx)
 
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).Return(requesterSigningKey.PublicKey, nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), nil, types.NutsSigningKeyType).Return(requesterSigningKey.PublicKey, nil)
 
 		err := ctx.oauthService.parseAndValidateJwtBearerToken(tokenCtx)
 		assert.NoError(t, err)
@@ -625,7 +625,7 @@ func TestService_parseAndValidateJwtBearerToken(t *testing.T) {
 		tokenCtx.jwtBearerToken.Set(jwt.ExpirationKey, time.Now().Add(-4*time.Minute))
 		signToken(tokenCtx)
 
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).Return(requesterSigningKey.PublicKey, nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), nil, types.NutsSigningKeyType).Return(requesterSigningKey.PublicKey, nil)
 
 		err := ctx.oauthService.parseAndValidateJwtBearerToken(tokenCtx)
 		assert.NoError(t, err)
@@ -640,7 +640,7 @@ func TestService_parseAndValidateJwtBearerToken(t *testing.T) {
 		tokenCtx.jwtBearerToken.Set(jwt.ExpirationKey, time.Now().Add(-4*time.Minute))
 		signToken(tokenCtx)
 
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).Return(requesterSigningKey.PublicKey, nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), nil, types.NutsSigningKeyType).Return(requesterSigningKey.PublicKey, nil)
 
 		err := ctx.oauthService.parseAndValidateJwtBearerToken(tokenCtx)
 		assert.EqualError(t, err, "exp not satisfied")
@@ -653,7 +653,7 @@ func TestService_buildAccessToken(t *testing.T) {
 		ctx.oauthService.accessTokenLifeSpan = secureAccessTokenLifeSpan * 10 // ignored by secureMode == true
 		ctx.oauthService.Configure(5000, true)
 
-		ctx.keyResolver.EXPECT().ResolveSigningKeyID(authorizerDID, gomock.Any()).MinTimes(1).Return(authorizerSigningKeyID.String(), nil)
+		ctx.keyResolver.EXPECT().ResolveKey(authorizerDID, gomock.Any(), types.NutsSigningKeyType).MinTimes(1).Return(authorizerSigningKeyID, authorizerSigningKey, nil)
 
 		var actualClaims map[string]interface{}
 		ctx.keyStore.EXPECT().SignJWT(gomock.Any(), gomock.Any(), nil, gomock.Any()).
@@ -693,7 +693,7 @@ func TestService_IntrospectAccessToken(t *testing.T) {
 	t.Run("validate access token", func(t *testing.T) {
 		ctx := createContext(t)
 
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(requesterSigningKey.Public(), nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), nil, types.NutsSigningKeyType).MinTimes(1).Return(requesterSigningKey.Public(), nil)
 		ctx.keyStore.EXPECT().Exists(ctx.audit, requesterSigningKeyID.String()).Return(true)
 
 		// First build an access token
@@ -714,7 +714,7 @@ func TestService_IntrospectAccessToken(t *testing.T) {
 	t.Run("invalid signature", func(t *testing.T) {
 		ctx := createContext(t)
 
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(requesterSigningKey.Public(), nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), nil, types.NutsSigningKeyType).MinTimes(1).Return(requesterSigningKey.Public(), nil)
 		ctx.keyStore.EXPECT().Exists(ctx.audit, requesterSigningKeyID.String()).Return(true)
 
 		// First build an access token
@@ -747,7 +747,7 @@ func TestService_IntrospectAccessToken(t *testing.T) {
 		ctx := createContext(t)
 
 		ctx.keyStore.EXPECT().Exists(ctx.audit, requesterSigningKeyID.String()).Return(true)
-		ctx.keyResolver.EXPECT().ResolveSigningKey(requesterSigningKeyID.String(), gomock.Any()).MinTimes(1).Return(nil, types.ErrNotFound)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(requesterSigningKeyID.String(), nil, types.NutsSigningKeyType).MinTimes(1).Return(nil, types.ErrNotFound)
 
 		// First build an access token
 		tokenCtx := validContext()

--- a/auth/services/oauth/relying_party.go
+++ b/auth/services/oauth/relying_party.go
@@ -118,12 +118,11 @@ func (s *relyingParty) CreateJwtGrant(ctx context.Context, request services.Crea
 
 	keyVals := claimsFromRequest(request, endpointURL)
 
-	now := time.Now()
-	signingKeyID, err := s.keyResolver.ResolveSigningKeyID(*requester, &now)
+	signingKeyID, _, err := s.keyResolver.ResolveKey(*requester, nil, types.NutsSigningKeyType)
 	if err != nil {
 		return nil, err
 	}
-	signingString, err := s.privateKeyStore.SignJWT(ctx, keyVals, nil, signingKeyID)
+	signingString, err := s.privateKeyStore.SignJWT(ctx, keyVals, nil, signingKeyID.String())
 	if err != nil {
 		return nil, err
 	}

--- a/auth/services/oauth/relying_party_test.go
+++ b/auth/services/oauth/relying_party_test.go
@@ -151,7 +151,7 @@ func TestService_CreateJwtBearerToken(t *testing.T) {
 
 		ctx.didResolver.EXPECT().Resolve(authorizerDID, gomock.Any()).Return(authorizerDIDDocument, nil, nil).AnyTimes()
 		ctx.serviceResolver.EXPECT().GetCompoundServiceEndpoint(authorizerDID, expectedService, services.OAuthEndpointType, true).Return(expectedAudience, nil)
-		ctx.keyResolver.EXPECT().ResolveSigningKeyID(requesterDID, gomock.Any()).MinTimes(1).Return(requesterSigningKeyID.String(), nil)
+		ctx.keyResolver.EXPECT().ResolveKey(requesterDID, nil, types.NutsSigningKeyType).MinTimes(1).Return(requesterSigningKeyID, requesterSigningKey, nil)
 		ctx.keyStore.EXPECT().SignJWT(gomock.Any(), gomock.Any(), nil, requesterSigningKeyID.String()).Return("token", nil)
 
 		token, err := ctx.relyingParty.CreateJwtGrant(ctx.audit, request)
@@ -168,7 +168,7 @@ func TestService_CreateJwtBearerToken(t *testing.T) {
 
 		ctx.didResolver.EXPECT().Resolve(authorizerDID, gomock.Any()).Return(authorizerDIDDocument, nil, nil).AnyTimes()
 		ctx.serviceResolver.EXPECT().GetCompoundServiceEndpoint(authorizerDID, expectedService, services.OAuthEndpointType, true).Return(expectedAudience, nil)
-		ctx.keyResolver.EXPECT().ResolveSigningKeyID(requesterDID, gomock.Any()).MinTimes(1).Return(requesterSigningKeyID.String(), nil)
+		ctx.keyResolver.EXPECT().ResolveKey(requesterDID, nil, types.NutsSigningKeyType).MinTimes(1).Return(requesterSigningKeyID, requesterSigningKey, nil)
 		ctx.keyStore.EXPECT().SignJWT(gomock.Any(), gomock.Any(), nil, requesterSigningKeyID.String()).Return("token", nil)
 
 		validRequest := request
@@ -229,7 +229,7 @@ func TestService_CreateJwtBearerToken(t *testing.T) {
 
 		ctx.didResolver.EXPECT().Resolve(authorizerDID, gomock.Any()).Return(authorizerDIDDocument, nil, nil).AnyTimes()
 		ctx.serviceResolver.EXPECT().GetCompoundServiceEndpoint(authorizerDID, expectedService, services.OAuthEndpointType, true).Return(expectedAudience, nil)
-		ctx.keyResolver.EXPECT().ResolveSigningKeyID(requesterDID, gomock.Any()).MinTimes(1).Return(requesterSigningKeyID.String(), nil)
+		ctx.keyResolver.EXPECT().ResolveKey(requesterDID, nil, types.NutsSigningKeyType).MinTimes(1).Return(requesterSigningKeyID, requesterSigningKey, nil)
 		ctx.keyStore.EXPECT().SignJWT(gomock.Any(), gomock.Any(), nil, requesterSigningKeyID.String()).Return("", errors.New("boom!"))
 
 		token, err := ctx.relyingParty.CreateJwtGrant(ctx.audit, request)

--- a/crypto/api/v1/api.go
+++ b/crypto/api/v1/api.go
@@ -195,18 +195,14 @@ func (w *Wrapper) resolvePublicKey(id *did.DID) (key crypt.PublicKey, keyID ssi.
 	if id.IsURL() {
 		// Assume it is a keyId
 		now := time.Now()
-		key, err = w.K.ResolveRelationKey(id.String(), &now, types.KeyAgreement)
+		key, err = w.K.ResolveKeyByID(id.String(), &now, types.KeyAgreement)
 		if err != nil {
 			return nil, ssi.URI{}, err
 		}
 		keyID = id.URI()
 	} else {
 		// Assume it is a DID
-		key, err = w.K.ResolveKeyAgreementKey(*id)
-		if err != nil {
-			return nil, ssi.URI{}, err
-		}
-		keyID, err = w.K.ResolveRelationKeyID(*id, types.KeyAgreement)
+		keyID, key, err = w.K.ResolveKey(*id, nil, types.KeyAgreement)
 		if err != nil {
 			return nil, ssi.URI{}, err
 		}

--- a/crypto/api/v1/api_test.go
+++ b/crypto/api/v1/api_test.go
@@ -244,7 +244,7 @@ func TestWrapper_EncryptJwe(t *testing.T) {
 		assert.Equal(t, err.(core.HTTPStatusCodeError).StatusCode(), http.StatusBadRequest)
 		assert.Empty(t, jwe)
 	})
-	t.Run("ResolveKeyAgreementKey fails, returns 400", func(t *testing.T) {
+	t.Run("ResolveKey fails, returns 400", func(t *testing.T) {
 		ctx := newMockContext(t)
 		headers := map[string]interface{}{"typ": "JWE"}
 		request := EncryptJweRequest{
@@ -252,14 +252,14 @@ func TestWrapper_EncryptJwe(t *testing.T) {
 			Payload:  payload,
 			Headers:  headers,
 		}
-		ctx.keyResolver.EXPECT().ResolveKeyAgreementKey(gomock.Any()).Return(nil, errors.New("FAIL"))
+		ctx.keyResolver.EXPECT().ResolveKey(gomock.Any(), nil, types.KeyAgreement).Return(ssi.URI{}, nil, errors.New("FAIL"))
 
 		jwe, err := ctx.client.EncryptJwe(nil, EncryptJweRequestObject{Body: &request})
 		assert.EqualError(t, err, "invalid receiver: FAIL")
 		assert.Equal(t, err.(core.HTTPStatusCodeError).StatusCode(), http.StatusBadRequest)
 		assert.Empty(t, jwe)
 	})
-	t.Run("ResolveRelationKeyID fails, returns 400", func(t *testing.T) {
+	t.Run("ResolveKey fails, returns 400", func(t *testing.T) {
 		ctx := newMockContext(t)
 		headers := map[string]interface{}{"typ": "JWE"}
 		request := EncryptJweRequest{
@@ -267,15 +267,14 @@ func TestWrapper_EncryptJwe(t *testing.T) {
 			Payload:  payload,
 			Headers:  headers,
 		}
-		ctx.keyResolver.EXPECT().ResolveKeyAgreementKey(gomock.Any())
-		ctx.keyResolver.EXPECT().ResolveRelationKeyID(gomock.Any(), types.KeyAgreement).Return(ssi.URI{}, errors.New("FAIL"))
+		ctx.keyResolver.EXPECT().ResolveKey(gomock.Any(), nil, types.KeyAgreement).Return(ssi.URI{}, nil, errors.New("FAIL"))
 
 		jwe, err := ctx.client.EncryptJwe(nil, EncryptJweRequestObject{Body: &request})
 		assert.EqualError(t, err, "invalid receiver: FAIL")
 		assert.Equal(t, err.(core.HTTPStatusCodeError).StatusCode(), http.StatusBadRequest)
 		assert.Empty(t, jwe)
 	})
-	t.Run("ResolveRelationKey fails, returns 400", func(t *testing.T) {
+	t.Run("ResolveKeyByID fails, returns 400", func(t *testing.T) {
 		ctx := newMockContext(t)
 		headers := map[string]interface{}{"typ": "JWE"}
 		request := EncryptJweRequest{
@@ -283,14 +282,14 @@ func TestWrapper_EncryptJwe(t *testing.T) {
 			Payload:  payload,
 			Headers:  headers,
 		}
-		ctx.keyResolver.EXPECT().ResolveRelationKey(gomock.Any(), gomock.Any(), types.KeyAgreement).Return(ssi.URI{}, errors.New("FAIL"))
+		ctx.keyResolver.EXPECT().ResolveKeyByID(gomock.Any(), gomock.Any(), types.KeyAgreement).Return(ssi.URI{}, errors.New("FAIL"))
 
 		jwe, err := ctx.client.EncryptJwe(nil, EncryptJweRequestObject{Body: &request})
 		assert.EqualError(t, err, "invalid receiver: FAIL")
 		assert.Equal(t, err.(core.HTTPStatusCodeError).StatusCode(), http.StatusBadRequest)
 		assert.Empty(t, jwe)
 	})
-	t.Run("ResolveKeyAgreementKey not found, returns 400", func(t *testing.T) {
+	t.Run("KeyAgreement key not found, returns 400", func(t *testing.T) {
 		ctx := newMockContext(t)
 		headers := map[string]interface{}{"typ": "JWE"}
 		request := EncryptJweRequest{
@@ -298,14 +297,14 @@ func TestWrapper_EncryptJwe(t *testing.T) {
 			Payload:  payload,
 			Headers:  headers,
 		}
-		ctx.keyResolver.EXPECT().ResolveKeyAgreementKey(gomock.Any()).Return(nil, types.ErrNotFound)
+		ctx.keyResolver.EXPECT().ResolveKey(gomock.Any(), nil, types.KeyAgreement).Return(ssi.URI{}, nil, types.ErrNotFound)
 
 		jwe, err := ctx.client.EncryptJwe(nil, EncryptJweRequestObject{Body: &request})
 		assert.EqualError(t, err, "unable to locate receiver did:nuts:12345: unable to find the DID document")
 		assert.Equal(t, err.(core.HTTPStatusCodeError).StatusCode(), http.StatusBadRequest)
 		assert.Empty(t, jwe)
 	})
-	t.Run("ResolveRelationKeyID not found, returns 400", func(t *testing.T) {
+	t.Run("Key not found, returns 400", func(t *testing.T) {
 		ctx := newMockContext(t)
 		headers := map[string]interface{}{"typ": "JWE"}
 		request := EncryptJweRequest{
@@ -313,15 +312,14 @@ func TestWrapper_EncryptJwe(t *testing.T) {
 			Payload:  payload,
 			Headers:  headers,
 		}
-		ctx.keyResolver.EXPECT().ResolveKeyAgreementKey(gomock.Any())
-		ctx.keyResolver.EXPECT().ResolveRelationKeyID(gomock.Any(), types.KeyAgreement).Return(ssi.URI{}, types.ErrNotFound)
+		ctx.keyResolver.EXPECT().ResolveKey(gomock.Any(), nil, types.KeyAgreement).Return(ssi.URI{}, nil, types.ErrNotFound)
 
 		jwe, err := ctx.client.EncryptJwe(nil, EncryptJweRequestObject{Body: &request})
 		assert.EqualError(t, err, "unable to locate receiver did:nuts:12345: unable to find the DID document")
 		assert.Equal(t, err.(core.HTTPStatusCodeError).StatusCode(), http.StatusBadRequest)
 		assert.Empty(t, jwe)
 	})
-	t.Run("ResolveRelationKey not found, returns 400", func(t *testing.T) {
+	t.Run("KeyAgreement key not found, returns 400", func(t *testing.T) {
 		ctx := newMockContext(t)
 		headers := map[string]interface{}{"typ": "JWE"}
 		request := EncryptJweRequest{
@@ -329,7 +327,7 @@ func TestWrapper_EncryptJwe(t *testing.T) {
 			Payload:  payload,
 			Headers:  headers,
 		}
-		ctx.keyResolver.EXPECT().ResolveRelationKey(gomock.Any(), gomock.Any(), types.KeyAgreement).Return(ssi.URI{}, types.ErrNotFound)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(gomock.Any(), gomock.Any(), types.KeyAgreement).Return(ssi.URI{}, types.ErrNotFound)
 
 		jwe, err := ctx.client.EncryptJwe(nil, EncryptJweRequestObject{Body: &request})
 		assert.EqualError(t, err, "unable to locate receiver did:nuts:12345#key-1: unable to find the DID document")
@@ -360,9 +358,8 @@ func TestWrapper_EncryptJwe(t *testing.T) {
 		}
 		did, _ := ssi.ParseURI("did:nuts:12345")
 		ctx.keyStore.EXPECT().EncryptJWE(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("b00m!"))
-		ctx.keyResolver.EXPECT().ResolveKeyAgreementKey(gomock.Any())
 
-		ctx.keyResolver.EXPECT().ResolveRelationKeyID(gomock.Any(), types.KeyAgreement).Return(*did, nil)
+		ctx.keyResolver.EXPECT().ResolveKey(gomock.Any(), nil, types.KeyAgreement).Return(*did, nil, nil)
 
 		jwe, err := ctx.client.EncryptJwe(audit.TestContext(), EncryptJweRequestObject{Body: &request})
 
@@ -380,8 +377,7 @@ func TestWrapper_EncryptJwe(t *testing.T) {
 			Payload:  payload,
 		}
 		ctx.keyStore.EXPECT().EncryptJWE(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("jwe", nil)
-		ctx.keyResolver.EXPECT().ResolveKeyAgreementKey(gomock.Any())
-		ctx.keyResolver.EXPECT().ResolveRelationKeyID(gomock.Any(), types.KeyAgreement).Return(*did, nil)
+		ctx.keyResolver.EXPECT().ResolveKey(gomock.Any(), nil, types.KeyAgreement).Return(*did, nil, nil)
 
 		resp, err := ctx.client.EncryptJwe(nil, EncryptJweRequestObject{Body: &request})
 
@@ -399,7 +395,7 @@ func TestWrapper_EncryptJwe(t *testing.T) {
 			Payload:  payload,
 		}
 		ctx.keyStore.EXPECT().EncryptJWE(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("jwe", nil)
-		ctx.keyResolver.EXPECT().ResolveRelationKey(gomock.Any(), gomock.Any(), types.KeyAgreement).Return(*did, nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(gomock.Any(), gomock.Any(), types.KeyAgreement).Return(*did, nil)
 
 		resp, err := ctx.client.EncryptJwe(nil, EncryptJweRequestObject{Body: &request})
 
@@ -417,8 +413,7 @@ func TestWrapper_EncryptJwe(t *testing.T) {
 		}
 		did, _ := ssi.ParseURI(kid)
 		ctx.keyStore.EXPECT().EncryptJWE(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("jwe", nil)
-		ctx.keyResolver.EXPECT().ResolveKeyAgreementKey(gomock.Any())
-		ctx.keyResolver.EXPECT().ResolveRelationKeyID(gomock.Any(), types.KeyAgreement).Return(*did, nil)
+		ctx.keyResolver.EXPECT().ResolveKey(gomock.Any(), nil, types.KeyAgreement).Return(*did, nil, nil)
 
 		resp, err := ctx.client.EncryptJwe(nil, EncryptJweRequestObject{Body: &request})
 
@@ -434,8 +429,7 @@ func TestWrapper_EncryptJwe(t *testing.T) {
 			Receiver: did.String(),
 		}
 		ctx.keyStore.EXPECT().EncryptJWE(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("jwe", nil)
-		ctx.keyResolver.EXPECT().ResolveKeyAgreementKey(gomock.Any())
-		ctx.keyResolver.EXPECT().ResolveRelationKeyID(gomock.Any(), types.KeyAgreement).Return(*did, nil)
+		ctx.keyResolver.EXPECT().ResolveKey(gomock.Any(), nil, types.KeyAgreement).Return(*did, nil, nil)
 
 		resp, err := ctx.client.EncryptJwe(nil, EncryptJweRequestObject{Body: &request})
 

--- a/network/dag/pal.go
+++ b/network/dag/pal.go
@@ -58,7 +58,7 @@ func (pal PAL) Encrypt(keyResolver types.KeyResolver) (EncryptedPAL, error) {
 	var recipients [][]byte
 	for _, recipient := range pal {
 		recipients = append(recipients, []byte(recipient.String()))
-		rawKak, err := keyResolver.ResolveKeyAgreementKey(recipient)
+		_, rawKak, err := keyResolver.ResolveKey(recipient, nil, types.KeyAgreement)
 		if err != nil {
 			return nil, fmt.Errorf("unable to resolve keyAgreement key (recipient=%s): %w", recipient, err)
 		}

--- a/network/dag/verifier_test.go
+++ b/network/dag/verifier_test.go
@@ -30,8 +30,6 @@ import (
 	"time"
 
 	"github.com/lestrrat-go/jwx/jwk"
-	ssi "github.com/nuts-foundation/go-did"
-	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-stoabs"
 	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
@@ -126,7 +124,7 @@ func TestTransactionSignatureVerifier(t *testing.T) {
 	t.Run("unable to resolve key by hash", func(t *testing.T) {
 		d := CreateSignedTestTransaction(1, time.Now(), nil, "foo/bar", false)
 		ctrl := gomock.NewController(t)
-		keyResolver := types.NewMockKeyResolver(ctrl)
+		keyResolver := types.NewMockNutsKeyResolver(ctrl)
 		keyResolver.EXPECT().ResolvePublicKey(gomock.Any(), gomock.Any()).Return(nil, errors.New("failed"))
 
 		err := NewTransactionSignatureVerifier(keyResolver)(nil, d)
@@ -135,35 +133,12 @@ func TestTransactionSignatureVerifier(t *testing.T) {
 	})
 }
 
-var _ types.KeyResolver = &staticKeyResolver{}
 var _ types.NutsKeyResolver = &staticKeyResolver{}
 
 type staticKeyResolver struct {
 	Key crypto.PublicKey
 }
 
-func (s staticKeyResolver) ResolveKeyAgreementKey(_ did.DID) (crypto.PublicKey, error) {
-	return s.Key, nil
-}
-
 func (s staticKeyResolver) ResolvePublicKey(_ string, _ []hash.SHA256Hash) (crypto.PublicKey, error) {
 	return s.Key, nil
-}
-
-func (s staticKeyResolver) ResolveSigningKeyID(_ did.DID, _ *time.Time) (string, error) {
-	panic("implement me")
-}
-
-func (s staticKeyResolver) ResolveSigningKey(_ string, _ *time.Time) (crypto.PublicKey, error) {
-	panic("implement me")
-}
-func (s staticKeyResolver) ResolveRelationKey(_ string, _ *time.Time, _ types.RelationType) (crypto.PublicKey, error) {
-	panic("implement me")
-}
-
-func (s staticKeyResolver) ResolveAssertionKeyID(_ did.DID) (ssi.URI, error) {
-	panic("implement me")
-}
-func (s staticKeyResolver) ResolveRelationKeyID(_ did.DID, _ types.RelationType) (ssi.URI, error) {
-	panic("implement me")
 }

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -27,6 +27,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	ssi "github.com/nuts-foundation/go-did"
 	testPKI "github.com/nuts-foundation/nuts-node/test/pki"
 	"github.com/nuts-foundation/nuts-node/vdr/didservice"
 	"github.com/nuts-foundation/nuts-node/vdr/didstore"
@@ -463,8 +464,8 @@ func TestNetwork_CreateTransaction(t *testing.T) {
 			cxt.state.EXPECT().Head(gomock.Any())
 			cxt.state.EXPECT().Add(gomock.Any(), gomock.Any(), payload)
 
-			cxt.keyResolver.EXPECT().ResolveKeyAgreementKey(*sender).Return(senderKey.Public(), nil)
-			cxt.keyResolver.EXPECT().ResolveKeyAgreementKey(*receiver).Return(receiverKey.Public(), nil)
+			cxt.keyResolver.EXPECT().ResolveKey(*sender, nil, vdrTypes.KeyAgreement).Return(ssi.MustParseURI("sender"), senderKey.Public(), nil)
+			cxt.keyResolver.EXPECT().ResolveKey(*receiver, nil, vdrTypes.KeyAgreement).Return(ssi.MustParseURI("receiver"), receiverKey.Public(), nil)
 
 			_, err = cxt.network.CreateTransaction(ctx, TransactionTemplate(payloadType, payload, key).WithPrivate([]did.DID{*sender, *receiver}))
 			assert.NoError(t, err)

--- a/vcr/ambassador_test.go
+++ b/vcr/ambassador_test.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/audit"
+	types2 "github.com/nuts-foundation/nuts-node/vdr/types"
 	"github.com/piprate/json-gold/ld"
 	"github.com/stretchr/testify/require"
 	"net/http"
@@ -113,12 +114,12 @@ func TestAmbassador_handleReprocessEvent(t *testing.T) {
 	signer, _ := util.PemToPrivateKey(pem)
 	key := crypto.NewTestKey(fmt.Sprintf("%s#1", vc.Issuer.String()))
 
-	// trust otherwise Resolve wont work
+	// trust otherwise Resolve won't work
 	ctx.vcr.Trust(vc.Type[0], vc.Issuer)
 	ctx.vcr.Trust(vc.Type[1], vc.Issuer)
 
 	// mocks
-	ctx.keyResolver.EXPECT().ResolveSigningKey(gomock.Any(), gomock.Any()).Return(signer.Public(), nil)
+	ctx.keyResolver.EXPECT().ResolveKeyByID(gomock.Any(), gomock.Any(), types2.NutsSigningKeyType).Return(signer.Public(), nil)
 
 	// Publish a VC
 	payload, _ := json.Marshal(vc)

--- a/vcr/holder/holder.go
+++ b/vcr/holder/holder.go
@@ -62,7 +62,7 @@ func (h vcHolder) BuildVP(ctx context.Context, credentials []vc.VerifiableCreden
 		}
 	}
 
-	kid, err := h.keyResolver.ResolveAssertionKeyID(*signerDID)
+	kid, _, err := h.keyResolver.ResolveKey(*signerDID, nil, vdr.NutsSigningKeyType)
 	if err != nil {
 		return nil, fmt.Errorf("unable to resolve assertion key for signing VP (did=%s): %w", *signerDID, err)
 	}

--- a/vcr/holder/holder_test.go
+++ b/vcr/holder/holder_test.go
@@ -63,7 +63,7 @@ func TestHolder_BuildVP(t *testing.T) {
     "proof": {
         "created": "2021-12-24T13:21:29.087205+01:00",
         "jws": "eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..hPM2GLc1K9d2D8Sbve004x9SumjLqaXTjWhUhvqWRwxfRWlwfp5gHDUYuRoEjhCXfLt-_u-knChVmK980N3LBw",
-        "proofPurpose": "assertionMethod",
+        "proofPurpose": "NutsSigningKeyType",
         "type": "JsonWebSignature2020",
         "verificationMethod": "` + kid + `"
     },
@@ -90,7 +90,7 @@ func TestHolder_BuildVP(t *testing.T) {
 
 		keyResolver := types.NewMockKeyResolver(ctrl)
 
-		keyResolver.EXPECT().ResolveAssertionKeyID(testDID).Return(ssi.MustParseURI(kid), nil)
+		keyResolver.EXPECT().ResolveKey(testDID, nil, types.NutsSigningKeyType).Return(ssi.MustParseURI(kid), key.Public(), nil)
 
 		holder := New(keyResolver, keyStore, nil, jsonldManager)
 
@@ -111,7 +111,7 @@ func TestHolder_BuildVP(t *testing.T) {
 		}
 		keyResolver := types.NewMockKeyResolver(ctrl)
 
-		keyResolver.EXPECT().ResolveAssertionKeyID(testDID).Return(ssi.MustParseURI(kid), nil)
+		keyResolver.EXPECT().ResolveKey(testDID, nil, types.NutsSigningKeyType).Return(ssi.MustParseURI(kid), key.Public(), nil)
 
 		holder := New(keyResolver, keyStore, nil, jsonldManager)
 
@@ -130,7 +130,7 @@ func TestHolder_BuildVP(t *testing.T) {
 
 		keyResolver := types.NewMockKeyResolver(ctrl)
 
-		keyResolver.EXPECT().ResolveAssertionKeyID(testDID).Return(vdr.TestMethodDIDA.URI(), nil)
+		keyResolver.EXPECT().ResolveKey(testDID, nil, types.NutsSigningKeyType).Return(vdr.TestMethodDIDA.URI(), key.Public(), nil)
 
 		holder := New(keyResolver, keyStore, nil, jsonldManager)
 
@@ -150,7 +150,7 @@ func TestHolder_BuildVP(t *testing.T) {
 			mockVerifier := verifier.NewMockVerifier(ctrl)
 			mockVerifier.EXPECT().Validate(testCredential, &created)
 
-			keyResolver.EXPECT().ResolveAssertionKeyID(testDID).Return(ssi.MustParseURI(kid), nil)
+			keyResolver.EXPECT().ResolveKey(testDID, nil, types.NutsSigningKeyType).Return(ssi.MustParseURI(kid), key.Public(), nil)
 
 			holder := New(keyResolver, keyStore, mockVerifier, jsonldManager)
 
@@ -166,7 +166,7 @@ func TestHolder_BuildVP(t *testing.T) {
 			mockVerifier := verifier.NewMockVerifier(ctrl)
 			mockVerifier.EXPECT().Validate(testCredential, &created).Return(errors.New("failed"))
 
-			keyResolver.EXPECT().ResolveAssertionKeyID(testDID).Return(ssi.MustParseURI(kid), nil)
+			keyResolver.EXPECT().ResolveKey(testDID, nil, types.NutsSigningKeyType).Return(ssi.MustParseURI(kid), key.Public(), nil)
 
 			holder := New(keyResolver, keyStore, mockVerifier, jsonldManager)
 
@@ -184,7 +184,7 @@ func TestHolder_BuildVP(t *testing.T) {
 
 			keyResolver := types.NewMockKeyResolver(ctrl)
 
-			keyResolver.EXPECT().ResolveAssertionKeyID(testDID).Return(ssi.MustParseURI(kid), nil)
+			keyResolver.EXPECT().ResolveKey(testDID, nil, types.NutsSigningKeyType).Return(ssi.MustParseURI(kid), key.Public(), nil)
 
 			holder := New(keyResolver, keyStore, nil, jsonldManager)
 

--- a/vcr/holder/openid.go
+++ b/vcr/holder/openid.go
@@ -193,10 +193,10 @@ func getPreAuthorizedCodeFromOffer(offer openid4vci.CredentialOffer) string {
 }
 
 func (h *openidHandler) retrieveCredential(ctx context.Context, issuerClient openid4vci.IssuerAPIClient, offer *openid4vci.CredentialDefinition, tokenResponse *openid4vci.TokenResponse) (*vc.VerifiableCredential, error) {
-	keyID, err := h.resolver.ResolveSigningKeyID(h.did, nil)
+	keyID, _, err := h.resolver.ResolveKey(h.did, nil, vdr.NutsSigningKeyType)
 	headers := map[string]interface{}{
 		"typ": openid4vci.JWTTypeOpenID4VCIProof, // MUST be openid4vci-proof+jwt, which explicitly types the proof JWT as recommended in Section 3.11 of [RFC8725].
-		"kid": keyID,                             // JOSE Header containing the key ID. If the Credential shall be bound to a DID, the kid refers to a DID URL which identifies a particular key in the DID Document that the Credential shall be bound to.
+		"kid": keyID.String(),                    // JOSE Header containing the key ID. If the Credential shall be bound to a DID, the kid refers to a DID URL which identifies a particular key in the DID Document that the Credential shall be bound to.
 	}
 	claims := map[string]interface{}{
 		"aud":   issuerClient.Metadata().CredentialIssuer,
@@ -204,7 +204,7 @@ func (h *openidHandler) retrieveCredential(ctx context.Context, issuerClient ope
 		"nonce": tokenResponse.CNonce,
 	}
 
-	proof, err := h.signer.SignJWT(ctx, claims, headers, keyID)
+	proof, err := h.signer.SignJWT(ctx, claims, headers, keyID.String())
 	if err != nil {
 		return nil, fmt.Errorf("unable to sign request proof: %w", err)
 	}

--- a/vcr/holder/openid_test.go
+++ b/vcr/holder/openid_test.go
@@ -98,7 +98,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 			"nonce": nonce,
 		}, gomock.Any(), "key-id").Return("signed-jwt", nil)
 		keyResolver := vdrTypes.NewMockKeyResolver(ctrl)
-		keyResolver.EXPECT().ResolveSigningKeyID(holderDID, nil).Return("key-id", nil)
+		keyResolver.EXPECT().ResolveKey(holderDID, nil, vdrTypes.NutsSigningKeyType).Return(ssi.MustParseURI("key-id"), nil, nil)
 
 		nowFunc = func() time.Time {
 			return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -238,7 +238,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 		jwtSigner := crypto.NewMockJWTSigner(ctrl)
 		jwtSigner.EXPECT().SignJWT(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 		keyResolver := vdrTypes.NewMockKeyResolver(ctrl)
-		keyResolver.EXPECT().ResolveSigningKeyID(holderDID, nil)
+		keyResolver.EXPECT().ResolveKey(holderDID, nil, vdrTypes.NutsSigningKeyType)
 
 		w := NewOpenIDHandler(holderDID, "https://holder.example.com", &http.Client{}, nil, jwtSigner, keyResolver).(*openidHandler)
 		w.issuerClientCreator = func(_ context.Context, _ core.HTTPRequestDoer, _ string) (openid4vci.IssuerAPIClient, error) {

--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -56,7 +56,10 @@ func NewIssuer(store Store, vcrStore types.Writer, networkPublisher Publisher,
 	openidHandlerFn func(ctx context.Context, id did.DID) (OpenIDHandler, error),
 	didstore didstore.Store, keyStore crypto.KeyStore, jsonldManager jsonld.JSONLD, trustConfig *trust.Config,
 ) Issuer {
-	resolver := vdrKeyResolver{didResolver: didservice.Resolver{Store: didstore}, keyResolver: keyStore}
+	resolver := vdrKeyResolver{
+		publicKeyResolver:  didservice.KeyResolver{Store: didstore},
+		privateKeyResolver: keyStore,
+	}
 	return &issuer{
 		store:            store,
 		networkPublisher: networkPublisher,

--- a/vcr/issuer/keyresolver.go
+++ b/vcr/issuer/keyresolver.go
@@ -23,31 +23,23 @@ import (
 	"fmt"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/crypto"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
 	vdr "github.com/nuts-foundation/nuts-node/vdr/types"
 )
 
 // vdrKeyResolver resolves private keys based upon the VDR document resolver
 type vdrKeyResolver struct {
-	didResolver vdr.DIDResolver
-	keyResolver crypto.KeyResolver
+	publicKeyResolver  vdr.KeyResolver
+	privateKeyResolver crypto.KeyResolver
 }
 
 // ResolveAssertionKey is a convenience method which tries to find a assertionKey on in the VDR for a given issuerDID.
 func (r vdrKeyResolver) ResolveAssertionKey(ctx context.Context, issuerDID did.DID) (crypto.Key, error) {
-	// find did document/metadata for originating TXs
-	document, _, err := r.didResolver.Resolve(issuerDID, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// resolve an assertionMethod key for issuer
-	kid, err := didservice.ExtractFirstRelationKeyIDByType(*document, vdr.AssertionMethod)
+	kid, _, err := r.publicKeyResolver.ResolveKey(issuerDID, nil, vdr.AssertionMethod)
 	if err != nil {
 		return nil, fmt.Errorf("invalid issuer: %w", err)
 	}
 
-	key, err := r.keyResolver.Resolve(ctx, kid.String())
+	key, err := r.privateKeyResolver.Resolve(ctx, kid.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve assertionKey: could not resolve key from keyStore: %w", err)
 	}

--- a/vcr/issuer/keyresolver_test.go
+++ b/vcr/issuer/keyresolver_test.go
@@ -36,21 +36,22 @@ func Test_vdrKeyResolver_ResolveAssertionKey(t *testing.T) {
 	issuerDID, _ := did.ParseDID("did:nuts:123")
 	methodID := *issuerDID
 	methodID.Fragment = "abc"
-	newMethod, err := did.NewVerificationMethod(methodID, ssi.JsonWebKey2020, *issuerDID, crypto.NewTestKey(issuerDID.String()+"abc").Public())
+	publicKey := crypto.NewTestKey(issuerDID.String() + "abc").Public()
+	newMethod, err := did.NewVerificationMethod(methodID, ssi.JsonWebKey2020, *issuerDID, publicKey)
 	require.NoError(t, err)
 	docWithAssertionKey := &did.Document{}
 	docWithAssertionKey.AddAssertionMethod(newMethod)
 
 	t.Run("ok", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		mockDockResolver := types.NewMockDIDResolver(ctrl)
-		mockDockResolver.EXPECT().Resolve(*issuerDID, nil).Return(docWithAssertionKey, &types.DocumentMetadata{}, nil)
-		mockKeyResolver := crypto.NewMockKeyResolver(ctrl)
-		mockKeyResolver.EXPECT().Resolve(ctx, methodID.String()).Return(crypto.NewTestKey(methodID.String()), nil)
+		mockPubKeyResolver := types.NewMockKeyResolver(ctrl)
+		mockPubKeyResolver.EXPECT().ResolveKey(*issuerDID, nil, types.NutsSigningKeyType).Return(methodID.URI(), publicKey, nil)
+		mockPrivKeyResolver := crypto.NewMockKeyResolver(ctrl)
+		mockPrivKeyResolver.EXPECT().Resolve(ctx, methodID.String()).Return(crypto.NewTestKey(methodID.String()), nil)
 
 		sut := vdrKeyResolver{
-			didResolver: mockDockResolver,
-			keyResolver: mockKeyResolver,
+			publicKeyResolver:  mockPubKeyResolver,
+			privateKeyResolver: mockPrivKeyResolver,
 		}
 
 		key, err := sut.ResolveAssertionKey(ctx, *issuerDID)
@@ -62,52 +63,35 @@ func Test_vdrKeyResolver_ResolveAssertionKey(t *testing.T) {
 
 	t.Run("document for issuer not found in vdr", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		mockDockResolver := types.NewMockDIDResolver(ctrl)
-		mockDockResolver.EXPECT().Resolve(*issuerDID, nil).Return(nil, nil, errors.New("not found"))
-		mockKeyResolver := crypto.NewMockKeyResolver(ctrl)
+		mockPubKeyResolver := types.NewMockKeyResolver(ctrl)
+		mockPubKeyResolver.EXPECT().ResolveKey(*issuerDID, nil, types.NutsSigningKeyType).Return(ssi.URI{}, nil, errors.New("not found"))
+		mockPrivKeyResolver := crypto.NewMockKeyResolver(ctrl)
 
 		sut := vdrKeyResolver{
-			didResolver: mockDockResolver,
-			keyResolver: mockKeyResolver,
+			publicKeyResolver:  mockPubKeyResolver,
+			privateKeyResolver: mockPrivKeyResolver,
 		}
 
 		key, err := sut.ResolveAssertionKey(ctx, *issuerDID)
 
 		assert.Nil(t, key)
-		assert.EqualError(t, err, "not found")
+		assert.EqualError(t, err, "invalid issuer: not found")
 	})
 
 	t.Run("key not found in crypto", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		mockDockResolver := types.NewMockDIDResolver(ctrl)
-		mockDockResolver.EXPECT().Resolve(*issuerDID, nil).Return(docWithAssertionKey, &types.DocumentMetadata{}, nil)
-		mockKeyResolver := crypto.NewMockKeyResolver(ctrl)
-		mockKeyResolver.EXPECT().Resolve(ctx, methodID.String()).Return(nil, errors.New("not found"))
+		mockPubKeyResolver := types.NewMockKeyResolver(ctrl)
+		mockPubKeyResolver.EXPECT().ResolveKey(*issuerDID, nil, types.NutsSigningKeyType).Return(methodID.URI(), publicKey, nil)
+		mockPrivKeyResolver := crypto.NewMockKeyResolver(ctrl)
+		mockPrivKeyResolver.EXPECT().Resolve(ctx, methodID.String()).Return(nil, errors.New("not found"))
 
 		sut := vdrKeyResolver{
-			didResolver: mockDockResolver,
-			keyResolver: mockKeyResolver,
+			publicKeyResolver:  mockPubKeyResolver,
+			privateKeyResolver: mockPrivKeyResolver,
 		}
 
 		key, err := sut.ResolveAssertionKey(ctx, *issuerDID)
 		assert.Nil(t, key)
 		assert.EqualError(t, err, "failed to resolve assertionKey: could not resolve key from keyStore: not found")
 	})
-
-	t.Run("did document has no assertionKey", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockDockResolver := types.NewMockDIDResolver(ctrl)
-		mockDockResolver.EXPECT().Resolve(*issuerDID, nil).Return(&did.Document{}, &types.DocumentMetadata{}, nil)
-		mockKeyResolver := crypto.NewMockKeyResolver(ctrl)
-
-		sut := vdrKeyResolver{
-			didResolver: mockDockResolver,
-			keyResolver: mockKeyResolver,
-		}
-
-		key, err := sut.ResolveAssertionKey(ctx, *issuerDID)
-		assert.Nil(t, key)
-		assert.EqualError(t, err, "invalid issuer: key not found in DID document")
-	})
-
 }

--- a/vcr/issuer/network_publisher.go
+++ b/vcr/issuer/network_publisher.go
@@ -52,8 +52,8 @@ func NewNetworkPublisher(networkTx network.Transactions, store didstore.Store, k
 		didResolver:     didResolver,
 		serviceResolver: didservice.ServiceResolver{Store: store},
 		keyResolver: vdrKeyResolver{
-			didResolver: didResolver,
-			keyResolver: keyResolver,
+			publicKeyResolver:  didservice.KeyResolver{Store: store},
+			privateKeyResolver: keyResolver,
 		},
 	}
 

--- a/vcr/issuer/openid.go
+++ b/vcr/issuer/openid.go
@@ -321,7 +321,7 @@ func (i *openidHandler) validateProof(ctx context.Context, flow *Flow, request o
 	var signingKeyID string
 	token, err := crypto.ParseJWT(request.Proof.Jwt, func(kid string) (crypt.PublicKey, error) {
 		signingKeyID = kid
-		return i.keyResolver.ResolveSigningKey(kid, nil)
+		return i.keyResolver.ResolveKeyByID(kid, nil, types.NutsSigningKeyType)
 	}, jwt.WithAcceptableSkew(5*time.Second))
 	if err != nil {
 		return generateProofError(openid4vci.Error{

--- a/vcr/issuer/openid_test.go
+++ b/vcr/issuer/openid_test.go
@@ -123,7 +123,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 	})
 	ctrl := gomock.NewController(t)
 	keyResolver := types.NewMockKeyResolver(ctrl)
-	keyResolver.EXPECT().ResolveSigningKey(keyID, nil).AnyTimes().Return(signerKey.Public(), nil)
+	keyResolver.EXPECT().ResolveKeyByID(keyID, nil, types.NutsSigningKeyType).AnyTimes().Return(signerKey.Public(), nil)
 
 	createHeaders := func() map[string]interface{} {
 		return map[string]interface{}{
@@ -265,7 +265,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 			})
 			t.Run("signing key is unknown", func(t *testing.T) {
 				keyResolver := types.NewMockKeyResolver(ctrl)
-				keyResolver.EXPECT().ResolveSigningKey(keyID, nil).AnyTimes().Return(nil, types.ErrKeyNotFound)
+				keyResolver.EXPECT().ResolveKeyByID(keyID, nil, types.NutsSigningKeyType).AnyTimes().Return(nil, types.ErrKeyNotFound)
 				service := requireNewTestHandler(t, keyResolver)
 				_, err := service.createOffer(ctx, issuedVC, preAuthCode)
 				require.NoError(t, err)

--- a/vcr/store_test.go
+++ b/vcr/store_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/sha1"
 	"encoding/json"
 	"github.com/nuts-foundation/nuts-node/crypto/storage/spi"
+	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
@@ -50,7 +51,7 @@ func TestVcr_StoreCredential(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		ctx := newMockContext(t)
 
-		ctx.keyResolver.EXPECT().ResolveSigningKey(gomock.Any(), nil).Return(pk, nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(gomock.Any(), nil, types.NutsSigningKeyType).Return(pk, nil)
 
 		err := ctx.vcr.StoreCredential(target, nil)
 
@@ -61,7 +62,7 @@ func TestVcr_StoreCredential(t *testing.T) {
 		ctx := newMockContext(t)
 		now := time.Now()
 
-		ctx.keyResolver.EXPECT().ResolveSigningKey(gomock.Any(), &now).Return(pk, nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(gomock.Any(), &now, types.NutsSigningKeyType).Return(pk, nil)
 
 		err := ctx.vcr.StoreCredential(target, &now)
 
@@ -72,7 +73,7 @@ func TestVcr_StoreCredential(t *testing.T) {
 		ctx := newMockContext(t)
 		now := time.Now()
 
-		ctx.keyResolver.EXPECT().ResolveSigningKey(gomock.Any(), &now).Return(pk, nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(gomock.Any(), &now, types.NutsSigningKeyType).Return(pk, nil)
 
 		_ = ctx.vcr.StoreCredential(target, &now)
 
@@ -85,7 +86,7 @@ func TestVcr_StoreCredential(t *testing.T) {
 		ctx := newMockContext(t)
 		now := time.Now()
 
-		ctx.keyResolver.EXPECT().ResolveSigningKey(gomock.Any(), &now).Return(pk, nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(gomock.Any(), &now, types.NutsSigningKeyType).Return(pk, nil)
 
 		_ = ctx.vcr.StoreCredential(target, &now)
 

--- a/vcr/verifier/verifier.go
+++ b/vcr/verifier/verifier.go
@@ -128,7 +128,7 @@ func (v *verifier) Validate(credentialToVerify vc.VerifiableCredential, at *time
 	}
 
 	// find key
-	pk, err := v.keyResolver.ResolveSigningKey(ldProof.VerificationMethod.String(), at)
+	pk, err := v.keyResolver.ResolveKeyByID(ldProof.VerificationMethod.String(), at, vdr.NutsSigningKeyType)
 	if err != nil {
 		if at == nil {
 			return fmt.Errorf("unable to resolve signing key: %w", err)
@@ -239,7 +239,7 @@ func (v *verifier) RegisterRevocation(revocation credential.Revocation) error {
 		return errors.New("verificationMethod should owned by the issuer")
 	}
 
-	pk, err := v.keyResolver.ResolveSigningKey(revocation.Proof.VerificationMethod.String(), &revocation.Date)
+	pk, err := v.keyResolver.ResolveKeyByID(revocation.Proof.VerificationMethod.String(), &revocation.Date, vdr.NutsSigningKeyType)
 	if err != nil {
 		return fmt.Errorf("unable to resolve key for revocation: %w", err)
 	}
@@ -283,7 +283,7 @@ func (v verifier) doVerifyVP(vcVerifier Verifier, vp vc.VerifiablePresentation, 
 	}
 
 	// Validate signature
-	signingKey, err := v.keyResolver.ResolveSigningKey(ldProof.VerificationMethod.String(), validAt)
+	signingKey, err := v.keyResolver.ResolveKeyByID(ldProof.VerificationMethod.String(), validAt, vdr.NutsSigningKeyType)
 	if err != nil {
 		return nil, fmt.Errorf("unable to resolve valid signing key: %w", err)
 	}

--- a/vdr/ambassador.go
+++ b/vdr/ambassador.go
@@ -63,7 +63,7 @@ type ambassador struct {
 	networkClient network.Transactions
 	didStore      didstore.Store
 	keyResolver   types.NutsKeyResolver
-	didResolver   *didservice.Resolver
+	didResolver   types.DIDResolver
 	eventManager  events.Event
 }
 

--- a/vdr/didservice/nuts_resolvers.go
+++ b/vdr/didservice/nuts_resolvers.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package didservice
+
+import (
+	"crypto"
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	"github.com/nuts-foundation/nuts-node/vdr/types"
+)
+
+// NutsKeyResolver implements the NutsKeyResolver interface.
+type NutsKeyResolver struct {
+	Resolver types.DIDResolver
+}
+
+func (r NutsKeyResolver) ResolvePublicKey(kid string, sourceTransactionsRefs []hash.SHA256Hash) (crypto.PublicKey, error) {
+	// try all keys, continue when err == types.ErrNotFound
+	for _, h := range sourceTransactionsRefs {
+		publicKey, err := resolvePublicKey(r.Resolver, kid, types.ResolveMetadata{
+			SourceTransaction: &h,
+		})
+		if err == nil {
+			return publicKey, nil
+		}
+		if err != types.ErrNotFound {
+			return nil, err
+		}
+	}
+
+	return nil, types.ErrNotFound
+}

--- a/vdr/didservice/nuts_resolvers_test.go
+++ b/vdr/didservice/nuts_resolvers_test.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package didservice
+
+import (
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	"github.com/nuts-foundation/nuts-node/vdr/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"testing"
+)
+
+func TestNutsKeyResolver_ResolvePublicKey(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	didResolver := types.NewMockDIDResolver(ctrl)
+	keyResolver := NutsKeyResolver{Resolver: didResolver}
+	keyCreator := newMockKeyCreator()
+	docCreator := Creator{KeyStore: keyCreator}
+	doc, _, _ := docCreator.Create(nil, DefaultCreationOptions())
+
+	t.Run("ok by hash", func(t *testing.T) {
+		didResolver.EXPECT().Resolve(testDID, gomock.Any()).Do(func(arg0 interface{}, arg1 interface{}) {
+			resolveMetadata := arg1.(*types.ResolveMetadata)
+			assert.Equal(t, hash.EmptyHash(), *resolveMetadata.SourceTransaction)
+		}).Return(doc, nil, nil)
+
+		key, err := keyResolver.ResolvePublicKey(mockKID, []hash.SHA256Hash{hash.EmptyHash()})
+		require.NoError(t, err)
+
+		assert.NotNil(t, key)
+	})
+
+}

--- a/vdr/didservice/resolvers_test.go
+++ b/vdr/didservice/resolvers_test.go
@@ -20,7 +20,6 @@ package didservice
 import (
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/nuts-node/audit"
 	"testing"
 	"time"
 
@@ -33,177 +32,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
-
-func TestResolveSigningKey(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	store := didstore.NewMockStore(ctrl)
-	keyResolver := KeyResolver{Store: store}
-	keyCreator := newMockKeyCreator()
-	docCreator := Creator{KeyStore: keyCreator}
-	doc, _, _ := docCreator.Create(nil, DefaultCreationOptions())
-	// add a second key to the document
-	methodID := doc.ID
-	methodID.Fragment = "key2"
-	newMethod := &did.VerificationMethod{ID: methodID}
-	doc.AddAssertionMethod(newMethod)
-
-	t.Run("ok", func(t *testing.T) {
-		store.EXPECT().Resolve(testDID, gomock.Any()).Return(doc, nil, nil)
-
-		key, err := keyResolver.ResolveSigningKey(mockKID, nil)
-
-		require.NoError(t, err)
-		assert.NotNil(t, key)
-	})
-
-	t.Run("unable to resolve document", func(t *testing.T) {
-		store.EXPECT().Resolve(testDID, gomock.Any()).Return(nil, nil, types.ErrNotFound)
-
-		_, err := keyResolver.ResolveSigningKey(mockKID, nil)
-
-		assert.Error(t, err)
-		assert.Equal(t, types.ErrNotFound, err)
-	})
-
-	t.Run("signing key not found in document", func(t *testing.T) {
-		store.EXPECT().Resolve(testDID, gomock.Any()).Return(doc, nil, nil)
-
-		_, err := keyResolver.ResolveSigningKey(mockKID[:len(mockKID)-2], nil)
-
-		assert.Error(t, err)
-		assert.Equal(t, types.ErrKeyNotFound, err)
-	})
-
-	t.Run("invalid key ID", func(t *testing.T) {
-		_, err := keyResolver.ResolveSigningKey("asdasdsa", nil)
-
-		assert.Error(t, err)
-		assert.ErrorIs(t, err, did.ErrInvalidDID)
-	})
-}
-
-func TestResolveSigningKeyID(t *testing.T) {
-	keyCreator := newMockKeyCreator()
-	docCreator := Creator{KeyStore: keyCreator}
-	doc, _, _ := docCreator.Create(nil, DefaultCreationOptions())
-
-	t.Run("ok", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		store := didstore.NewMockStore(ctrl)
-		keyResolver := KeyResolver{Store: store}
-		store.EXPECT().Resolve(testDID, gomock.Any()).Return(doc, nil, nil)
-
-		actual, err := keyResolver.ResolveSigningKeyID(testDID, nil)
-
-		require.NoError(t, err)
-		assert.Equal(t, mockKID, actual)
-	})
-
-	t.Run("unable to resolve", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		store := didstore.NewMockStore(ctrl)
-		keyResolver := KeyResolver{Store: store}
-		store.EXPECT().Resolve(testDID, gomock.Any()).Return(nil, nil, types.ErrNotFound)
-
-		_, err := keyResolver.ResolveSigningKeyID(testDID, nil)
-
-		assert.Error(t, err)
-		assert.Equal(t, types.ErrNotFound, err)
-	})
-
-	t.Run("signing key not found", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		store := didstore.NewMockStore(ctrl)
-		keyResolver := KeyResolver{Store: store}
-		store.EXPECT().Resolve(testDID, gomock.Any()).Return(&did.Document{}, nil, nil)
-
-		_, err := keyResolver.ResolveSigningKeyID(testDID, nil)
-
-		assert.Equal(t, types.ErrKeyNotFound, err)
-	})
-}
-
-func TestKeyResolver_ResolveAssertionKeyID(t *testing.T) {
-	keyCreator := newMockKeyCreator()
-	docCreator := Creator{KeyStore: keyCreator}
-	doc, _, _ := docCreator.Create(nil, DefaultCreationOptions())
-
-	t.Run("ok - resolve a known key", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		store := didstore.NewMockStore(ctrl)
-		keyResolver := KeyResolver{Store: store}
-		store.EXPECT().Resolve(testDID, gomock.Any()).Return(doc, nil, nil)
-
-		actual, err := keyResolver.ResolveAssertionKeyID(testDID)
-
-		require.NoError(t, err)
-		assert.Equal(t, mockKID, actual.String())
-	})
-
-	t.Run("unable to resolve", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		store := didstore.NewMockStore(ctrl)
-		keyResolver := KeyResolver{Store: store}
-		store.EXPECT().Resolve(testDID, gomock.Any()).Return(nil, nil, types.ErrNotFound)
-
-		_, err := keyResolver.ResolveAssertionKeyID(testDID)
-
-		assert.Error(t, err)
-		assert.Equal(t, types.ErrNotFound, err)
-	})
-
-	t.Run("signing key not found", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		store := didstore.NewMockStore(ctrl)
-		keyResolver := KeyResolver{Store: store}
-		store.EXPECT().Resolve(testDID, gomock.Any()).Return(&did.Document{}, nil, nil)
-
-		_, err := keyResolver.ResolveAssertionKeyID(testDID)
-
-		assert.Equal(t, types.ErrKeyNotFound, err)
-	})
-}
-
-func TestKeyResolver_ResolveKeyAgreementKey(t *testing.T) {
-	keyCreator := newMockKeyCreator()
-	docCreator := Creator{KeyStore: keyCreator}
-	doc, _, _ := docCreator.Create(audit.TestContext(), DefaultCreationOptions())
-
-	t.Run("ok - resolve a known key", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		store := didstore.NewMockStore(ctrl)
-		keyResolver := KeyResolver{Store: store}
-		store.EXPECT().Resolve(testDID, gomock.Any()).Return(doc, nil, nil)
-
-		actual, err := keyResolver.ResolveKeyAgreementKey(testDID)
-
-		require.NoError(t, err)
-		assert.NotNil(t, actual)
-	})
-
-	t.Run("unable to resolve", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		store := didstore.NewMockStore(ctrl)
-		keyResolver := KeyResolver{Store: store}
-		store.EXPECT().Resolve(testDID, gomock.Any()).Return(nil, nil, types.ErrNotFound)
-
-		_, err := keyResolver.ResolveKeyAgreementKey(testDID)
-
-		assert.Error(t, err)
-		assert.Equal(t, types.ErrNotFound, err)
-	})
-
-	t.Run("key not found", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		store := didstore.NewMockStore(ctrl)
-		keyResolver := KeyResolver{Store: store}
-		store.EXPECT().Resolve(testDID, gomock.Any()).Return(&did.Document{}, nil, nil)
-
-		_, err := keyResolver.ResolveKeyAgreementKey(testDID)
-
-		assert.Equal(t, types.ErrKeyNotFound, err)
-	})
-}
 
 func TestResolver_Resolve(t *testing.T) {
 	id123, _ := did.ParseDID("did:nuts:123")
@@ -452,28 +280,6 @@ func TestResolveControllers(t *testing.T) {
 	})
 }
 
-func TestNutsKeyResolver_ResolvePublicKey(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	didResolver := types.NewMockDIDResolver(ctrl)
-	keyResolver := NutsKeyResolver{Resolver: didResolver}
-	keyCreator := newMockKeyCreator()
-	docCreator := Creator{KeyStore: keyCreator}
-	doc, _, _ := docCreator.Create(nil, DefaultCreationOptions())
-
-	t.Run("ok by hash", func(t *testing.T) {
-		didResolver.EXPECT().Resolve(testDID, gomock.Any()).Do(func(arg0 interface{}, arg1 interface{}) {
-			resolveMetadata := arg1.(*types.ResolveMetadata)
-			assert.Equal(t, hash.EmptyHash(), *resolveMetadata.SourceTransaction)
-		}).Return(doc, nil, nil)
-
-		key, err := keyResolver.ResolvePublicKey(mockKID, []hash.SHA256Hash{hash.EmptyHash()})
-		require.NoError(t, err)
-
-		assert.NotNil(t, key)
-	})
-
-}
-
 func TestServiceResolver_Resolve(t *testing.T) {
 	meta := &types.DocumentMetadata{Hash: hash.EmptyHash()}
 
@@ -583,62 +389,7 @@ func TestServiceResolver_Resolve(t *testing.T) {
 
 }
 
-func TestExtractFirstRelationKeyIDByType(t *testing.T) {
-	keyCreator := newMockKeyCreator()
-	docCreator := Creator{KeyStore: keyCreator}
-	doc, _, err := docCreator.Create(nil, DefaultCreationOptions())
-	require.NoError(t, err)
-	type args struct {
-		doc          did.Document
-		relationType types.RelationType
-	}
-	tests := []struct {
-		name        string
-		args        args
-		want        ssi.URI
-		expectedErr error
-	}{
-		{
-			name: "ok - it finds the key",
-			args: args{
-				doc:          *doc,
-				relationType: types.AssertionMethod,
-			},
-			want:        doc.VerificationMethod[0].ID.URI(),
-			expectedErr: nil,
-		},
-		{
-			name: "err - key not found",
-			args: args{
-				doc:          *doc,
-				relationType: types.CapabilityDelegation,
-			},
-			want:        ssi.URI{},
-			expectedErr: types.ErrKeyNotFound,
-		},
-		{
-			name: "err - unknown relation type",
-			args: args{
-				doc:          *doc,
-				relationType: 20,
-			},
-			want:        ssi.URI{},
-			expectedErr: errors.New("unable to locate RelationType 20"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ExtractFirstRelationKeyIDByType(tt.args.doc, tt.args.relationType)
-			if tt.expectedErr != nil {
-				require.EqualError(t, err, tt.expectedErr.Error())
-				return
-			}
-			assert.Equalf(t, tt.want, got, "ExtractFirstRelationKeyIDByType(%v, %v)", tt.args.doc, tt.args.relationType)
-		})
-	}
-}
-
-func TestKeyResolver_ResolveRelationKeyID(t *testing.T) {
+func TestKeyResolver_ResolveKey(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := didstore.NewMockStore(ctrl)
 	keyResolver := KeyResolver{Store: store}
@@ -646,21 +397,82 @@ func TestKeyResolver_ResolveRelationKeyID(t *testing.T) {
 	keyCreator := newMockKeyCreator()
 	docCreator := Creator{KeyStore: keyCreator}
 	doc, _, err := docCreator.Create(nil, DefaultCreationOptions())
-	store.EXPECT().Resolve(doc.ID, gomock.Any()).Return(doc, nil, nil)
 	require.NoError(t, err)
+	store.EXPECT().Resolve(doc.ID, gomock.Any()).AnyTimes().Return(doc, nil, nil)
 
 	t.Run("ok - it finds the key", func(t *testing.T) {
-		keyId, err := keyResolver.ResolveRelationKeyID(doc.ID, types.AssertionMethod)
+		keyId, key, err := keyResolver.ResolveKey(doc.ID, nil, types.AssertionMethod)
 		require.NoError(t, err)
 		assert.Equal(t, doc.VerificationMethod[0].ID.URI(), keyId)
+		assert.NotNil(t, key)
 	})
 
-	t.Run("err - document not found", func(t *testing.T) {
+	t.Run("error - document not found", func(t *testing.T) {
 		unknownDID := did.MustParseDID("did:example:123")
 		store.EXPECT().Resolve(unknownDID, gomock.Any()).Return(nil, nil, types.ErrNotFound)
-		keyId, err := keyResolver.ResolveRelationKeyID(unknownDID, types.AssertionMethod)
-		require.EqualError(t, err, "unable to find the DID document")
-		require.Equal(t, ssi.URI{}, keyId)
+		keyId, key, err := keyResolver.ResolveKey(unknownDID, nil, types.AssertionMethod)
+		assert.EqualError(t, err, "unable to find the DID document")
+		assert.Empty(t, keyId)
+		assert.Nil(t, key)
+	})
+
+	t.Run("error - key not found", func(t *testing.T) {
+		keyId, key, err := keyResolver.ResolveKey(did.MustParseDIDURL(doc.ID.String()), nil, types.CapabilityDelegation)
+		assert.EqualError(t, err, "key not found in DID document")
+		assert.Empty(t, keyId)
+		assert.Nil(t, key)
+	})
+
+	t.Run("error - unknown relationship type", func(t *testing.T) {
+		keyId, key, err := keyResolver.ResolveKey(doc.ID, nil, 1000)
+		assert.EqualError(t, err, "unable to locate RelationType 1000")
+		assert.Empty(t, keyId)
+		assert.Nil(t, key)
+	})
+}
+
+func TestKeyResolver_ResolveKeyByID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := didstore.NewMockStore(ctrl)
+	keyResolver := KeyResolver{Store: store}
+
+	keyCreator := newMockKeyCreator()
+	docCreator := Creator{KeyStore: keyCreator}
+	doc, _, err := docCreator.Create(nil, DefaultCreationOptions())
+	require.NoError(t, err)
+	store.EXPECT().Resolve(doc.ID, gomock.Any()).AnyTimes().Return(doc, nil, nil)
+	keyID := doc.VerificationMethod[0].ID
+
+	t.Run("ok - it finds the key", func(t *testing.T) {
+		key, err := keyResolver.ResolveKeyByID(keyID.String(), nil, types.AssertionMethod)
+		assert.NoError(t, err)
+		assert.NotNil(t, key)
+	})
+
+	t.Run("error - invalid key ID", func(t *testing.T) {
+		key, err := keyResolver.ResolveKeyByID("abcdef", nil, types.AssertionMethod)
+		assert.EqualError(t, err, "invalid key ID (id=abcdef): invalid DID")
+		assert.Nil(t, key)
+	})
+
+	t.Run("error - document not found", func(t *testing.T) {
+		unknownDID := did.MustParseDIDURL("did:example:123")
+		store.EXPECT().Resolve(unknownDID, gomock.Any()).Return(nil, nil, types.ErrNotFound)
+		key, err := keyResolver.ResolveKeyByID(unknownDID.String()+"#456", nil, types.AssertionMethod)
+		assert.EqualError(t, err, "unable to find the DID document")
+		assert.Nil(t, key)
+	})
+
+	t.Run("error - key not found", func(t *testing.T) {
+		key, err := keyResolver.ResolveKeyByID(did.MustParseDIDURL(doc.ID.String()+"#123").String(), nil, types.AssertionMethod)
+		assert.EqualError(t, err, "key not found in DID document")
+		assert.Nil(t, key)
+	})
+
+	t.Run("error - unknown relationship type", func(t *testing.T) {
+		key, err := keyResolver.ResolveKeyByID(keyID.String(), nil, 1000)
+		assert.EqualError(t, err, "unable to locate RelationType 1000")
+		assert.Nil(t, key)
 	})
 }
 

--- a/vdr/integration_test.go
+++ b/vdr/integration_test.go
@@ -97,7 +97,7 @@ func TestVDRIntegration_Test(t *testing.T) {
 		"unexpected error while resolving documentB")
 
 	// Update the controller of DocumentA with DocumentB
-	// And remove it's own authenticationMethod
+	// And remove its own authenticationMethod
 	docA.Controller = []did.DID{docB.ID}
 	docA.AssertionMethod = []did.VerificationRelationship{}
 	docA.CapabilityInvocation = []did.VerificationRelationship{}

--- a/vdr/types/interface.go
+++ b/vdr/types/interface.go
@@ -79,27 +79,18 @@ type DocUpdater interface {
 // KeyResolver is the interface for resolving keys.
 // This can be used for checking if a signing key is valid at a point in time or to just find a valid key for signing.
 type KeyResolver interface {
-	// ResolveSigningKeyID looks up a signing key of the specified holder. It returns the ID
-	// of the found key. Typically used to find a key for signing one's own documents. If no suitable keys
-	// are found an error is returned.
-	ResolveSigningKeyID(holder did.DID, validAt *time.Time) (string, error)
-	// ResolveSigningKey looks up a specific signing key and returns it as crypto.PublicKey. If the key can't be found
-	// or isn't meant for signing an error is returned.
-	ResolveSigningKey(keyID string, validAt *time.Time) (crypto.PublicKey, error)
-	// ResolveAssertionKeyID look for a valid assertion key for the give DID. If multiple keys are valid, the first one is returned.
-	// An ErrKeyNotFound is returned when no key is found.
-	ResolveAssertionKeyID(id did.DID) (ssi.URI, error)
-	// ResolveKeyAgreementKey look for a valid keyAgreement key for the give DID. If multiple keys are valid, the first one is returned.
-	// An ErrKeyNotFound is returned when no key is found.
-	ResolveKeyAgreementKey(id did.DID) (crypto.PublicKey, error)
-	// ResolveRelationKey looks up a specific key of the given RelationType and returns it as crypto.PublicKey.
-	// If the key can't be found or isn't meant for signing an error is returned.
-	ResolveRelationKey(keyID string, validAt *time.Time, relationType RelationType) (crypto.PublicKey, error)
-	// ResolveRelationKeyID look for a valid key of the given RelationType for the give DID.
+	// ResolveKeyByID looks up a specific key of the given RelationType and returns it as crypto.PublicKey.
 	// If multiple keys are valid, the first one is returned.
-	// An ErrKeyNotFound is returned when no key is found.
-	ResolveRelationKeyID(id did.DID, relationType RelationType) (ssi.URI, error)
+	// An ErrKeyNotFound is returned when no key (of the specified type) is found.
+	ResolveKeyByID(keyID string, validAt *time.Time, relationType RelationType) (crypto.PublicKey, error)
+	// ResolveKey looks for a valid key of the given RelationType for the given DID, and returns its ID and the key itself.
+	// If multiple keys are valid, the first one is returned.
+	// An ErrKeyNotFound is returned when no key (of the specified type) is found.
+	ResolveKey(id did.DID, validAt *time.Time, relationType RelationType) (ssi.URI, crypto.PublicKey, error)
 }
+
+// NutsSigningKeyType defines the verification method relationship type for signing keys in Nuts DID Documents.
+const NutsSigningKeyType = AssertionMethod
 
 // NutsKeyResolver is the interface for resolving keys from Nuts DID Documents,
 // supporting Nuts-specific DID resolution parameters.

--- a/vdr/types/mock.go
+++ b/vdr/types/mock.go
@@ -271,38 +271,62 @@ func (m *MockKeyResolver) EXPECT() *MockKeyResolverMockRecorder {
 	return m.recorder
 }
 
-// ResolveAssertionKeyID mocks base method.
-func (m *MockKeyResolver) ResolveAssertionKeyID(id did.DID) (ssi.URI, error) {
+// ResolveKey mocks base method.
+func (m *MockKeyResolver) ResolveKey(id did.DID, validAt *time.Time, relationType RelationType) (ssi.URI, crypto.PublicKey, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveAssertionKeyID", id)
+	ret := m.ctrl.Call(m, "ResolveKey", id, validAt, relationType)
 	ret0, _ := ret[0].(ssi.URI)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(crypto.PublicKey)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
-// ResolveAssertionKeyID indicates an expected call of ResolveAssertionKeyID.
-func (mr *MockKeyResolverMockRecorder) ResolveAssertionKeyID(id interface{}) *gomock.Call {
+// ResolveKey indicates an expected call of ResolveKey.
+func (mr *MockKeyResolverMockRecorder) ResolveKey(id, validAt, relationType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveAssertionKeyID", reflect.TypeOf((*MockKeyResolver)(nil).ResolveAssertionKeyID), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveKey", reflect.TypeOf((*MockKeyResolver)(nil).ResolveKey), id, validAt, relationType)
 }
 
-// ResolveKeyAgreementKey mocks base method.
-func (m *MockKeyResolver) ResolveKeyAgreementKey(id did.DID) (crypto.PublicKey, error) {
+// ResolveKeyByID mocks base method.
+func (m *MockKeyResolver) ResolveKeyByID(keyID string, validAt *time.Time, relationType RelationType) (crypto.PublicKey, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveKeyAgreementKey", id)
+	ret := m.ctrl.Call(m, "ResolveKeyByID", keyID, validAt, relationType)
 	ret0, _ := ret[0].(crypto.PublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ResolveKeyAgreementKey indicates an expected call of ResolveKeyAgreementKey.
-func (mr *MockKeyResolverMockRecorder) ResolveKeyAgreementKey(id interface{}) *gomock.Call {
+// ResolveKeyByID indicates an expected call of ResolveKeyByID.
+func (mr *MockKeyResolverMockRecorder) ResolveKeyByID(keyID, validAt, relationType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveKeyAgreementKey", reflect.TypeOf((*MockKeyResolver)(nil).ResolveKeyAgreementKey), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveKeyByID", reflect.TypeOf((*MockKeyResolver)(nil).ResolveKeyByID), keyID, validAt, relationType)
+}
+
+// MockNutsKeyResolver is a mock of NutsKeyResolver interface.
+type MockNutsKeyResolver struct {
+	ctrl     *gomock.Controller
+	recorder *MockNutsKeyResolverMockRecorder
+}
+
+// MockNutsKeyResolverMockRecorder is the mock recorder for MockNutsKeyResolver.
+type MockNutsKeyResolverMockRecorder struct {
+	mock *MockNutsKeyResolver
+}
+
+// NewMockNutsKeyResolver creates a new mock instance.
+func NewMockNutsKeyResolver(ctrl *gomock.Controller) *MockNutsKeyResolver {
+	mock := &MockNutsKeyResolver{ctrl: ctrl}
+	mock.recorder = &MockNutsKeyResolverMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockNutsKeyResolver) EXPECT() *MockNutsKeyResolverMockRecorder {
+	return m.recorder
 }
 
 // ResolvePublicKey mocks base method.
-func (m *MockKeyResolver) ResolvePublicKey(kid string, sourceTransactionsRefs []hash.SHA256Hash) (crypto.PublicKey, error) {
+func (m *MockNutsKeyResolver) ResolvePublicKey(kid string, sourceTransactionsRefs []hash.SHA256Hash) (crypto.PublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolvePublicKey", kid, sourceTransactionsRefs)
 	ret0, _ := ret[0].(crypto.PublicKey)
@@ -311,69 +335,9 @@ func (m *MockKeyResolver) ResolvePublicKey(kid string, sourceTransactionsRefs []
 }
 
 // ResolvePublicKey indicates an expected call of ResolvePublicKey.
-func (mr *MockKeyResolverMockRecorder) ResolvePublicKey(kid, sourceTransactionsRefs interface{}) *gomock.Call {
+func (mr *MockNutsKeyResolverMockRecorder) ResolvePublicKey(kid, sourceTransactionsRefs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolvePublicKey", reflect.TypeOf((*MockKeyResolver)(nil).ResolvePublicKey), kid, sourceTransactionsRefs)
-}
-
-// ResolveRelationKey mocks base method.
-func (m *MockKeyResolver) ResolveRelationKey(keyID string, validAt *time.Time, relationType RelationType) (crypto.PublicKey, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveRelationKey", keyID, validAt, relationType)
-	ret0, _ := ret[0].(crypto.PublicKey)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ResolveRelationKey indicates an expected call of ResolveRelationKey.
-func (mr *MockKeyResolverMockRecorder) ResolveRelationKey(keyID, validAt, relationType interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveRelationKey", reflect.TypeOf((*MockKeyResolver)(nil).ResolveRelationKey), keyID, validAt, relationType)
-}
-
-// ResolveRelationKeyID mocks base method.
-func (m *MockKeyResolver) ResolveRelationKeyID(id did.DID, relationType RelationType) (ssi.URI, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveRelationKeyID", id, relationType)
-	ret0, _ := ret[0].(ssi.URI)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ResolveRelationKeyID indicates an expected call of ResolveRelationKeyID.
-func (mr *MockKeyResolverMockRecorder) ResolveRelationKeyID(id, relationType interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveRelationKeyID", reflect.TypeOf((*MockKeyResolver)(nil).ResolveRelationKeyID), id, relationType)
-}
-
-// ResolveSigningKey mocks base method.
-func (m *MockKeyResolver) ResolveSigningKey(keyID string, validAt *time.Time) (crypto.PublicKey, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveSigningKey", keyID, validAt)
-	ret0, _ := ret[0].(crypto.PublicKey)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ResolveSigningKey indicates an expected call of ResolveSigningKey.
-func (mr *MockKeyResolverMockRecorder) ResolveSigningKey(keyID, validAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveSigningKey", reflect.TypeOf((*MockKeyResolver)(nil).ResolveSigningKey), keyID, validAt)
-}
-
-// ResolveSigningKeyID mocks base method.
-func (m *MockKeyResolver) ResolveSigningKeyID(holder did.DID, validAt *time.Time) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveSigningKeyID", holder, validAt)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ResolveSigningKeyID indicates an expected call of ResolveSigningKeyID.
-func (mr *MockKeyResolverMockRecorder) ResolveSigningKeyID(holder, validAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveSigningKeyID", reflect.TypeOf((*MockKeyResolver)(nil).ResolveSigningKeyID), holder, validAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolvePublicKey", reflect.TypeOf((*MockNutsKeyResolver)(nil).ResolvePublicKey), kid, sourceTransactionsRefs)
 }
 
 // MockVDR is a mock of VDR interface.


### PR DESCRIPTION
 Builds on https://github.com/nuts-foundation/nuts-node/pull/2364 (review and merge first)

This PR removes all relationship-specific resolve functions in favor of 2 functions, to be used by all:
- `ResolveKey` resolves a key of the given type for the given DID. It returns the key ID and public key.
- `ResolveKeyByID` resolves a specific key of the given DID, given the key ID. It returns the public key.

The interface became wonly since it had 3 API styles: for specific relationship types (e.g. KeyAgreement keys), abstraction levels (`ResolveSigningKey`, which isn't a DID verification method relationship), and more generic functions (the 2 above).

I also made the usage consistent, since before some functions returned the actual public key, some the key ID, some worked on a key ID, some on a DID.

Lots of lines changed, but mostly tests.