### PR TITLE
Switch to mrtron/base58 lib, maintainer looks more reputable 

### DIFF
--- a/crypto/jwx.go
+++ b/crypto/jwx.go
@@ -32,10 +32,10 @@ import (
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/lestrrat-go/jwx/jws"
 	"github.com/lestrrat-go/jwx/jwt"
+	"github.com/mr-tron/base58"
 	"github.com/nuts-foundation/nuts-node/audit"
 	"github.com/nuts-foundation/nuts-node/crypto/log"
 	"github.com/nuts-foundation/nuts-node/crypto/storage/spi"
-	"github.com/shengdoushi/base58"
 )
 
 // ErrUnsupportedSigningKey is returned when an unsupported private key is used to sign. Currently only ecdsa and rsa keys are supported
@@ -449,5 +449,5 @@ func Thumbprint(key jwk.Key) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return base58.Encode(pkHash[:], base58.BitcoinAlphabet), nil
+	return base58.EncodeAlphabet(pkHash[:], base58.BTCAlphabet), nil
 }

--- a/crypto/jwx_test.go
+++ b/crypto/jwx_test.go
@@ -36,7 +36,7 @@ import (
 	"time"
 
 	"github.com/lestrrat-go/jwx/jwt"
-	"github.com/shengdoushi/base58"
+	"github.com/mr-tron/base58"
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"
@@ -542,7 +542,7 @@ func TestThumbprint(t *testing.T) {
 	t.Run("rsa", func(t *testing.T) {
 		// example from https://tools.ietf.org/html/rfc7638#page-3
 		testRsa := "{\"e\":\"AQAB\",\"kty\":\"RSA\",\"n\":\"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw\"}"
-		expectedThumbPrint := base58.Encode([]byte{55, 54, 203, 177, 120, 124, 184, 48, 156, 119, 238, 140, 55, 5, 197, 225, 111, 251, 158, 133, 151, 21, 144, 31, 30, 76, 89, 177, 17, 130, 245, 123}, base58.BitcoinAlphabet)
+		expectedThumbPrint := base58.EncodeAlphabet([]byte{55, 54, 203, 177, 120, 124, 184, 48, 156, 119, 238, 140, 55, 5, 197, 225, 111, 251, 158, 133, 151, 21, 144, 31, 30, 76, 89, 177, 17, 130, 245, 123}, base58.BTCAlphabet)
 
 		set, err := jwk.ParseString(testRsa)
 		require.NoError(t, err)

--- a/didman/didman.go
+++ b/didman/didman.go
@@ -30,6 +30,7 @@ import (
 	"net/url"
 	"sync"
 
+	"github.com/mr-tron/base58"
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
@@ -38,7 +39,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/jsonld"
 	"github.com/nuts-foundation/nuts-node/vcr"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
-	"github.com/shengdoushi/base58"
 )
 
 // ModuleName contains the name of this module: Didman
@@ -601,7 +601,7 @@ func generateIDForService(id did.DID, service did.Service) ssi.URI {
 	bytes, _ := json.Marshal(service)
 	shaBytes := sha256.Sum256(bytes)
 	d := id.URI()
-	d.Fragment = base58.Encode(shaBytes[:], base58.BitcoinAlphabet)
+	d.Fragment = base58.EncodeAlphabet(shaBytes[:], base58.BTCAlphabet)
 	return d
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/lestrrat-go/jwx v1.2.26
 	github.com/magiconair/properties v1.8.7
 	github.com/mdp/qrterminal/v3 v3.1.1
+	github.com/mr-tron/base58 v1.1.3
 	github.com/multiformats/go-multicodec v0.9.0
 	github.com/nats-io/nats-server/v2 v2.10.3
 	github.com/nats-io/nats.go v1.31.0
@@ -32,7 +33,6 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/prometheus/client_model v0.5.0
 	github.com/redis/go-redis/v9 v9.2.1
-	github.com/shengdoushi/base58 v1.0.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
@@ -124,7 +124,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/mr-tron/base58 v1.1.3 // indirect
 	github.com/multiformats/go-base32 v0.0.3 // indirect
 	github.com/multiformats/go-base36 v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.2.0 // indirect
@@ -142,6 +141,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/shengdoushi/base58 v1.0.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sietseringers/go-sse v0.0.0-20200801161811-e2cf2c63ca50 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect

--- a/vdr/didkey/resolver.go
+++ b/vdr/didkey/resolver.go
@@ -29,11 +29,11 @@ import (
 	"errors"
 	"fmt"
 	"github.com/lestrrat-go/jwx/x25519"
+	"github.com/mr-tron/base58"
 	"github.com/multiformats/go-multicodec"
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
-	"github.com/shengdoushi/base58"
 	"io"
 )
 
@@ -60,7 +60,7 @@ func (r Resolver) Resolve(id did.DID, _ *resolver.ResolveMetadata) (*did.Documen
 	if len(encodedKey) == 0 || encodedKey[0] != 'z' {
 		return nil, nil, errors.New("did:key does not start with 'z'")
 	}
-	mcBytes, err := base58.Decode(encodedKey[1:], base58.BitcoinAlphabet)
+	mcBytes, err := base58.DecodeAlphabet(encodedKey[1:], base58.BTCAlphabet)
 	if err != nil {
 		return nil, nil, fmt.Errorf("did:key: invalid base58btc: %w", err)
 	}

--- a/vdr/didkey/resolver_test.go
+++ b/vdr/didkey/resolver_test.go
@@ -198,11 +198,11 @@ func TestResolver_Resolve(t *testing.T) {
 	})
 	t.Run("did:key ID is not valid base58btc encoded 'z'", func(t *testing.T) {
 		_, _, err := Resolver{}.Resolve(did.MustParseDID("did:key:z291830129"), nil)
-		require.EqualError(t, err, "did:key: invalid base58btc: invalid base58 string")
+		require.EqualError(t, err, "did:key: invalid base58btc: invalid base58 digit ('0')")
 	})
 	t.Run("invalid multicodec key type", func(t *testing.T) {
 		_, _, err := Resolver{}.Resolve(did.MustParseDID("did:key:z"), nil)
-		require.EqualError(t, err, "did:key: invalid multicodec value: EOF")
+		require.EqualError(t, err, "did:key: invalid base58btc: zero length string")
 	})
 	t.Run("unsupported key type", func(t *testing.T) {
 		didKey := createDIDKey(multicodec.Aes256, []byte{1, 2, 3})

--- a/vdr/didkey/resolver_test.go
+++ b/vdr/didkey/resolver_test.go
@@ -27,9 +27,9 @@ import (
 	"crypto/x509"
 	"encoding/binary"
 	"encoding/json"
+	"github.com/mr-tron/base58"
 	"github.com/multiformats/go-multicodec"
 	"github.com/nuts-foundation/go-did/did"
-	"github.com/shengdoushi/base58"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -265,7 +265,7 @@ func TestNewResolver(t *testing.T) {
 
 func createDIDKey(keyType multicodec.Code, data []byte) string {
 	mcBytes := append(binary.AppendUvarint([]byte{}, uint64(keyType)), data...)
-	return "did:key:z" + string(base58.Encode(mcBytes, base58.BitcoinAlphabet))
+	return "did:key:z" + string(base58.EncodeAlphabet(mcBytes, base58.BTCAlphabet))
 }
 
 func TestRoundTrip(t *testing.T) {


### PR DESCRIPTION
(more active OSS contributor)

Both libraries were already a transitive dependency, just replaced the direct usage.