### PR TITLE
IAM: Implement correct OAuth2 error handling

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -116,19 +116,27 @@ func (r Wrapper) HandleTokenRequest(ctx context.Context, request HandleTokenRequ
 		// Options:
 		// - OpenID4VCI
 		// - OpenID4VP, vp_token is sent in Token Response
-		panic("not implemented")
+		return nil, OAuth2Error{
+			Code:        UnsupportedGrantType,
+			Description: "not implemented yet",
+		}
 	case "vp_token":
 		// Options:
 		// - service-to-service vp_token flow
-		panic("not implemented")
+		return nil, OAuth2Error{
+			Code:        UnsupportedGrantType,
+			Description: "not implemented yet",
+		}
 	case "urn:ietf:params:oauth:grant-type:pre-authorized_code":
 		// Options:
 		// - OpenID4VCI
-		panic("not implemented")
+		return nil, OAuth2Error{
+			Code:        UnsupportedGrantType,
+			Description: "not implemented yet",
+		}
 	default:
 		return nil, OAuth2Error{
-			Code:        InvalidRequest,
-			Description: "unsupported grant_type",
+			Code: UnsupportedGrantType,
 		}
 	}
 }

--- a/auth/api/iam/authorized_code.go
+++ b/auth/api/iam/authorized_code.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"github.com/labstack/echo/v4"
 	"github.com/nuts-foundation/nuts-node/core"
-	"github.com/nuts-foundation/nuts-node/vcr/openid4vci"
 	"html/template"
 	"net/http"
 	"net/url"
@@ -92,20 +91,16 @@ func (a authorizedCodeFlow) handleAuthConsent(c echo.Context) error {
 
 func (a authorizedCodeFlow) validateCode(params map[string]string) (string, error) {
 	code, ok := params["code"]
+	invalidCodeError := OAuth2Error{
+		Code:        InvalidRequest,
+		Description: "missing or invalid code parameter",
+	}
 	if !ok {
-		return "", openid4vci.Error{
-			Code:       openid4vci.InvalidRequest,
-			StatusCode: http.StatusBadRequest,
-			//Description: "missing or invalid code parameter",
-		}
+		return "", invalidCodeError
 	}
 	session := a.sessions.Get(code)
 	if session == nil {
-		return "", openid4vci.Error{
-			Code:       openid4vci.InvalidRequest,
-			StatusCode: http.StatusBadRequest,
-			//Description: "invalid code",
-		}
+		return "", invalidCodeError
 	}
 	return session.Scope, nil
 }

--- a/auth/api/iam/error.go
+++ b/auth/api/iam/error.go
@@ -60,7 +60,7 @@ type OAuth2Error struct {
 	RedirectURI string `json:"-"`
 }
 
-// StatusCode returns the HTTP status code to be returned to the client. It is defined for compatibility with core.HTTPStatusCodeError.
+// StatusCode returns the HTTP status code to be returned to the client, in case the user-agent can't be redirected with HTTP 302 - Found.
 func (e OAuth2Error) StatusCode() int {
 	switch e.Code {
 	case ServerError:

--- a/auth/api/iam/error.go
+++ b/auth/api/iam/error.go
@@ -35,6 +35,8 @@ const (
 	// InvalidRequest is returned when the request is missing a required parameter, includes an invalid parameter value,
 	// includes a parameter more than once, or is otherwise malformed.
 	InvalidRequest ErrorCode = "invalid_request"
+	// UnsupportedGrantType is returned when the authorization grant type is not supported by the authorization server.
+	UnsupportedGrantType ErrorCode = "unsupported_grant_type"
 	// UnsupportedResponseType is returned when the authorization server does not support obtaining an authorization code using this method.
 	UnsupportedResponseType ErrorCode = "unsupported_response_type"
 	// ServerError is returned when the Authorization Server encounters an unexpected condition that prevents it from fulfilling the request.

--- a/auth/api/iam/error.go
+++ b/auth/api/iam/error.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package iam
+
+import (
+	"errors"
+	"github.com/labstack/echo/v4"
+	"github.com/nuts-foundation/nuts-node/core"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ErrorCode specifies error codes as defined by the OAuth2 specifications.
+// Codes and descriptions are taken from https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1
+type ErrorCode string
+
+const (
+	// InvalidRequest is returned when the request is missing a required parameter, includes an invalid parameter value,
+	// includes a parameter more than once, or is otherwise malformed.
+	InvalidRequest ErrorCode = "invalid_request"
+	// UnsupportedResponseType is returned when the authorization server does not support obtaining an authorization code using this method.
+	UnsupportedResponseType ErrorCode = "unsupported_response_type"
+	// ServerError is returned when the Authorization Server encounters an unexpected condition that prevents it from fulfilling the request.
+	ServerError ErrorCode = "server_error"
+)
+
+// Make sure the error implements core.HTTPStatusCodeError, so the HTTP request logger can log the correct status code.
+var _ core.HTTPStatusCodeError = OAuth2Error{}
+
+// OAuth2Error is an OAuth2 error that signals the error was (probably) caused by the client (e.g. bad request),
+// or that the client can recover from the error (e.g. retry).
+type OAuth2Error struct {
+	// Code is the error code as defined by the OAuth2 specification.
+	Code ErrorCode `json:"error"`
+	// Description is a human-readable ASCII [USASCII] text providing additional information, used to assist the client developer in understanding the error that occurred.
+	Description string `json:"error_description,omitempty"`
+	// InternalError is the underlying error, may be omitted. It is not intended to be returned to the client, only to be logged.
+	InternalError error `json:"-"`
+	// RedirectURI is the redirect URI that should be used to redirect the client to, in case the user-agent is a browser.
+	// It should not be set if the user-agent is not a browser, or there is no redirect_uri (because the request was malformed), this field is empty.
+	// When the field is set, the user-agent is redirected to the specified URI with the error code and description as query parameters.
+	// If it's not set, the error code and description are returned in the response body (plain text or JSON).
+	RedirectURI string `json:"-"`
+}
+
+// StatusCode returns the HTTP status code to be returned to the client. It is defined for compatibility with core.HTTPStatusCodeError.
+func (e OAuth2Error) StatusCode() int {
+	switch e.Code {
+	case ServerError:
+		return http.StatusInternalServerError
+	default:
+		return http.StatusBadRequest
+	}
+}
+
+// OAuth2Error returns the error message, which is either the underlying error or the code if there is no underlying error
+func (e OAuth2Error) Error() string {
+	var parts []string
+	parts = append(parts, string(e.Code))
+	if e.InternalError != nil {
+		parts = append(parts, e.InternalError.Error())
+	}
+	if e.Description != "" {
+		parts = append(parts, e.Description)
+	}
+	return strings.Join(parts, " - ")
+}
+
+type oauth2ErrorWriter struct{}
+
+func (p oauth2ErrorWriter) Write(echoContext echo.Context, _ int, _ string, err error) error {
+	var oauthErr OAuth2Error
+	if !errors.As(err, &oauthErr) {
+		// Internal error, wrap it in an OAuth2 error
+		oauthErr = OAuth2Error{
+			Code:          ServerError,
+			InternalError: err,
+		}
+	}
+	if oauthErr.Code == "" {
+		// Somebody forgot to set a code
+		oauthErr.Code = ServerError
+	}
+	redirectURI, _ := url.Parse(oauthErr.RedirectURI)
+	if oauthErr.RedirectURI == "" || redirectURI == nil {
+		// Can't redirect the user-agent back, render error as JSON or plain text (depending on content-type)
+		contentType := echoContext.Request().Header.Get("Content-Type")
+		if strings.Contains(contentType, "application/json") {
+			// Return JSON response
+			return echoContext.JSON(oauthErr.StatusCode(), oauthErr)
+		} else {
+			// Return plain text response
+			parts := []string{string(oauthErr.Code)}
+			if oauthErr.Description != "" {
+				parts = append(parts, oauthErr.Description)
+			}
+			return echoContext.String(oauthErr.StatusCode(), strings.Join(parts, " - "))
+		}
+	}
+	// Redirect the user-agent back to the client
+	query := redirectURI.Query()
+	query.Set("error", string(oauthErr.Code))
+	if oauthErr.Description != "" {
+		query.Set("error_description", oauthErr.Description)
+	}
+	redirectURI.RawQuery = query.Encode()
+	return echoContext.Redirect(http.StatusFound, redirectURI.String())
+}

--- a/auth/api/iam/error_test.go
+++ b/auth/api/iam/error_test.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package iam
+
+import (
+	"errors"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestError_Error(t *testing.T) {
+	t.Run("with underlying error", func(t *testing.T) {
+		assert.EqualError(t, OAuth2Error{InternalError: errors.New("token has expired"), Code: InvalidRequest}, "invalid_request - token has expired")
+	})
+	t.Run("without underlying error", func(t *testing.T) {
+		assert.EqualError(t, OAuth2Error{Code: InvalidRequest}, "invalid_request")
+	})
+}
+
+func Test_oauth2ErrorWriter_Write(t *testing.T) {
+	t.Run("user-agent is browser with redirect URI", func(t *testing.T) {
+		server := echo.New()
+		httpRequest := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+		ctx := server.NewContext(httpRequest, rec)
+
+		err := oauth2ErrorWriter{}.Write(ctx, 0, "", OAuth2Error{
+			Code:        InvalidRequest,
+			Description: "failure",
+			RedirectURI: "https://example.com",
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusFound, rec.Code)
+		assert.Equal(t, "https://example.com?error=invalid_request&error_description=failure", rec.Header().Get("Location"))
+	})
+	t.Run("user-agent is browser without redirect URI", func(t *testing.T) {
+		server := echo.New()
+		httpRequest := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+		ctx := server.NewContext(httpRequest, rec)
+
+		err := oauth2ErrorWriter{}.Write(ctx, 0, "", OAuth2Error{
+			Code:        InvalidRequest,
+			Description: "failure",
+		})
+
+		assert.NoError(t, err)
+		body, _ := io.ReadAll(rec.Body)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "text/plain; charset=UTF-8", rec.Header().Get("Content-Type"))
+		assert.Equal(t, "invalid_request - failure", string(body))
+		assert.Empty(t, rec.Header().Get("Location"))
+	})
+	t.Run("user-agent is API client (sent JSON)", func(t *testing.T) {
+		server := echo.New()
+		httpRequest := httptest.NewRequest("GET", "/", nil)
+		httpRequest.Header["Content-Type"] = []string{"application/json"}
+		rec := httptest.NewRecorder()
+		ctx := server.NewContext(httpRequest, rec)
+
+		err := oauth2ErrorWriter{}.Write(ctx, 0, "", OAuth2Error{
+			Code:        InvalidRequest,
+			Description: "failure",
+		})
+
+		assert.NoError(t, err)
+		body, _ := io.ReadAll(rec.Body)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "application/json; charset=UTF-8", rec.Header().Get("Content-Type"))
+		assert.Equal(t, `{"error":"invalid_request","error_description":"failure"}`, strings.TrimSpace(string(body)))
+		assert.Empty(t, rec.Header().Get("Location"))
+	})
+	t.Run("OAuth2 error without code, defaults to server_error", func(t *testing.T) {
+		server := echo.New()
+		httpRequest := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+		ctx := server.NewContext(httpRequest, rec)
+
+		err := oauth2ErrorWriter{}.Write(ctx, 0, "", OAuth2Error{
+			Description: "failure",
+		})
+
+		assert.NoError(t, err)
+		body, _ := io.ReadAll(rec.Body)
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		assert.Equal(t, `server_error - failure`, strings.TrimSpace(string(body)))
+	})
+	t.Run("error is not an OAuth2 error, should be wrapped", func(t *testing.T) {
+		server := echo.New()
+		httpRequest := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+		ctx := server.NewContext(httpRequest, rec)
+
+		err := oauth2ErrorWriter{}.Write(ctx, 0, "", errors.New("catastrophic"))
+
+		assert.NoError(t, err)
+		body, _ := io.ReadAll(rec.Body)
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		assert.Equal(t, `server_error`, strings.TrimSpace(string(body)))
+	})
+}

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -15,12 +15,6 @@ import (
 	strictecho "github.com/oapi-codegen/runtime/strictmiddleware/echo"
 )
 
-// ErrorResponse defines model for ErrorResponse.
-type ErrorResponse struct {
-	// Error Code identifying the error that occurred.
-	Error string `json:"error"`
-}
-
 // TokenResponse Token Responses are made as defined in (RFC6749)[https://datatracker.ietf.org/doc/html/rfc6749#section-5.1]
 type TokenResponse struct {
 	// AccessToken The access token issued by the authorization server.

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -81,14 +81,22 @@ func (r *Wrapper) handlePresentationRequest(params map[string]string, session *S
 	}
 	// Response mode is always direct_post for now
 	if params[responseModeParam] != responseModeDirectPost {
-		return nil, errors.New("response_mode must be direct_post")
+		return nil, OAuth2Error{
+			Code:        InvalidRequest,
+			Description: "response_mode must be direct_post",
+			RedirectURI: session.RedirectURI,
+		}
 	}
 
 	// TODO: This is the easiest for now, but is this the way?
 	// For compatibility, we probably need to support presentation_definition and/or presentation_definition_uri.
 	presentationDefinition := r.auth.PresentationDefinitions().ByScope(params[scopeParam])
 	if presentationDefinition == nil {
-		return nil, fmt.Errorf("unsupported scope for presentation exchange: %s", params[scopeParam])
+		return nil, OAuth2Error{
+			Code:        InvalidRequest,
+			Description: fmt.Sprintf("unsupported scope for presentation exchange: %s", params[scopeParam]),
+			RedirectURI: session.RedirectURI,
+		}
 	}
 
 	// Render HTML

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -212,7 +212,6 @@ func (r *Wrapper) handlePresentationRequestAccept(c echo.Context) error {
 }
 
 func (r *Wrapper) handlePresentationRequestCompleted(ctx echo.Context) error {
-	// TODO: support error response
 	// TODO: response direct_post mode
 	vpToken := ctx.QueryParams()[vpTokenParam]
 	if len(vpToken) == 0 {

--- a/auth/api/iam/types.go
+++ b/auth/api/iam/types.go
@@ -29,6 +29,9 @@ type DIDDocument = did.Document
 // DIDDocumentMetadata is an alias
 type DIDDocumentMetadata = resolver.DocumentMetadata
 
+// ErrorResponse is an alias
+type ErrorResponse = OAuth2Error
+
 const (
 	// responseTypeParam is the name of the response_type parameter.
 	// Specified by https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.1

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -160,7 +160,7 @@ func startServer(ctx context.Context, system *core.System) error {
 	logrus.Info("Shutting down...")
 	err := system.Shutdown()
 	if err != nil {
-		logrus.Errorf("Error shutting down system: %v", err)
+		logrus.Errorf("OAuth2Error shutting down system: %v", err)
 	} else {
 		logrus.Info("Shutdown complete. Goodbye!")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -160,7 +160,7 @@ func startServer(ctx context.Context, system *core.System) error {
 	logrus.Info("Shutting down...")
 	err := system.Shutdown()
 	if err != nil {
-		logrus.Errorf("OAuth2Error shutting down system: %v", err)
+		logrus.Errorf("Error shutting down system: %v", err)
 	} else {
 		logrus.Info("Shutdown complete. Goodbye!")
 	}

--- a/codegen/configs/auth_iam.yaml
+++ b/codegen/configs/auth_iam.yaml
@@ -9,3 +9,4 @@ output-options:
     - DIDDocument
     - OAuthAuthorizationServerMetadata
     - OAuthClientMetadata
+    - ErrorResponse


### PR DESCRIPTION
This PR introduces an OAuth2 error handler that:

- Redirects the browser back to the provided `redirect_uri` (with `error` and `error_description` parameters)
- If there's no `redirect_uri`, it either prints the error as plain text (for a browser) or JSON (for an API client)

It also fixes HTTP request logging status codes for the IAM API package.