### PR TITLE
Set govulncheck's go-version to 'stable'

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -25,5 +25,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version: 'stable'
+          go-version-input: 'stable'
           go-package: ./...

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -25,4 +25,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
+          go-version: 'stable'
           go-package: ./...


### PR DESCRIPTION
The check now automatically uses the latest `stable` version of go. This means that we will not get notified of any vulnerabilities that may exist in go patch versions, but should be fine since we update asap anyway.