### PR TITLE
VDR: Use cached IsOwned function for finding owned conflicts

### DIFF
--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -147,12 +147,16 @@ func (r *VDR) newOwnConflictedDocIterator(totalCount, ownedCount *int) types.Doc
 			return nil
 		}
 		for _, controller := range controllers {
-			for _, vr := range controller.CapabilityInvocation {
-				// TODO: Fix context.TODO() when we have a context in the Diagnostics() method
-				if r.keyStore.Exists(context.TODO(), vr.ID.String()) {
-					*ownedCount++
-					return nil
-				}
+			// TODO: Fix context.TODO() when we have a context in the Diagnostics() method
+			isOwned, err := r.IsOwner(context.TODO(), controller.ID)
+			if err != nil {
+				log.Logger().
+					WithField(core.LogFieldDID, controller.ID).
+					WithError(err).
+					Info("failed to check ownership of conflicted DID document")
+			}
+			if isOwned {
+				*ownedCount++
 			}
 		}
 		return nil


### PR DESCRIPTION
Semantics are slightly different (now any private key matches) but it's for diagnostics only, so an extra false positive in a super-super edge case doesn't hurt.

Fixes https://github.com/nuts-foundation/nuts-node/issues/2311