### PR TITLE
ResolveControllers should return controllers that can be resolved

### DIFF
--- a/vdr/didnuts/resolver.go
+++ b/vdr/didnuts/resolver.go
@@ -101,7 +101,7 @@ func resolveControllers(resolver types.DIDResolver, doc did.Document, metadata *
 	// resolve all unresolved doc
 	for _, ref := range refsToResolve {
 		node, _, err := resolve(resolver, ref, metadata, depth)
-		if errors.Is(err, types.ErrDeactivated) || errors.Is(err, types.ErrNoActiveController) {
+		if errors.Is(err, types.ErrDeactivated) || errors.Is(err, types.ErrNoActiveController) || errors.Is(err, types.ErrNotFound) {
 			continue
 		}
 		if errors.Is(err, ErrNestedDocumentsTooDeep) {

--- a/vdr/didnuts/resolver_test.go
+++ b/vdr/didnuts/resolver_test.go
@@ -282,7 +282,7 @@ func TestResolveControllers(t *testing.T) {
 			"expected docA to be resolved as controller for docB")
 	})
 
-	t.Run("error - Resolve can not find the document", func(t *testing.T) {
+	t.Run("ok - Resolve can not find the document", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		resolver := types.NewMockDIDResolver(ctrl)
 		resolver.EXPECT().Resolve(*id123, gomock.Any()).Return(nil, nil, types.ErrNotFound)
@@ -290,7 +290,7 @@ func TestResolveControllers(t *testing.T) {
 		docB := did.Document{ID: *id456, Controller: []did.DID{*id123}}
 
 		docs, err := ResolveControllers(resolver, docB, nil)
-		assert.EqualError(t, err, "unable to resolve controller ref: unable to find the DID document")
+		require.NoError(t, err)
 		assert.Len(t, docs, 0)
 	})
 }

--- a/vdr/didnuts/resolver_test.go
+++ b/vdr/didnuts/resolver_test.go
@@ -215,6 +215,25 @@ func TestResolveControllers(t *testing.T) {
 			"expected docA and docB to be resolved as controller of docB")
 	})
 
+	t.Run("docA and docB are both the controllers of docB, resolve by source transaction", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		resolver := types.NewMockDIDResolver(ctrl)
+		docA := did.Document{ID: *id123}
+		docA.AddCapabilityInvocation(&did.VerificationMethod{ID: *id123Method1})
+
+		// when we resolve by source TX, we will not find the other controller
+		resolver.EXPECT().Resolve(*id123, gomock.Any()).Return(nil, nil, types.ErrNotFound)
+
+		docB := did.Document{ID: *id456, Controller: []did.DID{*id123, *id456}}
+		docB.AddCapabilityInvocation(&did.VerificationMethod{ID: *id456Method1})
+
+		docs, err := ResolveControllers(resolver, docB, nil)
+		assert.NoError(t, err)
+		assert.Len(t, docs, 1)
+		assert.Equal(t, []did.Document{docB}, docs,
+			"expected docB to be resolved as controller of docB")
+	})
+
 	t.Run("docA, docB and docC are controllers of docA, docB is deactivated", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		resolver := types.NewMockDIDResolver(ctrl)


### PR DESCRIPTION
fixes #2405 

only broken on master, probably due to the resolver refactor.
Added a test case to reproduce.

The resolver#ResolveControllers returned an error if one of the controllers couldn't be resolved. This is always the case when you resolve with a sourceTX in the resolveMetadata. On the development network this will always fail at tx:555. The ResolveControllers method should not stop on ErrNotFound but it should continue with resolving the other controllers.