### PR TITLE
added auth v2 request access token api for s2s flow

### DIFF
--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -150,7 +150,7 @@ func TestWrapper_GetOAuthClientMetadata(t *testing.T) {
 		//	200
 		ctx := newTestClient(t)
 		did := did.MustParseDID("did:nuts:123")
-		ctx.vdrInstance.EXPECT().IsOwner(nil, did).Return(true, nil)
+		ctx.vdr.EXPECT().IsOwner(nil, did).Return(true, nil)
 
 		res, err := ctx.client.GetOAuthClientMetadata(nil, GetOAuthClientMetadataRequestObject{Id: did.ID})
 
@@ -181,7 +181,7 @@ func TestWrapper_GetOAuthClientMetadata(t *testing.T) {
 		//404
 		ctx := newTestClient(t)
 		did := did.MustParseDID("did:nuts:123")
-		ctx.vdrInstance.EXPECT().IsOwner(nil, did)
+		ctx.vdr.EXPECT().IsOwner(nil, did)
 
 		res, err := ctx.client.GetOAuthClientMetadata(nil, GetOAuthClientMetadataRequestObject{Id: did.ID})
 
@@ -193,7 +193,7 @@ func TestWrapper_GetOAuthClientMetadata(t *testing.T) {
 		//404
 		ctx := newTestClient(t)
 		did := did.MustParseDID("did:nuts:123")
-		ctx.vdrInstance.EXPECT().IsOwner(nil, did).Return(false, vdr.ErrNotFound)
+		ctx.vdr.EXPECT().IsOwner(nil, did).Return(false, vdr.ErrNotFound)
 
 		res, err := ctx.client.GetOAuthClientMetadata(nil, GetOAuthClientMetadataRequestObject{Id: did.ID})
 
@@ -205,7 +205,7 @@ func TestWrapper_GetOAuthClientMetadata(t *testing.T) {
 		//500
 		ctx := newTestClient(t)
 		did := did.MustParseDID("did:nuts:123")
-		ctx.vdrInstance.EXPECT().IsOwner(nil, did).Return(false, errors.New("unknown error"))
+		ctx.vdr.EXPECT().IsOwner(nil, did).Return(false, errors.New("unknown error"))
 
 		res, err := ctx.client.GetOAuthClientMetadata(nil, GetOAuthClientMetadataRequestObject{Id: did.ID})
 

--- a/auth/api/iam/s2s_vptoken_test.go
+++ b/auth/api/iam/s2s_vptoken_test.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package iam
+
+import (
+	"github.com/nuts-foundation/nuts-node/vdr/types"
+	"testing"
+
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapper_RequestAccessToken(t *testing.T) {
+	walletDID := did.MustParseDID("did:test:123")
+	verifierDID := did.MustParseDID("did:test:456")
+	body := &RequestAccessTokenJSONRequestBody{Verifier: verifierDID.String()}
+
+	t.Run("ok", func(t *testing.T) {
+		ctx := newTestClient(t)
+		ctx.vdr.EXPECT().IsOwner(nil, walletDID).Return(true, nil)
+		ctx.resolver.EXPECT().Resolve(verifierDID, nil).Return(&did.Document{}, &types.DocumentMetadata{}, nil)
+
+		_, err := ctx.client.RequestAccessToken(nil, RequestAccessTokenRequestObject{Did: walletDID.String(), Body: body})
+
+		require.NoError(t, err)
+	})
+	t.Run("error - DID not owned", func(t *testing.T) {
+		ctx := newTestClient(t)
+		ctx.vdr.EXPECT().IsOwner(nil, walletDID).Return(false, nil)
+
+		_, err := ctx.client.RequestAccessToken(nil, RequestAccessTokenRequestObject{Did: walletDID.String(), Body: body})
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "not owned by this node")
+	})
+	t.Run("error - invalid DID", func(t *testing.T) {
+		ctx := newTestClient(t)
+
+		_, err := ctx.client.RequestAccessToken(nil, RequestAccessTokenRequestObject{Did: "invalid", Body: body})
+
+		require.EqualError(t, err, "did not found: invalid DID")
+	})
+	t.Run("missing request body", func(t *testing.T) {
+		ctx := newTestClient(t)
+
+		_, err := ctx.client.RequestAccessToken(nil, RequestAccessTokenRequestObject{Did: walletDID.String()})
+
+		require.Error(t, err)
+		assert.EqualError(t, err, "missing request body")
+	})
+	t.Run("invalid verifier did", func(t *testing.T) {
+		ctx := newTestClient(t)
+		body := &RequestAccessTokenJSONRequestBody{Verifier: "invalid"}
+		ctx.vdr.EXPECT().IsOwner(nil, walletDID).Return(true, nil)
+
+		_, err := ctx.client.RequestAccessToken(nil, RequestAccessTokenRequestObject{Did: walletDID.String(), Body: body})
+
+		require.Error(t, err)
+		assert.EqualError(t, err, "invalid verifier: invalid DID")
+	})
+	t.Run("verifier not found", func(t *testing.T) {
+		ctx := newTestClient(t)
+		ctx.vdr.EXPECT().IsOwner(nil, walletDID).Return(true, nil)
+		ctx.resolver.EXPECT().Resolve(verifierDID, nil).Return(nil, nil, types.ErrNotFound)
+
+		_, err := ctx.client.RequestAccessToken(nil, RequestAccessTokenRequestObject{Did: walletDID.String(), Body: body})
+
+		require.Error(t, err)
+		assert.EqualError(t, err, "verifier not found: unable to find the DID document")
+	})
+}

--- a/docs/_static/auth/iam.yaml
+++ b/docs/_static/auth/iam.yaml
@@ -242,52 +242,52 @@ paths:
 #                    type: string
 #        default:
 #          $ref: '../common/error_response.yaml'
-#  /internal/auth/v2/{did}/request-access-token:
-#    post:
-#      operationId: requestAccessToken
-#      summary: Requests an access token using OAuth2.
-#      description: |
-#        Initiates an OAuth2 flow to request an access token from a remote authorization server.
-#
-#        error returns:
-#        * 400 - one of the parameters has the wrong format
-#        * 503 - the authorizer could not be reached or returned an error
-#      tags:
-#        - auth
-#      parameters:
-#        - name: did
-#          in: path
-#          required: true
-#          schema:
-#            type: string
-#            example: did:nuts:123
-#      requestBody:
-#        required: true
-#        content:
-#          application/json:
-#            schema:
-#              required:
-#                - authorizer
-#                - requester
-#                - scope
-#              properties:
-#                authorizer:
-#                  type: string
-#                requester:
-#                  type: string
-#                scope:
-#                  type: string
-#                  description: The scope that will be The service for which this access token can be used. The right oauth endpoint is selected based on the service.
-#                  example: nuts-patient-transfer
-#      responses:
-#        '200':
-#          description: Successful request. Responds with an access token as described in rfc6749 section 5.1.
-#          content:
-#            application/json:
-#              schema:
-#                $ref: '#/components/schemas/TokenResponse'
-#        default:
-#          $ref: '../common/error_response.yaml'
+  /internal/auth/v2/{did}/request-access-token:
+    post:
+      operationId: requestAccessToken
+      summary: Requests an access token using the vp_token-bearer grant.
+      description: |
+        Initiates an OAuth2 flow to request an access token from a remote authorization server.
+        This endpoint is only usable for a service 2 service flow.
+
+        error returns:
+        * 400 - one of the parameters has the wrong format
+        * 503 - the authorizer could not be reached or returned an error
+      tags:
+        - auth
+      parameters:
+        - name: did
+          in: path
+          required: true
+          description: The DID of the requester, a Wallet owner at this node.
+          schema:
+            type: string
+            example: did:nuts:123
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - verifier
+                - scope
+              properties:
+                verifier:
+                  type: string
+                  example: did:nuts:123
+                scope:
+                  type: string
+                  description: The scope that will be The service for which this access token can be used.
+                  example: eOverdracht-sender
+      responses:
+        '200':
+          description: Successful request. Responds with an access token as described in rfc6749 section 5.1.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        default:
+          $ref: '../common/error_response.yaml'
 components:
   schemas:
     DIDDocument:


### PR DESCRIPTION
fixes #2484 

This is a scaffold + input checking for the s2s RequestAccessToken internal API.
Placed under iam package. I could imagine our internal APIs for authv2 to be placed under the auth package instead?

+regenerated APIs using codegen 1.15.0