### PR TITLE
PEX: Changed path_nested to be object instead of slice

### DIFF
--- a/vcr/pe/presentation_submission.go
+++ b/vcr/pe/presentation_submission.go
@@ -121,7 +121,7 @@ func (b *PresentationSubmissionBuilder) Build(format string) (PresentationSubmis
 		for i, walletVCs := range b.wallets {
 			for _, walletVC := range walletVCs {
 				// do a JSON equality check
-				if vcEqual(selectedVCs[j], walletVC) {
+				if selectedVCs[j].Raw() == walletVC.Raw() {
 					signInstructions[i].Holder = b.holders[i]
 					signInstructions[i].VerifiableCredentials = append(signInstructions[i].VerifiableCredentials, selectedVCs[j])
 					// remap the path to the correct wallet index

--- a/vcr/pe/presentation_submission.go
+++ b/vcr/pe/presentation_submission.go
@@ -143,7 +143,7 @@ func (b *PresentationSubmissionBuilder) Build(format string) (PresentationSubmis
 		}
 	}
 
-	presentationIndex := 0
+	index := 0
 	// last we create the descriptor map for the presentation submission
 	// If there's only one sign instruction the Path will be $.
 	// If there are multiple sign instructions (each yielding a VP) the Path will be $[0], $[1], etc.
@@ -155,7 +155,7 @@ func (b *PresentationSubmissionBuilder) Build(format string) (PresentationSubmis
 					presentationSubmission.DescriptorMap = append(presentationSubmission.DescriptorMap, InputDescriptorMappingObject{
 						Id:         inputDescriptorMapping.Id,
 						Format:     format,
-						Path:       fmt.Sprintf("$[%d]", presentationIndex),
+						Path:       fmt.Sprintf("$[%d]", index),
 						PathNested: &inputDescriptorMapping,
 					})
 				} else {
@@ -163,7 +163,7 @@ func (b *PresentationSubmissionBuilder) Build(format string) (PresentationSubmis
 					presentationSubmission.DescriptorMap = append(presentationSubmission.DescriptorMap, inputDescriptorMapping)
 				}
 			}
-			presentationIndex++
+			index++
 		}
 	}
 

--- a/vcr/pe/presentation_submission.go
+++ b/vcr/pe/presentation_submission.go
@@ -127,7 +127,8 @@ func (b *PresentationSubmissionBuilder) Build(format string) (PresentationSubmis
 						Holder: holderID,
 					}
 				}
-				// remap the path to the correct wallet index
+				// the path property would be incorrect if there's multiple presentations,
+				// so remap the path to the correct index of the VC within the presentation that will be created (through sign instruction).
 				mapping := inputDescriptorMappingObjects[i]
 				mapping.Path = fmt.Sprintf("$.verifiableCredential[%d]", len(signInstruction.VerifiableCredentials))
 				mapping.Format = selectedVC.Format()

--- a/vcr/pe/presentation_submission.go
+++ b/vcr/pe/presentation_submission.go
@@ -169,18 +169,3 @@ func (b *PresentationSubmissionBuilder) Build(format string) (PresentationSubmis
 
 	return presentationSubmission, nonEmptySignInstructions, nil
 }
-
-// isHolder returns true if the wallet of the specified subject contains the given VC.
-func (b *PresentationSubmissionBuilder) isHolder(subjectID did.DID, credential vc.VerifiableCredential) bool {
-	for i, holder := range b.holders {
-		if holder == subjectID {
-			// find VC in slice
-			for _, curr := range b.wallets[i] {
-				if curr.Raw() == credential.Raw() {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}

--- a/vcr/pe/presentation_submission.go
+++ b/vcr/pe/presentation_submission.go
@@ -71,8 +71,9 @@ type SignInstruction struct {
 	// Holder contains the DID of the holder that should sign the VP.
 	Holder did.DID
 	// VerifiableCredentials contains the VCs that should be included in the VP.
-	VerifiableCredentials         []vc.VerifiableCredential
-	inputDescriptorMappingObjects []InputDescriptorMappingObject
+	VerifiableCredentials []vc.VerifiableCredential
+	// Mappings contains the Input Descriptor that are mapped by this SignInstruction.
+	Mappings []InputDescriptorMappingObject
 }
 
 // Empty returns true if there are no VCs in the SignInstruction.
@@ -100,7 +101,6 @@ func (b *PresentationSubmissionBuilder) Build(format string) (PresentationSubmis
 		Id:           uuid.New().String(),
 		DefinitionId: b.presentationDefinition.Id,
 	}
-	signInstructions := make([]SignInstruction, len(b.wallets))
 
 	// first we need to select the VCs from all wallets that match the presentation definition
 	allVCs := make([]vc.VerifiableCredential, 0)
@@ -115,43 +115,69 @@ func (b *PresentationSubmissionBuilder) Build(format string) (PresentationSubmis
 
 	// next we need to map the selected VCs to the correct wallet
 	// loop over all selected VCs and find the wallet that contains the VC
-	for j := range selectedVCs {
-		for i, walletVCs := range b.wallets {
-			var index int
-			for _, walletVC := range walletVCs {
-				// do a JSON equality check
-				if vcEqual(selectedVCs[j], walletVC) {
-					signInstructions[i].Holder = b.holders[i]
-					signInstructions[i].VerifiableCredentials = append(signInstructions[i].VerifiableCredentials, selectedVCs[j])
-					// remap the path to the correct wallet index
-					inputDescriptorMappingObjectForVC := inputDescriptorMappingObjects[j]
-					inputDescriptorMappingObjectForVC.Path = fmt.Sprintf("$.verifiableCredential[%d]", index)
-					signInstructions[i].inputDescriptorMappingObjects = append(signInstructions[i].inputDescriptorMappingObjects, inputDescriptorMappingObjectForVC)
-					index++
+	// there will be at most len(b.wallets) sign instructions
+	var signInstructions []SignInstruction
+	for _, holderID := range b.holders {
+		var signInstruction *SignInstruction
+		// find VCs that need to be in this sign instruction/verifiable presentation
+		for i, selectedVC := range selectedVCs {
+			if b.isHolder(holderID, selectedVC) {
+				if signInstruction == nil {
+					signInstruction = &SignInstruction{
+						Holder: holderID,
+					}
 				}
+				// remap the path to the correct wallet index
+				mapping := inputDescriptorMappingObjects[i]
+				mapping.Path = fmt.Sprintf("$.verifiableCredential[%d]", len(signInstruction.VerifiableCredentials))
+				mapping.Format = selectedVC.Format()
+				signInstruction.VerifiableCredentials = append(signInstruction.VerifiableCredentials, selectedVC)
+				signInstruction.Mappings = append(signInstruction.Mappings, mapping)
 			}
+		}
+		if signInstruction != nil {
+			signInstructions = append(signInstructions, *signInstruction)
 		}
 	}
 
-	index := 0
+	presentationIndex := 0
 	// last we create the descriptor map for the presentation submission
-	// If there's only one sign instruction the Path will be $. If there are multiple sign instructions the Path will be $[0], $[1], etc.
+	// If there's only one sign instruction the Path will be $.
+	// If there are multiple sign instructions (each yielding a VP) the Path will be $[0], $[1], etc.
 	for _, signInstruction := range signInstructions {
-		if len(signInstruction.VerifiableCredentials) > 0 {
-			// wrap each InputDescriptorMappingObject for the outer VP
-			nestedDescriptorMap := InputDescriptorMappingObject{
-				Id:         "", // todo what to add here?
-				Format:     format,
-				Path:       "$.",
-				PathNested: signInstruction.inputDescriptorMappingObjects,
+		if len(signInstruction.Mappings) > 0 {
+			for _, inputDescriptorMapping := range signInstruction.Mappings {
+				// If we have multiple VPs in the resulting submission, wrap each in a nested descriptor map (see path_nested in PEX specification).
+				if len(signInstructions) > 1 {
+					presentationSubmission.DescriptorMap = append(presentationSubmission.DescriptorMap, InputDescriptorMappingObject{
+						Id:         inputDescriptorMapping.Id,
+						Format:     format,
+						Path:       fmt.Sprintf("$[%d]", presentationIndex),
+						PathNested: &inputDescriptorMapping,
+					})
+				} else {
+					// Just 1 VP, no nesting needed
+					presentationSubmission.DescriptorMap = append(presentationSubmission.DescriptorMap, inputDescriptorMapping)
+				}
 			}
-			if len(signInstructions) > 1 {
-				nestedDescriptorMap.Path = fmt.Sprintf("$[%d]", index)
-			}
-			presentationSubmission.DescriptorMap = append(presentationSubmission.DescriptorMap, nestedDescriptorMap)
-			index++
+			presentationIndex++
 		}
 	}
 
 	return presentationSubmission, signInstructions, nil
+}
+
+// isHolder returns true if the wallet of the specified subject contains the given VC.
+func (b *PresentationSubmissionBuilder) isHolder(subjectID did.DID, credential vc.VerifiableCredential) bool {
+	for i, holder := range b.holders {
+		if holder == subjectID {
+			// find VC in slice
+			for _, curr := range b.wallets[i] {
+				if curr.Raw() == credential.Raw() {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/vcr/pe/presentation_submission_test.go
+++ b/vcr/pe/presentation_submission_test.go
@@ -83,6 +83,7 @@ func TestPresentationSubmissionBuilder_Build(t *testing.T) {
 
 		submission.Id = "for-test" // easier assertion
 		actualJSON, _ := json.MarshalIndent(submission, "", "  ")
+		println(string(actualJSON))
 		assert.JSONEq(t, expectedJSON, string(actualJSON))
 	})
 	t.Run("2 presentations", func(t *testing.T) {
@@ -164,6 +165,7 @@ func TestPresentationSubmissionBuilder_Build(t *testing.T) {
 
 		submission.Id = "for-test" // easier assertion
 		actualJSON, _ := json.MarshalIndent(submission, "", "  ")
+		println(string(actualJSON))
 		assert.JSONEq(t, expectedJSON, string(actualJSON))
 	})
 }

--- a/vcr/pe/test/test_definitions.go
+++ b/vcr/pe/test/test_definitions.go
@@ -183,7 +183,7 @@ const All = `
   ],
   "input_descriptors": [
 	{
-	  "name": "Match ID=1",
+	  "id": "Match ID=1",
       "group": ["A"],
 	  "constraints": {
 		"fields": [
@@ -200,7 +200,7 @@ const All = `
 	  }
     },
     {
-	  "name": "Match ID=2",
+	  "id": "Match ID=2",
       "group": ["A"],
 	  "constraints": {
 		"fields": [

--- a/vcr/pe/types.go
+++ b/vcr/pe/types.go
@@ -34,10 +34,10 @@ type PresentationSubmission struct {
 
 // InputDescriptorMappingObject
 type InputDescriptorMappingObject struct {
-	Format     string                         `json:"format"`
-	Id         string                         `json:"id"`
-	Path       string                         `json:"path"`
-	PathNested []InputDescriptorMappingObject `json:"path_nested,omitempty"`
+	Format     string                        `json:"format"`
+	Id         string                        `json:"id"`
+	Path       string                        `json:"path"`
+	PathNested *InputDescriptorMappingObject `json:"path_nested,omitempty"`
 }
 
 // Constraints


### PR DESCRIPTION
Simplified logic a bit; `1 InputDescriptorMapping = 1 Credential` (instead of `1..n` credentials), nesting only if there's multiple VPs.