### PR TITLE
move session store to storage.SessionDatabase

### DIFF
--- a/network/dag/consistency_test.go
+++ b/network/dag/consistency_test.go
@@ -35,9 +35,7 @@ import (
 )
 
 func TestXorTreeRepair(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t)
-	})
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	tx, _, _ := CreateTestTransaction(1)
 	t.Run("xor tree repaired after 2 signals", func(t *testing.T) {

--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -215,7 +215,7 @@ func Test_grpcConnectionManager_hasActiveConnection(t *testing.T) {
 
 func Test_grpcConnectionManager_dialerLoop(t *testing.T) {
 	// make sure connectLoop only returns after all of its goroutines are closed
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	targetAddress := "bootstrap"
 	var capturedAddress string

--- a/network/transport/v2/gossip/manager_test.go
+++ b/network/transport/v2/gossip/manager_test.go
@@ -97,7 +97,7 @@ func TestManager_PeerDisconnected(t *testing.T) {
 
 	t.Run("stops ticker", func(t *testing.T) {
 		// Use uber/goleak to assert the goroutine started by PeerConnected is stopped when PeerDisconnected is called
-		defer goleak.VerifyNone(t)
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 		gMan := giveMeAgMan(t)
 		gMan.interval = time.Millisecond

--- a/network/transport/v2/protocol_test.go
+++ b/network/transport/v2/protocol_test.go
@@ -202,7 +202,7 @@ func TestProtocol_Start(t *testing.T) {
 
 func TestProtocol_Stop(t *testing.T) {
 	t.Run("waits until goroutines have finished", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 		// Use waitgroup to make sure the goroutine that blocks has started
 		wg := &sync.WaitGroup{}

--- a/network/transport/v2/transactionlist_handler_test.go
+++ b/network/transport/v2/transactionlist_handler_test.go
@@ -37,9 +37,7 @@ import (
 )
 
 func TestTransactionListHandler(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t)
-	})
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	t.Run("fn is called", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/pki/validator_test.go
+++ b/pki/validator_test.go
@@ -57,7 +57,7 @@ var crlPathMap = map[string]string{
 }
 
 func TestValidator_Start(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 	store, err := core.LoadTrustStore(truststorePKIo)
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -91,7 +91,7 @@ func (e engine) Shutdown() error {
 		return errors.New("one or more stores failed to close")
 	}
 
-	e.sessionDatabase.Close()
+	e.sessionDatabase.close()
 
 	return nil
 }

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -65,21 +65,20 @@ type database interface {
 
 var ErrNotFound = errors.New("not found")
 
-// SessionDatabase is an in memory database that holds session data on a KV basis.
+// SessionDatabase is a non-persistent database that holds session data on a KV basis.
 // Keys could be access tokens, nonce's, authorization codes, etc.
 // All entries are stored with a TTL, so they will be removed automatically.
 type SessionDatabase interface {
 	// GetStore returns a SessionStore with the given keys as key prefixes.
-	// The keys are used to logically partition the store.
+	// The keys are used to logically partition the store, eg: tenants and/or flows that are not allowed to overlap like credential issuance and verification.
 	// The TTL is the time-to-live for the entries in the store.
 	GetStore(ttl time.Duration, keys ...string) SessionStore
-	// Close stops any background processes and closes the database.
-	Close()
+	// close stops any background processes and closes the database.
+	close()
 }
 
 // SessionStore is a key-value store that holds session data.
-// The SessionStore is a wrapper for the SessionDatabase, it automatically adds prefixes for logical partitions.
-// It uses JSON marshalling to store the entries.
+// The SessionStore is an abstraction for underlying storage, it automatically adds prefixes for logical partitions.
 type SessionStore interface {
 	// Delete deletes the entry for the given key.
 	// It does not return an error if the key does not exist.

--- a/storage/mock.go
+++ b/storage/mock.go
@@ -235,18 +235,6 @@ func (m *MockSessionDatabase) EXPECT() *MockSessionDatabaseMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method.
-func (m *MockSessionDatabase) Close() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Close")
-}
-
-// Close indicates an expected call of Close.
-func (mr *MockSessionDatabaseMockRecorder) Close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockSessionDatabase)(nil).Close))
-}
-
 // GetStore mocks base method.
 func (m *MockSessionDatabase) GetStore(ttl time.Duration, keys ...string) SessionStore {
 	m.ctrl.T.Helper()
@@ -264,6 +252,18 @@ func (mr *MockSessionDatabaseMockRecorder) GetStore(ttl interface{}, keys ...int
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ttl}, keys...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStore", reflect.TypeOf((*MockSessionDatabase)(nil).GetStore), varargs...)
+}
+
+// close mocks base method.
+func (m *MockSessionDatabase) close() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "close")
+}
+
+// close indicates an expected call of close.
+func (mr *MockSessionDatabaseMockRecorder) close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "close", reflect.TypeOf((*MockSessionDatabase)(nil).close))
 }
 
 // MockSessionStore is a mock of SessionStore interface.

--- a/storage/mock.go
+++ b/storage/mock.go
@@ -10,6 +10,7 @@ package storage
 
 import (
 	reflect "reflect"
+	time "time"
 
 	stoabs "github.com/nuts-foundation/go-stoabs"
 	core "github.com/nuts-foundation/nuts-node/core"
@@ -65,6 +66,20 @@ func (m *MockEngine) GetProvider(moduleName string) Provider {
 func (mr *MockEngineMockRecorder) GetProvider(moduleName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProvider", reflect.TypeOf((*MockEngine)(nil).GetProvider), moduleName)
+}
+
+// GetSessionDatabase mocks base method.
+func (m *MockEngine) GetSessionDatabase() SessionDatabase {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSessionDatabase")
+	ret0, _ := ret[0].(SessionDatabase)
+	return ret0
+}
+
+// GetSessionDatabase indicates an expected call of GetSessionDatabase.
+func (mr *MockEngineMockRecorder) GetSessionDatabase() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSessionDatabase", reflect.TypeOf((*MockEngine)(nil).GetSessionDatabase))
 }
 
 // Shutdown mocks base method.
@@ -195,4 +210,137 @@ func (m *Mockdatabase) getClass() Class {
 func (mr *MockdatabaseMockRecorder) getClass() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getClass", reflect.TypeOf((*Mockdatabase)(nil).getClass))
+}
+
+// MockSessionDatabase is a mock of SessionDatabase interface.
+type MockSessionDatabase struct {
+	ctrl     *gomock.Controller
+	recorder *MockSessionDatabaseMockRecorder
+}
+
+// MockSessionDatabaseMockRecorder is the mock recorder for MockSessionDatabase.
+type MockSessionDatabaseMockRecorder struct {
+	mock *MockSessionDatabase
+}
+
+// NewMockSessionDatabase creates a new mock instance.
+func NewMockSessionDatabase(ctrl *gomock.Controller) *MockSessionDatabase {
+	mock := &MockSessionDatabase{ctrl: ctrl}
+	mock.recorder = &MockSessionDatabaseMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockSessionDatabase) EXPECT() *MockSessionDatabaseMockRecorder {
+	return m.recorder
+}
+
+// Close mocks base method.
+func (m *MockSessionDatabase) Close() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Close")
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockSessionDatabaseMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockSessionDatabase)(nil).Close))
+}
+
+// GetStore mocks base method.
+func (m *MockSessionDatabase) GetStore(ttl time.Duration, keys ...string) SessionStore {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ttl}
+	for _, a := range keys {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetStore", varargs...)
+	ret0, _ := ret[0].(SessionStore)
+	return ret0
+}
+
+// GetStore indicates an expected call of GetStore.
+func (mr *MockSessionDatabaseMockRecorder) GetStore(ttl interface{}, keys ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ttl}, keys...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStore", reflect.TypeOf((*MockSessionDatabase)(nil).GetStore), varargs...)
+}
+
+// MockSessionStore is a mock of SessionStore interface.
+type MockSessionStore struct {
+	ctrl     *gomock.Controller
+	recorder *MockSessionStoreMockRecorder
+}
+
+// MockSessionStoreMockRecorder is the mock recorder for MockSessionStore.
+type MockSessionStoreMockRecorder struct {
+	mock *MockSessionStore
+}
+
+// NewMockSessionStore creates a new mock instance.
+func NewMockSessionStore(ctrl *gomock.Controller) *MockSessionStore {
+	mock := &MockSessionStore{ctrl: ctrl}
+	mock.recorder = &MockSessionStoreMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockSessionStore) EXPECT() *MockSessionStoreMockRecorder {
+	return m.recorder
+}
+
+// Delete mocks base method.
+func (m *MockSessionStore) Delete(key string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", key)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockSessionStoreMockRecorder) Delete(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockSessionStore)(nil).Delete), key)
+}
+
+// Exists mocks base method.
+func (m *MockSessionStore) Exists(key string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Exists", key)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Exists indicates an expected call of Exists.
+func (mr *MockSessionStoreMockRecorder) Exists(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockSessionStore)(nil).Exists), key)
+}
+
+// Get mocks base method.
+func (m *MockSessionStore) Get(key string, target interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", key, target)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockSessionStoreMockRecorder) Get(key, target interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSessionStore)(nil).Get), key, target)
+}
+
+// Put mocks base method.
+func (m *MockSessionStore) Put(key string, value interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Put", key, value)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Put indicates an expected call of Put.
+func (mr *MockSessionStoreMockRecorder) Put(key, value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockSessionStore)(nil).Put), key, value)
 }

--- a/storage/session.go
+++ b/storage/session.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/nuts-foundation/nuts-node/storage/log"
+	"strings"
+	"sync"
+	"time"
+)
+
+var _ SessionDatabase = (*inMemorySessionDatabase)(nil)
+var _ SessionStore = (*inMemorySessionStore)(nil)
+
+var sessionStorePruneInterval = 10 * time.Minute
+
+type expiringEntry struct {
+	// Value stores the actual value as JSON
+	Value  string
+	Expiry time.Time
+}
+
+// SessionDatabase is an in memory database that holds session data on a KV basis.
+// Keys could be access tokens, nonce's, authorization codes, etc.
+// All entries are stored with a TTL, so they will be removed automatically.
+type inMemorySessionDatabase struct {
+	cancel   context.CancelFunc
+	ctx      context.Context
+	mux      sync.RWMutex
+	routines sync.WaitGroup
+	entries  map[string]expiringEntry
+}
+
+// NewInMemorySessionDatabase creates a new in memory session database.
+func NewInMemorySessionDatabase() SessionDatabase {
+	result := &inMemorySessionDatabase{
+		entries: map[string]expiringEntry{},
+	}
+	result.ctx, result.cancel = context.WithCancel(context.Background())
+	result.startPruning(sessionStorePruneInterval)
+	return result
+}
+
+func (i *inMemorySessionDatabase) GetStore(ttl time.Duration, keys ...string) SessionStore {
+	return inMemorySessionStore{
+		ttl:      ttl,
+		prefixes: keys,
+		db:       i,
+	}
+}
+
+func (i *inMemorySessionDatabase) Close() {
+	// Signal pruner to stop and wait for it to finish
+	i.cancel()
+	i.routines.Wait()
+}
+
+func (i *inMemorySessionDatabase) startPruning(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	i.routines.Add(1)
+	go func(ctx context.Context) {
+		defer i.routines.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				valsPruned := i.prune()
+				if valsPruned > 0 {
+					log.Logger().Debugf("Pruned %d expired session variables", valsPruned)
+				}
+			}
+		}
+	}(i.ctx)
+}
+
+func (i *inMemorySessionDatabase) prune() int {
+	i.mux.Lock()
+	defer i.mux.Unlock()
+
+	moment := time.Now()
+
+	// Find expired flows and delete them
+	var count int
+	for key, entry := range i.entries {
+		if entry.Expiry.Before(moment) {
+			count++
+			delete(i.entries, key)
+		}
+	}
+
+	return count
+}
+
+type inMemorySessionStore struct {
+	ttl      time.Duration
+	prefixes []string
+	db       *inMemorySessionDatabase
+}
+
+func (i inMemorySessionStore) Delete(key string) error {
+	i.db.mux.Lock()
+	defer i.db.mux.Unlock()
+
+	delete(i.db.entries, i.getFullKey(key))
+	return nil
+}
+
+func (i inMemorySessionStore) Exists(key string) bool {
+	i.db.mux.Lock()
+	defer i.db.mux.Unlock()
+
+	_, ok := i.db.entries[i.getFullKey(key)]
+	return ok
+}
+
+func (i inMemorySessionStore) Get(key string, target interface{}) error {
+	i.db.mux.Lock()
+	defer i.db.mux.Unlock()
+
+	fullKey := i.getFullKey(key)
+	entry, ok := i.db.entries[fullKey]
+	if !ok {
+		return ErrNotFound
+	}
+	if entry.Expiry.Before(time.Now()) {
+		delete(i.db.entries, fullKey)
+		return ErrNotFound
+	}
+
+	return json.Unmarshal([]byte(entry.Value), target)
+}
+
+func (i inMemorySessionStore) Put(key string, value interface{}) error {
+	i.db.mux.Lock()
+	defer i.db.mux.Unlock()
+
+	bytes, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	entry := expiringEntry{
+		Value:  string(bytes),
+		Expiry: time.Now().Add(i.ttl),
+	}
+
+	i.db.entries[i.getFullKey(key)] = entry
+	return nil
+}
+
+func (i inMemorySessionStore) getFullKey(key string) string {
+	return strings.Join(append(i.prefixes, key), "/")
+}

--- a/storage/session_test.go
+++ b/storage/session_test.go
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package storage
+
+import (
+	"github.com/nuts-foundation/nuts-node/test"
+	"go.uber.org/goleak"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInMemorySessionDatabase(t *testing.T) {
+	db := createDatabase(t)
+
+	assert.NotNil(t, db)
+}
+
+func TestInMemorySessionDatabase_GetStore(t *testing.T) {
+	db := createDatabase(t)
+
+	store := db.GetStore(time.Minute, "key1", "key2").(inMemorySessionStore)
+
+	require.NotNil(t, store)
+	assert.Equal(t, time.Minute, store.ttl)
+	assert.Equal(t, []string{"key1", "key2"}, store.prefixes)
+}
+
+func TestInMemorySessionStore_Put(t *testing.T) {
+	db := createDatabase(t)
+	store := db.GetStore(time.Minute, "prefix").(inMemorySessionStore)
+
+	t.Run("string value is stored", func(t *testing.T) {
+		err := store.Put("key", "value")
+
+		require.NoError(t, err)
+		assert.Equal(t, `"value"`, store.db.entries["prefix/key"].Value)
+	})
+
+	t.Run("float value is stored", func(t *testing.T) {
+		err := store.Put("key", 1.23)
+
+		require.NoError(t, err)
+		assert.Equal(t, "1.23", store.db.entries["prefix/key"].Value)
+	})
+
+	t.Run("struct value is stored", func(t *testing.T) {
+		value := testStruct{
+			Field1: "value",
+		}
+
+		err := store.Put("key", value)
+
+		require.NoError(t, err)
+		assert.Equal(t, "{\"field1\":\"value\"}", store.db.entries["prefix/key"].Value)
+	})
+
+	t.Run("value is not JSON", func(t *testing.T) {
+		err := store.Put("key", make(chan int))
+
+		assert.Error(t, err)
+	})
+}
+
+func TestInMemorySessionStore_Get(t *testing.T) {
+	db := createDatabase(t)
+	store := db.GetStore(time.Minute, "prefix").(inMemorySessionStore)
+
+	t.Run("string value is retrieved correctly", func(t *testing.T) {
+		_ = store.Put(t.Name(), "value")
+		var actual string
+
+		err := store.Get(t.Name(), &actual)
+
+		require.NoError(t, err)
+		assert.Equal(t, "value", actual)
+	})
+
+	t.Run("float value is retrieved correctly", func(t *testing.T) {
+		_ = store.Put(t.Name(), 1.23)
+		var actual float64
+
+		err := store.Get(t.Name(), &actual)
+
+		require.NoError(t, err)
+		assert.Equal(t, 1.23, actual)
+	})
+
+	t.Run("struct value is retrieved correctly", func(t *testing.T) {
+		value := testStruct{
+			Field1: "value",
+		}
+		_ = store.Put(t.Name(), value)
+		var actual testStruct
+
+		err := store.Get(t.Name(), &actual)
+
+		require.NoError(t, err)
+		assert.Equal(t, value, actual)
+	})
+
+	t.Run("value is not found", func(t *testing.T) {
+		var actual string
+
+		err := store.Get(t.Name(), &actual)
+
+		assert.Equal(t, ErrNotFound, err)
+	})
+
+	t.Run("value is expired", func(t *testing.T) {
+		store.db.entries["prefix/key"] = expiringEntry{
+			Value:  "",
+			Expiry: time.Now().Add(-time.Minute),
+		}
+		var actual string
+
+		err := store.Get("key", &actual)
+
+		assert.Equal(t, ErrNotFound, err)
+	})
+
+	t.Run("value is not JSON", func(t *testing.T) {
+		store.db.entries["prefix/key"] = expiringEntry{
+			Value:  "not JSON",
+			Expiry: time.Now().Add(time.Minute),
+		}
+		var actual string
+
+		err := store.Get("key", &actual)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("value is not a pointer", func(t *testing.T) {
+		_ = store.Put(t.Name(), "value")
+
+		err := store.Get(t.Name(), "not a pointer")
+
+		assert.Error(t, err)
+	})
+}
+
+func TestInMemorySessionStore_Delete(t *testing.T) {
+	db := createDatabase(t)
+	store := db.GetStore(time.Minute, "prefix").(inMemorySessionStore)
+
+	t.Run("value is deleted", func(t *testing.T) {
+		_ = store.Put(t.Name(), "value")
+
+		err := store.Delete(t.Name())
+
+		require.NoError(t, err)
+		_, ok := store.db.entries["prefix/key"]
+		assert.False(t, ok)
+	})
+
+	t.Run("value is not found", func(t *testing.T) {
+		err := store.Delete(t.Name())
+
+		assert.NoError(t, err)
+	})
+}
+
+func TestInMemorySessionDatabase_Close(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	t.Run("assert Close() waits for pruning to finish to avoid leaking goroutines", func(t *testing.T) {
+		sessionStorePruneInterval = 10 * time.Millisecond
+		defer func() {
+			sessionStorePruneInterval = 10 * time.Minute
+		}()
+		store := NewInMemorySessionDatabase()
+		time.Sleep(50 * time.Millisecond) // make sure pruning is running
+		store.Close()
+	})
+}
+
+func Test_memoryStore_prune(t *testing.T) {
+	t.Run("automatic", func(t *testing.T) {
+		store := createDatabase(t)
+		// we call startPruning a second time ourselves to speed things up, make sure not to leak the original goroutine
+		cancelFunc := store.cancel
+		defer cancelFunc()
+		store.startPruning(10 * time.Millisecond)
+
+		err := store.GetStore(time.Millisecond).Put("key", "value")
+		require.NoError(t, err)
+
+		test.WaitFor(t, func() (bool, error) {
+			store.mux.Lock()
+			defer store.mux.Unlock()
+			_, exists := store.entries["key"]
+			return !exists, nil
+		}, time.Second, "time-out waiting for entry to be pruned")
+	})
+	t.Run("prunes expired flows", func(t *testing.T) {
+		store := createDatabase(t)
+		defer store.Close()
+
+		_ = store.GetStore(0).Put("key1", "value")
+		_ = store.GetStore(time.Minute).Put("key2", "value")
+
+		count := store.prune()
+
+		assert.Equal(t, 1, count)
+
+		// Second round to assert there's nothing to prune now
+		count = store.prune()
+
+		assert.Equal(t, 0, count)
+	})
+}
+
+type testStruct struct {
+	Field1 string `json:"field1"`
+}
+
+func createDatabase(t *testing.T) *inMemorySessionDatabase {
+	return NewTestInMemorySessionDatabase(t).(*inMemorySessionDatabase)
+}

--- a/storage/test.go
+++ b/storage/test.go
@@ -67,3 +67,11 @@ func (p *StaticKVStoreProvider) GetKVStore(_ string, _ Class) (stoabs.KVStore, e
 	}
 	return p.Store, nil
 }
+
+func NewTestInMemorySessionDatabase(t *testing.T) SessionDatabase {
+	db := NewInMemorySessionDatabase()
+	t.Cleanup(func() {
+		db.Close()
+	})
+	return db
+}

--- a/storage/test.go
+++ b/storage/test.go
@@ -68,10 +68,10 @@ func (p *StaticKVStoreProvider) GetKVStore(_ string, _ Class) (stoabs.KVStore, e
 	return p.Store, nil
 }
 
-func NewTestInMemorySessionDatabase(t *testing.T) SessionDatabase {
+func NewTestInMemorySessionDatabase(t *testing.T) *InMemorySessionDatabase {
 	db := NewInMemorySessionDatabase()
 	t.Cleanup(func() {
-		db.Close()
+		db.close()
 	})
 	return db
 }

--- a/vcr/issuer/openid_store_test.go
+++ b/vcr/issuer/openid_store_test.go
@@ -20,11 +20,9 @@ package issuer
 
 import (
 	"context"
-	"github.com/nuts-foundation/nuts-node/test"
+	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
-	"time"
 )
 
 const refType = "ref-type"
@@ -34,12 +32,11 @@ func Test_memoryStore_DeleteReference(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		store := createStore(t)
 		expected := Flow{
-			ID:     "flow-id",
-			Expiry: futureExpiry(),
+			ID: "flow-id",
 		}
 		err := store.Store(context.Background(), expected)
 		assert.NoError(t, err)
-		err = store.StoreReference(context.Background(), expected.ID, refType, ref, futureExpiry())
+		err = store.StoreReference(context.Background(), expected.ID, refType, ref)
 		assert.NoError(t, err)
 
 		err = store.DeleteReference(context.Background(), refType, ref)
@@ -63,48 +60,30 @@ func Test_memoryStore_FindByReference(t *testing.T) {
 	t.Run("reference already exists", func(t *testing.T) {
 		store := createStore(t)
 		expected := Flow{
-			ID:     "flow-id",
-			Expiry: futureExpiry(),
+			ID: "flow-id",
 		}
 		err := store.Store(context.Background(), expected)
 		assert.NoError(t, err)
 
-		err = store.StoreReference(context.Background(), expected.ID, refType, ref, futureExpiry())
+		err = store.StoreReference(context.Background(), expected.ID, refType, ref)
 		assert.NoError(t, err)
-		err = store.StoreReference(context.Background(), expected.ID, refType, ref, futureExpiry())
+		err = store.StoreReference(context.Background(), expected.ID, refType, ref)
 
 		assert.EqualError(t, err, "reference already exists")
 	})
 	t.Run("invalid reference", func(t *testing.T) {
 		store := createStore(t)
 
-		err := store.StoreReference(context.Background(), "unknown", refType, "", futureExpiry())
+		err := store.StoreReference(context.Background(), "unknown", refType, "")
 
 		assert.EqualError(t, err, "invalid reference")
 	})
 	t.Run("unknown flow", func(t *testing.T) {
 		store := createStore(t)
 
-		err := store.StoreReference(context.Background(), "unknown", refType, ref, futureExpiry())
+		err := store.StoreReference(context.Background(), "unknown", refType, ref)
 
 		assert.EqualError(t, err, "OAuth2 flow with this ID does not exist")
-	})
-	t.Run("reference has expired", func(t *testing.T) {
-		store := createStore(t)
-		expected := Flow{
-			ID:     "flow-id",
-			Expiry: futureExpiry(),
-		}
-
-		err := store.Store(context.Background(), expected)
-		assert.NoError(t, err)
-		// We need a reference to resolve it
-		err = store.StoreReference(context.Background(), expected.ID, refType, ref, pastExpiry())
-		assert.NoError(t, err)
-
-		actual, err := store.FindByReference(context.Background(), refType, ref)
-		assert.NoError(t, err)
-		assert.Nil(t, actual)
 	})
 }
 
@@ -113,14 +92,13 @@ func Test_memoryStore_Store(t *testing.T) {
 	t.Run("write, then read", func(t *testing.T) {
 		store := createStore(t)
 		expected := Flow{
-			ID:     "flow-id",
-			Expiry: futureExpiry(),
+			ID: "flow-id",
 		}
 
 		err := store.Store(ctx, expected)
 		assert.NoError(t, err)
 		// We need a reference to resolve it
-		err = store.StoreReference(ctx, expected.ID, refType, ref, futureExpiry())
+		err = store.StoreReference(ctx, expected.ID, refType, ref)
 		assert.NoError(t, err)
 
 		actual, err := store.FindByReference(ctx, refType, ref)
@@ -130,8 +108,7 @@ func Test_memoryStore_Store(t *testing.T) {
 	t.Run("already exists", func(t *testing.T) {
 		store := createStore(t)
 		expected := Flow{
-			ID:     "flow-id",
-			Expiry: futureExpiry(),
+			ID: "flow-id",
 		}
 
 		err := store.Store(ctx, expected)
@@ -140,124 +117,10 @@ func Test_memoryStore_Store(t *testing.T) {
 
 		assert.EqualError(t, err, "OAuth2 flow with this ID already exists")
 	})
-	t.Run("flow has expired", func(t *testing.T) {
-		store := createStore(t)
-		expected := Flow{
-			ID:     "flow-id",
-			Expiry: pastExpiry(),
-		}
-
-		err := store.Store(ctx, expected)
-		assert.NoError(t, err)
-		// We need a reference to resolve it
-		err = store.StoreReference(ctx, expected.ID, refType, ref, futureExpiry())
-		assert.NoError(t, err)
-
-		actual, err := store.FindByReference(ctx, refType, ref)
-		assert.NoError(t, err)
-		assert.Nil(t, actual)
-	})
-}
-
-func Test_memoryStore_Close(t *testing.T) {
-	t.Run("assert Close() waits for pruning to finish to avoid leaking goroutines", func(t *testing.T) {
-		openidStorePruneInterval = 10 * time.Millisecond
-		store := createStore(t)
-		time.Sleep(50 * time.Millisecond) // make sure pruning is running
-		store.Close()
-	})
-}
-
-func Test_memoryStore_prune(t *testing.T) {
-	ctx := context.Background()
-	t.Run("automatic", func(t *testing.T) {
-		store := createStore(t)
-		// we call startPruning a second time ourselves, make sure not to leak the original goroutine
-		cancelFunc := store.cancel
-		defer cancelFunc()
-		store.startPruning(10 * time.Millisecond)
-
-		// Feed it something to prune
-		expiredFlow := Flow{
-			ID: "expired",
-		}
-		err := store.Store(ctx, expiredFlow)
-		require.NoError(t, err)
-
-		test.WaitFor(t, func() (bool, error) {
-			store.mux.Lock()
-			defer store.mux.Unlock()
-			_, exists := store.flows[expiredFlow.ID]
-			return !exists, nil
-		}, time.Second, "time-out waiting for flow to be pruned")
-	})
-	t.Run("prunes expired flows", func(t *testing.T) {
-		store := createStore(t)
-
-		expiredFlow := Flow{
-			ID: "expired",
-		}
-		unexpiredFlow := Flow{
-			ID:     "unexpired",
-			Expiry: futureExpiry(),
-		}
-		_ = store.Store(ctx, expiredFlow)
-		_ = store.Store(ctx, unexpiredFlow)
-
-		flows, refs := store.prune()
-
-		assert.Equal(t, 1, flows)
-		assert.Equal(t, 0, refs)
-
-		// Second round to assert there's nothing to prune now
-		flows, refs = store.prune()
-
-		assert.Equal(t, 0, flows)
-		assert.Equal(t, 0, refs)
-	})
-	t.Run("prunes expired refs", func(t *testing.T) {
-		store := createStore(t)
-
-		flow := Flow{
-			ID:     "f",
-			Expiry: futureExpiry(),
-		}
-		err := store.Store(ctx, flow)
-		require.NoError(t, err)
-		err = store.StoreReference(ctx, flow.ID, refType, "expired", pastExpiry())
-		require.NoError(t, err)
-		err = store.StoreReference(ctx, flow.ID, refType, "unexpired", futureExpiry())
-		require.NoError(t, err)
-
-		flows, refs := store.prune()
-
-		assert.Equal(t, 0, flows)
-		assert.Equal(t, 1, refs)
-
-		// Second round to assert there's nothing to prune now
-		flows, refs = store.prune()
-
-		assert.NoError(t, err)
-		assert.Equal(t, 0, flows)
-		assert.Equal(t, 0, refs)
-	})
 }
 
 func createStore(t *testing.T) *openidMemoryStore {
-	store := NewOpenIDMemoryStore().(*openidMemoryStore)
-	t.Cleanup(store.Close)
+	storageDatabase := storage.NewTestInMemorySessionDatabase(t)
+	store := NewOpenIDMemoryStore(storageDatabase).(*openidMemoryStore)
 	return store
-}
-
-func moment() time.Time {
-	return time.Now().In(time.UTC)
-}
-
-func pastExpiry() time.Time {
-	return moment().Add(-time.Hour)
-}
-
-func futureExpiry() time.Time {
-	// truncating makes assertion easier
-	return moment().Add(time.Hour).Truncate(time.Second)
 }


### PR DESCRIPTION
closes #2391 

This moves the in memory session store to the storage engine. In a later stage this makes it easier to change the in memory variant to a clustered variant.

The generic one includes expiry out-of-the-box.

It uses the JSON marshalling style of set and get for generics.