### PR TITLE
limit number of nats messages waiting for an ack to 1000 at the client

### DIFF
--- a/events/event.go
+++ b/events/event.go
@@ -76,7 +76,7 @@ func (m *manager) Configure(config core.ServerConfig) error {
 		MaxAge:    168 * time.Hour, // week
 		Discard:   nats.DiscardOld,
 		Storage:   nats.FileStorage,
-	}, []nats.SubOpt{}, true)
+	}, true)
 
 	// register Data stream
 	m.streams[DataStream] = newStream(&nats.StreamConfig{
@@ -86,7 +86,7 @@ func (m *manager) Configure(config core.ServerConfig) error {
 		MaxAge:    168 * time.Hour, // week
 		Discard:   nats.DiscardOld,
 		Storage:   nats.FileStorage,
-	}, []nats.SubOpt{}, true)
+	}, true)
 
 	return nil
 }

--- a/events/stream_test.go
+++ b/events/stream_test.go
@@ -39,10 +39,10 @@ func TestStream_Subscribe(t *testing.T) {
 		jsFirst := NewMockJetStreamContext(ctrl)
 		jsFirst.EXPECT().StreamInfo("example").Return(nil, nats.ErrStreamNotFound)
 		jsFirst.EXPECT().AddStream(disposableStream.Config()).Return(mockStreamInfo, nil)
-		jsFirst.EXPECT().Subscribe("subject", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&nats.Subscription{}, nil)
+		jsFirst.EXPECT().Subscribe("subject", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&nats.Subscription{}, nil)
 
 		jsLast := NewMockJetStreamContext(ctrl)
-		jsLast.EXPECT().Subscribe("subject", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&nats.Subscription{}, nil)
+		jsLast.EXPECT().Subscribe("subject", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&nats.Subscription{}, nil)
 
 		conn := NewMockConn(ctrl)
 		conn.EXPECT().JetStream().Return(jsFirst, nil)
@@ -64,7 +64,7 @@ func TestStream_Subscribe(t *testing.T) {
 
 		js := NewMockJetStreamContext(ctrl)
 		js.EXPECT().StreamInfo("example").Return(mockStreamInfo, nil)
-		js.EXPECT().Subscribe("subject", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&nats.Subscription{}, nil)
+		js.EXPECT().Subscribe("subject", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&nats.Subscription{}, nil)
 
 		conn := NewMockConn(ctrl)
 		conn.EXPECT().JetStream().Return(js, nil)
@@ -97,7 +97,7 @@ func TestStream_Subscribe(t *testing.T) {
 
 		js := NewMockJetStreamContext(ctrl)
 		js.EXPECT().StreamInfo("example").Return(mockStreamInfo, nil)
-		js.EXPECT().Subscribe("subject", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("random error"))
+		js.EXPECT().Subscribe("subject", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("random error"))
 
 		conn := NewMockConn(ctrl)
 		conn.EXPECT().JetStream().Return(js, nil)
@@ -132,10 +132,4 @@ func TestStream_Subscribe(t *testing.T) {
 		err := disposableStream.Subscribe(conn, "test", "subject", nil)
 		assert.Error(t, err)
 	})
-}
-
-func TestStream_ClientOpts(t *testing.T) {
-	disposableStream := NewDisposableStream("example", []string{}, 100)
-
-	assert.Len(t, disposableStream.ClientOpts(), 3)
 }


### PR DESCRIPTION
fixes #2401 

this PR sets the limit to a 1000 messages (arbitrary) at the client waiting for an ack. Without this config the server would send all possible messages as fast as it could. Since the server is localhost, this is quite fast.
Now the server will wait at a thousand messages.

I also removed some dead configuration code...