### PR TITLE
OAuth add /.well-known/oauth-authorization-server endpoint

### DIFF
--- a/auth/api/auth/v1/api_test.go
+++ b/auth/api/auth/v1/api_test.go
@@ -80,6 +80,10 @@ func (m *mockAuthClient) ContractNotary() services.ContractNotary {
 	return m.contractNotary
 }
 
+func (m *mockAuthClient) PublicURL() *url.URL {
+	return nil
+}
+
 func createContext(t *testing.T) *TestContext {
 	t.Helper()
 	ctrl := gomock.NewController(t)

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -181,23 +181,23 @@ func (r Wrapper) HandleAuthorizeRequest(ctx context.Context, request HandleAutho
 func (r Wrapper) GetOAuthAuthorizationServerMetadata(ctx context.Context, request GetOAuthAuthorizationServerMetadataRequestObject) (GetOAuthAuthorizationServerMetadataResponseObject, error) {
 	id, err := did.ParseDID(request.Did)
 	if err != nil {
-		return nil, err
+		return nil, core.InvalidInputError("authz server metadata: %w", err)
 	}
 
 	if id.Method != "nuts" {
-		return nil, core.InvalidInputError("only did:nuts is supported")
+		return nil, core.InvalidInputError("authz server metadata: only did:nuts is supported")
 	}
 
 	owned, err := r.vdr.IsOwner(ctx, *id)
 	if err != nil {
 		if didservice.IsFunctionalResolveError(err) {
-			return nil, core.NotFoundError(err.Error())
+			return nil, core.NotFoundError("authz server metadata: %w", err)
 		}
-		log.Logger().WithField("did", id.String()).Errorf("failed to assert ownership of did: %s", err.Error())
-		return nil, err
+		log.Logger().WithField("did", id.String()).Errorf("authz server metadata: failed to assert ownership of did: %s", err.Error())
+		return nil, core.Error(500, "authz server metadata: %w", err)
 	}
 	if !owned {
-		return nil, core.NotFoundError(err.Error())
+		return nil, core.NotFoundError("authz server metadata: did not owned")
 	}
 
 	identity := r.auth.PublicURL().JoinPath("iam", id.WithoutURL().String())

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -1,0 +1,127 @@
+package iam
+
+import (
+	"errors"
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/auth"
+	"github.com/nuts-foundation/nuts-node/core"
+	vdr "github.com/nuts-foundation/nuts-node/vdr/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"testing"
+)
+
+func TestWrapper_GetOAuthAuthorizationServerMetadata(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		//	200
+		publicUrl := "https://example.com:443"
+		ctx := newTestClient(t, publicUrl)
+		did := did.MustParseDID("did:nuts:123")
+		ctx.documentOwner.EXPECT().IsOwner(nil, did).Return(true, nil)
+		identity := publicUrl + "/iam/" + did.String()
+
+		expected := GetOAuthAuthorizationServerMetadata200JSONResponse(OAuthAuthorizationServerMetadata{
+			Issuer:                 identity,
+			AuthorizationEndpoint:  identity + "/authorize",
+			ResponseTypesSupported: []string{"code", "vp_token", "vp_token id_token"},
+			ResponseModesSupported: []string{"query", "direct_post"},
+			TokenEndpoint:          identity + "/token",
+			GrantTypesSupported:    []string{"authorization_code", "vp_token", "urn:ietf:params:oauth:grant-type:pre-authorized_code"},
+			PreAuthorizedGrantAnonymousAccessSupported: true,
+			VPFormatsSupported: map[string]map[string][]string{
+				"jwt_vp": {"alg_values_supported": []string{"PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}},
+				"ldp_vc": {"proof_type_values_supported": []string{"JsonWebSignature2020"}},
+			},
+			ClientIdSchemesSupported: []string{"did"},
+		})
+
+		res, err := ctx.client.GetOAuthAuthorizationServerMetadata(nil, GetOAuthAuthorizationServerMetadataRequestObject{Did: did.String()})
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, res)
+
+	})
+	t.Run("error - not a did", func(t *testing.T) {
+		//400
+		ctx := newTestClient(t, "")
+
+		res, err := ctx.client.GetOAuthAuthorizationServerMetadata(nil, GetOAuthAuthorizationServerMetadataRequestObject{})
+
+		assert.Equal(t, 400, statusCodeFrom(err))
+		assert.EqualError(t, err, "authz server metadata: invalid DID")
+		assert.Nil(t, res)
+	})
+	t.Run("error - not a did:nuts", func(t *testing.T) {
+		//400
+		ctx := newTestClient(t, "")
+
+		res, err := ctx.client.GetOAuthAuthorizationServerMetadata(nil, GetOAuthAuthorizationServerMetadataRequestObject{Did: "did:web:example.com"})
+
+		assert.Equal(t, 400, statusCodeFrom(err))
+		assert.EqualError(t, err, "authz server metadata: only did:nuts is supported")
+		assert.Nil(t, res)
+	})
+	t.Run("error - did not managed by this node", func(t *testing.T) {
+		//404
+		ctx := newTestClient(t, "")
+		did := did.MustParseDID("did:nuts:123")
+		ctx.documentOwner.EXPECT().IsOwner(nil, did)
+
+		res, err := ctx.client.GetOAuthAuthorizationServerMetadata(nil, GetOAuthAuthorizationServerMetadataRequestObject{Did: did.String()})
+
+		assert.Equal(t, 404, statusCodeFrom(err))
+		assert.EqualError(t, err, "authz server metadata: did not owned")
+		assert.Nil(t, res)
+	})
+	t.Run("error - did does not exist", func(t *testing.T) {
+		//404
+		ctx := newTestClient(t, "")
+		did := did.MustParseDID("did:nuts:123")
+		ctx.documentOwner.EXPECT().IsOwner(nil, did).Return(false, vdr.ErrNotFound)
+
+		res, err := ctx.client.GetOAuthAuthorizationServerMetadata(nil, GetOAuthAuthorizationServerMetadataRequestObject{Did: did.String()})
+
+		assert.Equal(t, 404, statusCodeFrom(err))
+		assert.EqualError(t, err, "authz server metadata: unable to find the DID document")
+		assert.Nil(t, res)
+	})
+	t.Run("error - internal error 500", func(t *testing.T) {
+		//500
+		ctx := newTestClient(t, "")
+		did := did.MustParseDID("did:nuts:123")
+		ctx.documentOwner.EXPECT().IsOwner(nil, did).Return(false, errors.New("unknown error"))
+
+		res, err := ctx.client.GetOAuthAuthorizationServerMetadata(nil, GetOAuthAuthorizationServerMetadataRequestObject{Did: did.String()})
+
+		assert.Equal(t, 500, statusCodeFrom(err))
+		assert.EqualError(t, err, "authz server metadata: unknown error")
+		assert.Nil(t, res)
+	})
+}
+
+// statusCodeFrom returns the statuscode if err is core.HTTPStatusCodeError, or 0 if it isn't
+func statusCodeFrom(err error) int {
+	var SE core.HTTPStatusCodeError
+	if errors.As(err, &SE) {
+		return SE.StatusCode()
+	}
+	return 0
+}
+
+type testCtx struct {
+	client        *Wrapper
+	documentOwner *vdr.MockDocumentOwner
+}
+
+func newTestClient(t testing.TB, publicUrl string) *testCtx {
+	ctrl := gomock.NewController(t)
+	ctx := &testCtx{
+		documentOwner: vdr.NewMockDocumentOwner(ctrl),
+	}
+	ctx.client = &Wrapper{
+		auth: auth.NewAuthInstance(auth.Config{PublicURL: publicUrl}, nil, nil, nil, nil, nil, nil),
+		vdr:  ctx.documentOwner,
+	}
+	return ctx
+}

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package iam
 
 import (
@@ -15,36 +33,19 @@ import (
 func TestWrapper_GetOAuthAuthorizationServerMetadata(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		//	200
-		publicUrl := "https://example.com:443"
-		ctx := newTestClient(t, publicUrl)
+		ctx := newTestClient(t)
 		did := did.MustParseDID("did:nuts:123")
 		ctx.documentOwner.EXPECT().IsOwner(nil, did).Return(true, nil)
-		identity := publicUrl + "/iam/" + did.String()
-
-		expected := GetOAuthAuthorizationServerMetadata200JSONResponse(OAuthAuthorizationServerMetadata{
-			Issuer:                 identity,
-			AuthorizationEndpoint:  identity + "/authorize",
-			ResponseTypesSupported: []string{"code", "vp_token", "vp_token id_token"},
-			ResponseModesSupported: []string{"query", "direct_post"},
-			TokenEndpoint:          identity + "/token",
-			GrantTypesSupported:    []string{"authorization_code", "vp_token", "urn:ietf:params:oauth:grant-type:pre-authorized_code"},
-			PreAuthorizedGrantAnonymousAccessSupported: true,
-			VPFormatsSupported: map[string]map[string][]string{
-				"jwt_vp": {"alg_values_supported": []string{"PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}},
-				"ldp_vc": {"proof_type_values_supported": []string{"JsonWebSignature2020"}},
-			},
-			ClientIdSchemesSupported: []string{"did"},
-		})
 
 		res, err := ctx.client.GetOAuthAuthorizationServerMetadata(nil, GetOAuthAuthorizationServerMetadataRequestObject{Did: did.String()})
 
 		require.NoError(t, err)
-		assert.Equal(t, expected, res)
+		assert.IsType(t, GetOAuthAuthorizationServerMetadata200JSONResponse{}, res)
 
 	})
 	t.Run("error - not a did", func(t *testing.T) {
 		//400
-		ctx := newTestClient(t, "")
+		ctx := newTestClient(t)
 
 		res, err := ctx.client.GetOAuthAuthorizationServerMetadata(nil, GetOAuthAuthorizationServerMetadataRequestObject{})
 
@@ -54,7 +55,7 @@ func TestWrapper_GetOAuthAuthorizationServerMetadata(t *testing.T) {
 	})
 	t.Run("error - not a did:nuts", func(t *testing.T) {
 		//400
-		ctx := newTestClient(t, "")
+		ctx := newTestClient(t)
 
 		res, err := ctx.client.GetOAuthAuthorizationServerMetadata(nil, GetOAuthAuthorizationServerMetadataRequestObject{Did: "did:web:example.com"})
 
@@ -64,7 +65,7 @@ func TestWrapper_GetOAuthAuthorizationServerMetadata(t *testing.T) {
 	})
 	t.Run("error - did not managed by this node", func(t *testing.T) {
 		//404
-		ctx := newTestClient(t, "")
+		ctx := newTestClient(t)
 		did := did.MustParseDID("did:nuts:123")
 		ctx.documentOwner.EXPECT().IsOwner(nil, did)
 
@@ -76,7 +77,7 @@ func TestWrapper_GetOAuthAuthorizationServerMetadata(t *testing.T) {
 	})
 	t.Run("error - did does not exist", func(t *testing.T) {
 		//404
-		ctx := newTestClient(t, "")
+		ctx := newTestClient(t)
 		did := did.MustParseDID("did:nuts:123")
 		ctx.documentOwner.EXPECT().IsOwner(nil, did).Return(false, vdr.ErrNotFound)
 
@@ -88,7 +89,7 @@ func TestWrapper_GetOAuthAuthorizationServerMetadata(t *testing.T) {
 	})
 	t.Run("error - internal error 500", func(t *testing.T) {
 		//500
-		ctx := newTestClient(t, "")
+		ctx := newTestClient(t)
 		did := did.MustParseDID("did:nuts:123")
 		ctx.documentOwner.EXPECT().IsOwner(nil, did).Return(false, errors.New("unknown error"))
 
@@ -114,13 +115,13 @@ type testCtx struct {
 	documentOwner *vdr.MockDocumentOwner
 }
 
-func newTestClient(t testing.TB, publicUrl string) *testCtx {
+func newTestClient(t testing.TB) *testCtx {
 	ctrl := gomock.NewController(t)
 	ctx := &testCtx{
 		documentOwner: vdr.NewMockDocumentOwner(ctrl),
 	}
 	ctx.client = &Wrapper{
-		auth: auth.NewAuthInstance(auth.Config{PublicURL: publicUrl}, nil, nil, nil, nil, nil, nil),
+		auth: auth.NewAuthInstance(auth.Config{PublicURL: "https://example.com"}, nil, nil, nil, nil, nil, nil),
 		vdr:  ctx.documentOwner,
 	}
 	return ctx

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -376,13 +376,25 @@ func (response GetOAuthAuthorizationServerMetadata200JSONResponse) VisitGetOAuth
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetOAuthAuthorizationServerMetadata404JSONResponse ErrorResponse
+type GetOAuthAuthorizationServerMetadatadefaultApplicationProblemPlusJSONResponse struct {
+	Body struct {
+		// Detail A human-readable explanation specific to this occurrence of the problem.
+		Detail string `json:"detail"`
 
-func (response GetOAuthAuthorizationServerMetadata404JSONResponse) VisitGetOAuthAuthorizationServerMetadataResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(404)
+		// Status HTTP statuscode
+		Status float32 `json:"status"`
 
-	return json.NewEncoder(w).Encode(response)
+		// Title A short, human-readable summary of the problem type.
+		Title string `json:"title"`
+	}
+	StatusCode int
+}
+
+func (response GetOAuthAuthorizationServerMetadatadefaultApplicationProblemPlusJSONResponse) VisitGetOAuthAuthorizationServerMetadataResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(response.StatusCode)
+
+	return json.NewEncoder(w).Encode(response.Body)
 }
 
 type HandleAuthorizeRequestRequestObject struct {

--- a/auth/api/iam/implementation_documentation/README
+++ b/auth/api/iam/implementation_documentation/README
@@ -1,0 +1,5 @@
+THIS DIRECTORY WILL BE REMOVED WHEN THE OAUTH / OPENID4VC IMPLEMENTATIONS ARE COMPLETE
+
+This directory can be used to jolt down some notes / thoughts while building.
+It is alo useful to collect all info on a specific topic from all relevant RFCs/specs in a single file to prevent going through all specification over and over again to find the relevant bits.
+

--- a/auth/api/iam/implementation_documentation/README
+++ b/auth/api/iam/implementation_documentation/README
@@ -1,5 +1,5 @@
 THIS DIRECTORY WILL BE REMOVED WHEN THE OAUTH / OPENID4VC IMPLEMENTATIONS ARE COMPLETE
 
-This directory can be used to jolt down some notes / thoughts while building.
+This directory can be used to jot down some notes / thoughts while building.
 It is alo useful to collect all info on a specific topic from all relevant RFCs/specs in a single file to prevent going through all specification over and over again to find the relevant bits.
 

--- a/auth/api/iam/implementation_documentation/metadata_types.go
+++ b/auth/api/iam/implementation_documentation/metadata_types.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package implementation_documentation
 
 import "net/url"

--- a/auth/api/iam/implementation_documentation/metadata_types.go
+++ b/auth/api/iam/implementation_documentation/metadata_types.go
@@ -1,0 +1,264 @@
+package implementation_documentation
+
+import "net/url"
+
+// Form OAuth 2.0 Authorization Server Metadata https://www.rfc-editor.org/rfc/rfc8414.html
+type RFC8414Fields struct {
+	Issuer string `json:"issuer"`
+	//	REQUIRED.  The authorization server's issuer identifier, which is
+	//	a URL that uses the "https" scheme and has no query or fragment
+	//	components.  Authorization server metadata is published at a
+	//	location that is ".well-known" according to RFC 5785 [RFC5785]
+	//	derived from this issuer identifier, as described in Section 3.
+	//	The issuer identifier is used to prevent authorization server mix-
+	//	up attacks, as described in "OAuth 2.0 Mix-Up Mitigation"
+	//[MIX-UP].
+
+	AuthorizationEndpoint url.URL `json:"authorization_endpoint"`
+	//	URL of the authorization server's authorization endpoint
+	//[RFC6749].  This is REQUIRED unless no grant types are supported
+	//	that use the authorization endpoint.
+
+	TokenEndpoint url.URL `json:"token_endpoint"`
+	//URL of the authorization server's token endpoint [RFC6749].  This
+	//is REQUIRED unless only the implicit grant type is supported.
+
+	// TODO: Can we use this for none-did:nuts wallets to get the public key?
+	JwksURI url.URL `json:"jwks_uri"`
+	//OPTIONAL.  URL of the authorization server's JWK Set [JWK]
+	//document.  The referenced document contains the signing key(s) the
+	//client uses to validate signatures from the authorization server.
+	//This URL MUST use the "https" scheme.  The JWK Set MAY also
+	//contain the server's encryption key or keys, which are used by
+	//clients to encrypt requests to the server.  When both signing and
+	//encryption keys are made available, a "use" (public key use)
+	//parameter value is REQUIRED for all keys in the referenced JWK Set
+	//to indicate each key's intended usage.
+
+	// TODO: drop?
+	RegistrationEndpoint url.URL `json:"registration_endpoint"`
+	//OPTIONAL.  URL of the authorization server's OAuth 2.0 Dynamic
+	//Client Registration endpoint [RFC7591].
+
+	// NOTE: If added, should this be configurable or hardcoded?
+	// Configurable allows specifying per care organization what use-cases are supported,
+	// but that also requires configuration per care organization. Sounds like too much complexity for now.
+	ScopesSupported []string `json:"scopes_supported"`
+	//	RECOMMENDED.  JSON array containing a list of the OAuth 2.0
+	//[RFC6749] "scope" values that this authorization server supports.
+	//	Servers MAY choose not to advertise some supported scope values
+	//	even when this parameter is used.
+
+	// NOTE: currently ["code", "vp_token", "vp_token id_token"] vp_token standalone is used in eOverdracht notification?
+	// RFC6749? specifies this `response_type` as an unordered list, so that applies here too?
+	ResponseTypesSupported []string `json:"response_types_supported"`
+	//REQUIRED.  JSON array containing a list of the OAuth 2.0
+	//"response_type" values that this authorization server supports.
+	//The array values used are the same as those used with the
+	//"response_types" parameter defined by "OAuth 2.0 Dynamic Client
+	//Registration Protocol" [RFC7591].
+
+	// TODO: extend list ["query", "direct_post"]
+	// From https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#ResponseModes
+	//		query
+	//			In this mode, Authorization Response parameters are encoded in the query string added to the redirect_uri when redirecting back to the Client.
+	//			For purposes of this specification, the default Response Mode for the OAuth 2.0 `code` Response Type is the `query` encoding.
+	//		fragment (NOTE: should be removed since this is part of the deprecated implicit flow (response_type=token)?)
+	//			In this mode, Authorization Response parameters are encoded in the fragment added to the redirect_uri when redirecting back to the Client.
+	//			For purposes of this specification, the default Response Mode for the OAuth 2.0 `token` Response Type is the `fragment` encoding.
+	// From https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html
+	//		form_post (TODO: do we want this?)
+	//			In this mode, Authorization Response parameters are encoded as HTML form values that are auto-submitted in the User Agent,
+	//			and thus are transmitted via the HTTP POST method to the Client, with the result parameters being encoded in the body using the application/x-www-form-urlencoded format.
+	//			The action attribute of the form MUST be the Client's Redirection URI. The method of the form attribute MUST be POST.
+	//			Because the Authorization Response is intended to be used only once,
+	//			the Authorization Server MUST instruct the User Agent (and any intermediaries) not to store or reuse the content of the response.
+	// From https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-response-mode-direct_post
+	//		direct_post
+	//			In this mode, the Authorization Response is sent to the Verifier using an HTTPS POST request to an endpoint controlled by the Verifier.
+	//			The Authorization Response parameters are encoded in the body using the application/x-www-form-urlencoded content type.
+	//			The flow can end with an HTTPS POST request from the Wallet to the Verifier, or it can end with a redirect that follows the HTTPS POST request,
+	//			if the Verifier responds with a redirect URI to the Wallet.
+	//		direct_post.jwt
+	//			same as direct post but data wrapped in a jwt
+	//		TODO: direct_post.jwt allows putting a signature on the entire response (vp_token + id_token) if we ever need that
+	ResponseModesSupported []string `json:"response_modes_supported"`
+	//	OPTIONAL.  JSON array containing a list of the OAuth 2.0
+	//	"response_mode" values that this authorization server supports, as
+	//	specified in "OAuth 2.0 Multiple Response Type Encoding Practices"
+	//[OAuth.Responses].  If omitted, the default is "["query",
+	//	"fragment"]".  The response mode value "form_post" is also defined
+	//	in "OAuth 2.0 Form Post Response Mode" [OAuth.Post].
+
+	// TODO: extend ["authorization_code", "vp_token" (s2s flow), "pre-authorized_code"]
+	GrantTypesSupported []string `json:"grant_types_supported"`
+	//OPTIONAL.  JSON array containing a list of the OAuth 2.0 grant
+	//type values that this authorization server supports.  The array
+	//values used are the same as those used with the "grant_types"
+	//parameter defined by "OAuth 2.0 Dynamic Client Registration
+	//Protocol" [RFC7591].  If omitted, the default value is
+	//"["authorization_code", "implicit"]".
+
+	// TODO: what do we support?
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
+	//	OPTIONAL.  JSON array containing a list of client authentication
+	//	methods supported by this token endpoint.  Client authentication
+	//	method values are used in the "token_endpoint_auth_method"
+	//	parameter defined in Section 2 of [RFC7591].  If omitted, the
+	//default is "client_secret_basic" -- the HTTP Basic Authentication
+	//	Scheme specified in Section 2.3.1 of OAuth 2.0 [RFC6749].
+
+	// TODO: what do we support?
+	TokenEndpointAuthSigningAlgValuesSupported []string `json:"token_endpoint_auth_signing_alg_values_supported"`
+	//OPTIONAL.  JSON array containing a list of the JWS signing
+	//algorithms ("alg" values) supported by the token endpoint for the
+	//signature on the JWT [JWT] used to authenticate the client at the
+	//token endpoint for the "private_key_jwt" and "client_secret_jwt"
+	//authentication methods.  This metadata entry MUST be present if
+	//either of these authentication methods are specified in the
+	//"token_endpoint_auth_methods_supported" entry.  No default
+	//algorithms are implied if this entry is omitted.  Servers SHOULD
+	//support "RS256".  The value "none" MUST NOT be used.
+
+	//TODO: drop or point to nuts rtd?
+	ServiceDocumentation url.URL `json:"service_documentation"`
+	//OPTIONAL.  URL of a page containing human-readable information
+	//that developers might want or need to know when using the
+	//authorization server.  In particular, if the authorization server
+	//does not support Dynamic Client Registration, then information on
+	//how to register clients needs to be provided in this
+	//documentation.
+
+	// TODO: drop
+	UILocalesSupported []string `json:"ui_locales_supported"`
+	//	OPTIONAL.  Languages and scripts supported for the user interface,
+	//	represented as a JSON array of language tag values from BCP 47
+	//[RFC5646].  If omitted, the set of supported languages and scripts
+	//	is unspecified.
+
+	// NOTE: `op` refers to openid provider
+	// TODO: drop
+	OPPolicyURI url.URL `json:"op_policy_uri"`
+	//OPTIONAL.  URL that the authorization server provides to the
+	//person registering the client to read about the authorization
+	//server's requirements on how the client can use the data provided
+	//by the authorization server.  The registration process SHOULD
+	//display this URL to the person registering the client if it is
+	//given.  As described in Section 5, despite the identifier
+	//"op_policy_uri" appearing to be OpenID-specific, its usage in this
+	//specification is actually referring to a general OAuth 2.0 feature
+	//that is not specific to OpenID Connect.
+
+	// TODO: drop
+	OPTOSURI url.URL `json:"op_tos_uri"`
+	//OPTIONAL.  URL that the authorization server provides to the
+	//person registering the client to read about the authorization
+	//server's terms of service.  The registration process SHOULD
+	//display this URL to the person registering the client if it is
+	//given.  As described in Section 5, despite the identifier
+	//"op_tos_uri", appearing to be OpenID-specific, its usage in this
+	//specification is actually referring to a general OAuth 2.0 feature
+	//that is not specific to OpenID Connect.
+
+	// TODO: do we want this?
+	RevocationEndpoint url.URL `json:"revocation_endpoint"`
+	//OPTIONAL.  URL of the authorization server's OAuth 2.0 revocation
+	//endpoint [RFC7009].
+
+	RevocationEndpointAuthMethodsSupported []string `json:"revocation_endpoint_auth_methods_supported"`
+	//	OPTIONAL.  JSON array containing a list of client authentication
+	//	methods supported by this revocation endpoint.  The valid client
+	//	authentication method values are those registered in the IANA
+	//	"OAuth Token Endpoint Authentication Methods" registry
+	//[IANA.OAuth.Parameters].  If omitted, the default is
+	//	"client_secret_basic" -- the HTTP Basic Authentication Scheme
+	//	specified in Section 2.3.1 of OAuth 2.0 [RFC6749].
+
+	RevocationEndpointAuthSigningAlgValuesSupported []string `json:"revocation_endpoint_auth_signing_alg_values_supported"`
+	//OPTIONAL.  JSON array containing a list of the JWS signing
+	//algorithms ("alg" values) supported by the revocation endpoint for
+	//the signature on the JWT [JWT] used to authenticate the client at
+	//the revocation endpoint for the "private_key_jwt" and
+	//"client_secret_jwt" authentication methods.  This metadata entry
+	//MUST be present if either of these authentication methods are
+	//specified in the "revocation_endpoint_auth_methods_supported"
+	//entry.  No default algorithms are implied if this entry is
+	//omitted.  The value "none" MUST NOT be used.
+
+	// TODO: we will have an introspection endpoint, but will it be public?
+	IntrospectionEndpoint url.URL `json:"introspection_endpoint"`
+	//OPTIONAL.  URL of the authorization server's OAuth 2.0
+	//introspection endpoint [RFC7662].
+
+	IntrospectionEndpointAuthMethodsSupported []string `json:"introspection_endpoint_auth_methods_supported"`
+	//	OPTIONAL.  JSON array containing a list of client authentication
+	//	methods supported by this introspection endpoint.  The valid
+	//	client authentication method values are those registered in the
+	//	IANA "OAuth Token Endpoint Authentication Methods" registry
+	//[IANA.OAuth.Parameters] or those registered in the IANA "OAuth
+	//	Access Token Types" registry [IANA.OAuth.Parameters].  (These
+	//	values are and will remain distinct, due to Section 7.2.)  If
+	//	omitted, the set of supported authentication methods MUST be
+	//	determined by other means.
+
+	IntrospectionEndpointAuthSigningAlgValuesSupported []string `json:"introspection_endpoint_auth_signing_alg_values_supported"`
+	//OPTIONAL.  JSON array containing a list of the JWS signing
+	//algorithms ("alg" values) supported by the introspection endpoint
+	//for the signature on the JWT [JWT] used to authenticate the client
+	//at the introspection endpoint for the "private_key_jwt" and
+	//"client_secret_jwt" authentication methods.  This metadata entry
+	//MUST be present if either of these authentication methods are
+	//specified in the "introspection_endpoint_auth_methods_supported"
+	//entry.  No default algorithms are implied if this entry is
+	//omitted.  The value "none" MUST NOT be used.
+
+	// TODO: Probably good to add?
+	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported"`
+	//	OPTIONAL.  JSON array containing a list of Proof Key for Code
+	//	Exchange (PKCE) [RFC7636] code challenge methods supported by this
+	//	authorization server.  Code challenge method values are used in
+	//	the "code_challenge_method" parameter defined in Section 4.3 of
+	//[RFC7636].  The valid code challenge method values are those
+	//	registered in the IANA "PKCE Code Challenge Methods" registry
+	//[IANA.OAuth.Parameters].  If omitted, the authorization server
+	//	does not support PKCE.
+}
+
+// OpenID4VPFields contains all fields defined in the OpenID4VP specification https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-wallet-metadata-authorizati
+type OpenID4VPFields struct {
+	// NOTE: default is true
+	PresentationDefinitionUriSupported *bool `json:"presentation_definition_uri_supported,omitempty"`
+	//OPTIONAL. Boolean value specifying whether the Wallet supports the transfer of presentation_definition by reference, with true indicating support. If omitted, the default value is true.
+
+	// following NCSC guidelines
+	VPFormatsSupported map[string]any `json:"vp_formats_supported,omitempty"`
+	//REQUIRED. An object containing a list of key value pairs, where the key is a string identifying a Credential format supported by the Wallet.
+	//Valid Credential format identifier values are defined in Annex E of [OpenID.VCI]. Other values may be used when defined in the profiles of this specification.
+	//The value is an object containing a parameter defined below:
+	//	alg_values_supported:
+	//	An object where the value is an array of case sensitive strings that identify the cryptographic suites that are supported.
+	//	Parties will need to agree upon the meanings of the values used, which may be context-specific.
+	//	For specific values that can be used depending on the Credential format, see Appendix A.
+	//
+	//The following is a non-normative example of a vp_formats_supported parameter:
+	//	"vp_formats_supported": {
+	//		 "jwt_vc_json": {
+	//			 "alg_values_supported": ["ES256K", "ES384"]
+	//		 },
+	//		 "jwt_vp_json": {
+	//			"alg_values_supported": ["ES256K", "EdDSA"]
+	//		 }
+	//	}
+
+	// We are using ["did"]
+	ClientIdSchemesSupported []string `json:"client_id_schemes_supported,omitempty"`
+	//OPTIONAL. Array of JSON Strings containing the values of the Client Identifier schemes that the Wallet supports.
+	//The values defined by this specification are pre-registered, redirect_uri, entity_id, did. If omitted, the default value is pre-registered.
+	//Other values may be used when defined in the profiles of this specification.
+}
+
+// OpenID4VCIFields contains all fields defined in the OpenID4VCI specification https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-oauth-20-authorization-serv
+type OpenID4VCIFields struct {
+	PreAuthorizedGrantAnonymousAccessSupported bool `json:"pre-authorized_grant_anonymous_access_supported"`
+	//OPTIONAL. A JSON Boolean indicating whether the issuer accepts a Token Request with a Pre-Authorized Code but without a client id. The default is false.
+}

--- a/auth/api/iam/metadata.go
+++ b/auth/api/iam/metadata.go
@@ -1,12 +1,32 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package iam
 
-func authorizationServerMetadata(identity string) OAuthAuthorizationServerMetadata {
+import "net/url"
+
+func authorizationServerMetadata(identity url.URL) OAuthAuthorizationServerMetadata {
 	return OAuthAuthorizationServerMetadata{
-		Issuer:                 identity,
-		AuthorizationEndpoint:  identity + "/authorize",
+		Issuer:                 identity.String(),
+		AuthorizationEndpoint:  identity.JoinPath("authorize").String(),
 		ResponseTypesSupported: responseTypesSupported,
 		ResponseModesSupported: responseModesSupported,
-		TokenEndpoint:          identity + "/token",
+		TokenEndpoint:          identity.JoinPath("token").String(),
 		GrantTypesSupported:    grantTypesSupported,
 		PreAuthorizedGrantAnonymousAccessSupported: true,
 		VPFormatsSupported:                         vpFormatsSupported,

--- a/auth/api/iam/metadata.go
+++ b/auth/api/iam/metadata.go
@@ -1,0 +1,15 @@
+package iam
+
+func authorizationServerMetadata(identity string) OAuthAuthorizationServerMetadata {
+	return OAuthAuthorizationServerMetadata{
+		Issuer:                 identity,
+		AuthorizationEndpoint:  identity + "/authorize",
+		ResponseTypesSupported: responseTypesSupported,
+		ResponseModesSupported: responseModesSupported,
+		TokenEndpoint:          identity + "/token",
+		GrantTypesSupported:    grantTypesSupported,
+		PreAuthorizedGrantAnonymousAccessSupported: true,
+		VPFormatsSupported:                         vpFormatsSupported,
+		ClientIdSchemesSupported:                   clientIdSchemesSupported,
+	}
+}

--- a/auth/api/iam/metadata_test.go
+++ b/auth/api/iam/metadata_test.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package iam
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/url"
+	"testing"
+)
+
+func Test_authorizationServerMetadata(t *testing.T) {
+	identity := "https://example.com/iam/did:nuts:123"
+	identityURL, _ := url.Parse(identity)
+	expected := OAuthAuthorizationServerMetadata{
+		Issuer:                 identity,
+		AuthorizationEndpoint:  identity + "/authorize",
+		ResponseTypesSupported: []string{"code", "vp_token", "vp_token id_token"},
+		ResponseModesSupported: []string{"query", "direct_post"},
+		TokenEndpoint:          identity + "/token",
+		GrantTypesSupported:    []string{"authorization_code", "vp_token", "urn:ietf:params:oauth:grant-type:pre-authorized_code"},
+		PreAuthorizedGrantAnonymousAccessSupported: true,
+		VPFormatsSupported: map[string]map[string][]string{
+			"jwt_vp": {"alg_values_supported": []string{"PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}},
+			"ldp_vc": {"proof_type_values_supported": []string{"JsonWebSignature2020"}},
+		},
+		ClientIdSchemesSupported: []string{"did"},
+	}
+	assert.Equal(t, expected, authorizationServerMetadata(*identityURL))
+}

--- a/auth/api/iam/types.go
+++ b/auth/api/iam/types.go
@@ -1,0 +1,152 @@
+package iam
+
+// responseType
+// TODO: reconsider the following
+// https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.1
+//
+//	Extension response types MAY contain a space-delimited (%x20) list of
+//	values, where the order of values does not matter (e.g., response
+//	type "a b" is the same as "b a").  The meaning of such composite
+//	response types is defined by their respective specifications.
+//
+//	If an authorization request is missing the "response_type" parameter,
+//	or if the response type is not understood, the authorization server
+//	MUST return an error response as described in Section 4.1.2.1.
+type responseType = string
+
+const (
+	// responseTypeCode is the default response_type in the OAuth2 authorized code flow
+	responseTypeCode responseType = "code"
+	// responseTypeVPToken is defined in the OpenID4VP vp_token flow
+	// https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#appendix-B
+	responseTypeVPToken responseType = "vp_token"
+	// responseTypeVPIDToken is defined in the OpenID4VP flow that combines its vp_token with SIOPv2's id_token
+	// https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#appendix-B
+	responseTypeVPIDToken responseType = "vp_token id_token"
+)
+
+var responseTypesSupported = []responseType{responseTypeCode, responseTypeVPToken, responseTypeVPIDToken}
+
+// responseMode
+type responseMode = string
+
+const (
+	// responseModeQuery returns the answer to the authorization request append as query parameters to the provided redirect_uri
+	responseModeQuery responseMode = "query" // default if no response_mode is specified
+	// responseModeDirectPost signals the Authorization Server to POST the requested presentation definition to the provided response_uri
+	// https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-response-mode-direct_post
+	responseModeDirectPost responseMode = "direct_post"
+)
+
+var responseModesSupported = []responseMode{responseModeQuery, responseModeDirectPost}
+
+// grantType
+type grantType = string
+
+const (
+	// grantTypeAuthorizationCode is the default OAuth2 grant type
+	grantTypeAuthorizationCode grantType = "authorization_code"
+	// grantTypeVPToken is used to present a vp_token in exchange for an access_token in service-to-service flows
+	// TODO: EBSI inspired flow that is not standardized
+	// 		 https://api-conformance.ebsi.eu/docs/ct/verifiable-presentation-exchange-guidelines-v3#service-to-service-token-flow
+	grantTypeVPToken grantType = "vp_token"
+	// grantTypePreAuthorizedCode is defined in the pre-authorized_code flow of OpenID4VCI
+	// https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-sub-namespace-registration
+	grantTypePreAuthorizedCode grantType = "urn:ietf:params:oauth:grant-type:pre-authorized_code"
+)
+
+var grantTypesSupported = []grantType{grantTypeAuthorizationCode, grantTypeVPToken, grantTypePreAuthorizedCode}
+
+// algValuesSupported contains a list of supported cipher suites for jwt_vc_json & jwt_vp_json presentation formats
+// Recommended list of options https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms
+// TODO: validate list, should reflect current recommendations from https://www.ncsc.nl
+var algValuesSupported = []string{"PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}
+
+// proofTypesSupported contains a list of supported cipher suites for ldp_vc & ldp_vp presentation formats
+// Recommended list of options https://w3c-ccg.github.io/ld-cryptosuite-registry/
+var proofTypesSupported = []string{"JsonWebSignature2020"}
+
+// vpFormatsSupported defines the supported formats and is used in the
+//   - Authorization Server's metadata field `vp_formats_supported`
+//   - Client's metadata field `vp_formats`
+//
+// TODO: spec is very unclear about this part.
+//
+//	It refers to the OpenID4VCI spec for definition of valid credential formats but then also defines its own,
+//	but neither is followed in the examples.
+//
+// OpenID4VCI defined formats are jwt_vc_json, jwt_vc_json-ld, ldp_vc
+//
+// OpenID4VP defines:
+//   - jwt_vc_json & jwt_vp_json   that should use values defined on https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms
+//   - ldp_vc      & ldp_vp		that should use valued defined on https://w3c-ccg.github.io/ld-cryptosuite-registry/
+//
+// but the examples then seem to be a mix and match of everything.
+var vpFormatsSupported = map[string]map[string][]string{
+	"jwt_vp": {"algValuesSupported": algValuesSupported},
+	"ldp_vc": {"algValuesSupported": proofTypesSupported}, // certain examples suggest that "algValuesSupported" should be "proof_types" but this is not specced
+}
+
+// clientIdSchemesSupported lists the supported client_id_scheme
+// https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-verifier-metadata-managemen
+var clientIdSchemesSupported = []string{"did"}
+
+// OAuthAuthorizationServerMetadata defines the OAuth Authorization Server metadata.
+// Specified by https://www.rfc-editor.org/rfc/rfc8414.txt
+type OAuthAuthorizationServerMetadata struct {
+	// Issuer defines the authorization server's identifier, which is a URL that uses the "https" scheme and has no query or fragment components.
+	Issuer string `json:"issuer"`
+
+	/* ******** /authorize ******** */
+
+	// AuthorizationEndpoint defines the URL of the authorization server's authorization endpoint [RFC6749]
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+
+	// ResponseTypesSupported defines what response types a client can request
+	ResponseTypesSupported []string `json:"response_types_supported,omitempty"`
+
+	// ResponseModesSupported defines what response modes a client can request
+	// Currently supports
+	// - query for response_type=code
+	// - direct_post for response_type=["vp_token", "vp_token id_token"]
+	// TODO: is `form_post` something we want in the future?
+	ResponseModesSupported []string `json:"response_modes_supported,omitempty"`
+
+	/* ******** /token ******** */
+
+	// TokenEndpoint defines the URL of the authorization server's token endpoint [RFC6749].
+	TokenEndpoint string `json:"token_endpoint"`
+
+	// GrantTypesSupported is a list of the OAuth 2.0 grant type values that this authorization server supports.
+	GrantTypesSupported []string `json:"grant_types_supported,omitempty"`
+
+	//// TODO: what do we support?
+	//// TokenEndpointAuthMethodsSupported is a JSON array containing a list of client authentication methods supported by this token endpoint.
+	//// Client authentication method values are used in the "token_endpoint_auth_method" parameter defined in Section 2 of [RFC7591].
+	//// If omitted, the default is "client_secret_basic" -- the HTTP Basic Authentication Scheme specified in Section 2.3.1 of OAuth 2.0 [RFC6749].
+	//TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+	//
+	//// TODO: May be needed depending on TokenEndpointAuthMethodsSupported
+	//// TokenEndpointAuthSigningAlgValuesSupported is a JSON array containing a list of the JWS signing algorithms ("alg" values) supported by the token endpoint
+	//// for the signature on the JWT [JWT] used to authenticate the client at the token endpoint for the "private_key_jwt" and "client_secret_jwt" authentication methods.
+	//// This metadata entry MUST be present if either of these authentication methods are specified in the "token_endpoint_auth_methods_supported" entry.
+	//// No default algorithms are implied if this entry is omitted. Servers SHOULD support "RS256". The value "none" MUST NOT be used.
+	//TokenEndpointAuthSigningAlgValuesSupported []string `json:"token_endpoint_auth_signing_alg_values_supported,omitempty"`
+
+	/* ******** openid4vc ******** */
+
+	// PreAuthorizedGrantAnonymousAccessSupported indicates whether anonymous access (requests without client_id) for pre-authorized code grant flows.
+	// See https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-oauth-20-authorization-serv
+	PreAuthorizedGrantAnonymousAccessSupported bool `json:"pre-authorized_grant_anonymous_access_supported"`
+
+	// PresentationDefinitionUriSupported specifies whether the Wallet supports the transfer of presentation_definition by reference, with true indicating support.
+	// If omitted, the default value is true. (hence pointer, or add custom unmarshalling)
+	PresentationDefinitionUriSupported *bool `json:"presentation_definition_uri_supported,omitempty"`
+
+	// VPFormatsSupported is an object containing a list of key value pairs, where the key is a string identifying a Credential format supported by the Wallet.
+	VPFormatsSupported map[string]map[string][]string `json:"vp_formats_supported,omitempty"`
+
+	// ClientIdSchemesSupported defines the `client_id_schemes` currently supported.
+	// If omitted, the default value is `pre-registered` (referring to the client), which is currently not supported.
+	ClientIdSchemesSupported []string `json:"client_id_schemes_supported,omitempty"`
+}

--- a/auth/api/iam/types.go
+++ b/auth/api/iam/types.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package iam
 
 // responseType
@@ -62,29 +80,19 @@ var grantTypesSupported = []grantType{grantTypeAuthorizationCode, grantTypeVPTok
 // TODO: validate list, should reflect current recommendations from https://www.ncsc.nl
 var algValuesSupported = []string{"PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}
 
-// proofTypesSupported contains a list of supported cipher suites for ldp_vc & ldp_vp presentation formats
+// proofTypeValuesSupported contains a list of supported cipher suites for ldp_vc & ldp_vp presentation formats
 // Recommended list of options https://w3c-ccg.github.io/ld-cryptosuite-registry/
-var proofTypesSupported = []string{"JsonWebSignature2020"}
+var proofTypeValuesSupported = []string{"JsonWebSignature2020"}
 
 // vpFormatsSupported defines the supported formats and is used in the
 //   - Authorization Server's metadata field `vp_formats_supported`
 //   - Client's metadata field `vp_formats`
 //
 // TODO: spec is very unclear about this part.
-//
-//	It refers to the OpenID4VCI spec for definition of valid credential formats but then also defines its own,
-//	but neither is followed in the examples.
-//
-// OpenID4VCI defined formats are jwt_vc_json, jwt_vc_json-ld, ldp_vc
-//
-// OpenID4VP defines:
-//   - jwt_vc_json & jwt_vp_json   that should use values defined on https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms
-//   - ldp_vc      & ldp_vp		that should use valued defined on https://w3c-ccg.github.io/ld-cryptosuite-registry/
-//
-// but the examples then seem to be a mix and match of everything.
+// See https://github.com/nuts-foundation/nuts-node/issues/2447
 var vpFormatsSupported = map[string]map[string][]string{
-	"jwt_vp": {"algValuesSupported": algValuesSupported},
-	"ldp_vc": {"algValuesSupported": proofTypesSupported}, // certain examples suggest that "algValuesSupported" should be "proof_types" but this is not specced
+	"jwt_vp": {"alg_values_supported": algValuesSupported},
+	"ldp_vc": {"proof_type_values_supported": proofTypeValuesSupported},
 }
 
 // clientIdSchemesSupported lists the supported client_id_scheme

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"github.com/nuts-foundation/nuts-node/vdr/didservice"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
+	"net/url"
 	"path"
 	"time"
 
@@ -71,6 +72,15 @@ func (auth *Auth) Config() interface{} {
 // V2APIEnabled returns true if the v2 API is enabled
 func (auth *Auth) V2APIEnabled() bool {
 	return auth.config.V2APIEnabled
+}
+
+// PublicURL returns the public URL of the node.
+func (auth *Auth) PublicURL() *url.URL {
+	if auth.config.PublicURL == "" {
+		panic("auth.publicurl must be set")
+	}
+	publicURL, _ := url.Parse(auth.config.PublicURL)
+	return publicURL
 }
 
 // ContractNotary returns an implementation of the ContractNotary interface.

--- a/auth/interface.go
+++ b/auth/interface.go
@@ -21,6 +21,7 @@ package auth
 import (
 	"github.com/nuts-foundation/nuts-node/auth/services"
 	"github.com/nuts-foundation/nuts-node/auth/services/oauth"
+	"net/url"
 )
 
 // AuthenticationServices is the interface which should be implemented for clients or mocks
@@ -34,4 +35,6 @@ type AuthenticationServices interface {
 	// V2APIEnabled returns true if the V2 API is enabled.
 	// It is disabled by default, since it's still in development.
 	V2APIEnabled() bool
+	// PublicURL returns the public URL of the node.
+	PublicURL() *url.URL
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -214,7 +214,7 @@ func CreateSystem(shutdownCallback context.CancelFunc) *core.System {
 	system.RegisterRoutes(statusEngine.(core.Routable))
 	system.RegisterRoutes(metricsEngine.(core.Routable))
 	system.RegisterRoutes(&authAPIv1.Wrapper{Auth: authInstance, CredentialResolver: credentialInstance})
-	system.RegisterRoutes(authIAMAPI.New(authInstance, credentialInstance))
+	system.RegisterRoutes(authIAMAPI.New(authInstance, credentialInstance, vdrInstance))
 	system.RegisterRoutes(&authMeansAPI.Wrapper{Auth: authInstance})
 	system.RegisterRoutes(&didmanAPI.Wrapper{Didman: didmanInstance})
 

--- a/codegen/configs/auth_iam.yaml
+++ b/codegen/configs/auth_iam.yaml
@@ -3,3 +3,7 @@ generate:
   echo-server: true
   models: true
   strict-server: true
+output-options:
+  skip-prune: false
+  exclude-schemas:
+    - OAuthAuthorizationServerMetadata

--- a/docs/_static/auth/iam.yaml
+++ b/docs/_static/auth/iam.yaml
@@ -111,6 +111,43 @@ paths:
               schema:
                 type: string
                 format: uri
+  # TODO: What format to use? (codegenerator breaks on aliases)
+  # See issue https://github.com/nuts-foundation/nuts-node/issues/2365
+  # create aliases for the specced path
+#  /iam/{did}/oauth-authorization-server:
+#    $ref: '#/paths/~1.well-known~1oauth-authorization-server~1iam~1{did}'
+#  /iam/{did}/.well-known/oauth-authorization-server:
+#    $ref: '#/paths/~1.well-known~1oauth-authorization-server~1iam~1{did}'
+  /.well-known/oauth-authorization-server/iam/{did}:
+    get:
+      tags:
+        - well-known
+      summary: Get the OAuth2 Authorization Server metadata
+      description: >
+        Specified by https://www.rfc-editor.org/info/rfc8414
+        The well-known path is the default specified by https://www.rfc-editor.org/rfc/rfc8414.html#section-3
+      operationId: getOAuthAuthorizationServerMetadata
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema:
+            description: must be did:nuts for now
+            type: string
+            example: did:nuts:123
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/OAuthAuthorizationServerMetadata"
+        "404":
+          description: Unknown issuer
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
 #  /internal/auth/v2/{did}/request-presentation:
 #    post:
 #      operationId: requestPresentation
@@ -238,6 +275,35 @@ components:
           "token_type": "bearer",
           "expires_in": 3600,
         }
+    OAuthAuthorizationServerMetadata:
+      description: |
+        OAuth2 Authorization Server Metadata
+        Contain properties from several specifications and will grow over time
+      type: object
+      required:
+        - issuer
+        - authorization_endpoint
+        - token_endpoint
+      properties:
+        issuer:
+          type: string
+          description: |
+            The authorization server's issuer identifier, which is
+            a URL that uses the "https" scheme and has no query or fragment
+            components.
+          example: https://issuer.example.com
+        authorization_endpoint:
+          type: string
+          description: |
+            URL of the authorization server's authorization endpoint [RFC6749].
+          example: https://issuer.example.com/authorize
+        token_endpoint:
+          type: string
+          description: |
+            URL of the authorization server's token endpoint [RFC6749].
+          example: https://issuer.example.com/token
+
+
     ErrorResponse:
       type: object
       required:

--- a/docs/_static/auth/iam.yaml
+++ b/docs/_static/auth/iam.yaml
@@ -126,6 +126,11 @@ paths:
       description: >
         Specified by https://www.rfc-editor.org/info/rfc8414
         The well-known path is the default specified by https://www.rfc-editor.org/rfc/rfc8414.html#section-3
+        
+        error returns:
+        * 400 - invalid input
+        * 404 - did not found; possibly be non-existing, deactivated, or not managed by this node
+        * 500 - internal server error
       operationId: getOAuthAuthorizationServerMetadata
       parameters:
         - name: did
@@ -142,12 +147,8 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/OAuthAuthorizationServerMetadata"
-        "404":
-          description: Unknown issuer
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
+        default:
+          $ref: '../common/error_response.yaml'
 #  /internal/auth/v2/{did}/request-presentation:
 #    post:
 #      operationId: requestPresentation
@@ -280,30 +281,6 @@ components:
         OAuth2 Authorization Server Metadata
         Contain properties from several specifications and will grow over time
       type: object
-      required:
-        - issuer
-        - authorization_endpoint
-        - token_endpoint
-      properties:
-        issuer:
-          type: string
-          description: |
-            The authorization server's issuer identifier, which is
-            a URL that uses the "https" scheme and has no query or fragment
-            components.
-          example: https://issuer.example.com
-        authorization_endpoint:
-          type: string
-          description: |
-            URL of the authorization server's authorization endpoint [RFC6749].
-          example: https://issuer.example.com/authorize
-        token_endpoint:
-          type: string
-          description: |
-            URL of the authorization server's token endpoint [RFC6749].
-          example: https://issuer.example.com/token
-
-
     ErrorResponse:
       type: object
       required:


### PR DESCRIPTION
WIP

discussion point: 
auth.publicurl should become a required config field (and possibly move to root of config).
Its value is required on all .well-known endpoints. (oauth-authorization-server, (oauth) client, openid-credential-issuer, openid-credential-wallet, did.json, ...) 

To me it makes a lot of sense that you have to configure the _public address_ of the node for it to work (vault and redis require it too). We could set the default to http://localhost:1323 in non-strict mode when no value is provided, but guessing what the address is just adds to much complexity and room for errors (will require support) for something that is not very hard to configure.

TODO
 - [x] tests
 - [ ] auth.PublicURL should not panic