### PR TITLE
Update 1-running-docker.rst

### DIFF
--- a/docs/pages/getting-started/1-running-docker.rst
+++ b/docs/pages/getting-started/1-running-docker.rst
@@ -48,6 +48,8 @@ This setup uses the following ``nuts.yaml`` configuration file:
   network:
     bootstrapnodes:
       - example.com:5555
+  auth:
+    publicurl: https://example.com
 
 .. note::
 


### PR DESCRIPTION
auth.publicurl is required, added property to the example.

Prevents error:
Could not start the server" error="unable to configure Auth: invalid auth.publicurl: must provide url