### PR TITLE
Chore: rename VDR didservice package to service

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -30,7 +30,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/vcr"
 	"github.com/nuts-foundation/nuts-node/vcr/openid4vci"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	vdr "github.com/nuts-foundation/nuts-node/vdr/types"
 	"html/template"
 	"net/http"
@@ -215,7 +215,7 @@ func (r Wrapper) GetOAuthAuthorizationServerMetadata(ctx context.Context, reques
 
 	owned, err := r.vdr.IsOwner(ctx, *id)
 	if err != nil {
-		if didservice.IsFunctionalResolveError(err) {
+		if service.IsFunctionalResolveError(err) {
 			return nil, core.NotFoundError("authz server metadata: %w", err)
 		}
 		log.Logger().WithField("did", id.String()).Errorf("authz server metadata: failed to assert ownership of did: %s", err.Error())

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -21,7 +21,7 @@ package auth
 import (
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"net/url"
 	"path"
@@ -139,7 +139,7 @@ func (auth *Auth) Configure(config core.ServerConfig) error {
 		ContractValidators:    auth.config.ContractValidators,
 		ContractValidity:      contractValidity,
 		StrictMode:            config.Strictmode,
-	}, auth.vcr, didservice.KeyResolver{Resolver: auth.vdrInstance.Resolver()}, auth.keyStore, auth.jsonldManager, auth.pkiProvider)
+	}, auth.vcr, service.KeyResolver{Resolver: auth.vdrInstance.Resolver()}, auth.keyStore, auth.jsonldManager, auth.pkiProvider)
 
 	tlsEnabled := config.TLS.Enabled()
 	if config.Strictmode && !tlsEnabled {

--- a/auth/services/notary/notary_test.go
+++ b/auth/services/notary/notary_test.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"testing"
 	"time"
 
@@ -239,7 +239,7 @@ func TestNewContractNotary(t *testing.T) {
 				ContractValidity: 60 * time.Minute,
 			},
 			vcr.NewTestVCRInstance(t),
-			didservice.KeyResolver{},
+			service.KeyResolver{},
 			crypto.NewMemoryCryptoInstance(),
 			nil,
 			nil,

--- a/auth/services/oauth/authz_server.go
+++ b/auth/services/oauth/authz_server.go
@@ -24,7 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"time"
 
 	"github.com/lestrrat-go/jwx/jwt"
@@ -172,7 +172,7 @@ func NewAuthorizationServer(
 	serviceResolver didman.CompoundServiceResolver, privateKeyStore nutsCrypto.KeyStore,
 	contractNotary services.ContractNotary, jsonldManager jsonld.JSONLD, accessTokenLifeSpan time.Duration) AuthorizationServer {
 	return &authzServer{
-		keyResolver:         didservice.KeyResolver{Resolver: didResolver},
+		keyResolver:         service.KeyResolver{Resolver: didResolver},
 		serviceResolver:     serviceResolver,
 		contractNotary:      contractNotary,
 		jsonldManager:       jsonldManager,

--- a/auth/services/oauth/relying_party.go
+++ b/auth/services/oauth/relying_party.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"net/http"
 	"net/url"
 	"strings"
@@ -55,7 +55,7 @@ func NewRelyingParty(
 	didResolver types.DIDResolver, serviceResolver didman.CompoundServiceResolver, privateKeyStore nutsCrypto.KeyStore,
 	httpClientTimeout time.Duration, httpClientTLS *tls.Config) RelyingParty {
 	return &relyingParty{
-		keyResolver:       didservice.KeyResolver{Resolver: didResolver},
+		keyResolver:       service.KeyResolver{Resolver: didResolver},
 		serviceResolver:   serviceResolver,
 		privateKeyStore:   privateKeyStore,
 		httpClientTimeout: httpClientTimeout,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ import (
 	goldenHammerCmd "github.com/nuts-foundation/nuts-node/golden_hammer/cmd"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"io"
 	"os"
 	"runtime/pprof"
@@ -199,7 +199,7 @@ func CreateSystem(shutdownCallback context.CancelFunc) *core.System {
 
 	// Register HTTP routes
 	system.RegisterRoutes(&core.LandingPage{})
-	system.RegisterRoutes(&cryptoAPI.Wrapper{C: cryptoInstance, K: didservice.KeyResolver{Resolver: vdrInstance.Resolver()}})
+	system.RegisterRoutes(&cryptoAPI.Wrapper{C: cryptoInstance, K: service.KeyResolver{Resolver: vdrInstance.Resolver()}})
 	system.RegisterRoutes(&networkAPI.Wrapper{Service: networkInstance})
 	system.RegisterRoutes(&vdrAPI.Wrapper{VDR: vdrInstance, DocManipulator: &didnuts.Manipulator{
 		KeyCreator: cryptoInstance,

--- a/didman/api/v1/api.go
+++ b/didman/api/v1/api.go
@@ -25,7 +25,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/nuts-foundation/nuts-node/audit"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"net/http"
 	"net/url"
 	"strings"
@@ -66,7 +66,7 @@ func (w *Wrapper) ResolveStatusCode(err error) int {
 		return http.StatusNotFound
 	case errors.As(err, new(didnuts.InvalidServiceError)):
 		return http.StatusBadRequest
-	case errors.As(err, new(didservice.ServiceQueryError)):
+	case errors.As(err, new(service.ServiceQueryError)):
 		return http.StatusBadRequest
 	case errors.Is(err, types.ErrServiceReferenceToDeep):
 		return http.StatusNotAcceptable

--- a/didman/api/v1/api_test.go
+++ b/didman/api/v1/api_test.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"github.com/nuts-foundation/nuts-node/audit"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"net/http"
 	"net/url"
 	"testing"
@@ -497,7 +497,7 @@ func TestWrapper_GetCompoundServiceEndpoint(t *testing.T) {
 	t.Run("error mapping", func(t *testing.T) {
 		ctx := newMockContext(t)
 		assert.Equal(t, http.StatusNotFound, ctx.wrapper.ResolveStatusCode(types.ErrServiceNotFound))
-		assert.Equal(t, http.StatusBadRequest, ctx.wrapper.ResolveStatusCode(didservice.ServiceQueryError{errors.New("arbitrary")}))
+		assert.Equal(t, http.StatusBadRequest, ctx.wrapper.ResolveStatusCode(service.ServiceQueryError{errors.New("arbitrary")}))
 		assert.Equal(t, http.StatusNotAcceptable, ctx.wrapper.ResolveStatusCode(types.ErrServiceReferenceToDeep))
 		assert.Equal(t, http.StatusNotAcceptable, ctx.wrapper.ResolveStatusCode(didman.ErrReferencedServiceNotAnEndpoint{}))
 		assert.Equal(t, http.StatusNotFound, ctx.wrapper.ResolveStatusCode(types.ErrNotFound))

--- a/didman/didman_test.go
+++ b/didman/didman_test.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/audit"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"io"
 	"net/url"
 	"strings"
@@ -200,10 +200,10 @@ func TestDidman_UpdateEndpoint(t *testing.T) {
 func TestDidman_AddCompoundService(t *testing.T) {
 	meta := &types.DocumentMetadata{Hash: hash.EmptyHash()}
 
-	helloServiceQuery := didservice.MakeServiceReference(testDIDA, "hello")
-	worldServiceQuery := didservice.MakeServiceReference(testDIDB, "world")
-	universeServiceQuery := didservice.MakeServiceReference(testDIDB, "universe")
-	universeNestedServiceQuery := didservice.MakeServiceReference(testDIDB, "universe-ref")
+	helloServiceQuery := service.MakeServiceReference(testDIDA, "hello")
+	worldServiceQuery := service.MakeServiceReference(testDIDB, "world")
+	universeServiceQuery := service.MakeServiceReference(testDIDB, "universe")
+	universeNestedServiceQuery := service.MakeServiceReference(testDIDB, "universe-ref")
 	references := make(map[string]ssi.URI, 0)
 	references["hello"] = helloServiceQuery
 	references["world"] = worldServiceQuery
@@ -255,7 +255,7 @@ func TestDidman_AddCompoundService(t *testing.T) {
 		ctx.vdr.EXPECT().Update(ctx.audit, testDIDA, gomock.Any()).DoAndReturn(
 			func(_ context.Context, _ interface{}, doc did.Document) error {
 				newDoc = doc
-				return didnuts.ManagedDocumentValidator(didservice.ServiceResolver{Resolver: ctx.didResolver}).Validate(newDoc)
+				return didnuts.ManagedDocumentValidator(service.ServiceResolver{Resolver: ctx.didResolver}).Validate(newDoc)
 			})
 
 		_, err := ctx.instance.AddCompoundService(ctx.audit, testDIDA, "helloworld", references)
@@ -289,9 +289,9 @@ func TestDidman_AddCompoundService(t *testing.T) {
 func TestDidman_UpdateCompoundService(t *testing.T) {
 	meta := &types.DocumentMetadata{Hash: hash.EmptyHash()}
 
-	helloServiceQuery := didservice.MakeServiceReference(testDIDA, "hello")
-	worldServiceQuery := didservice.MakeServiceReference(testDIDB, "world")
-	universeServiceQuery := didservice.MakeServiceReference(testDIDB, "universe")
+	helloServiceQuery := service.MakeServiceReference(testDIDA, "hello")
+	worldServiceQuery := service.MakeServiceReference(testDIDB, "world")
+	universeServiceQuery := service.MakeServiceReference(testDIDB, "universe")
 	references := make(map[string]ssi.URI, 0)
 	references["hello"] = helloServiceQuery
 	references["world"] = worldServiceQuery
@@ -608,7 +608,7 @@ func TestDidman_DeleteEndpointsByType(t *testing.T) {
 			{
 				ID:              ssi.MustParseURI(id.String() + "#123"),
 				Type:            "refType",
-				ServiceEndpoint: didservice.MakeServiceReference(*id, endpointType),
+				ServiceEndpoint: service.MakeServiceReference(*id, endpointType),
 			},
 		}
 		didDocErrServiceInUse := &did.Document{ID: *id, Service: endpointsWithSelfReference}
@@ -944,7 +944,7 @@ func TestReferencedService(t *testing.T) {
 	trueDID := did.MustParseDID("did:nuts:123")
 	falseDID := did.MustParseDID("did:nuts:abc")
 	serviceType := "RefType"
-	serviceRef := didservice.MakeServiceReference(trueDID, serviceType).String()
+	serviceRef := service.MakeServiceReference(trueDID, serviceType).String()
 	compoundDocStr := `{"service":[{"id":"did:nuts:123#1","serviceEndpoint":{"nested":"%s/serviceEndpoint?type=RefType"},"type":"OtherType"}]}`
 	endpointDocStr := `{"service":[{"id":"did:nuts:123#1","serviceEndpoint":"%s/serviceEndpoint?type=RefType","type":"OtherType"}]}`
 	didDoc := &did.Document{}

--- a/golden_hammer/module.go
+++ b/golden_hammer/module.go
@@ -29,7 +29,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/network/transport"
 	"github.com/nuts-foundation/nuts-node/vcr"
 	"github.com/nuts-foundation/nuts-node/vcr/openid4vci"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"net/url"
 	"sort"
@@ -139,9 +139,9 @@ func (h *GoldenHammer) registerServiceBaseURLs() error {
 	for _, document := range documents {
 		var endpointToRegister url.URL
 		serviceEndpoint := getServiceEndpoint(document, transport.NutsCommServiceType)
-		if didservice.IsServiceReference(serviceEndpoint) {
+		if service.IsServiceReference(serviceEndpoint) {
 			// Care organization DID document, register service pointing to vendor DID.
-			parentDID, err := didservice.GetDIDFromURL(serviceEndpoint)
+			parentDID, err := service.GetDIDFromURL(serviceEndpoint)
 			if err != nil {
 				// Invalid NutsComm reference, skip
 				log.Logger().WithError(err).
@@ -154,7 +154,7 @@ func (h *GoldenHammer) registerServiceBaseURLs() error {
 				continue
 			}
 			// All us OK
-			endpointToRegister = didservice.MakeServiceReference(parentDID, types.BaseURLServiceType).URL
+			endpointToRegister = service.MakeServiceReference(parentDID, types.BaseURLServiceType).URL
 		} else {
 			// Vendor DID document, register resolved identifier
 			identifier, err := h.tryResolveURL(document.ID)
@@ -193,7 +193,7 @@ func (h *GoldenHammer) listDocumentToFix() ([]did.Document, error) {
 		}
 		document, _, err := h.vdrInstance.Resolver().Resolve(id, nil)
 		if err != nil {
-			if !didservice.IsFunctionalResolveError(err) {
+			if !service.IsFunctionalResolveError(err) {
 				log.Logger().WithError(err).Infof("Can't resolve DID document, skipping fix (did=%s)", id)
 			}
 			continue
@@ -215,7 +215,7 @@ func (h *GoldenHammer) listDocumentToFix() ([]did.Document, error) {
 	// vendor DIDs should be fixed first. Meaning DIDs with NutsComm URL (instead of a reference).
 	sort.SliceStable(documents, func(i, j int) bool {
 		endpoint := getServiceEndpoint(documents[i], transport.NutsCommServiceType)
-		return !didservice.IsServiceReference(endpoint)
+		return !service.IsServiceReference(endpoint)
 	})
 	return documents, nil
 }
@@ -237,7 +237,7 @@ func (h *GoldenHammer) tryResolveURL(id did.DID) (*url.URL, error) {
 // resolveContainsService returns whether 1. given DID document can be resolved, and 2. it contains the specified service.
 func (h *GoldenHammer) resolveContainsService(id did.DID, serviceType string) bool {
 	document, _, err := h.vdrInstance.Resolver().Resolve(id, nil)
-	if didservice.IsFunctionalResolveError(err) {
+	if service.IsFunctionalResolveError(err) {
 		// Unresolvable DID document, nothing to do
 		return false
 	}

--- a/golden_hammer/module_test.go
+++ b/golden_hammer/module_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/test/pki"
 	"github.com/nuts-foundation/nuts-node/vcr/openid4vci"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,7 +61,7 @@ func TestGoldenHammer_Fix(t *testing.T) {
 			},
 			{
 				Type:            transport.NutsCommServiceType,
-				ServiceEndpoint: didservice.MakeServiceReference(vendorDID, transport.NutsCommServiceType),
+				ServiceEndpoint: service.MakeServiceReference(vendorDID, transport.NutsCommServiceType),
 			},
 		},
 	}
@@ -78,7 +78,7 @@ func TestGoldenHammer_Fix(t *testing.T) {
 		Service: []did.Service{
 			{
 				Type:            transport.NutsCommServiceType,
-				ServiceEndpoint: didservice.MakeServiceReference(vendorDID, transport.NutsCommServiceType),
+				ServiceEndpoint: service.MakeServiceReference(vendorDID, transport.NutsCommServiceType),
 			},
 		},
 	}
@@ -86,11 +86,11 @@ func TestGoldenHammer_Fix(t *testing.T) {
 		Service: []did.Service{
 			{
 				Type:            types.BaseURLServiceType,
-				ServiceEndpoint: didservice.MakeServiceReference(vendorDID, types.BaseURLServiceType),
+				ServiceEndpoint: service.MakeServiceReference(vendorDID, types.BaseURLServiceType),
 			},
 			{
 				Type:            transport.NutsCommServiceType,
-				ServiceEndpoint: didservice.MakeServiceReference(vendorDID, transport.NutsCommServiceType),
+				ServiceEndpoint: service.MakeServiceReference(vendorDID, transport.NutsCommServiceType),
 			},
 		},
 	}

--- a/network/dag/keys.go
+++ b/network/dag/keys.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 )
 
@@ -53,7 +53,7 @@ func resolvePublicKey(resolver types.DIDResolver, kid string, metadata types.Res
 	if err != nil {
 		return nil, fmt.Errorf("invalid key ID (id=%s): %w", kid, err)
 	}
-	holder, _ := didservice.GetDIDFromURL(kid) // can't fail, already parsed
+	holder, _ := service.GetDIDFromURL(kid) // can't fail, already parsed
 	doc, _, err := resolver.Resolve(holder, &metadata)
 	if err != nil {
 		return nil, err

--- a/network/network.go
+++ b/network/network.go
@@ -26,7 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"net"
 	"strings"
 	"sync/atomic"
@@ -149,11 +149,11 @@ func NewNetworkInstance(
 ) *Network {
 	return &Network{
 		config:            config,
-		keyResolver:       didservice.KeyResolver{Resolver: store},
+		keyResolver:       service.KeyResolver{Resolver: store},
 		keyStore:          keyStore,
 		didStore:          store,
 		didDocumentFinder: didstore.Finder{Store: store},
-		serviceResolver:   didservice.ServiceResolver{Resolver: store},
+		serviceResolver:   service.ServiceResolver{Resolver: store},
 		eventPublisher:    eventPublisher,
 		storeProvider:     storeProvider,
 		pkiValidator:      pkiValidator,
@@ -390,7 +390,7 @@ func (n *Network) connectToKnownNodes(nodeDID did.DID) error {
 	}
 
 	// start connecting to published NutsComm addresses
-	otherNodes, err := n.didDocumentFinder.Find(didservice.IsActive(), didservice.ValidAt(time.Now()), didservice.ByServiceType(transport.NutsCommServiceType))
+	otherNodes, err := n.didDocumentFinder.Find(service.IsActive(), service.ValidAt(time.Now()), service.ByServiceType(transport.NutsCommServiceType))
 	if err != nil {
 		return err
 	}
@@ -477,8 +477,8 @@ func (n *Network) checkNodeDIDHealth(ctx context.Context, nodeDID did.DID) core.
 	}
 
 	// Check if the DID document has a resolvable and valid NutsComm endpoint
-	serviceRef := didservice.MakeServiceReference(nodeDID, transport.NutsCommServiceType)
-	nutsCommService, err := n.serviceResolver.Resolve(serviceRef, didservice.DefaultMaxServiceReferenceDepth)
+	serviceRef := service.MakeServiceReference(nodeDID, transport.NutsCommServiceType)
+	nutsCommService, err := n.serviceResolver.Resolve(serviceRef, service.DefaultMaxServiceReferenceDepth)
 	if err != nil {
 		// Non-existing NutsComm results in HealthStatusUnknown to make it easier to fix the issue (HealthStatusDown kills the node in certain environments)
 		return core.Health{

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	testPKI "github.com/nuts-foundation/nuts-node/test/pki"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"hash/crc32"
 	"math/rand"
 	"net/url"
@@ -1110,8 +1110,8 @@ func startNode(t *testing.T, name string, testDirectory string, opts ...func(ser
 		config:          config,
 		didStore:        didStore,
 		keyStore:        keyStore,
-		keyResolver:     didservice.KeyResolver{Resolver: didStore},
-		serviceResolver: didservice.ServiceResolver{Resolver: didStore},
+		keyResolver:     service.KeyResolver{Resolver: didStore},
+		serviceResolver: service.ServiceResolver{Resolver: didStore},
 		eventPublisher:  eventPublisher,
 		storeProvider:   &storeProvider,
 		pkiValidator:    pkiValidator,

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -30,7 +30,7 @@ import (
 	ssi "github.com/nuts-foundation/go-did"
 	testPKI "github.com/nuts-foundation/nuts-node/test/pki"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -1333,7 +1333,7 @@ func createNetwork(t *testing.T, ctrl *gomock.Controller, cfgFn ...func(config *
 	network := NewNetworkInstance(networkConfig, didStore, keyStore, eventPublisher, storageEngine.GetProvider(ModuleName), pkiMock)
 	network.keyResolver = keyResolver
 	network.didStore = didStore
-	network.serviceResolver = didservice.ServiceResolver{Resolver: didStore}
+	network.serviceResolver = service.ServiceResolver{Resolver: didStore}
 	network.didDocumentFinder = docFinder
 	network.state = state
 	network.connectionManager = connectionManager

--- a/network/transport/grpc/authenticator.go
+++ b/network/transport/grpc/authenticator.go
@@ -25,7 +25,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/network/log"
 	"github.com/nuts-foundation/nuts-node/network/transport"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"net/url"
 	"strings"
@@ -55,7 +55,7 @@ func (t tlsAuthenticator) Authenticate(nodeDID did.DID, peer transport.Peer) (tr
 	}
 
 	// Resolve NutsComm endpoint of contained in DID document associated with node DID
-	nutsCommService, err := t.serviceResolver.Resolve(didservice.MakeServiceReference(nodeDID, transport.NutsCommServiceType), didservice.DefaultMaxServiceReferenceDepth)
+	nutsCommService, err := t.serviceResolver.Resolve(service.MakeServiceReference(nodeDID, transport.NutsCommServiceType), service.DefaultMaxServiceReferenceDepth)
 	var nutsCommURL *url.URL
 	if err == nil {
 		var nutsCommURLStr string

--- a/network/transport/v2/protocol_integration_test.go
+++ b/network/transport/v2/protocol_integration_test.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"hash/crc32"
 	"path"
 	"sync"
@@ -162,7 +162,7 @@ func startNode(t *testing.T, name string, configurers ...func(config *Config)) *
 	listenAddress := fmt.Sprintf("localhost:%d", nameToPort(name))
 	ctx.protocol = New(*cfg, did.DID{}, ctx.state, didResolver, keyStore, nil, bboltStore).(*protocol)
 
-	authenticator := grpc.NewTLSAuthenticator(didservice.ServiceResolver{Resolver: didResolver})
+	authenticator := grpc.NewTLSAuthenticator(service.ServiceResolver{Resolver: didResolver})
 	connectionsStore, _ := storageClient.GetProvider("network").GetKVStore("connections", storage.VolatileStorageClass)
 	grpcCfg, err := grpc.NewConfig(listenAddress, peerID)
 	require.NoError(t, err)

--- a/vcr/credential/validator.go
+++ b/vcr/credential/validator.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/go-did/did"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"github.com/piprate/json-gold/ld"
 	"strings"
 
@@ -238,7 +238,7 @@ func validOperation(operation string) bool {
 }
 
 func validateNutsCredentialID(credential vc.VerifiableCredential) error {
-	id, err := didservice.GetDIDFromURL(credential.ID.String())
+	id, err := service.GetDIDFromURL(credential.ID.String())
 	if err != nil {
 		return err
 	}

--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/vcr/openid4vci"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"time"
 
 	"github.com/google/uuid"
@@ -56,7 +56,7 @@ func NewIssuer(store Store, vcrStore types.Writer, networkPublisher Publisher,
 	didResolver vdr.DIDResolver, keyStore crypto.KeyStore, jsonldManager jsonld.JSONLD, trustConfig *trust.Config,
 ) Issuer {
 	resolver := vdrKeyResolver{
-		publicKeyResolver:  didservice.KeyResolver{Resolver: didResolver},
+		publicKeyResolver:  service.KeyResolver{Resolver: didResolver},
 		privateKeyResolver: keyStore,
 	}
 	return &issuer{
@@ -64,7 +64,7 @@ func NewIssuer(store Store, vcrStore types.Writer, networkPublisher Publisher,
 		networkPublisher: networkPublisher,
 		openidHandlerFn:  openidHandlerFn,
 		walletResolver: openid4vci.DIDIdentifierResolver{
-			ServiceResolver: didservice.ServiceResolver{Resolver: didResolver},
+			ServiceResolver: service.ServiceResolver{Resolver: didResolver},
 		},
 		keyResolver:   resolver,
 		keyStore:      keyStore,
@@ -202,7 +202,7 @@ func (i issuer) buildVC(ctx context.Context, credentialOptions vc.VerifiableCred
 	if err != nil {
 		const errString = "failed to sign credential: could not resolve an assertionKey for issuer: %w"
 		// Differentiate between a DID document not found and some other error:
-		if didservice.IsFunctionalResolveError(err) {
+		if service.IsFunctionalResolveError(err) {
 			return nil, core.InvalidInputError(errString, err)
 		}
 		return nil, fmt.Errorf(errString, err)
@@ -306,7 +306,7 @@ func (i issuer) buildRevocation(ctx context.Context, credentialID ssi.URI) (*cre
 	if err != nil {
 		const errString = "failed to revoke credential (%s): could not resolve an assertionKey for issuer: %w"
 		// Differentiate between a DID document not found and some other error:
-		if didservice.IsFunctionalResolveError(err) {
+		if service.IsFunctionalResolveError(err) {
 			return nil, core.InvalidInputError(errString, credentialID, err)
 		}
 		return nil, fmt.Errorf(errString, credentialID, err)

--- a/vcr/issuer/network_publisher.go
+++ b/vcr/issuer/network_publisher.go
@@ -31,7 +31,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/log"
 	"github.com/nuts-foundation/nuts-node/vcr/types"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	vdr "github.com/nuts-foundation/nuts-node/vdr/types"
 )
 
@@ -48,9 +48,9 @@ func NewNetworkPublisher(networkTx network.Transactions, didResolver vdr.DIDReso
 	return &networkPublisher{
 		networkTx:       networkTx,
 		didResolver:     didResolver,
-		serviceResolver: didservice.ServiceResolver{Resolver: didResolver},
+		serviceResolver: service.ServiceResolver{Resolver: didResolver},
 		keyResolver: vdrKeyResolver{
-			publicKeyResolver:  didservice.KeyResolver{Resolver: didResolver},
+			publicKeyResolver:  service.KeyResolver{Resolver: didResolver},
 			privateKeyResolver: keyResolver,
 		},
 	}
@@ -131,7 +131,7 @@ func (p networkPublisher) generateParticipants(verifiableCredential vc.Verifiabl
 }
 
 func (p networkPublisher) resolveNutsCommServiceOwner(DID did.DID) (*did.DID, error) {
-	serviceUser := didservice.MakeServiceReference(DID, transport.NutsCommServiceType)
+	serviceUser := service.MakeServiceReference(DID, transport.NutsCommServiceType)
 
 	service, err := p.serviceResolver.Resolve(serviceUser, 5)
 	if err != nil {

--- a/vcr/issuer/openid.go
+++ b/vcr/issuer/openid.go
@@ -37,7 +37,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/vcr/issuer/assets"
 	"github.com/nuts-foundation/nuts-node/vcr/log"
 	"github.com/nuts-foundation/nuts-node/vcr/openid4vci"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"io/fs"
 	"net/http"
@@ -332,7 +332,7 @@ func (i *openidHandler) validateProof(ctx context.Context, flow *Flow, request o
 	}
 
 	// Proof must be signed by wallet to which it was offered (proof signer == offer receiver)
-	if signerDID, err := didservice.GetDIDFromURL(signingKeyID); err != nil || signerDID.String() != wallet.String() {
+	if signerDID, err := service.GetDIDFromURL(signingKeyID); err != nil || signerDID.String() != wallet.String() {
 		return generateProofError(openid4vci.Error{
 			Err:        fmt.Errorf("credential offer was signed by other DID than intended wallet: %s", signingKeyID),
 			Code:       openid4vci.InvalidProof,

--- a/vcr/openid4vci/identifiers.go
+++ b/vcr/openid4vci/identifiers.go
@@ -24,7 +24,7 @@ import (
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/vcr/log"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"net/http"
 	"net/url"
@@ -57,14 +57,14 @@ type DIDIdentifierResolver struct {
 }
 
 func (i DIDIdentifierResolver) Resolve(id did.DID) (string, error) {
-	service, err := i.ServiceResolver.Resolve(didservice.MakeServiceReference(id, types.BaseURLServiceType), didservice.DefaultMaxServiceReferenceDepth)
-	if didservice.IsFunctionalResolveError(err) {
+	svc, err := i.ServiceResolver.Resolve(service.MakeServiceReference(id, types.BaseURLServiceType), service.DefaultMaxServiceReferenceDepth)
+	if service.IsFunctionalResolveError(err) {
 		return "", nil
 	} else if err != nil {
 		return "", fmt.Errorf("unable to resolve %s service: %w", types.BaseURLServiceType, err)
 	}
 	var result string
-	_ = service.UnmarshalServiceEndpoint(&result)
+	_ = svc.UnmarshalServiceEndpoint(&result)
 	if result != "" {
 		result = CreateIdentifier(result, id)
 	}

--- a/vcr/openid4vci/identifiers_test.go
+++ b/vcr/openid4vci/identifiers_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/jsonld"
 	"github.com/nuts-foundation/nuts-node/test/pki"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -56,7 +56,7 @@ func TestDIDIdentifierResolver_Resolve(t *testing.T) {
 	t.Run("found", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		serviceResolver := types.NewMockServiceResolver(ctrl)
-		serviceResolver.EXPECT().Resolve(issuerQuery, didservice.DefaultMaxServiceReferenceDepth).Return(issuerService, nil)
+		serviceResolver.EXPECT().Resolve(issuerQuery, service.DefaultMaxServiceReferenceDepth).Return(issuerService, nil)
 		resolver := DIDIdentifierResolver{ServiceResolver: serviceResolver}
 
 		identifier, err := resolver.Resolve(issuerDID)
@@ -67,7 +67,7 @@ func TestDIDIdentifierResolver_Resolve(t *testing.T) {
 	t.Run("DID not found", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		serviceResolver := types.NewMockServiceResolver(ctrl)
-		serviceResolver.EXPECT().Resolve(issuerQuery, didservice.DefaultMaxServiceReferenceDepth).Return(did.Service{}, types.ErrNotFound)
+		serviceResolver.EXPECT().Resolve(issuerQuery, service.DefaultMaxServiceReferenceDepth).Return(did.Service{}, types.ErrNotFound)
 		resolver := DIDIdentifierResolver{ServiceResolver: serviceResolver}
 
 		identifier, err := resolver.Resolve(issuerDID)
@@ -78,7 +78,7 @@ func TestDIDIdentifierResolver_Resolve(t *testing.T) {
 	t.Run("service not found", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		serviceResolver := types.NewMockServiceResolver(ctrl)
-		serviceResolver.EXPECT().Resolve(issuerQuery, didservice.DefaultMaxServiceReferenceDepth).Return(did.Service{}, types.ErrServiceNotFound)
+		serviceResolver.EXPECT().Resolve(issuerQuery, service.DefaultMaxServiceReferenceDepth).Return(did.Service{}, types.ErrServiceNotFound)
 		resolver := DIDIdentifierResolver{ServiceResolver: serviceResolver}
 
 		identifier, err := resolver.Resolve(issuerDID)
@@ -89,7 +89,7 @@ func TestDIDIdentifierResolver_Resolve(t *testing.T) {
 	t.Run("invalid service", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		serviceResolver := types.NewMockServiceResolver(ctrl)
-		serviceResolver.EXPECT().Resolve(issuerQuery, didservice.DefaultMaxServiceReferenceDepth).
+		serviceResolver.EXPECT().Resolve(issuerQuery, service.DefaultMaxServiceReferenceDepth).
 			Return(did.Service{ServiceEndpoint: map[string]string{"foo": "bar"}}, nil)
 		resolver := DIDIdentifierResolver{ServiceResolver: serviceResolver}
 
@@ -101,7 +101,7 @@ func TestDIDIdentifierResolver_Resolve(t *testing.T) {
 	t.Run("other error", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		serviceResolver := types.NewMockServiceResolver(ctrl)
-		serviceResolver.EXPECT().Resolve(issuerQuery, didservice.DefaultMaxServiceReferenceDepth).Return(did.Service{}, errors.New("b00m!"))
+		serviceResolver.EXPECT().Resolve(issuerQuery, service.DefaultMaxServiceReferenceDepth).Return(did.Service{}, errors.New("b00m!"))
 		resolver := DIDIdentifierResolver{ServiceResolver: serviceResolver}
 
 		identifier, err := resolver.Resolve(issuerDID)

--- a/vcr/test.go
+++ b/vcr/test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/vdr"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -54,7 +54,7 @@ func NewTestVCRContext(t *testing.T, keyStore crypto.KeyStore) TestVCRContext {
 	ctx := TestVCRContext{
 		DIDStore:    didStore,
 		KeyStore:    keyStore,
-		KeyResolver: didservice.KeyResolver{Resolver: didResolver},
+		KeyResolver: service.KeyResolver{Resolver: didResolver},
 	}
 
 	testDirectory := io.TestDirectory(t)

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -27,7 +27,7 @@ import (
 	"github.com/nuts-foundation/go-leia/v4"
 	"github.com/nuts-foundation/nuts-node/pki"
 	"github.com/nuts-foundation/nuts-node/vcr/openid4vci"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"io/fs"
 	"net/http"
 	"path"
@@ -197,8 +197,8 @@ func (c *vcr) Configure(config core.ServerConfig) error {
 	var openidHandlerFn func(ctx context.Context, id did.DID) (issuer.OpenIDHandler, error)
 
 	didResolver := c.vdrInstance.Resolver()
-	c.keyResolver = didservice.KeyResolver{Resolver: didResolver}
-	c.serviceResolver = didservice.ServiceResolver{Resolver: didResolver}
+	c.keyResolver = service.KeyResolver{Resolver: didResolver}
+	c.serviceResolver = service.ServiceResolver{Resolver: didResolver}
 
 	networkPublisher := issuer.NewNetworkPublisher(c.network, didResolver, c.keyStore)
 	if c.config.OpenID4VCI.Enabled {

--- a/vdr/cmd/cmd.go
+++ b/vdr/cmd/cmd.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"io"
 	"os"
 	"strings"
@@ -286,7 +286,7 @@ func addKeyAgreementKeyCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("invalid key ID '%s': %w", args[0], err)
 			}
-			targetDID, _ := didservice.GetDIDFromURL(args[0]) // can't fail because we already parsed the key ID
+			targetDID, _ := service.GetDIDFromURL(args[0]) // can't fail because we already parsed the key ID
 
 			clientConfig := core.NewClientConfigForCommand(cmd)
 			client := httpClient(clientConfig)

--- a/vdr/did_owner.go
+++ b/vdr/did_owner.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/crypto"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 	"strings"
 	"sync"
@@ -76,7 +76,7 @@ func (t *cachingDocumentOwner) IsOwner(ctx context.Context, id did.DID) (bool, e
 	// First perform a cheap DID existence check (subsequent checks are more expensive),
 	// without caching it as negative match (would allow unbound number of negative matches).
 	_, _, err := t.didResolver.Resolve(id, nil)
-	if didservice.IsFunctionalResolveError(err) {
+	if service.IsFunctionalResolveError(err) {
 		return false, nil
 	} else if err != nil {
 		return false, fmt.Errorf("unable to check ownership of DID: %w", err)

--- a/vdr/didnuts/creator.go
+++ b/vdr/didnuts/creator.go
@@ -22,7 +22,7 @@ import (
 	"crypto"
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 
 	ssi "github.com/nuts-foundation/go-did"
 
@@ -153,7 +153,7 @@ func (n Creator) Create(ctx context.Context, options vdr.DIDCreationOptions) (*d
 	}
 
 	// Create the bare document. The Document DID will be the keyIDStr without the fragment.
-	didID, _ := didservice.GetDIDFromURL(key.KID())
+	didID, _ := service.GetDIDFromURL(key.KID())
 	doc := CreateDocument()
 	doc.ID = didID
 	doc.Controller = options.Controllers

--- a/vdr/didnuts/didstore/finder_test.go
+++ b/vdr/didnuts/didstore/finder_test.go
@@ -19,7 +19,7 @@ package didstore
 
 import (
 	"errors"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"github.com/stretchr/testify/require"
 	"testing"
 
@@ -39,7 +39,7 @@ func TestFinder_Find(t *testing.T) {
 			f(did.Document{}, types.DocumentMetadata{})
 		})
 
-		docs, err := finder.Find(didservice.IsActive())
+		docs, err := finder.Find(service.IsActive())
 
 		require.NoError(t, err)
 		assert.Len(t, docs, 1)
@@ -51,7 +51,7 @@ func TestFinder_Find(t *testing.T) {
 		finder := Finder{Store: didStore}
 		didStore.EXPECT().Iterate(gomock.Any()).Return(errors.New("b00m!"))
 
-		_, err := finder.Find(didservice.IsActive())
+		_, err := finder.Find(service.IsActive())
 
 		assert.Error(t, err)
 	})

--- a/vdr/didnuts/resolver.go
+++ b/vdr/didnuts/resolver.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 )
 
@@ -116,7 +116,7 @@ func resolveControllers(resolver types.DIDResolver, doc did.Document, metadata *
 	// filter deactivated
 	j := 0
 	for _, leaf := range leaves {
-		if !didservice.IsDeactivated(leaf) {
+		if !service.IsDeactivated(leaf) {
 			leaves[j] = leaf
 			j++
 		}

--- a/vdr/didnuts/validators.go
+++ b/vdr/didnuts/validators.go
@@ -25,7 +25,7 @@ import (
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/network/transport"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"github.com/nuts-foundation/nuts-node/vdr/types"
 )
 
@@ -186,21 +186,21 @@ func (m managedServiceValidator) Validate(document did.Document) error {
 	return nil
 }
 
-func (m managedServiceValidator) resolveOrReturnEndpoint(service did.Service, cache map[string]*did.Document) (any, error) {
+func (m managedServiceValidator) resolveOrReturnEndpoint(svc did.Service, cache map[string]*did.Document) (any, error) {
 	var serviceEndpoint string
-	if err := service.UnmarshalServiceEndpoint(&serviceEndpoint); err != nil {
+	if err := svc.UnmarshalServiceEndpoint(&serviceEndpoint); err != nil {
 		return nil, errors.New("invalid service format")
 	}
 	// make sure that it resolves if it is a reference
-	if didservice.IsServiceReference(serviceEndpoint) {
+	if service.IsServiceReference(serviceEndpoint) {
 		serviceURI, err := ssi.ParseURI(serviceEndpoint)
 		if err != nil {
 			return nil, err
 		}
-		if err = didservice.ValidateServiceReference(*serviceURI); err != nil {
+		if err = service.ValidateServiceReference(*serviceURI); err != nil {
 			return nil, err
 		}
-		resolvedService, err := m.serviceResolver.ResolveEx(*serviceURI, 0, didservice.DefaultMaxServiceReferenceDepth, cache)
+		resolvedService, err := m.serviceResolver.ResolveEx(*serviceURI, 0, service.DefaultMaxServiceReferenceDepth, cache)
 		if err != nil {
 			return nil, err
 		}

--- a/vdr/service/finder.go
+++ b/vdr/service/finder.go
@@ -16,7 +16,7 @@
  *
  */
 
-package didservice
+package service
 
 import (
 	"github.com/nuts-foundation/go-did/did"

--- a/vdr/service/finder_test.go
+++ b/vdr/service/finder_test.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package didservice
+package service
 
 import (
 	"testing"

--- a/vdr/service/resolvers.go
+++ b/vdr/service/resolvers.go
@@ -17,7 +17,7 @@
 
 // Package service contains DID Document related functionality that only matters to the current node.
 // All functionality here has zero relations to the network.
-package didservice
+package service
 
 import (
 	"crypto"

--- a/vdr/service/resolvers_test.go
+++ b/vdr/service/resolvers_test.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package didservice
+package service
 
 import (
 	"crypto/ecdsa"

--- a/vdr/service/test.go
+++ b/vdr/service/test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package didservice
+package service
 
 import (
 	ssi "github.com/nuts-foundation/go-did"

--- a/vdr/service/util.go
+++ b/vdr/service/util.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package didservice
+package service
 
 import (
 	"errors"

--- a/vdr/service/util_test.go
+++ b/vdr/service/util_test.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package didservice
+package service
 
 import (
 	"testing"

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -33,8 +33,8 @@ import (
 	"github.com/nuts-foundation/nuts-node/vdr/didjwk"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts"
 	didnutsStore "github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
 	"github.com/nuts-foundation/nuts-node/vdr/didweb"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
@@ -61,7 +61,7 @@ type VDR struct {
 	network           network.Transactions
 	networkAmbassador didnuts.Ambassador
 	didDocCreator     types.DocCreator
-	didResolver       *didservice.DIDResolverRouter
+	didResolver       *service.DIDResolverRouter
 	serviceResolver   types.ServiceResolver
 	documentOwner     types.DocumentOwner
 	keyStore          crypto.KeyStore
@@ -76,14 +76,14 @@ func (r *VDR) Resolver() types.DIDResolver {
 // NewVDR creates a new VDR with provided params
 func NewVDR(cryptoClient crypto.KeyStore, networkClient network.Transactions,
 	didStore didnutsStore.Store, eventManager events.Event) *VDR {
-	didResolver := &didservice.DIDResolverRouter{}
+	didResolver := &service.DIDResolverRouter{}
 	return &VDR{
 		network:         networkClient,
 		eventManager:    eventManager,
 		didDocCreator:   didnuts.Creator{KeyStore: cryptoClient},
 		didResolver:     didResolver,
 		store:           didStore,
-		serviceResolver: didservice.ServiceResolver{Resolver: didResolver},
+		serviceResolver: service.ServiceResolver{Resolver: didResolver},
 		documentOwner:   newCachingDocumentOwner(privateKeyDocumentOwner{keyResolver: cryptoClient}, didResolver),
 		keyStore:        cryptoClient,
 	}
@@ -290,7 +290,7 @@ func (r *VDR) Update(ctx context.Context, id did.DID, next did.Document) error {
 	if err != nil {
 		return fmt.Errorf("update DID document: %w", err)
 	}
-	if didservice.IsDeactivated(*currentDIDDocument) {
+	if service.IsDeactivated(*currentDIDDocument) {
 		return fmt.Errorf("update DID document: %w", types.ErrDeactivated)
 	}
 

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
-	"github.com/nuts-foundation/nuts-node/vdr/didservice"
+	"github.com/nuts-foundation/nuts-node/vdr/service"
 	"io"
 	"net/http"
 	"strings"
@@ -68,7 +68,7 @@ func newVDRTestCtx(t *testing.T) vdrTestCtx {
 	mockStore := didstore.NewMockStore(ctrl)
 	mockNetwork := network.NewMockTransactions(ctrl)
 	mockKeyStore := crypto.NewMockKeyStore(ctrl)
-	resolverRouter := &didservice.DIDResolverRouter{}
+	resolverRouter := &service.DIDResolverRouter{}
 	vdr := VDR{
 		store:             mockStore,
 		network:           mockNetwork,


### PR DESCRIPTION
Since we now have DID method implementations in the `didweb`, `didjwk` and `didnuts` packages, `didservice` has become a bad package name. Renamed to `service`.