### PR TITLE
OpenID4VP: Implement authorization request and handling

### DIFF
--- a/audit/http.go
+++ b/audit/http.go
@@ -32,6 +32,16 @@ func StrictMiddleware(next func(ctx echo.Context, args interface{}) (interface{}
 	}
 }
 
+// Middleware is like SetOnEchoContext but then as handler for server interfaces.
+func Middleware(moduleName, operationID string) func(echo.HandlerFunc) echo.HandlerFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			SetOnEchoContext(c, moduleName, operationID)
+			return next(c)
+		}
+	}
+}
+
 // SetOnEchoContext adds audit information to the Echo request context so that the audit logger can log it.
 // It sets the following fields:
 // - actor, which is the subject of the JWT. Falls back to the client IP address if no authentication is used.

--- a/audit/http.go
+++ b/audit/http.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"github.com/labstack/echo/v4"
 	"github.com/nuts-foundation/nuts-node/core"
+	"strings"
 )
 
 // StrictMiddleware is like SetOnEchoContext but then as handler for strict server interfaces.
@@ -33,9 +34,12 @@ func StrictMiddleware(next func(ctx echo.Context, args interface{}) (interface{}
 }
 
 // Middleware is like SetOnEchoContext but then as handler for server interfaces.
-func Middleware(moduleName, operationID string) func(echo.HandlerFunc) echo.HandlerFunc {
+// The operation ID is derived from the last part of the request path.
+func Middleware(moduleName string) func(echo.HandlerFunc) echo.HandlerFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
+			pathParts := strings.Split(c.Request().URL.Path, "/")
+			operationID := pathParts[len(pathParts)-1]
 			SetOnEchoContext(c, moduleName, operationID)
 			return next(c)
 		}

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -159,18 +159,7 @@ func (r Wrapper) HandleAuthorizeRequest(ctx context.Context, request HandleAutho
 	for key, value := range httpRequest.URL.Query() {
 		params[key] = value[0]
 	}
-	session := &Session{
-		// TODO: Validate client ID
-		ClientID: params[clientIDParam],
-		// TODO: Validate scope
-		Scope:       params[scopeParam],
-		ClientState: params[stateParam],
-		ServerState: map[string]interface{}{},
-		// TODO: Validate according to https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2
-		RedirectURI:  params[redirectURIParam],
-		OwnDID:       *ownDID,
-		ResponseType: params[responseTypeParam],
-	}
+	session := createSession(params, *ownDID)
 	if session.RedirectURI == "" {
 		// TODO: Spec says that the redirect URI is optional, but it's not clear what to do if it's not provided.
 		//       Threat models say it's unsafe to omit redirect_uri.
@@ -240,4 +229,20 @@ func (r Wrapper) GetOAuthAuthorizationServerMetadata(ctx context.Context, reques
 	identity := r.auth.PublicURL().JoinPath("iam", id.WithoutURL().String())
 
 	return GetOAuthAuthorizationServerMetadata200JSONResponse(authorizationServerMetadata(*identity)), nil
+}
+
+func createSession(params map[string]string, ownDID did.DID) *Session {
+	session := &Session{
+		// TODO: Validate client ID
+		ClientID: params[clientIDParam],
+		// TODO: Validate scope
+		Scope:       params[scopeParam],
+		ClientState: params[stateParam],
+		ServerState: map[string]interface{}{},
+		// TODO: Validate according to https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2
+		RedirectURI:  params[redirectURIParam],
+		OwnDID:       ownDID,
+		ResponseType: params[responseTypeParam],
+	}
+	return session
 }

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -204,6 +204,7 @@ func (r Wrapper) HandleAuthorizeRequest(ctx context.Context, request HandleAutho
 		// TODO: Validate scope
 		Scope:       params[scopeParam],
 		ClientState: params[stateParam],
+		ServerState: map[string]interface{}{},
 		// TODO: Validate according to https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2
 		RedirectURI: params[redirectURIParam],
 		OwnDID:      *ownDID,

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -28,10 +28,8 @@ import (
 	"github.com/nuts-foundation/nuts-node/auth"
 	"github.com/nuts-foundation/nuts-node/auth/log"
 	"github.com/nuts-foundation/nuts-node/core"
-	"github.com/nuts-foundation/nuts-node/jsonld"
 	"github.com/nuts-foundation/nuts-node/vcr"
 	"github.com/nuts-foundation/nuts-node/vcr/openid4vci"
-	vdr "github.com/nuts-foundation/nuts-node/vdr/types"
 	"github.com/nuts-foundation/nuts-node/vdr/didservice"
 	vdr "github.com/nuts-foundation/nuts-node/vdr/types"
 	"html/template"
@@ -167,7 +165,7 @@ func (r Wrapper) HandleAuthorizeRequest(ctx context.Context, request HandleAutho
 		return nil, errors.New("missing redirect URI")
 	}
 
-	switch request.Body.ResponseType {
+	switch session.ResponseType {
 	case responseTypeCode:
 		// Options:
 		// - Regular authorization code flow for EHR data access through access token, authentication of end-user using OpenID4VP.

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -167,8 +167,9 @@ func (r Wrapper) HandleAuthorizeRequest(ctx context.Context, request HandleAutho
 		ClientState: params[stateParam],
 		ServerState: map[string]interface{}{},
 		// TODO: Validate according to https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2
-		RedirectURI: params[redirectURIParam],
-		OwnDID:      *ownDID,
+		RedirectURI:  params[redirectURIParam],
+		OwnDID:       *ownDID,
+		ResponseType: params[responseTypeParam],
 	}
 	if session.RedirectURI == "" {
 		// TODO: Spec says that the redirect URI is optional, but it's not clear what to do if it's not provided.

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -19,6 +19,7 @@
 package iam
 
 import (
+	"bytes"
 	"context"
 	"embed"
 	"errors"
@@ -32,7 +33,10 @@ import (
 	"github.com/nuts-foundation/nuts-node/vcr/openid4vci"
 	"github.com/nuts-foundation/nuts-node/vdr/didservice"
 	vdr "github.com/nuts-foundation/nuts-node/vdr/types"
+	"html/template"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 )
 
@@ -44,18 +48,27 @@ var assets embed.FS
 
 // Wrapper handles OAuth2 flows.
 type Wrapper struct {
-	vcr      vcr.VCR
-	vdr      vdr.DocumentOwner
-	auth     auth.AuthenticationServices
-	sessions *SessionManager
+	vcr                     vcr.VCR
+	vdr                     vdr.DocumentOwner
+	auth                    auth.AuthenticationServices
+	sessions                *SessionManager
+	presentationDefinitions presentationDefinitionRegistry
+	templates               *template.Template
 }
 
 func New(authInstance auth.AuthenticationServices, vcrInstance vcr.VCR, vdrInstance vdr.DocumentOwner) *Wrapper {
+	templates := template.New("oauth2 templates")
+	_, err := templates.ParseFS(assets, "assets/*.html")
+	if err != nil {
+		panic(err)
+	}
 	return &Wrapper{
-		sessions: &SessionManager{sessions: new(sync.Map)},
-		auth:     authInstance,
-		vcr:      vcrInstance,
-		vdr:      vdrInstance,
+		sessions:                &SessionManager{sessions: new(sync.Map)},
+		auth:                    authInstance,
+		vcr:                     vcrInstance,
+		vdr:                     vdrInstance,
+		presentationDefinitions: nutsPresentationDefinitionRegistry{},
+		templates:               templates,
 	}
 }
 
@@ -82,6 +95,53 @@ func (r Wrapper) Routes(router core.EchoRouter) {
 			return audit.StrictMiddleware(f, auth.ModuleName+"/v2", operationID)
 		},
 	}))
+	// The following handler is of the OpenID4VP verifier where the browser will be redirected to by the wallet,
+	// after completing a presentation exchange.
+	router.GET("/iam/:did/openid4vp_completed", func(echoCtx echo.Context) error {
+		return errors.New("not implemented")
+	})
+	// The following 2 handlers are used to test/demo the OpenID4VP flow.
+	// - GET renders an HTML page with a form to start the flow.
+	// - POST handles the form submission, initiating the flow.
+	router.GET("/iam/:did/openid4vp_demo", func(echoCtx echo.Context) error {
+		requestURL := *echoCtx.Request().URL
+		requestURL.Host = echoCtx.Request().Host
+		requestURL.Scheme = "http"
+		verifierID := requestURL.String()
+		verifierID, _ = strings.CutSuffix(verifierID, "/openid4vp_demo")
+
+		buf := new(bytes.Buffer)
+		if err := r.templates.ExecuteTemplate(buf, "openid4vp_demo.html", struct {
+			VerifierID string
+			WalletID   string
+		}{
+			VerifierID: verifierID,
+			WalletID:   verifierID,
+		}); err != nil {
+			return err
+		}
+		return echoCtx.HTML(http.StatusOK, buf.String())
+	})
+	router.POST("/iam/:did/openid4vp_demo", func(echoCtx echo.Context) error {
+		verifierID := echoCtx.FormValue("verifier_id")
+		if verifierID == "" {
+			return errors.New("missing verifier_id")
+		}
+		walletID := echoCtx.FormValue("wallet_id")
+		if walletID == "" {
+			return errors.New("missing wallet_id")
+		}
+		scope := echoCtx.FormValue("scope")
+		if scope == "" {
+			return errors.New("missing scope")
+		}
+		walletURL, _ := url.Parse(walletID)
+		verifierURL, _ := url.Parse(verifierID)
+		return r.sendPresentationRequest(
+			echoCtx.Request().Context(), echoCtx.Response(), scope,
+			*walletURL.JoinPath("openid4vp_completed"), *verifierURL, *walletURL,
+		)
+	})
 }
 
 // HandleTokenRequest handles calls to the token endpoint for exchanging a grant (e.g authorization code or pre-authorized code) for an access token.
@@ -156,7 +216,7 @@ func (r Wrapper) HandleAuthorizeRequest(ctx context.Context, request HandleAutho
 	case responseTypeVPIDToken:
 		// Options:
 		// - OpenID4VP+SIOP flow, vp_token is sent in Authorization Response
-		// TODO: Check parameters for right flow
+		return r.handlePresentationRequest(request.Body.AdditionalProperties, session)
 	default:
 		// TODO: This should be a redirect?
 		// TODO: Don't use openid4vci package for errors

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -100,11 +100,17 @@ func (r Wrapper) Routes(router core.EchoRouter) {
 			return audit.StrictMiddleware(f, auth.ModuleName+"/v2", operationID)
 		},
 	}))
+	// The following handler is of the OpenID4VCI wallet which is called by the holder (wallet owner)
+	// when accepting an OpenID4VP authorization request.
+	router.POST("/iam/:did/openid4vp_authz_accept", func(echoCtx echo.Context) error {
+		return r.handlePresentationRequestAccept(echoCtx)
+	}, audit.Middleware(vcr.ModuleName+"/v2", "openid4vp_authz_accept"))
 	// The following handler is of the OpenID4VP verifier where the browser will be redirected to by the wallet,
 	// after completing a presentation exchange.
 	router.GET("/iam/:did/openid4vp_completed", func(echoCtx echo.Context) error {
-		return errors.New("not implemented")
-	})
+		// TODO: error case
+		return r.handlePresentationRequestCompleted(echoCtx)
+	}, audit.Middleware(vcr.ModuleName+"/v2", "openid4vp_completed"))
 	// The following 2 handlers are used to test/demo the OpenID4VP flow.
 	// - GET renders an HTML page with a form to start the flow.
 	// - POST handles the form submission, initiating the flow.

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -19,7 +19,6 @@
 package iam
 
 import (
-	"bytes"
 	"context"
 	"embed"
 	"errors"
@@ -37,8 +36,6 @@ import (
 	vdr "github.com/nuts-foundation/nuts-node/vdr/types"
 	"html/template"
 	"net/http"
-	"net/url"
-	"strings"
 	"sync"
 )
 
@@ -102,57 +99,15 @@ func (r Wrapper) Routes(router core.EchoRouter) {
 	}))
 	// The following handler is of the OpenID4VCI wallet which is called by the holder (wallet owner)
 	// when accepting an OpenID4VP authorization request.
-	router.POST("/iam/:did/openid4vp_authz_accept", func(echoCtx echo.Context) error {
-		return r.handlePresentationRequestAccept(echoCtx)
-	}, audit.Middleware(vcr.ModuleName+"/v2", "openid4vp_authz_accept"))
+	router.POST("/iam/:did/openid4vp_authz_accept", r.handlePresentationRequestAccept, audit.Middleware(vcr.ModuleName+"/v2", "openid4vp_authz_accept"))
 	// The following handler is of the OpenID4VP verifier where the browser will be redirected to by the wallet,
 	// after completing a presentation exchange.
-	router.GET("/iam/:did/openid4vp_completed", func(echoCtx echo.Context) error {
-		// TODO: error case
-		return r.handlePresentationRequestCompleted(echoCtx)
-	}, audit.Middleware(vcr.ModuleName+"/v2", "openid4vp_completed"))
+	router.GET("/iam/:did/openid4vp_completed", r.handlePresentationRequestCompleted, audit.Middleware(vcr.ModuleName+"/v2", "openid4vp_completed"))
 	// The following 2 handlers are used to test/demo the OpenID4VP flow.
 	// - GET renders an HTML page with a form to start the flow.
 	// - POST handles the form submission, initiating the flow.
-	router.GET("/iam/:did/openid4vp_demo", func(echoCtx echo.Context) error {
-		requestURL := *echoCtx.Request().URL
-		requestURL.Host = echoCtx.Request().Host
-		requestURL.Scheme = "http"
-		verifierID := requestURL.String()
-		verifierID, _ = strings.CutSuffix(verifierID, "/openid4vp_demo")
-
-		buf := new(bytes.Buffer)
-		if err := r.templates.ExecuteTemplate(buf, "openid4vp_demo.html", struct {
-			VerifierID string
-			WalletID   string
-		}{
-			VerifierID: verifierID,
-			WalletID:   verifierID,
-		}); err != nil {
-			return err
-		}
-		return echoCtx.HTML(http.StatusOK, buf.String())
-	})
-	router.POST("/iam/:did/openid4vp_demo", func(echoCtx echo.Context) error {
-		verifierID := echoCtx.FormValue("verifier_id")
-		if verifierID == "" {
-			return errors.New("missing verifier_id")
-		}
-		walletID := echoCtx.FormValue("wallet_id")
-		if walletID == "" {
-			return errors.New("missing wallet_id")
-		}
-		scope := echoCtx.FormValue("scope")
-		if scope == "" {
-			return errors.New("missing scope")
-		}
-		walletURL, _ := url.Parse(walletID)
-		verifierURL, _ := url.Parse(verifierID)
-		return r.sendPresentationRequest(
-			echoCtx.Request().Context(), echoCtx.Response(), scope,
-			*walletURL.JoinPath("openid4vp_completed"), *verifierURL, *walletURL,
-		)
-	})
+	router.GET("/iam/:did/openid4vp_demo", r.handleOpenID4VPDemoLanding)
+	router.POST("/iam/:did/openid4vp_demo", r.handleOpenID4VPDemoSendRequest)
 }
 
 // HandleTokenRequest handles calls to the token endpoint for exchanging a grant (e.g authorization code or pre-authorized code) for an access token.

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -95,17 +95,18 @@ func (r Wrapper) Routes(router core.EchoRouter) {
 			return audit.StrictMiddleware(f, auth.ModuleName+"/v2", operationID)
 		},
 	}))
+	auditMiddleware := audit.Middleware(vcr.ModuleName + "/v2")
 	// The following handler is of the OpenID4VCI wallet which is called by the holder (wallet owner)
 	// when accepting an OpenID4VP authorization request.
-	router.POST("/iam/:did/openid4vp_authz_accept", r.handlePresentationRequestAccept, audit.Middleware(vcr.ModuleName+"/v2", "openid4vp_authz_accept"))
+	router.POST("/iam/:did/openid4vp_authz_accept", r.handlePresentationRequestAccept, auditMiddleware)
 	// The following handler is of the OpenID4VP verifier where the browser will be redirected to by the wallet,
 	// after completing a presentation exchange.
-	router.GET("/iam/:did/openid4vp_completed", r.handlePresentationRequestCompleted, audit.Middleware(vcr.ModuleName+"/v2", "openid4vp_completed"))
+	router.GET("/iam/:did/openid4vp_completed", r.handlePresentationRequestCompleted, auditMiddleware)
 	// The following 2 handlers are used to test/demo the OpenID4VP flow.
 	// - GET renders an HTML page with a form to start the flow.
 	// - POST handles the form submission, initiating the flow.
-	router.GET("/iam/:did/openid4vp_demo", r.handleOpenID4VPDemoLanding)
-	router.POST("/iam/:did/openid4vp_demo", r.handleOpenID4VPDemoSendRequest)
+	router.GET("/iam/:did/openid4vp_demo", r.handleOpenID4VPDemoLanding, auditMiddleware)
+	router.POST("/iam/:did/openid4vp_demo", r.handleOpenID4VPDemoSendRequest, auditMiddleware)
 }
 
 // HandleTokenRequest handles calls to the token endpoint for exchanging a grant (e.g authorization code or pre-authorized code) for an access token.

--- a/auth/api/iam/assets/authz_wallet_en.html
+++ b/auth/api/iam/assets/authz_wallet_en.html
@@ -18,14 +18,33 @@
                             {{if $i}}, {{end}}{{ $type }}
                         {{ end }}
                     </h5>
-                    {{ range $attr := $credential.Attributes }}
                     <ul>
+                        {{ range $attr := $credential.Attributes }}
                         <li>
                             <span>{{ $attr.Name }}:</span>
                             <span>{{ $attr.Value }}</span>
                         </li>
+                        {{ end }}
                     </ul>
-                    {{ end }}
+                </div>
+            </div>
+            {{ end }}
+            {{ if .RequiresUserIdentity }}
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">
+                        ZorgverlenerCredential
+                    </h5>
+                    <ul>
+                        <li>
+                            <span>Naam:</span>
+                            <span>M. Visser (zorgverlener)</span>
+                        </li>
+                        <li>
+                            <span>Rol:</span>
+                            <span>Verpleegkundige niveau 4</span>
+                        </li>
+                    </ul>
                 </div>
             </div>
             {{ end }}

--- a/auth/api/iam/assets/authz_wallet_en.html
+++ b/auth/api/iam/assets/authz_wallet_en.html
@@ -5,11 +5,28 @@
 </head>
 <body>
     <h1>Credential required</h1>
-    <p>XYZ requests identification using one or more credentials in your wallet:</p>
-    <ul>
-        <li>Care Organization Credential</li>
-        <li>Chamber of Commerce Credential</li>
-    </ul>
+    <p>{{ .VerifierName }} requests identification using one or more credentials in your wallet:</p>
+
+    {{ range $credential := .Credentials }}
+    <div class="card" style="width: 18rem;">
+        <div class="card-body">
+            <h5 class="card-title">
+                {{ range $i, $type := $credential.Types }}
+                    {{if $i}}, {{end}}{{ $type }}
+                {{ end }}
+            </h5>
+            {{ range $attr := $credential.Attributes }}
+            <ul>
+                <li>
+                    <label>{{ $attr.Name }}</label>
+                    <label>{{ $attr.Value }}</label>
+                </li>
+            </ul>
+            {{ end }}
+        </div>
+    </div>
+    {{ end }}
+
     <form method="post" action="./openid4vp_authz_consent">
         <input type="hidden" name="sessionID" value="{{.SessionID}}">
         <input type="submit" value="Authorize">

--- a/auth/api/iam/assets/authz_wallet_en.html
+++ b/auth/api/iam/assets/authz_wallet_en.html
@@ -2,34 +2,40 @@
 <head>
     <meta charset="UTF-8">
     <title>Credential required</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
 </head>
 <body>
     <h1>Credential required</h1>
     <p>{{ .VerifierName }} requests identification using one or more credentials in your wallet:</p>
 
-    {{ range $credential := .Credentials }}
-    <div class="card" style="width: 18rem;">
-        <div class="card-body">
-            <h5 class="card-title">
-                {{ range $i, $type := $credential.Types }}
-                    {{if $i}}, {{end}}{{ $type }}
-                {{ end }}
-            </h5>
-            {{ range $attr := $credential.Attributes }}
-            <ul>
-                <li>
-                    <label>{{ $attr.Name }}</label>
-                    <label>{{ $attr.Value }}</label>
-                </li>
-            </ul>
+    <form method="post" class="form" action="./openid4vp_authz_consent">
+        <div class="form-group">
+            {{ range $credential := .Credentials }}
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">
+                        {{ range $i, $type := $credential.Type }}
+                            {{if $i}}, {{end}}{{ $type }}
+                        {{ end }}
+                    </h5>
+                    {{ range $attr := $credential.Attributes }}
+                    <ul>
+                        <li>
+                            <span>{{ $attr.Name }}:</span>
+                            <span>{{ $attr.Value }}</span>
+                        </li>
+                    </ul>
+                    {{ end }}
+                </div>
+            </div>
             {{ end }}
         </div>
-    </div>
-    {{ end }}
 
-    <form method="post" action="./openid4vp_authz_consent">
         <input type="hidden" name="sessionID" value="{{.SessionID}}">
-        <input type="submit" value="Authorize">
+        <div class="form-group">
+            <input type="submit" value="Authorize" class="btn btn-primary">
+            <input type="button" value="Reject"  class="btn btn-secondary" onclick="alert('TODO: Abort authz request')">
+        </div>
     </form>
 </body>
 </html>

--- a/auth/api/iam/assets/authz_wallet_en.html
+++ b/auth/api/iam/assets/authz_wallet_en.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
 </head>
 <body>
-    <h1>Credential required</h1>
+    <h1>Credential required (Wallet)</h1>
     <p>{{ .VerifierName }} requests identification using one or more credentials in your wallet:</p>
 
     <form method="post" class="form" action="./openid4vp_authz_accept">

--- a/auth/api/iam/assets/authz_wallet_en.html
+++ b/auth/api/iam/assets/authz_wallet_en.html
@@ -8,7 +8,7 @@
     <h1>Credential required</h1>
     <p>{{ .VerifierName }} requests identification using one or more credentials in your wallet:</p>
 
-    <form method="post" class="form" action="./openid4vp_authz_consent">
+    <form method="post" class="form" action="./openid4vp_authz_accept">
         <div class="form-group">
             {{ range $credential := .Credentials }}
             <div class="card">

--- a/auth/api/iam/assets/openid4vp_demo.html
+++ b/auth/api/iam/assets/openid4vp_demo.html
@@ -1,0 +1,17 @@
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>OpenID4VP Demo</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+</head>
+<body>
+<h1>OpenID4VP Demo</h1>
+<p>This is a demo to have a verifier request a Verifiable Presentation from a wallet.</p>
+<form method="post" class="form-control">
+    <div>Scope: <input class="form-control" type="text" name="scope" value="medical-metadata"></div>
+    <div>Verifier Identifier: <input class="form-control" type="text" name="verifier_id" value="{{.VerifierID}}"></div>
+    <div>Wallet Identifier: <input class="form-control" type="text" name="wallet_id" value="{{.WalletID}}"></div>
+    <div><input type="submit" value="Request Presentation"></div>
+</form>
+</body>
+</html>

--- a/auth/api/iam/assets/openid4vp_demo.html
+++ b/auth/api/iam/assets/openid4vp_demo.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
 </head>
 <body>
-<h1>OpenID4VP Demo</h1>
+<h1>OpenID4VP Demo (Verifier)</h1>
 <p>This is a demo to have a verifier request a Verifiable Presentation from a wallet.</p>
 <form method="post" class="form-control">
     <div>Scope: <input class="form-control" type="text" name="scope" value="medical-metadata"></div>

--- a/auth/api/iam/assets/openid4vp_demo.html
+++ b/auth/api/iam/assets/openid4vp_demo.html
@@ -8,8 +8,14 @@
 <h1>OpenID4VP Demo (Verifier)</h1>
 <p>This is a demo to have a verifier request a Verifiable Presentation from a wallet.</p>
 <form method="post" class="form-control">
-    <div>Scope: <input class="form-control" type="text" name="scope" value="medical-metadata"></div>
-    <div>Verifier Identifier: <input class="form-control" type="text" name="verifier_id" value="{{.VerifierID}}"></div>
+    <div>
+        Scope:
+        <select name="scope" class="form-control">
+            <option value="eOverdracht-overdrachtsbericht" selected>eOverdracht-overdrachtsbericht (requires user identity)</option>
+            <option>eOverdracht-aanmeldbericht</option>
+        </select>
+    </div>
+    <input type="hidden" name="verifier_id" value="{{.VerifierID}}">
     <div>Wallet Identifier: <input class="form-control" type="text" name="wallet_id" value="{{.WalletID}}"></div>
     <div><input type="submit" value="Request Presentation"></div>
 </form>

--- a/auth/api/iam/assets/openid4vp_demo_completed.html
+++ b/auth/api/iam/assets/openid4vp_demo_completed.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
 </head>
 <body>
-<h1>OpenID4VP Demo</h1>
+<h1>OpenID4VP Demo (Verifier)</h1>
 <p>Presented credentials:</p>
 {{ range $credential := .Credentials }}
 <div class="card">

--- a/auth/api/iam/assets/openid4vp_demo_completed.html
+++ b/auth/api/iam/assets/openid4vp_demo_completed.html
@@ -1,0 +1,30 @@
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>OpenID4VP Demo</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+</head>
+<body>
+<h1>OpenID4VP Demo</h1>
+<p>Presented credentials:</p>
+{{ range $credential := .Credentials }}
+<div class="card">
+    <div class="card-body">
+        <h5 class="card-title">
+            {{ range $i, $type := $credential.Type }}
+            {{if $i}}, {{end}}{{ $type }}
+            {{ end }}
+        </h5>
+        {{ range $attr := $credential.Attributes }}
+        <ul>
+            <li>
+                <span>{{ $attr.Name }}:</span>
+                <span>{{ $attr.Value }}</span>
+            </li>
+        </ul>
+        {{ end }}
+    </div>
+</div>
+{{ end }}
+</body>
+</html>

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -33,14 +33,9 @@ type TokenResponse struct {
 	TokenType string `json:"token_type"`
 }
 
-// HandleAuthorizeRequestFormdataBody defines parameters for HandleAuthorizeRequest.
-type HandleAuthorizeRequestFormdataBody struct {
-	ClientId             string            `form:"client_id" json:"client_id"`
-	RedirectUri          *string           `form:"redirect_uri,omitempty" json:"redirect_uri,omitempty"`
-	ResponseType         string            `form:"response_type" json:"response_type"`
-	Scope                *string           `form:"scope,omitempty" json:"scope,omitempty"`
-	State                *string           `form:"state,omitempty" json:"state,omitempty"`
-	AdditionalProperties map[string]string `json:"-"`
+// HandleAuthorizeRequestParams defines parameters for HandleAuthorizeRequest.
+type HandleAuthorizeRequestParams struct {
+	Params *map[string]string `form:"params,omitempty" json:"params,omitempty"`
 }
 
 // HandleTokenRequestFormdataBody defines parameters for HandleTokenRequest.
@@ -50,135 +45,8 @@ type HandleTokenRequestFormdataBody struct {
 	AdditionalProperties map[string]string `json:"-"`
 }
 
-// HandleAuthorizeRequestFormdataRequestBody defines body for HandleAuthorizeRequest for application/x-www-form-urlencoded ContentType.
-type HandleAuthorizeRequestFormdataRequestBody HandleAuthorizeRequestFormdataBody
-
 // HandleTokenRequestFormdataRequestBody defines body for HandleTokenRequest for application/x-www-form-urlencoded ContentType.
 type HandleTokenRequestFormdataRequestBody HandleTokenRequestFormdataBody
-
-// Getter for additional properties for HandleAuthorizeRequestFormdataBody. Returns the specified
-// element and whether it was found
-func (a HandleAuthorizeRequestFormdataBody) Get(fieldName string) (value string, found bool) {
-	if a.AdditionalProperties != nil {
-		value, found = a.AdditionalProperties[fieldName]
-	}
-	return
-}
-
-// Setter for additional properties for HandleAuthorizeRequestFormdataBody
-func (a *HandleAuthorizeRequestFormdataBody) Set(fieldName string, value string) {
-	if a.AdditionalProperties == nil {
-		a.AdditionalProperties = make(map[string]string)
-	}
-	a.AdditionalProperties[fieldName] = value
-}
-
-// Override default JSON handling for HandleAuthorizeRequestFormdataBody to handle AdditionalProperties
-func (a *HandleAuthorizeRequestFormdataBody) UnmarshalJSON(b []byte) error {
-	object := make(map[string]json.RawMessage)
-	err := json.Unmarshal(b, &object)
-	if err != nil {
-		return err
-	}
-
-	if raw, found := object["client_id"]; found {
-		err = json.Unmarshal(raw, &a.ClientId)
-		if err != nil {
-			return fmt.Errorf("error reading 'client_id': %w", err)
-		}
-		delete(object, "client_id")
-	}
-
-	if raw, found := object["redirect_uri"]; found {
-		err = json.Unmarshal(raw, &a.RedirectUri)
-		if err != nil {
-			return fmt.Errorf("error reading 'redirect_uri': %w", err)
-		}
-		delete(object, "redirect_uri")
-	}
-
-	if raw, found := object["response_type"]; found {
-		err = json.Unmarshal(raw, &a.ResponseType)
-		if err != nil {
-			return fmt.Errorf("error reading 'response_type': %w", err)
-		}
-		delete(object, "response_type")
-	}
-
-	if raw, found := object["scope"]; found {
-		err = json.Unmarshal(raw, &a.Scope)
-		if err != nil {
-			return fmt.Errorf("error reading 'scope': %w", err)
-		}
-		delete(object, "scope")
-	}
-
-	if raw, found := object["state"]; found {
-		err = json.Unmarshal(raw, &a.State)
-		if err != nil {
-			return fmt.Errorf("error reading 'state': %w", err)
-		}
-		delete(object, "state")
-	}
-
-	if len(object) != 0 {
-		a.AdditionalProperties = make(map[string]string)
-		for fieldName, fieldBuf := range object {
-			var fieldVal string
-			err := json.Unmarshal(fieldBuf, &fieldVal)
-			if err != nil {
-				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
-			}
-			a.AdditionalProperties[fieldName] = fieldVal
-		}
-	}
-	return nil
-}
-
-// Override default JSON handling for HandleAuthorizeRequestFormdataBody to handle AdditionalProperties
-func (a HandleAuthorizeRequestFormdataBody) MarshalJSON() ([]byte, error) {
-	var err error
-	object := make(map[string]json.RawMessage)
-
-	object["client_id"], err = json.Marshal(a.ClientId)
-	if err != nil {
-		return nil, fmt.Errorf("error marshaling 'client_id': %w", err)
-	}
-
-	if a.RedirectUri != nil {
-		object["redirect_uri"], err = json.Marshal(a.RedirectUri)
-		if err != nil {
-			return nil, fmt.Errorf("error marshaling 'redirect_uri': %w", err)
-		}
-	}
-
-	object["response_type"], err = json.Marshal(a.ResponseType)
-	if err != nil {
-		return nil, fmt.Errorf("error marshaling 'response_type': %w", err)
-	}
-
-	if a.Scope != nil {
-		object["scope"], err = json.Marshal(a.Scope)
-		if err != nil {
-			return nil, fmt.Errorf("error marshaling 'scope': %w", err)
-		}
-	}
-
-	if a.State != nil {
-		object["state"], err = json.Marshal(a.State)
-		if err != nil {
-			return nil, fmt.Errorf("error marshaling 'state': %w", err)
-		}
-	}
-
-	for fieldName, field := range a.AdditionalProperties {
-		object[fieldName], err = json.Marshal(field)
-		if err != nil {
-			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
-		}
-	}
-	return json.Marshal(object)
-}
 
 // Getter for additional properties for HandleTokenRequestFormdataBody. Returns the specified
 // element and whether it was found
@@ -266,7 +134,7 @@ type ServerInterface interface {
 	GetOAuthAuthorizationServerMetadata(ctx echo.Context, did string) error
 	// Used by resource owners to initiate the authorization code flow.
 	// (GET /iam/{did}/authorize)
-	HandleAuthorizeRequest(ctx echo.Context, did string) error
+	HandleAuthorizeRequest(ctx echo.Context, did string, params HandleAuthorizeRequestParams) error
 	// Used by to request access- or refresh tokens.
 	// (POST /iam/{did}/token)
 	HandleTokenRequest(ctx echo.Context, did string) error
@@ -304,8 +172,17 @@ func (w *ServerInterfaceWrapper) HandleAuthorizeRequest(ctx echo.Context) error 
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter did: %s", err))
 	}
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params HandleAuthorizeRequestParams
+	// ------------- Optional query parameter "params" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "params", ctx.QueryParams(), &params.Params)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter params: %s", err))
+	}
+
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.HandleAuthorizeRequest(ctx, did)
+	err = w.Handler.HandleAuthorizeRequest(ctx, did, params)
 	return err
 }
 
@@ -398,8 +275,8 @@ func (response GetOAuthAuthorizationServerMetadatadefaultApplicationProblemPlusJ
 }
 
 type HandleAuthorizeRequestRequestObject struct {
-	Did  string `json:"did"`
-	Body *HandleAuthorizeRequestFormdataRequestBody
+	Did    string `json:"did"`
+	Params HandleAuthorizeRequestParams
 }
 
 type HandleAuthorizeRequestResponseObject interface {
@@ -526,20 +403,11 @@ func (sh *strictHandler) GetOAuthAuthorizationServerMetadata(ctx echo.Context, d
 }
 
 // HandleAuthorizeRequest operation middleware
-func (sh *strictHandler) HandleAuthorizeRequest(ctx echo.Context, did string) error {
+func (sh *strictHandler) HandleAuthorizeRequest(ctx echo.Context, did string, params HandleAuthorizeRequestParams) error {
 	var request HandleAuthorizeRequestRequestObject
 
 	request.Did = did
-
-	if form, err := ctx.FormParams(); err == nil {
-		var body HandleAuthorizeRequestFormdataRequestBody
-		if err := runtime.BindForm(&body, form, nil, nil); err != nil {
-			return err
-		}
-		request.Body = &body
-	} else {
-		return err
-	}
+	request.Params = params
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.HandleAuthorizeRequest(ctx.Request().Context(), request.(HandleAuthorizeRequestRequestObject))

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -197,7 +197,7 @@ func (r *Wrapper) handlePresentationRequestAccept(c echo.Context) error {
 	}
 	presentationSubmissionJSON, _ := json.Marshal(presentationSubmission)
 	resultParams[presentationSubmissionParam] = string(presentationSubmissionJSON)
-	verifiablePresentation, err := r.VCR.Holder().BuildVP(c.Request().Context(), credentials, holder.PresentationOptions{}, &session.OwnDID, false)
+	verifiablePresentation, err := r.VCR.Wallet().BuildPresentation(c.Request().Context(), credentials, holder.PresentationOptions{}, &session.OwnDID, false)
 	if err != nil {
 		return err
 	}

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -112,7 +112,7 @@ func (r *Wrapper) handlePresentationRequest(params map[string]string, session *S
 		{IRIPath: jsonld.OrganizationNamePath, Type: vcr.NotNil},
 		{IRIPath: jsonld.OrganizationCityPath, Type: vcr.NotNil},
 	}
-	credentials, err := r.VCR.Search(ctx, searchTerms, false, nil)
+	credentials, err := r.vcr.Search(ctx, searchTerms, false, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to search for credentials: %w", err)
 	}
@@ -125,7 +125,7 @@ func (r *Wrapper) handlePresentationRequest(params map[string]string, session *S
 		if len(subject) != 1 {
 			continue
 		}
-		isOwner, _ := r.VDR.IsOwner(ctx, did.MustParseDID(subject[0].ID))
+		isOwner, _ := r.vdr.IsOwner(ctx, did.MustParseDID(subject[0].ID))
 		if isOwner {
 			ownCredentials = append(ownCredentials, cred)
 		}
@@ -180,7 +180,7 @@ func (r *Wrapper) handlePresentationRequestAccept(c echo.Context) error {
 		if credentialID == nil {
 			continue // should be impossible
 		}
-		cred, err := r.VCR.Resolve(*credentialID, nil)
+		cred, err := r.vcr.Resolve(*credentialID, nil)
 		if err != nil {
 			return err
 		}
@@ -199,7 +199,7 @@ func (r *Wrapper) handlePresentationRequestAccept(c echo.Context) error {
 	}
 	presentationSubmissionJSON, _ := json.Marshal(presentationSubmission)
 	resultParams[presentationSubmissionParam] = string(presentationSubmissionJSON)
-	verifiablePresentation, err := r.VCR.Wallet().BuildPresentation(c.Request().Context(), credentials, holder.PresentationOptions{}, &session.OwnDID, false)
+	verifiablePresentation, err := r.vcr.Wallet().BuildPresentation(c.Request().Context(), credentials, holder.PresentationOptions{}, &session.OwnDID, false)
 	if err != nil {
 		return err
 	}

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 const clientIDParam = "client_id"
@@ -93,12 +94,14 @@ func (r *Wrapper) handlePresentationRequest(params map[string]string, session *S
 
 	// Render HTML
 	templateParams := struct {
-		SessionID    string
-		VerifierName string
-		Credentials  []CredentialInfo
+		SessionID            string
+		RequiresUserIdentity bool
+		VerifierName         string
+		Credentials          []CredentialInfo
 	}{
 		// TODO: Maybe this should the verifier name be read from registered client metadata?
-		VerifierName: ssi.MustParseURI(session.RedirectURI).Host,
+		VerifierName:         ssi.MustParseURI(session.RedirectURI).Host,
+		RequiresUserIdentity: strings.Contains(session.ResponseType, "id_token"),
 	}
 
 	// TODO: https://github.com/nuts-foundation/nuts-node/issues/2357

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -129,7 +129,6 @@ func (r *Wrapper) handlePresentationRequest(params map[string]string, session *S
 	}
 
 	// TODO: https://github.com/nuts-foundation/nuts-node/issues/2359
-	// TODO: Match presentation definition (search for org credential for now)
 	// TODO: What if multiple credentials of the same type match?
 	_, matchingCredentials, err := presentationDefinition.Match(credentials)
 	if err != nil {

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -2,40 +2,83 @@ package iam
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"github.com/labstack/echo/v4"
-	"github.com/nuts-foundation/nuts-node/core"
-	"html/template"
 	"net/http"
+	"net/url"
 )
 
-// openID4VP implements verifiable presentation exchanges as specified by https://openid.net/specs/openid-4-verifiable-presentations-1_0.html.
-type openID4VP struct {
-	sessions      *SessionManager
-	authzTemplate *template.Template
+const responseTypeParam = "response_type"
+const scopeParam = "scope"
+const redirectURIParam = "redirect_uri"
+const presentationDefParam = "presentation_definition"
+const presentationDefUriParam = "presentation_definition_uri"
+const clientMetadataParam = "client_metadata"
+const clientMetadataURIParam = "client_metadata_uri"
+const clientIDSchemeParam = "client_id_scheme"
+const responseModeParam = "response_mode"
+
+// createPresentationRequest creates a new Authorization Request as specified by OpenID4VP: https://openid.net/specs/openid-4-verifiable-presentations-1_0.html.
+// It is sent by a verifier to a wallet, to request one or more verifiable credentials as verifiable presentation from the wallet.
+func (r *Wrapper) sendPresentationRequest(ctx context.Context, response http.ResponseWriter, scope string,
+	redirectURL url.URL, verifierIdentifier url.URL, walletIdentifier url.URL) error {
+	// TODO: Lookup wallet metadata for correct authorization endpoint. But for Nuts nodes, we derive it from the walletIdentifier
+	authzEndpoint := walletIdentifier.JoinPath("/authorize")
+	params := make(map[string]string)
+	params[scopeParam] = scope
+	params[redirectURIParam] = redirectURL.String()
+	// TODO: Check this
+	params[clientMetadataURIParam] = verifierIdentifier.JoinPath("/.well-known/openid-wallet-metadata/metadata.xml").String()
+	// TODO: use constants from @gsn
+	params[responseModeParam] = "direct_post"
+	// TODO: use constants from @gsn
+	params[responseTypeParam] = "vp_token id_token"
+	// TODO: Depending on parameter size, we either use redirect with query parameters or a form post.
+	//       For simplicity, we now just query parameters.
+	result := AddQueryParams(*authzEndpoint, params)
+	response.Header().Add("Location", result.String())
+	response.WriteHeader(http.StatusFound)
+	return nil
 }
 
-func (a openID4VP) Routes(router core.EchoRouter) {
-	router.Add(http.MethodPost, "/public/oauth2/:did/authz_consent", a.handleAuthConsent)
-}
-
-func (a openID4VP) handleAuthzRequest(params map[string]string, session *Session) (*authzResponse, error) {
-	presentationDef := params["presentation_definition"]
-	presentationDefUri := params["presentation_definition_uri"]
-	clientIdScheme := params["client_id_scheme"]
-	clientMetadata := params["client_metadata"]
-	clientMetadataUri := params["client_metadata_uri"]
-
-	if presentationDef == "" &&
-		presentationDefUri == "" &&
-		clientIdScheme == "" &&
-		clientMetadata == "" &&
-		clientMetadataUri == "" {
-		// Not an OpenID4VP Authorization Request
-		return nil, nil
+// handlePresentationRequest handles an Authorization Request as specified by OpenID4VP: https://openid.net/specs/openid-4-verifiable-presentations-1_0.html.
+// It is handled by a wallet, called by a verifier who wants the wallet to present one or more verifiable credentials.
+func (r *Wrapper) handlePresentationRequest(params map[string]string, session *Session) (HandleAuthorizeRequestResponseObject, error) {
+	// Presentation definition is always derived from the scope.
+	// Later on, we might support presentation_definition and/or presentation_definition_uri parameters instead of scope as well.
+	if err := assertParamNotPresent(params, presentationDefParam, presentationDefUriParam); err != nil {
+		return nil, err
 	}
-	sessionId := a.sessions.Create(*session)
+	if err := assertParamPresent(params, scopeParam); err != nil {
+		return nil, err
+	}
+	if err := assertParamPresent(params, responseTypeParam); err != nil {
+		return nil, err
+	}
+	// Not supported: client_id_schema, client_metadata
+	if err := assertParamNotPresent(params, clientIDSchemeParam, clientMetadataParam); err != nil {
+		return nil, err
+	}
+	// Required: client_metadata_uri
+	if err := assertParamPresent(params, clientMetadataURIParam); err != nil {
+		return nil, err
+	}
+	// Response mode is always direct_post for now
+	// TODO: Use constant defined by @gsn
+	if params[responseModeParam] != "direct_post" {
+		return nil, errors.New("response_mode must be direct_post")
+	}
+
+	// TODO: This is the easiest for now, but is this the way?
+	// For compatibility, we probably need to support presentation_definition and/or presentation_definition_uri.
+	presentationDefinition := r.presentationDefinitions.ByScope(params[scopeParam])
+	if presentationDefinition == nil {
+		return nil, fmt.Errorf("unsupported scope for presentation exchange: %s", params[scopeParam])
+	}
+
+	sessionId := r.sessions.Create(*session)
 
 	// TODO: https://github.com/nuts-foundation/nuts-node/issues/2357
 	// TODO: Retrieve presentation definition
@@ -45,7 +88,7 @@ func (a openID4VP) handleAuthzRequest(params map[string]string, session *Session
 	// Render HTML
 	buf := new(bytes.Buffer)
 	// TODO: Support multiple languages
-	err := a.authzTemplate.Execute(buf, struct {
+	err := r.templates.ExecuteTemplate(buf, "assets/authz_wallet_en.html", struct {
 		SessionID string
 		Session
 	}{
@@ -53,19 +96,20 @@ func (a openID4VP) handleAuthzRequest(params map[string]string, session *Session
 		Session:   *session,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to render authorization page: %w", err)
+		return nil, fmt.Errorf("unable to render authz page: %w", err)
 	}
-	return &authzResponse{
-		html: buf.Bytes(),
+	return HandleAuthorizeRequest200TexthtmlResponse{
+		Body:          buf,
+		ContentLength: int64(buf.Len()),
 	}, nil
 }
 
 // handleAuthConsent handles the authorization consent form submission.
-func (a openID4VP) handleAuthConsent(c echo.Context) error {
+func (r *Wrapper) handlePresentationRequestConsent(c echo.Context) error {
 	// TODO: Needs authentication?
 	var session *Session
 	if sessionID := c.Param("sessionID"); sessionID != "" {
-		session = a.sessions.Get(sessionID)
+		session = r.sessions.Get(sessionID)
 	}
 	if session == nil {
 		return errors.New("invalid session")
@@ -73,4 +117,22 @@ func (a openID4VP) handleAuthConsent(c echo.Context) error {
 	// TODO: create presentation submission
 	// TODO: check response mode, and submit accordingly (direct_post)
 	return c.Redirect(http.StatusFound, session.CreateRedirectURI(map[string]string{}))
+}
+
+func assertParamPresent(params map[string]string, param ...string) error {
+	for _, param := range param {
+		if len(params[param]) == 0 {
+			return fmt.Errorf("%s parameter must be present", param)
+		}
+	}
+	return nil
+}
+
+func assertParamNotPresent(params map[string]string, param ...string) error {
+	for _, param := range param {
+		if len(params[param]) > 0 {
+			return fmt.Errorf("%s parameter must not be present", param)
+		}
+	}
+	return nil
 }

--- a/auth/api/iam/openid4vp_demo.go
+++ b/auth/api/iam/openid4vp_demo.go
@@ -1,0 +1,51 @@
+package iam
+
+import (
+	"bytes"
+	"errors"
+	"github.com/labstack/echo/v4"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func (r *Wrapper) handleOpenID4VPDemoLanding(echoCtx echo.Context) error {
+	requestURL := *echoCtx.Request().URL
+	requestURL.Host = echoCtx.Request().Host
+	requestURL.Scheme = "http"
+	verifierID := requestURL.String()
+	verifierID, _ = strings.CutSuffix(verifierID, "/openid4vp_demo")
+
+	buf := new(bytes.Buffer)
+	if err := r.templates.ExecuteTemplate(buf, "openid4vp_demo.html", struct {
+		VerifierID string
+		WalletID   string
+	}{
+		VerifierID: verifierID,
+		WalletID:   verifierID,
+	}); err != nil {
+		return err
+	}
+	return echoCtx.HTML(http.StatusOK, buf.String())
+}
+
+func (r *Wrapper) handleOpenID4VPDemoSendRequest(echoCtx echo.Context) error {
+	verifierID := echoCtx.FormValue("verifier_id")
+	if verifierID == "" {
+		return errors.New("missing verifier_id")
+	}
+	walletID := echoCtx.FormValue("wallet_id")
+	if walletID == "" {
+		return errors.New("missing wallet_id")
+	}
+	scope := echoCtx.FormValue("scope")
+	if scope == "" {
+		return errors.New("missing scope")
+	}
+	walletURL, _ := url.Parse(walletID)
+	verifierURL, _ := url.Parse(verifierID)
+	return r.sendPresentationRequest(
+		echoCtx.Request().Context(), echoCtx.Response(), scope,
+		*walletURL.JoinPath("openid4vp_completed"), *verifierURL, *walletURL,
+	)
+}

--- a/auth/api/iam/openid4vp_test.go
+++ b/auth/api/iam/openid4vp_test.go
@@ -21,7 +21,7 @@ var holderDID = did.MustParseDID("did:web:example.com:holder")
 var issuerDID = did.MustParseDID("did:web:example.com:issuer")
 
 func TestWrapper_sendPresentationRequest(t *testing.T) {
-	instance := New(nil, nil, nil, nil)
+	instance := New(nil, nil, nil)
 
 	redirectURI, _ := url.Parse("https://example.com/redirect")
 	verifierID, _ := url.Parse("https://example.com/verifier")
@@ -72,7 +72,7 @@ func TestWrapper_handlePresentationRequest(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockVDR := types.NewMockVDR(ctrl)
 		mockVCR := vcr.NewMockVCR(ctrl)
-		instance := New(nil, mockVCR, mockVDR, nil)
+		instance := New(nil, mockVCR, mockVDR)
 		mockVCR.EXPECT().Search(gomock.Any(), gomock.Any(), false, nil).Return(walletCredentials, nil)
 		mockVDR.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
 

--- a/auth/api/iam/openid4vp_test.go
+++ b/auth/api/iam/openid4vp_test.go
@@ -1,0 +1,90 @@
+package iam
+
+import (
+	"bytes"
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/go-did/vc"
+	"github.com/nuts-foundation/nuts-node/vcr"
+	"github.com/nuts-foundation/nuts-node/vcr/credential"
+	"github.com/nuts-foundation/nuts-node/vdr/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"net/http"
+	"testing"
+)
+
+func TestWrapper_handlePresentationRequest(t *testing.T) {
+	holderDID := did.MustParseDID("did:web:example.com:holder")
+	issuerDID := did.MustParseDID("did:web:example.com:issuer")
+	credentialID, _ := ssi.ParseURI("did:web:example.com:issuer#6AF53584-3337-4766-8C8D-0BFD54F6E527")
+	walletCredentials := []vc.VerifiableCredential{
+		{
+			Context: []ssi.URI{
+				vc.VCContextV1URI(),
+				credential.NutsV1ContextURI,
+			},
+			ID:     credentialID,
+			Issuer: issuerDID.URI(),
+			Type:   []ssi.URI{vc.VerifiableCredentialTypeV1URI(), *credential.NutsOrganizationCredentialTypeURI},
+			CredentialSubject: []interface{}{
+				map[string]interface{}{
+					"id": holderDID.URI(),
+					"organization": map[string]interface{}{
+						"name": "Test Organization",
+						"city": "Test City",
+					},
+				},
+			},
+		},
+	}
+	t.Run("with scope", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockVDR := types.NewMockVDR(ctrl)
+		mockVCR := vcr.NewMockVCR(ctrl)
+		instance := New(nil, mockVCR, mockVDR, nil)
+		mockVCR.EXPECT().Search(gomock.Any(), gomock.Any(), false, nil).Return(walletCredentials, nil)
+		mockVDR.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
+
+		params := map[string]string{
+			"scope":               "eOverdracht-overdrachtsbericht",
+			"response_type":       "code",
+			"response_mode":       "direct_post",
+			"client_metadata_uri": "https://example.com/client_metadata.xml",
+		}
+
+		response, err := instance.handlePresentationRequest(params, createSession(params, holderDID))
+
+		require.NoError(t, err)
+		httpResponse := &stubResponseWriter{}
+		_ = response.VisitHandleAuthorizeRequestResponse(httpResponse)
+		require.Equal(t, http.StatusOK, httpResponse.statusCode)
+		assert.Contains(t, httpResponse.buffer.String(), "</html>")
+	})
+}
+
+type stubResponseWriter struct {
+	headers    http.Header
+	buffer     *bytes.Buffer
+	statusCode int
+}
+
+func (s *stubResponseWriter) Header() http.Header {
+	if s.headers == nil {
+		s.headers = make(http.Header)
+	}
+	return s.headers
+
+}
+
+func (s *stubResponseWriter) Write(i []byte) (int, error) {
+	if s.buffer == nil {
+		s.buffer = new(bytes.Buffer)
+	}
+	return s.buffer.Write(i)
+}
+
+func (s *stubResponseWriter) WriteHeader(statusCode int) {
+	s.statusCode = statusCode
+}

--- a/auth/api/iam/presentation_definitions.go
+++ b/auth/api/iam/presentation_definitions.go
@@ -5,9 +5,8 @@ import (
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
 )
 
-// MedicalMetadataScope is the scope for interacting with medical metadata (non-PII).
 // TODO: We need to decide on these.
-const MedicalMetadataScope = "medical-metadata"
+const eOverdrachtOverdrachtsberichtScope = "eOverdracht-overdrachtsbericht"
 
 // presentationDefinitionRegistry is a registry for presentation definitions.
 type presentationDefinitionRegistry interface {
@@ -20,7 +19,7 @@ type nutsPresentationDefinitionRegistry struct {
 }
 
 func (n nutsPresentationDefinitionRegistry) ByScope(scope string) *pe.PresentationDefinition {
-	if scope != MedicalMetadataScope {
+	if scope != eOverdrachtOverdrachtsberichtScope {
 		return nil
 	}
 	return &pe.PresentationDefinition{

--- a/auth/api/iam/presentation_definitions.go
+++ b/auth/api/iam/presentation_definitions.go
@@ -1,0 +1,69 @@
+package iam
+
+import (
+	"github.com/google/uuid"
+	"github.com/nuts-foundation/nuts-node/vcr/pe"
+)
+
+// MedicalMetadataScope is the scope for interacting with medical metadata (non-PII).
+// TODO: We need to decide on these.
+const MedicalMetadataScope = "medical-metadata"
+
+// presentationDefinitionRegistry is a registry for presentation definitions.
+type presentationDefinitionRegistry interface {
+	// ByScope returns the presentation definition for the given scope.
+	// If it can't map the scope to a presentation definition, nil is returned.
+	ByScope(scope string) *pe.PresentationDefinition
+}
+
+type nutsPresentationDefinitionRegistry struct {
+}
+
+func (n nutsPresentationDefinitionRegistry) ByScope(scope string) *pe.PresentationDefinition {
+	if scope != MedicalMetadataScope {
+		return nil
+	}
+	return &pe.PresentationDefinition{
+		Format: &pe.PresentationDefinitionClaimFormatDesignations{
+			// TODO: Might have to support jwt_vc, but node doesn't support it yet.
+			"ldp_vc": {
+				"proof_type": []string{"JsonWebSignature2020"},
+			},
+		},
+		Id: "pd_any_care_organization",
+		InputDescriptors: []*pe.InputDescriptor{
+			{
+				Id: uuid.NewString(), // TODO: What should this be?
+				Constraints: &pe.Constraints{
+					Fields: []pe.Field{
+						{
+							Path: []string{"$.type"},
+							Filter: &pe.Filter{
+								Type:  "string",
+								Const: pString("NutsOrganizationCredential"),
+							},
+						},
+						{
+							Path: []string{"$.credentialSubject.organization.name"},
+							Filter: &pe.Filter{
+								Type: "string",
+							},
+						},
+						{
+							Path: []string{"$.credentialSubject.organization.city"},
+							Filter: &pe.Filter{
+								Type: "string",
+							},
+						},
+					},
+				},
+			},
+		},
+		Name:    "Care organization",
+		Purpose: "Finding a care organization for authorizing access to medical metadata",
+	}
+}
+
+func pString(val string) *string {
+	return &val
+}

--- a/auth/api/iam/rendering.go
+++ b/auth/api/iam/rendering.go
@@ -1,0 +1,70 @@
+package iam
+
+import (
+	"fmt"
+	"github.com/nuts-foundation/go-did/vc"
+	"sort"
+	"strconv"
+)
+
+type CredentialInfoAttribute struct {
+	Name  string
+	Value string
+}
+
+type CredentialInfo struct {
+	ID         string
+	Type       []string
+	Attributes []CredentialInfoAttribute
+}
+
+func makeCredentialInfo(cred vc.VerifiableCredential) CredentialInfo {
+	result := CredentialInfo{
+		ID: cred.ID.String(),
+	}
+
+	for _, curr := range cred.Type {
+		if curr.String() != vc.VerifiableCredentialType {
+			result.Type = append(result.Type, curr.String())
+		}
+	}
+
+	// Collect all properties from the credential subject
+	// This assumes it's a compacted JSON-LD document, with arrays compacted
+	propsMap := map[string]interface{}{}
+	for _, curr := range cred.CredentialSubject {
+		asMap, ok := curr.(map[string]interface{})
+		if ok {
+			flatMap("", " ", asMap, propsMap)
+		}
+	}
+
+	for key, value := range propsMap {
+		result.Attributes = append(result.Attributes, CredentialInfoAttribute{
+			Name:  key,
+			Value: fmt.Sprintf("%sv", value),
+		})
+	}
+	sort.SliceStable(result.Attributes, func(i, j int) bool {
+		return result.Attributes[i].Name < result.Attributes[j].Name
+	})
+	return result
+}
+
+func flatMap(path string, separator string, src map[string]interface{}, dest map[string]interface{}) {
+	if len(path) > 0 {
+		path += separator
+	}
+	for key, value := range src {
+		switch next := value.(type) {
+		case map[string]interface{}:
+			flatMap(path+key, separator, next, dest)
+		case []interface{}:
+			for i := 0; i < len(next); i++ {
+				dest[path+key+"."+strconv.Itoa(i)] = next[i]
+			}
+		default:
+			dest[path+key] = value
+		}
+	}
+}

--- a/auth/api/iam/rendering.go
+++ b/auth/api/iam/rendering.go
@@ -40,9 +40,13 @@ func makeCredentialInfo(cred vc.VerifiableCredential) CredentialInfo {
 	}
 
 	for key, value := range propsMap {
+		if key == "id" {
+			// omit ID attribute
+			continue
+		}
 		result.Attributes = append(result.Attributes, CredentialInfoAttribute{
 			Name:  key,
-			Value: fmt.Sprintf("%sv", value),
+			Value: fmt.Sprintf("%s", value),
 		})
 	}
 	sort.SliceStable(result.Attributes, func(i, j int) bool {

--- a/auth/api/iam/rendering_test.go
+++ b/auth/api/iam/rendering_test.go
@@ -1,24 +1,26 @@
 package iam
 
 import (
-	"context"
 	"github.com/nuts-foundation/go-did/vc"
-	"github.com/nuts-foundation/nuts-node/jsonld"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
-func TestHtmlCredentialRenderer_Render(t *testing.T) {
+func Test_makeCredentialInfo(t *testing.T) {
 	var cred vc.VerifiableCredential
 	err := cred.UnmarshalJSON([]byte(nutsOrgCredentialJSON))
 	require.NoError(t, err)
-	jsonldManager := jsonld.NewTestJSONLDManager(t)
-	renderer := HtmlCredentialRenderer{DocumentLoader: jsonldManager.DocumentLoader()}
 
-	result, err := renderer.Render(context.Background(), cred)
+	info := makeCredentialInfo(cred)
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
+	assert.Equal(t, cred.ID.String(), info.ID)
+	assert.Equal(t, []string{"NutsOrganizationCredential"}, info.Type)
+	assert.Len(t, info.Attributes, 2)
+	assert.Equal(t, "organization city", info.Attributes[0].Name)
+	assert.Equal(t, "IJbergen", info.Attributes[0].Value)
+	assert.Equal(t, "organization name", info.Attributes[1].Name)
+	assert.Equal(t, "Because we care B.V.", info.Attributes[1].Value)
 }
 
 const nutsOrgCredentialJSON = `

--- a/auth/api/iam/rendering_test.go
+++ b/auth/api/iam/rendering_test.go
@@ -1,0 +1,53 @@
+package iam
+
+import (
+	"context"
+	"github.com/nuts-foundation/go-did/vc"
+	"github.com/nuts-foundation/nuts-node/jsonld"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestHtmlCredentialRenderer_Render(t *testing.T) {
+	var cred vc.VerifiableCredential
+	err := cred.UnmarshalJSON([]byte(nutsOrgCredentialJSON))
+	require.NoError(t, err)
+	jsonldManager := jsonld.NewTestJSONLDManager(t)
+	renderer := HtmlCredentialRenderer{DocumentLoader: jsonldManager.DocumentLoader()}
+
+	result, err := renderer.Render(context.Background(), cred)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+const nutsOrgCredentialJSON = `
+{
+  "@context": [
+    "https://nuts.nl/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json"
+  ],
+  "credentialSubject": {
+    "id": "did:nuts:CuE3qeFGGLhEAS3gKzhMCeqd1dGa9at5JCbmCfyMU2Ey",
+    "organization": {
+      "city": "IJbergen",
+      "name": "Because we care B.V."
+    }
+  },
+  "id": "did:nuts:CuE3qeFGGLhEAS3gKzhMCeqd1dGa9at5JCbmCfyMU2Ey#ec8af8cf-67d4-4b54-9bd6-8a861e729e11",
+  "issuanceDate": "2022-06-01T15:34:40.65319+02:00",
+  "issuer": "did:nuts:CuE3qeFGGLhEAS3gKzhMCeqd1dGa9at5JCbmCfyMU2Ey",
+  "proof": {
+    "created": "2022-06-01T12:00:00Z",
+    "jws": "eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Za6h29jt9fJMUDs9wkkbZAtB3-PTHfGBhFzPGz_DkWXariFkPQdd75BZU9-tQraiA7X8wMSSKQuYnQsNXMxvmw",
+    "proofPurpose": "assertionMethod",
+    "type": "JsonWebSignature2020",
+    "verificationMethod": "did:nuts:CuE3qeFGGLhEAS3gKzhMCeqd1dGa9at5JCbmCfyMU2Ey#sNGDQ3NlOe6Icv0E7_ufviOLG6Y25bSEyS5EbXBgp8Y"
+  },
+  "type": [
+    "NutsOrganizationCredential",
+    "VerifiableCredential"
+  ]
+}
+`

--- a/auth/api/iam/session.go
+++ b/auth/api/iam/session.go
@@ -30,12 +30,13 @@ func (s *SessionManager) Get(id string) *Session {
 }
 
 type Session struct {
-	ClientID    string
-	Scope       string
-	OwnDID      did.DID
-	ClientState string
-	RedirectURI string
-	ServerState map[string]interface{}
+	ClientID     string
+	Scope        string
+	OwnDID       did.DID
+	ClientState  string
+	RedirectURI  string
+	ServerState  map[string]interface{}
+	ResponseType string
 }
 
 func AddQueryParams(u url.URL, params map[string]string) url.URL {

--- a/auth/api/iam/session.go
+++ b/auth/api/iam/session.go
@@ -35,6 +35,7 @@ type Session struct {
 	OwnDID      did.DID
 	ClientState string
 	RedirectURI string
+	ServerState map[string]interface{}
 }
 
 func AddQueryParams(u url.URL, params map[string]string) url.URL {

--- a/auth/api/iam/session.go
+++ b/auth/api/iam/session.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"github.com/google/uuid"
+	"github.com/nuts-foundation/go-did/did"
 	"net/url"
 	"sync"
 )
@@ -31,6 +32,7 @@ func (s *SessionManager) Get(id string) *Session {
 type Session struct {
 	ClientID    string
 	Scope       string
+	OwnDID      did.DID
 	ClientState string
 	RedirectURI string
 }

--- a/auth/api/iam/session.go
+++ b/auth/api/iam/session.go
@@ -35,12 +35,17 @@ type Session struct {
 	RedirectURI string
 }
 
+func AddQueryParams(u url.URL, params map[string]string) url.URL {
+	values := u.Query()
+	for key, value := range params {
+		values.Add(key, value)
+	}
+	u.RawQuery = values.Encode()
+	return u
+}
+
 func (s Session) CreateRedirectURI(params map[string]string) string {
 	redirectURI, _ := url.Parse(s.RedirectURI)
-	query := redirectURI.Query()
-	for key, value := range params {
-		query.Add(key, value)
-	}
-	redirectURI.RawQuery = query.Encode()
-	return redirectURI.String()
+	r := AddQueryParams(*redirectURI, params)
+	return r.String()
 }

--- a/docs/_static/auth/iam.yaml
+++ b/docs/_static/auth/iam.yaml
@@ -73,29 +73,16 @@ paths:
           schema:
             type: string
             example: did:nuts:123
-      requestBody:
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              description: See https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
-              type: object
-              required:
-                - response_type
-                - client_id
-              properties:
-                response_type:
-                  type: string
-                  example: code
-                client_id:
-                  type: string
-                redirect_uri:
-                  type: string
-                scope:
-                  type: string
-                state:
-                  type: string
-              additionalProperties:
-                type: string
+        # Way to specify dynamic query parameters
+        # See https://stackoverflow.com/questions/49582559/how-to-document-dynamic-query-parameter-names-in-openapi-swagger
+        - in: query
+          name: params
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+          style: form
+          explode: true
       responses:
         "200":
           description: Authorization request accepted, user is asked for consent.


### PR DESCRIPTION
Next things to work on, fitting into this PR:
- Support direct_post mode for sending the authorization response from wallet to verifier, instead of having it as parameters on the redirect back to the verifier.
- Replace hardcoded metadata URLs with the ones specified by https://github.com/nuts-foundation/nuts-node/pull/2443 
- Support VPs in JWT format (consuming and producing), for compatibility with non-Nuts nodes
- Match Presentation Definition with credentials in wallet, instead of just loading credentials from VCR store (requires  https://github.com/nuts-foundation/nuts-node/issues/2389)
- Do some styling of the HTML templates for the "WOW!" factor
- i18n HTML templates (we should at least support Dutch)
- Support presentation_definition and presentation_definition_uri, so the presentation definition can be specified there (by the verifier) instead of mapping it from scope.
- Validate redirect URI sent by verifier
- Implement id_token (needs design work)
- Implement /token path