### PR TITLE
Refactor ParsePublicURL

### DIFF
--- a/auth/api/iam/metadata.go
+++ b/auth/api/iam/metadata.go
@@ -36,13 +36,7 @@ const (
 // IssuerIdToWellKnown converts the OAuth2 Issuer identity to the specified well-known endpoint by inserting the well-known at the root of the path.
 // It returns no url and an error when issuer is not a valid URL.
 func IssuerIdToWellKnown(issuer string, wellKnown string, strictmode bool) (*url.URL, error) {
-	var issuerURL *url.URL
-	var err error
-	if strictmode {
-		issuerURL, err = core.ParsePublicURL(issuer, false, "https")
-	} else {
-		issuerURL, err = core.ParsePublicURL(issuer, true, "https", "http")
-	}
+	issuerURL, err := core.ParsePublicURL(issuer, strictmode)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -128,11 +128,7 @@ func (auth *Auth) Configure(config core.ServerConfig) error {
 		return errors.New("invalid auth.publicurl: must provide url")
 	}
 	var err error
-	if config.Strictmode {
-		auth.publicURL, err = core.ParsePublicURL(auth.config.PublicURL, false, "https")
-	} else {
-		auth.publicURL, err = core.ParsePublicURL(auth.config.PublicURL, true, "http", "https")
-	}
+	auth.publicURL, err = core.ParsePublicURL(auth.config.PublicURL, config.Strictmode)
 	if err != nil {
 		return fmt.Errorf("invalid auth.publicurl: %w", err)
 	}

--- a/core/url.go
+++ b/core/url.go
@@ -43,11 +43,20 @@ func JoinURLPaths(parts ...string) string {
 	return result
 }
 
-// ParsePublicURL parses the given input string as URL and asserts that
+// ParsePublicURL parses the input URL using ParsePublicURLWithScheme.
+// If strictmode is true, no reserved addresses are allowed and the scheme MUST be 'https'
+func ParsePublicURL(input string, strictmode bool) (*url.URL, error) {
+	if !strictmode {
+		return ParsePublicURLWithScheme(input, true, "http", "https")
+	}
+	return ParsePublicURLWithScheme(input, false, "https")
+}
+
+// ParsePublicURLWithScheme parses the given input string as URL and asserts that
 // it has a scheme and that it is in the allowedSchemes if provided,
 // it is not an IP address, and
 // it is not (depending on allowReserved) a reserved address or TLD as described in RFC2606 or https://www.ietf.org/archive/id/draft-chapin-rfc2606bis-00.html.
-func ParsePublicURL(input string, allowReserved bool, allowedSchemes ...string) (*url.URL, error) {
+func ParsePublicURLWithScheme(input string, allowReserved bool, allowedSchemes ...string) (*url.URL, error) {
 	parsed, err := url.Parse(input)
 	if err != nil {
 		return nil, err

--- a/core/url_test.go
+++ b/core/url_test.go
@@ -40,10 +40,20 @@ func Test_ParsePublicURL(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "https://non.reserved", u.String())
 	})
-	t.Run("error - strict", func(t *testing.T) {
+	t.Run("error - strict - scheme must be https", func(t *testing.T) {
 		u, err := ParsePublicURL("http://localhost", true)
 		assert.Nil(t, u)
 		assert.EqualError(t, err, "scheme must be https")
+	})
+	t.Run("error - strict - reserved address", func(t *testing.T) {
+		u, err := ParsePublicURL("https://localhost", true)
+		assert.Nil(t, u)
+		assert.EqualError(t, err, "hostname is RFC2606 reserved")
+	})
+	t.Run("error - strict - IP address", func(t *testing.T) {
+		u, err := ParsePublicURL("https://127.0.0.1", true)
+		assert.Nil(t, u)
+		assert.EqualError(t, err, "hostname is IP")
 	})
 	t.Run("ok - non-strict", func(t *testing.T) {
 		u, err := ParsePublicURL("http://localhost", false)

--- a/core/url_test.go
+++ b/core/url_test.go
@@ -35,6 +35,24 @@ func TestJoinURLPaths(t *testing.T) {
 }
 
 func Test_ParsePublicURL(t *testing.T) {
+	t.Run("ok - strict", func(t *testing.T) {
+		u, err := ParsePublicURL("https://non.reserved", true)
+		require.NoError(t, err)
+		assert.Equal(t, "https://non.reserved", u.String())
+	})
+	t.Run("error - strict", func(t *testing.T) {
+		u, err := ParsePublicURL("http://localhost", true)
+		assert.Nil(t, u)
+		assert.EqualError(t, err, "scheme must be https")
+	})
+	t.Run("ok - non-strict", func(t *testing.T) {
+		u, err := ParsePublicURL("http://localhost", false)
+		require.NoError(t, err)
+		assert.Equal(t, "http://localhost", u.String())
+	})
+}
+
+func Test_ParsePublicURLWithScheme(t *testing.T) {
 	errIncompleteURL := errors.New("url must contain scheme and host")
 	errIsIpAddress := errors.New("hostname is IP")
 	errIsReserved := errors.New("hostname is RFC2606 reserved")
@@ -64,7 +82,7 @@ func Test_ParsePublicURL(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		addr, err := ParsePublicURL(tc.input, tc.allowReserved, "http", "https", "grpc")
+		addr, err := ParsePublicURLWithScheme(tc.input, tc.allowReserved, "http", "https", "grpc")
 		if tc.err == nil {
 			// valid test cases
 			require.NoError(t, err, "test case: %v", tc)

--- a/network/transport/types.go
+++ b/network/transport/types.go
@@ -144,7 +144,7 @@ func (s *NutsCommURL) UnmarshalJSON(bytes []byte) error {
 	if err := json.Unmarshal(bytes, &str); err != nil {
 		return errors.New("endpoint not a string")
 	}
-	endpoint, err := core.ParsePublicURL(str, false, "grpc")
+	endpoint, err := core.ParsePublicURLWithScheme(str, false, "grpc")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
All URLs obtained from external sources (metadata endpoints) need to be validated for OAuth2/OpenID4VC meaning that all methods using these URLs will require the following codeblok:
```
if strictmode {
	issuerURL, err = core.ParsePublicURL(issuer, false, "https")
} else {
	issuerURL, err = core.ParsePublicURL(issuer, true, "https", "http")
}
```

This PR makes that a bit easier