### PR TITLE
fix correct backup store initiation

### DIFF
--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -7,10 +7,11 @@ Release notes
 Hazelnut update (v5.4.3)
 ************************
 
-Release date: 2023-09-06
+Release date: 2023-09-07
 
 - Fixed an issue where revocations received through the network were not written to a backup that was introduced in v5.4.0.
 Nodes upgrading from v5.4.0-v5.4.2 need to make an empty POST call to ``<node-address>/internal/network/v1/reprocess?type=application/ld+json%3Btype=revocation``.
+- Fixed a performance issue with initializing the backup databases.
 
 **Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v5.4.2...v5.4.3
 

--- a/storage/leia.go
+++ b/storage/leia.go
@@ -127,7 +127,7 @@ func (k *kvBackedLeiaStore) handleRestore(config LeiaBackupConfiguration) error 
 		ref leia.Reference
 		doc leia.Document
 	}
-	var set []refDoc
+
 	writeDocuments := func(set []refDoc) error {
 		return k.backup.Write(context.Background(), func(tx stoabs.WriteTx) error {
 			writer := tx.GetShelfWriter(config.BackupShelf)
@@ -140,6 +140,7 @@ func (k *kvBackedLeiaStore) handleRestore(config LeiaBackupConfiguration) error 
 		})
 	}
 
+	var set []refDoc
 	err := collection.Iterate(query, func(ref leia.Reference, value []byte) error {
 		set = append(set, refDoc{ref: ref, doc: value})
 		if len(set) >= limit {

--- a/storage/leia.go
+++ b/storage/leia.go
@@ -140,12 +140,12 @@ func (k *kvBackedLeiaStore) handleRestore(config LeiaBackupConfiguration) error 
 		})
 	}
 
-	var set []refDoc
+	set := make([]refDoc, 0, limit)
 	err := collection.Iterate(query, func(ref leia.Reference, value []byte) error {
 		set = append(set, refDoc{ref: ref, doc: value})
 		if len(set) >= limit {
 			err := writeDocuments(set)
-			set = make([]refDoc, 0)
+			set = make([]refDoc, 0, limit)
 			return err
 		}
 		return nil

--- a/storage/leia.go
+++ b/storage/leia.go
@@ -136,7 +136,6 @@ func (k *kvBackedLeiaStore) handleRestore(config LeiaBackupConfiguration) error 
 					return err
 				}
 			}
-			set = make([]refDoc, 0)
 			return nil
 		})
 	}
@@ -144,7 +143,9 @@ func (k *kvBackedLeiaStore) handleRestore(config LeiaBackupConfiguration) error 
 	err := collection.Iterate(query, func(ref leia.Reference, value []byte) error {
 		set = append(set, refDoc{ref: ref, doc: value})
 		if len(set) >= limit {
-			return writeDocuments(set)
+			err := writeDocuments(set)
+			set = make([]refDoc, 0)
+			return err
 		}
 		return nil
 	})


### PR DESCRIPTION
fixes #2448 

The set that is written in a single transaction is now correctly reset after a transaction.