### PR TITLE
Flexible OAuth2 Server POC

### DIFF
--- a/vcr/api/oauth2/v0/api.go
+++ b/vcr/api/oauth2/v0/api.go
@@ -1,0 +1,75 @@
+package v0
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/nuts-foundation/nuts-node/core"
+	"github.com/nuts-foundation/nuts-node/vcr"
+	"net/http"
+)
+
+const GrantType = "grant_type"
+
+var _ core.Routable = &OAuth2API{}
+
+// OAuth2API handles OAuth2 flows. It registers flows registering the same endpoints as a chain in reverse order,
+// e.g., if OpenID4VP and OpenID4VCI both register an `/authorize` endpoint (in this order), the following call order applies:
+// 1. OpenID4VCI
+// 2. OpenID4VP
+// 3. Default error handler (invalid parameters)
+type OAuth2API struct {
+	VCR vcr.VCR
+}
+
+func (r OAuth2API) Routes(router core.EchoRouter) {
+	registrar := endpointRegistrar{
+		handlers: map[endpoint]func(echoCtx echo.Context) error{},
+		metadata: map[string]interface{}{},
+	}
+
+	// Let every protocol register its endpoints
+	for _, protocol := range []Protocol{S2SVPTokenProtocol{}, OpenID4VCIProtocol{}} {
+		protocol.RegisterEndpoints(registrar)
+	}
+
+	for currEndpoint, currHandler := range registrar.handlers {
+		router.Add(currEndpoint.method, currEndpoint.path, currHandler)
+	}
+
+	// Register common endpoints
+	// TODO: Probably not the right URL, but it's a POC
+	router.GET("/.well-known/oauth-authorization-server", func(c echo.Context) error {
+		return c.JSON(200, registrar.metadata)
+	})
+}
+
+type endpoint struct {
+	method string
+	path   string
+}
+
+type endpointRegistrar struct {
+	handlers map[endpoint]func(echoCtx echo.Context) error
+	metadata map[string]interface{}
+}
+
+func (e endpointRegistrar) RegisterMetadata(key string, value interface{}) {
+	e.metadata[key] = value
+}
+
+func (e endpointRegistrar) RegisterEndpoint(method string, path string, handler HandlerFunc) {
+	endpointKey := endpoint{
+		method: method,
+		path:   path,
+	}
+	prevHandler := e.handlers[endpointKey]
+	if prevHandler == nil {
+		prevHandler = func(echoCtx echo.Context) error {
+			// TODO: alter response type based on request type? (e.g. JSON vs. form)
+			// TODO: use oauth2 error code
+			return echoCtx.String(http.StatusBadRequest, "Unsupported combination of parameters")
+		}
+	}
+	e.handlers[endpointKey] = func(echoCtx echo.Context) error {
+		return handler(echoCtx, prevHandler)
+	}
+}

--- a/vcr/api/oauth2/v0/interface.go
+++ b/vcr/api/oauth2/v0/interface.go
@@ -1,0 +1,16 @@
+package v0
+
+import "github.com/labstack/echo/v4"
+
+// Protocol implements a OAuth2 flow, e.g. vp_token service-to-service, OpenID4VCI, OpenID4VP
+type Protocol interface {
+	RegisterEndpoints(router OAuth2Server)
+}
+
+type HandlerFunc func(echoCtx echo.Context, next func(echo.Context) error) error
+
+// OAuth2Server lets protocols interact with the containing OAuth2 server
+type OAuth2Server interface {
+	RegisterEndpoint(method string, path string, handler HandlerFunc)
+	RegisterMetadata(key string, value interface{})
+}

--- a/vcr/api/oauth2/v0/openid4vci.go
+++ b/vcr/api/oauth2/v0/openid4vci.go
@@ -1,0 +1,34 @@
+package v0
+
+import (
+	"github.com/labstack/echo/v4"
+	"net/http"
+)
+
+const PreAuthorizedCode = "pre-authorized_code"
+
+// OpenID4VCIProtocol adds support for issuing Verifiable Credentials using OpenID Connect.
+// Requires:
+// - GET /.well-known/openid-configuration (returns an OpenID Connect discovery document)
+// - /
+type OpenID4VCIProtocol struct {
+}
+
+func (p OpenID4VCIProtocol) RegisterEndpoints(router OAuth2Server) {
+	router.RegisterEndpoint(http.MethodGet, "/token", func(echoCtx echo.Context, next func(echo.Context) error) error {
+		if echoCtx.FormValue("grant_type") != "urn:ietf:params:oauth:grant-type:pre-authorized_code" {
+			return next(echoCtx)
+		}
+		code := echoCtx.FormValue(PreAuthorizedCode)
+		if code == "" {
+			// TODO: right error response
+			return echoCtx.JSON(http.StatusBadRequest, "missing required parameter")
+		}
+		// TODO: handle
+		return echoCtx.JSON(http.StatusOK, map[string]string{})
+	})
+	router.RegisterEndpoint(http.MethodGet, "/credential", func(echoCtx echo.Context, next func(echo.Context) error) error {
+		// TODO: handle
+		return echoCtx.JSON(http.StatusOK, map[string]string{})
+	})
+}

--- a/vcr/api/oauth2/v0/openid4vp.go
+++ b/vcr/api/oauth2/v0/openid4vp.go
@@ -1,0 +1,4 @@
+package v0
+
+type OpenID4VP struct {
+}

--- a/vcr/api/oauth2/v0/s2s_vptoken.go
+++ b/vcr/api/oauth2/v0/s2s_vptoken.go
@@ -1,0 +1,40 @@
+package v0
+
+import (
+	"github.com/labstack/echo/v4"
+	"net/http"
+)
+
+var _ Protocol = (*S2SVPTokenProtocol)(nil)
+
+// S2SVPTokenProtocol adds support for service-to-service OAuth2 flows,
+// which uses a custom vp_token grant to authenticate calls to the token endpoint.
+// Clients first call the presentation definition endpoint to get a presentation definition for the desired scope,
+// then create a presentation submission given the definition which is posted to the token endpoint as vp_token.
+// The AS then returns an access token with the requested scope.
+// Requires:
+// - GET /presentation_definition?scope=... (returns a presentation definition)
+// - POST /token (with vp_token grant)
+type S2SVPTokenProtocol struct {
+}
+
+func (s S2SVPTokenProtocol) RegisterEndpoints(router OAuth2Server) {
+	router.RegisterEndpoint(http.MethodGet, "/presentation_definition", func(echoCtx echo.Context, next func(echo.Context) error) error {
+		// TODO: Read scope, map to presentation definition, return
+		return echoCtx.JSON(http.StatusOK, map[string]string{})
+	})
+	router.RegisterEndpoint(http.MethodGet, "/token", func(echoCtx echo.Context, next func(echo.Context) error) error {
+		if echoCtx.FormValue(GrantType) != "vp_token" {
+			return next(echoCtx)
+		}
+		submission := echoCtx.FormValue("presentation_submission")
+		scope := echoCtx.FormValue("scope")
+		vp_token := echoCtx.FormValue("vp_token")
+		if submission == "" || scope == "" || vp_token == "" {
+			// TODO: right error response
+			return echoCtx.JSON(http.StatusBadRequest, "missing required parameters")
+		}
+		// TODO: Handle
+		return echoCtx.JSON(http.StatusOK, map[string]string{})
+	})
+}


### PR DESCRIPTION
PoC for https://github.com/nuts-foundation/nuts-node/issues/2424

Missing bits:
- Linking up with existing OpenID4VCI handlers in VCR issuer/holder
- Session management, maybe allowing `/token` for code flow to be generalized
- Registering the new API in the Nuts Node

Stuff to discuss:
- Applicable approach?
- What module should it reside in
- What API package