### PR TITLE
Add introspection endpoint for s2s flow

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -147,13 +147,6 @@ func (r Wrapper) HandleTokenRequest(ctx context.Context, request HandleTokenRequ
 
 // IntrospectAccessToken allows the resource server (XIS/EHR) to introspect details of an access token issued by this node
 func (r Wrapper) IntrospectAccessToken(ctx context.Context, request IntrospectAccessTokenRequestObject) (IntrospectAccessTokenResponseObject, error) {
-	// Client authentication if required, return 401 if fails.
-	// TODO: Is this relevant? Should be handled by API authentication middleware
-	clientAuthorized := true
-	if !clientAuthorized {
-		return IntrospectAccessToken401Response{}, nil
-	}
-
 	// Validate token
 	if request.Body.Token == "" {
 		// Return 200 + 'Active = false' when token is invalid or malformed

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -170,17 +170,17 @@ func (r Wrapper) IntrospectAccessToken(ctx context.Context, request IntrospectAc
 	iat := int(token.IssuedAt.Unix())
 	exp := int(token.Expiration.Unix())
 	response := IntrospectAccessToken200JSONResponse{
-		Active:                 true,
-		Iat:                    &iat,
-		Exp:                    &exp,
-		Iss:                    &token.Issuer,
-		Sub:                    &token.Issuer,
-		ClientId:               &token.ClientId,
-		Scope:                  &token.Scope,
-		PdpMap:                 &token.PDPMap,
-		PresentationDefinition: nil,
-		PresentationSubmission: nil,
-		Vps:                    &token.VPToken,
+		Active:                         true,
+		Iat:                            &iat,
+		Exp:                            &exp,
+		Iss:                            &token.Issuer,
+		Sub:                            &token.Issuer,
+		ClientId:                       &token.ClientId,
+		Scope:                          &token.Scope,
+		InputDescriptorConstraintIdMap: &token.InputDescriptorConstraintIdMap,
+		PresentationDefinition:         nil,
+		PresentationSubmission:         nil,
+		Vps:                            &token.VPToken,
 
 		// TODO: user authentication, used in OpenID4VP flow
 		FamilyName:     nil,

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -295,31 +295,31 @@ func TestWrapper_IntrospectAccessToken(t *testing.T) {
 		}
 		tNow := time.Now()
 		token := AccessToken{
-			Token:                  "token",
-			Issuer:                 "resource-owner",
-			ClientId:               "client",
-			IssuedAt:               tNow,
-			Expiration:             tNow.Add(time.Minute),
-			Scope:                  "test",
-			PDPMap:                 map[string]any{"key": "value"},
-			VPToken:                []VerifiablePresentation{presentation},
-			PresentationSubmission: &pe.PresentationSubmission{},
-			PresentationDefinition: &pe.PresentationDefinition{},
+			Token:                          "token",
+			Issuer:                         "resource-owner",
+			ClientId:                       "client",
+			IssuedAt:                       tNow,
+			Expiration:                     tNow.Add(time.Minute),
+			Scope:                          "test",
+			InputDescriptorConstraintIdMap: map[string]any{"key": "value"},
+			VPToken:                        []VerifiablePresentation{presentation},
+			PresentationSubmission:         &pe.PresentationSubmission{},
+			PresentationDefinition:         &pe.PresentationDefinition{},
 		}
 
 		require.NoError(t, ctx.client.s2sAccessTokenStore().Put(token.Token, token))
 		expectedResponse, err := json.Marshal(IntrospectAccessToken200JSONResponse{
-			Active:                 true,
-			ClientId:               ptrTo("client"),
-			Exp:                    ptrTo(int(tNow.Add(time.Minute).Unix())),
-			Iat:                    ptrTo(int(tNow.Unix())),
-			Iss:                    ptrTo("resource-owner"),
-			Scope:                  ptrTo("test"),
-			Sub:                    ptrTo("resource-owner"),
-			Vps:                    &[]VerifiablePresentation{presentation},
-			PdpMap:                 ptrTo(map[string]any{"key": "value"}),
-			PresentationSubmission: ptrTo(map[string]interface{}{"definition_id": "", "descriptor_map": nil, "id": ""}),
-			PresentationDefinition: ptrTo(map[string]interface{}{"id": "", "input_descriptors": nil}),
+			Active:                         true,
+			ClientId:                       ptrTo("client"),
+			Exp:                            ptrTo(int(tNow.Add(time.Minute).Unix())),
+			Iat:                            ptrTo(int(tNow.Unix())),
+			Iss:                            ptrTo("resource-owner"),
+			Scope:                          ptrTo("test"),
+			Sub:                            ptrTo("resource-owner"),
+			Vps:                            &[]VerifiablePresentation{presentation},
+			InputDescriptorConstraintIdMap: ptrTo(map[string]any{"key": "value"}),
+			PresentationSubmission:         ptrTo(map[string]interface{}{"definition_id": "", "descriptor_map": nil, "id": ""}),
+			PresentationDefinition:         ptrTo(map[string]interface{}{"id": "", "input_descriptors": nil}),
 		})
 		require.NoError(t, err)
 

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -15,8 +15,6 @@ import (
 	strictecho "github.com/oapi-codegen/runtime/strictmiddleware/echo"
 )
 
-<<<<<<< HEAD
-=======
 const (
 	JwtBearerAuthScopes = "jwtBearerAuth.Scopes"
 )
@@ -97,20 +95,6 @@ type TokenIntrospectionResponse struct {
 // TokenIntrospectionResponseAssuranceLevel Assurance level of the identity of the End-User.
 type TokenIntrospectionResponseAssuranceLevel string
 
-// TokenResponse Token Responses are made as defined in (RFC6749)[https://datatracker.ietf.org/doc/html/rfc6749#section-5.1]
-type TokenResponse struct {
-	// AccessToken The access token issued by the authorization server.
-	AccessToken string `json:"access_token"`
-
-	// ExpiresIn The lifetime in seconds of the access token.
-	ExpiresIn *int    `json:"expires_in,omitempty"`
-	Scope     *string `json:"scope,omitempty"`
-
-	// TokenType The type of the token issued as described in [RFC6749].
-	TokenType string `json:"token_type"`
-}
-
->>>>>>> 463be60f (add introspection endpoint)
 // PresentationDefinitionParams defines parameters for PresentationDefinition.
 type PresentationDefinitionParams struct {
 	Scope string `form:"scope" json:"scope"`

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -62,12 +62,12 @@ type TokenIntrospectionResponse struct {
 	// Initials Initials of the End-User.
 	Initials *string `json:"initials,omitempty"`
 
+	// InputDescriptorConstraintIdMap Mapping from the ID field of a 'presentation_definition' input descriptor constraints to the value provided in the 'vps' for the constraints.
+	// The Policy Decision Point can use this map to make decisions without having to deal with PEX/VCs/VPs/SignatureValidation
+	InputDescriptorConstraintIdMap *map[string]interface{} `json:"input_descriptor_constraint_id_map,omitempty"`
+
 	// Iss Contains the DID of the authorizer. Should be equal to 'sub'
 	Iss *string `json:"iss,omitempty"`
-
-	// PdpMap Mapping from the ID field of a 'presentation_definition' input descriptor constraint to the value provided in the 'vps' for the constraint.
-	// The Policy Decision Point can use this map to make decisions without having to deal with PEX/VCs/VPs/SignatureValidation
-	PdpMap *map[string]interface{} `json:"pdp_map,omitempty"`
 
 	// Prefix Surname prefix
 	Prefix *string `json:"prefix,omitempty"`

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -65,8 +65,18 @@ type TokenIntrospectionResponse struct {
 	// Iss Contains the DID of the authorizer. Should be equal to 'sub'
 	Iss *string `json:"iss,omitempty"`
 
+	// PdpMap Mapping from the ID field of a 'presentation_definition' input descriptor constraint to the value provided in the 'vps' for the constraint.
+	// The Policy Decision Point can use this map to make decisions without having to deal with PEX/VCs/VPs/SignatureValidation
+	PdpMap *map[string]interface{} `json:"pdp_map,omitempty"`
+
 	// Prefix Surname prefix
 	Prefix *string `json:"prefix,omitempty"`
+
+	// PresentationDefinition presentation definition, as described in presentation exchange specification, fulfilled to obtain the access token
+	PresentationDefinition *map[string]interface{} `json:"presentation_definition,omitempty"`
+
+	// PresentationSubmission mapping of 'vps' contents to the 'presentation_definition'
+	PresentationSubmission *map[string]interface{} `json:"presentation_submission,omitempty"`
 
 	// Scope granted scopes
 	Scope *string `json:"scope,omitempty"`
@@ -80,8 +90,8 @@ type TokenIntrospectionResponse struct {
 	// Username Identifier uniquely identifying the End-User's account in the issuing system.
 	Username *string `json:"username,omitempty"`
 
-	// Vcs The Verifiable Credentials that were used to request the access token using the same encoding as used in the access token request.
-	Vcs *[]VerifiableCredential `json:"vcs,omitempty"`
+	// Vps The Verifiable Presentations that were used to request the access token using the same encoding as used in the access token request.
+	Vps *[]VerifiablePresentation `json:"vps,omitempty"`
 }
 
 // TokenIntrospectionResponseAssuranceLevel Assurance level of the identity of the End-User.
@@ -274,6 +284,8 @@ func (w *ServerInterfaceWrapper) PresentationDefinition(ctx echo.Context) error 
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter did: %s", err))
 	}
+
+	ctx.Set(JwtBearerAuthScopes, []string{})
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params PresentationDefinitionParams

--- a/auth/api/iam/s2s_vptoken.go
+++ b/auth/api/iam/s2s_vptoken.go
@@ -125,10 +125,10 @@ func (r Wrapper) createAccessToken(issuer did.DID, issueTime time.Time, presenta
 		Expiration: issueTime.Add(accessTokenValidity),
 		Scope:      scope,
 		// TODO: set values
-		PDPMap:                 nil,
-		VPToken:                []VerifiablePresentation{presentation},
-		PresentationDefinition: nil,
-		PresentationSubmission: nil,
+		InputDescriptorConstraintIdMap: nil,
+		VPToken:                        []VerifiablePresentation{presentation},
+		PresentationDefinition:         nil,
+		PresentationSubmission:         nil,
 	}
 	err := r.s2sAccessTokenStore().Put(accessToken.Token, accessToken)
 	if err != nil {
@@ -160,9 +160,9 @@ type AccessToken struct {
 	Expiration time.Time
 	// Scope the token grants access to. Not necessarily the same as the requested scope
 	Scope string
-	// PDPMap maps the ID field of a PresentationDefinition input descriptor constraint to the value provided in the VPToken for the constraint.
+	// InputDescriptorConstraintIdMap maps the ID field of a PresentationDefinition input descriptor constraint to the value provided in the VPToken for the constraint.
 	// The Policy Decision Point can use this map to make decisions without having to deal with PEX/VCs/VPs/SignatureValidation
-	PDPMap map[string]any
+	InputDescriptorConstraintIdMap map[string]any
 
 	// additional fields to support unforeseen policy decision requirements
 

--- a/auth/api/iam/s2s_vptoken_test.go
+++ b/auth/api/iam/s2s_vptoken_test.go
@@ -123,7 +123,7 @@ func TestWrapper_createAccessToken(t *testing.T) {
 		assert.Equal(t, "everything", *accessToken.Scope)
 
 		var storedToken AccessToken
-		err = ctx.client.accessTokenStore(issuerDID).Get(accessToken.AccessToken, &storedToken)
+		err = ctx.client.s2sAccessTokenStore().Get(accessToken.AccessToken, &storedToken)
 		require.NoError(t, err)
 		assert.Equal(t, accessToken.AccessToken, storedToken.Token)
 		expectedVPJSON, _ := presentation.MarshalJSON()

--- a/auth/api/iam/s2s_vptoken_test.go
+++ b/auth/api/iam/s2s_vptoken_test.go
@@ -127,7 +127,7 @@ func TestWrapper_createAccessToken(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, accessToken.AccessToken, storedToken.Token)
 		expectedVPJSON, _ := presentation.MarshalJSON()
-		actualVPJSON, _ := storedToken.Presentation.MarshalJSON()
+		actualVPJSON, _ := storedToken.VPToken[0].MarshalJSON()
 		assert.JSONEq(t, string(expectedVPJSON), string(actualVPJSON))
 		assert.Equal(t, issuerDID.String(), storedToken.Issuer)
 		assert.NotEmpty(t, storedToken.Expiration)

--- a/auth/api/iam/types.go
+++ b/auth/api/iam/types.go
@@ -20,6 +20,7 @@ package iam
 
 import (
 	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
@@ -30,6 +31,12 @@ type DIDDocument = did.Document
 
 // DIDDocumentMetadata is an alias
 type DIDDocumentMetadata = resolver.DocumentMetadata
+
+// VerifiableCredential is an alias
+type VerifiableCredential = vc.VerifiableCredential
+
+// ErrorResponse is an alias
+type ErrorResponse = oauth.OAuth2Error
 
 // PresentationDefinition is an alias
 type PresentationDefinition = pe.PresentationDefinition

--- a/auth/api/iam/types.go
+++ b/auth/api/iam/types.go
@@ -35,6 +35,9 @@ type DIDDocumentMetadata = resolver.DocumentMetadata
 // VerifiableCredential is an alias
 type VerifiableCredential = vc.VerifiableCredential
 
+// VerifiableCredential is an alias
+type VerifiablePresentation = vc.VerifiablePresentation
+
 // ErrorResponse is an alias
 type ErrorResponse = oauth.OAuth2Error
 

--- a/auth/api/iam/types.go
+++ b/auth/api/iam/types.go
@@ -32,10 +32,7 @@ type DIDDocument = did.Document
 // DIDDocumentMetadata is an alias
 type DIDDocumentMetadata = resolver.DocumentMetadata
 
-// VerifiableCredential is an alias
-type VerifiableCredential = vc.VerifiableCredential
-
-// VerifiableCredential is an alias
+// VerifiablePresentation is an alias
 type VerifiablePresentation = vc.VerifiablePresentation
 
 // ErrorResponse is an alias

--- a/codegen/configs/auth_iam.yaml
+++ b/codegen/configs/auth_iam.yaml
@@ -11,4 +11,4 @@ output-options:
     - OAuthClientMetadata
     - PresentationDefinition
     - TokenResponse
-    - VerifiableCredential
+    - VerifiablePresentation

--- a/codegen/configs/auth_iam.yaml
+++ b/codegen/configs/auth_iam.yaml
@@ -11,3 +11,4 @@ output-options:
     - OAuthClientMetadata
     - PresentationDefinition
     - TokenResponse
+    - VerifiableCredential

--- a/docs/_static/auth/iam.yaml
+++ b/docs/_static/auth/iam.yaml
@@ -439,10 +439,10 @@ components:
         scope:
           type: string
           description: granted scopes
-        pdp_map:
+        input_descriptor_constraint_id_map:
           type: object
           description: |
-            Mapping from the ID field of a 'presentation_definition' input descriptor constraint to the value provided in the 'vps' for the constraint.
+            Mapping from the ID field of a 'presentation_definition' input descriptor constraints to the value provided in the 'vps' for the constraints.
             The Policy Decision Point can use this map to make decisions without having to deal with PEX/VCs/VPs/SignatureValidation
         presentation_definition:
           type: object

--- a/docs/_static/auth/iam.yaml
+++ b/docs/_static/auth/iam.yaml
@@ -340,8 +340,8 @@ components:
   schemas:
     DIDDocument:
       $ref: '../common/ssi_types.yaml#/components/schemas/DIDDocument'
-    VerifiableCredential:
-      $ref: '../common/ssi_types.yaml#/components/schemas/VerifiableCredential'
+    VerifiablePresentation:
+      $ref: '../common/ssi_types.yaml#/components/schemas/VerifiablePresentation'
     TokenResponse:
       type: object
       description: |
@@ -439,11 +439,24 @@ components:
         scope:
           type: string
           description: granted scopes
-        vcs:
+        pdp_map:
+          type: object
+          description: |
+            Mapping from the ID field of a 'presentation_definition' input descriptor constraint to the value provided in the 'vps' for the constraint.
+            The Policy Decision Point can use this map to make decisions without having to deal with PEX/VCs/VPs/SignatureValidation
+        presentation_definition:
+          type: object
+          description: presentation definition, as described in presentation exchange specification, fulfilled to obtain the access token
+          items:
+            $ref: '#/components/schemas/PresentationDefinition'
+        presentation_submission:
+          type: object
+          description: mapping of 'vps' contents to the 'presentation_definition'
+        vps:
           type: array
           items:
-            $ref: '#/components/schemas/VerifiableCredential'
-          description: The Verifiable Credentials that were used to request the access token using the same encoding as used in the access token request.
+            $ref: '#/components/schemas/VerifiablePresentation'
+          description: The Verifiable Presentations that were used to request the access token using the same encoding as used in the access token request.
 # TODO: below is copied from introspection/v1. Remove anything unused when flows are finalized.
 # TODO: existing contract validator responses
         family_name:

--- a/docs/_static/auth/iam.yaml
+++ b/docs/_static/auth/iam.yaml
@@ -285,7 +285,7 @@ paths:
           description: The DID of the requester, a Wallet owner at this node.
           schema:
             type: string
-            example: did:nuts:123
+            example: did:web:example.com
       requestBody:
         required: true
         content:
@@ -297,7 +297,7 @@ paths:
               properties:
                 verifier:
                   type: string
-                  example: did:nuts:123
+                  example: did:web:example.com
                 scope:
                   type: string
                   description: The scope that will be The service for which this access token can be used.
@@ -311,10 +311,37 @@ paths:
                 $ref: '#/components/schemas/TokenResponse'
         default:
           $ref: '../common/error_response.yaml'
+  /internal/auth/v2/accesstoken/introspect:
+    post:
+      operationId: introspectAccessToken
+      summary: Introspection endpoint to retrieve information from an Access Token as described by RFC7662
+      tags:
+        - auth
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/TokenIntrospectionRequest"
+      responses:
+        '200':
+          description: |
+            An Introspection response as described in RFC7662 section 2.2. The Irma, Dummy and Employee identity means all return 'username', 'initials',  'prefix', 'family_name' and 'assurance_level'.
+            'username' should be used as unique identifier for the user.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenIntrospectionResponse"
+        '401':
+          description: |
+            This is returned when an OAuth2 Client is unauthorized to talk to the introspection endpoint.
+            Note: introspection of an invalid or malformed token returns a 200 where with field 'active'=false
 components:
   schemas:
     DIDDocument:
       $ref: '../common/ssi_types.yaml#/components/schemas/DIDDocument'
+    VerifiableCredential:
+      $ref: '../common/ssi_types.yaml#/components/schemas/VerifiableCredential'
     TokenResponse:
       type: object
       description: |
@@ -360,3 +387,98 @@ components:
       description: |
         A presentation definition is a JSON object that describes the desired verifiable credentials and presentation formats.
         Specified at https://identity.foundation/presentation-exchange/spec/v2.0.0/
+      type: object
+    ErrorResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          description: Code identifying the error that occurred.
+          example: "invalid_request"
+    TokenIntrospectionRequest:
+      description: Token introspection request as described in RFC7662 section 2.1
+      required:
+        - token
+      properties:
+        token:
+          type: string
+          example:
+            eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhaWQiOiJ1cm46b2lkOjIuMTYuODQwLjEuMTEzODgzLjIuNC42LjE6MDAwMDAwMDAiLCJleHAiOjE1ODE0MTI2NjcsImlhdCI6MTU4MTQxMTc2NywiaXNzIjoidXJuOm9pZDoyLjE2Ljg0MC4xLjExMzg4My4yLjQuNi4xOjAwMDAwMDAxIiwic2lkIjoidXJuOm9pZDoyLjE2Ljg0MC4xLjExMzg4My4yLjQuNi4zOjk5OTk5OTk5MCIsInN1YiI6IiJ9.OhniTJcPS45nhJVqXfxsngG5eYS_0BvqFg-96zaWFO90I_5_N9Eg_k7NmIF5eNZ9Xutl1aqSxlSp80EX07Gmk8uzZO9PEReo0YZxnNQV-Zeq1njCMmfdwusmiczFlwcBi5Bl1xYGmLrxP7NcAoljmDgMgmLH0xaKfP4VVim6snPkPHqBdSzAgSrrc-cgVDLl-9V2obPB1HiVsFMYfbHEIb4MPsnPRnSGavYHTxt34mHbRsS8BvoBy3v6VNYaewLr6yz-_Zstrnr4I_wxtYbSiPJUeVQHcD-a9Ck53BdjspnhVHZ4IFVvuNrpflVaB1A7P3A2xZ7G_a8gF_SHMynYSA
+    TokenIntrospectionResponse:
+      description: Token introspection response as described in RFC7662 section 2.2
+      required:
+        - active
+      properties:
+        active:
+          type: boolean
+          description: True if the token is active, false if the token is expired, malformed etc. Required per RFC7662
+        iss:
+          type: string
+          description: Contains the DID of the authorizer. Should be equal to 'sub'
+          example: did:web:example.com:resource-owner
+        sub:
+          type: string
+          description: Contains the DID of the resource owner
+          example: did:web:example.com:resource-owner
+        aud:
+          type: string
+          description: RFC7662 - Service-specific string identifier or list of string identifiers representing the intended audience for this token, as defined in JWT [RFC7519].
+          example: "https://target_token_endpoint"
+        client_id:
+          type: string
+          description: The client (DID) the access token was issued to
+          example: did:web:example.com:client
+        exp:
+          type: integer
+          description: Expiration date in seconds since UNIX epoch
+        iat:
+          type: integer
+          description: Issuance time in seconds since UNIX epoch
+        scope:
+          type: string
+          description: granted scopes
+        vcs:
+          type: array
+          items:
+            $ref: '#/components/schemas/VerifiableCredential'
+          description: The Verifiable Credentials that were used to request the access token using the same encoding as used in the access token request.
+# TODO: below is copied from introspection/v1. Remove anything unused when flows are finalized.
+# TODO: existing contract validator responses
+        family_name:
+          type: string
+          description: Surname(s) or last name(s) of the End-User.
+          example: Bruijn
+        prefix:
+          type: string
+          description: Surname prefix
+          example: de
+        initials:
+          type: string
+          description: Initials of the End-User.
+          example: I.
+        username:
+          type: string
+          description: Identifier uniquely identifying the End-User's account in the issuing system.
+        assurance_level:
+          type: string
+          description: Assurance level of the identity of the End-User.
+          format: enum
+          enum: [low, substantial, high]
+# TODO: ???
+        email:
+          type: string
+          description: End-User's preferred e-mail address. Should be a personal email and can be used to uniquely identify a user. Just like the email used for an account.
+          example: w.debruijn@example.org
+        user_role:
+          type: string
+          description: Role of the End-User.
+  securitySchemes:
+    jwtBearerAuth:
+      type: http
+      scheme: bearer
+
+security:
+  - {}
+  - jwtBearerAuth: []


### PR DESCRIPTION
closes #2541

I've copied the v1 introspection OAPI and edited it. There are still a couple of fields unused for the user authentication part.

I've also removed the issuer key from the s2s access token store since its not available during introspection
