### PR TITLE
use correct versions output for determining latest tag

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -52,7 +52,7 @@ jobs:
             # generate v5 tag
             type=semver,pattern={{major}}
           flavor: |
-            latest=${{ github.ref == steps.get-latest-tag.outputs.tag }}
+            latest=${{ steps.version.outputs.git_version == steps.get-latest-tag.outputs.tag }}
             prefix=v,onlatest=false
 
       - name: Set up QEMU


### PR DESCRIPTION
It checked if `refs/tags/v5.4.0` matched `v5.4.0` .....