### PR TITLE
add vp_formats to authorization server metadata

### DIFF
--- a/auth/api/iam/metadata.go
+++ b/auth/api/iam/metadata.go
@@ -29,7 +29,8 @@ func authorizationServerMetadata(identity url.URL) OAuthAuthorizationServerMetad
 		TokenEndpoint:          identity.JoinPath("token").String(),
 		GrantTypesSupported:    grantTypesSupported,
 		PreAuthorizedGrantAnonymousAccessSupported: true,
-		VPFormatsSupported:                         vpFormatsSupported,
-		ClientIdSchemesSupported:                   clientIdSchemesSupported,
+		VPFormats:                vpFormatsSupported,
+		VPFormatsSupported:       vpFormatsSupported,
+		ClientIdSchemesSupported: clientIdSchemesSupported,
 	}
 }

--- a/auth/api/iam/metadata_test.go
+++ b/auth/api/iam/metadata_test.go
@@ -27,6 +27,12 @@ import (
 func Test_authorizationServerMetadata(t *testing.T) {
 	identity := "https://example.com/iam/did:nuts:123"
 	identityURL, _ := url.Parse(identity)
+	vpFormats := map[string]map[string][]string{
+		"jwt_vc_json": {"alg_values_supported": []string{"PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}},
+		"jwt_vp_json": {"alg_values_supported": []string{"PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}},
+		"ldp_vc":      {"proof_type_values_supported": []string{"JsonWebSignature2020"}},
+		"ldp_vp":      {"proof_type_values_supported": []string{"JsonWebSignature2020"}},
+	}
 	expected := OAuthAuthorizationServerMetadata{
 		Issuer:                 identity,
 		AuthorizationEndpoint:  identity + "/authorize",
@@ -35,10 +41,8 @@ func Test_authorizationServerMetadata(t *testing.T) {
 		TokenEndpoint:          identity + "/token",
 		GrantTypesSupported:    []string{"authorization_code", "vp_token", "urn:ietf:params:oauth:grant-type:pre-authorized_code"},
 		PreAuthorizedGrantAnonymousAccessSupported: true,
-		VPFormatsSupported: map[string]map[string][]string{
-			"jwt_vp": {"alg_values_supported": []string{"PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}},
-			"ldp_vc": {"proof_type_values_supported": []string{"JsonWebSignature2020"}},
-		},
+		VPFormats:                vpFormats,
+		VPFormatsSupported:       vpFormats,
 		ClientIdSchemesSupported: []string{"did"},
 	}
 	assert.Equal(t, expected, authorizationServerMetadata(*identityURL))

--- a/auth/api/iam/types.go
+++ b/auth/api/iam/types.go
@@ -87,8 +87,10 @@ var proofTypeValuesSupported = []string{"JsonWebSignature2020"}
 // TODO: spec is very unclear about this part.
 // See https://github.com/nuts-foundation/nuts-node/issues/2447
 var vpFormatsSupported = map[string]map[string][]string{
-	"jwt_vp": {"alg_values_supported": algValuesSupported},
-	"ldp_vc": {"proof_type_values_supported": proofTypeValuesSupported},
+	"jwt_vp_json": {"alg_values_supported": algValuesSupported},
+	"jwt_vc_json": {"alg_values_supported": algValuesSupported},
+	"ldp_vc":      {"proof_type_values_supported": proofTypeValuesSupported},
+	"ldp_vp":      {"proof_type_values_supported": proofTypeValuesSupported},
 }
 
 // clientIdSchemesSupported lists the supported client_id_scheme

--- a/auth/api/iam/types.go
+++ b/auth/api/iam/types.go
@@ -194,6 +194,9 @@ type OAuthAuthorizationServerMetadata struct {
 	// VPFormatsSupported is an object containing a list of key value pairs, where the key is a string identifying a Credential format supported by the Wallet.
 	VPFormatsSupported map[string]map[string][]string `json:"vp_formats_supported,omitempty"`
 
+	// VPFormats is an object containing a list of key value pairs, where the key is a string identifying a Credential format supported by the Verifier.
+	VPFormats map[string]map[string][]string `json:"vp_formats,omitempty"`
+
 	// ClientIdSchemesSupported defines the `client_id_schemes` currently supported.
 	// If omitted, the default value is `pre-registered` (referring to the client), which is currently not supported.
 	ClientIdSchemesSupported []string `json:"client_id_schemes_supported,omitempty"`


### PR DESCRIPTION
part of #2447

Adds `vp_formats` field to authorization server metadata.