### PR TITLE
Fix/2402/retry events synchronously at startup

### DIFF
--- a/network/dag/notifier.go
+++ b/network/dag/notifier.go
@@ -46,6 +46,9 @@ const (
 
 var timeFunc = time.Now
 
+// maxJitter is adjustable for testing purposes
+var maxJitter = time.Second
+
 // EventFatal signals that an Event receiver encountered a fatal error and that the Event should not be retried.
 type EventFatal struct {
 	Err error
@@ -360,8 +363,9 @@ func (p *notifier) retry(event Event) {
 		},
 			retry.Attempts(maxRetries-uint(initialCount)),
 			retry.MaxDelay(24*time.Hour),
+			retry.MaxJitter(maxJitter),
 			retry.Delay(delay),
-			retry.DelayType(retry.BackOffDelay),
+			retry.DelayType(retry.CombineDelay(retry.BackOffDelay, retry.RandomDelay)),
 			retry.Context(ctx),
 			retry.LastErrorOnly(true),
 			retry.OnRetry(func(n uint, err error) {

--- a/network/dag/notifier.go
+++ b/network/dag/notifier.go
@@ -348,8 +348,8 @@ func (p *notifier) retry(event Event) {
 	delay := p.retryDelay
 	initialCount := event.Retries + 1
 	attempts := maxRetries - uint(initialCount)
-	if attempts >= maxRetries {
-		attempts = 0
+	if attempts <= 0 || attempts >= maxRetries {
+		return
 	}
 
 	for i := 0; i < initialCount; i++ {

--- a/network/dag/notifier.go
+++ b/network/dag/notifier.go
@@ -247,7 +247,9 @@ func (p *notifier) Run() error {
 			_ = json.Unmarshal(v, &event)
 
 			if err := p.notifyNow(event); err != nil {
-				failedAtStartup = append(failedAtStartup, event)
+				if event.Retries < maxRetries {
+					failedAtStartup = append(failedAtStartup, event)
+				}
 			}
 
 			return nil

--- a/network/dag/notifier.go
+++ b/network/dag/notifier.go
@@ -244,7 +244,7 @@ func (p *notifier) Run() error {
 			event := Event{}
 			_ = json.Unmarshal(v, &event)
 
-			p.retry(event)
+			p.Notify(event)
 
 			return nil
 		}, stoabs.BytesKey{})

--- a/network/dag/notifier.go
+++ b/network/dag/notifier.go
@@ -357,8 +357,6 @@ func (p *notifier) retry(event Event) {
 	}
 
 	go func(ctx context.Context) {
-		// also an initial delay
-		time.Sleep(delay)
 		err := retry.Do(func() error {
 			return p.notifyNow(event)
 		},

--- a/network/dag/notifier_test.go
+++ b/network/dag/notifier_test.go
@@ -318,7 +318,8 @@ func TestNotifier_Notify(t *testing.T) {
 			return s.Save(tx, event)
 		})
 
-		s.Notify(event)
+		// we use retry here since Notify will run notifyNow twice asynchronously
+		s.retry(event)
 
 		test.WaitFor(t, func() (bool, error) {
 			return counter.N.Load() == 1, nil

--- a/network/dag/notifier_test.go
+++ b/network/dag/notifier_test.go
@@ -363,7 +363,7 @@ func TestNotifier_Run(t *testing.T) {
 	event := Event{
 		Type:        TransactionEventType,
 		Hash:        transaction.Ref(),
-		Retries:     1,
+		Retries:     10,
 		Transaction: transaction,
 		Payload:     []byte(payload),
 	}

--- a/network/dag/notifier_test.go
+++ b/network/dag/notifier_test.go
@@ -359,7 +359,6 @@ func TestNotifier_Notify(t *testing.T) {
 }
 
 func TestNotifier_Run(t *testing.T) {
-	maxJitter = time.Millisecond
 	transaction, _, _ := CreateTestTransaction(0)
 	payload := "payload"
 	event := Event{
@@ -477,7 +476,7 @@ func TestNotifier_VariousFlows(t *testing.T) {
 		kvStore := storage.CreateTestBBoltStore(t, path.Join(filePath, "test.db"))
 		counter := callbackCounter{}
 		notifiedCounter := &prometheusCounter{}
-		event := Event{Hash: hash.EmptyHash(), Transaction: transaction, Retries: 95}
+		event := Event{Hash: hash.EmptyHash(), Transaction: transaction, Retries: maxRetries - 5}
 		s := NewNotifier(t.Name(), counter.callbackFailure, WithPersistency(kvStore), WithRetryDelay(time.Nanosecond), withCounters(notifiedCounter, nil)).(*notifier)
 		defer s.Close()
 
@@ -494,7 +493,7 @@ func TestNotifier_VariousFlows(t *testing.T) {
 				return nil
 			})
 
-			return e.Retries == 100, nil
+			return e.Retries == maxRetries, nil
 		}, 2*time.Second, "timeout while waiting for receiver")
 
 		events, err := s.GetFailedEvents()

--- a/network/dag/notifier_test.go
+++ b/network/dag/notifier_test.go
@@ -312,7 +312,7 @@ func TestNotifier_Notify(t *testing.T) {
 		timeFunc = func() time.Time {
 			return now
 		}
-		s := NewNotifier(t.Name(), counter.callback, WithPersistency(kvStore)).(*notifier)
+		s := NewNotifier(t.Name(), counter.callback, WithRetryDelay(2*time.Second), WithPersistency(kvStore)).(*notifier)
 		defer s.Close()
 		kvStore.Write(ctx, func(tx stoabs.WriteTx) error {
 			return s.Save(tx, event)

--- a/network/dag/notifier_test.go
+++ b/network/dag/notifier_test.go
@@ -408,13 +408,12 @@ func TestNotifier_Run(t *testing.T) {
 		err := s.Run()
 		require.NoError(t, err)
 
-		time.Sleep(50 * time.Millisecond)
-
-		// the immediate callback has failed and the retry is scheduled within a new go routine
-		stack := make([]byte, 2*1024)
-		runtime.Stack(stack, true)
-		index := strings.Index(string(stack), "dag.(*notifier).retry.func1")
-		assert.True(t, index != -1)
+		stack := make([]byte, 4*1024)
+		test.WaitFor(t, func() (bool, error) {
+			runtime.Stack(stack, true)
+			index := strings.Index(string(stack), "dag.(*notifier).retry.func1")
+			return index != -1, nil
+		}, time.Second, "timeout while waiting for go routine to start")
 	})
 }
 


### PR DESCRIPTION
fixes #2402 

the call to retry is replaced with `notifyNow` for each event that failed in the past. The events are tried one by one. All events that still failed are then scheduled in the retry loop.

This will reduce the number of errors on startup due to DB lock errors. Events that still fail due to other causes still fail and will still be rescheduled.