### PR TITLE
Only request 2 pages per conversation on full sync

### DIFF
--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -243,12 +243,12 @@ func (p *protocol) handleTransactionRangeQuery(ctx context.Context, connection g
 
 	// limit to two pages to reduce load
 	limit := msg.Start + 2*dag.PageSize
-	requested := msg.End
-	if requested > limit {
-		requested = limit
+	end := msg.End
+	if end > limit {
+		end = limit
 	}
 
-	txs, err := p.state.FindBetweenLC(ctx, msg.Start, requested)
+	txs, err := p.state.FindBetweenLC(ctx, msg.Start, end)
 	if err != nil {
 		return err
 	}

--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -514,7 +514,8 @@ func (p *protocol) handleTransactionSet(_ context.Context, connection grpc.Conne
 			return p.sender.sendTransactionRangeQuery(connection, pageClockStart(reqPageNum+1), pageClockStart(reqPageNum+2))
 		}
 		// TODO: Distribute synchronization of new nodes over multiple peers.
-		return p.sender.sendTransactionRangeQuery(connection, pageClockStart(reqPageNum+1), dag.MaxLamportClock)
+		// Currently locked at 2 pages (~1000TX) per peer to prevent overloading the peer.
+		return p.sender.sendTransactionRangeQuery(connection, pageClockStart(reqPageNum+1), pageClockStart(reqPageNum+3))
 	}
 
 	// peer is behind

--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -241,7 +241,14 @@ func (p *protocol) handleTransactionRangeQuery(ctx context.Context, connection g
 		return errors.New("invalid range query")
 	}
 
-	txs, err := p.state.FindBetweenLC(ctx, msg.Start, msg.End)
+	// limit to two pages to reduce load
+	limit := msg.Start + 2*dag.PageSize
+	requested := msg.End
+	if requested > limit {
+		requested = limit
+	}
+
+	txs, err := p.state.FindBetweenLC(ctx, msg.Start, requested)
 	if err != nil {
 		return err
 	}

--- a/network/transport/v2/handlers_test.go
+++ b/network/transport/v2/handlers_test.go
@@ -650,7 +650,7 @@ func TestProtocol_handleTransactionSet(t *testing.T) {
 		conversation := p.cMan.startConversation(request, peer)
 		mocks.State.EXPECT().IBLT(requestLC).Return(*oneHashIblt.Clone().(*tree.Iblt), dag.PageSize-1)
 		mocks.State.EXPECT().XOR(uint32(dag.MaxLamportClock)).Return(hash.FromSlice([]byte("ignored")), requestLC)
-		mocks.Sender.EXPECT().sendTransactionRangeQuery(connection, dag.PageSize, uint32(dag.MaxLamportClock)).Return(nil)
+		mocks.Sender.EXPECT().sendTransactionRangeQuery(connection, dag.PageSize, 3*dag.PageSize).Return(nil)
 
 		err := p.handleTransactionSet(ctx, connection, &Envelope{Message: &Envelope_TransactionSet{
 			TransactionSet: &TransactionSet{ConversationID: conversation.conversationID.slice(), LCReq: requestLC, LC: peerLC, IBLT: oneHashIbltBytes},


### PR DESCRIPTION
fixes #2406 

When a node does a full sync it will request missing pages. This could result in a request of thousands of transactions. The peer sending those will not handle this request in a streaming way and will thus consume a lot of resources to fulfil the request. Syncing goes much smoother when only requesting 2 pages at a time. If more pages are requested, this PR will also change that the peer only sends 2.