### PR TITLE
PEX: Resolve credentials from presentation submission

### DIFF
--- a/vcr/credential/resolver.go
+++ b/vcr/credential/resolver.go
@@ -57,6 +57,10 @@ func ExtractTypes(credential vc.VerifiableCredential) []string {
 	return vcTypes
 }
 
+// PresentationSigner returns the DID of the signer of the presentation.
+// It does not do any signature validation.
+// For JWTs it returns the issuer (iss) of the JWT.
+// For JSON-LD it returns the verification method of the proof.
 func PresentationSigner(presentation vc.VerifiablePresentation) (*did.DID, error) {
 	switch presentation.Format() {
 	case vc.JWTPresentationProofFormat:
@@ -77,12 +81,9 @@ func PresentationSigner(presentation vc.VerifiablePresentation) (*did.DID, error
 			return nil, fmt.Errorf("presentation should have exactly 1 proof, got %d", len(proofs))
 		}
 		verificationMethod, err := did.ParseDIDURL(proofs[0].VerificationMethod.String())
-		if err != nil {
+		if err != nil || verificationMethod.DID.Empty() {
 			return nil, fmt.Errorf("invalid verification method for JSON-LD presentation: %w", err)
 		} else {
-			if verificationMethod.DID.Empty() {
-				return nil, fmt.Errorf("verification method for JSON-LD presentation does not have a DID")
-			}
 			return &verificationMethod.DID, nil
 		}
 	}

--- a/vcr/credential/resolver.go
+++ b/vcr/credential/resolver.go
@@ -83,8 +83,7 @@ func PresentationSigner(presentation vc.VerifiablePresentation) (*did.DID, error
 		verificationMethod, err := did.ParseDIDURL(proofs[0].VerificationMethod.String())
 		if err != nil || verificationMethod.DID.Empty() {
 			return nil, fmt.Errorf("invalid verification method for JSON-LD presentation: %w", err)
-		} else {
-			return &verificationMethod.DID, nil
 		}
+		return &verificationMethod.DID, nil
 	}
 }

--- a/vcr/pe/presentation_definition.go
+++ b/vcr/pe/presentation_definition.go
@@ -147,7 +147,7 @@ func (presentationDefinition PresentationDefinition) matchSubmissionRequirements
 	}
 	for _, group := range presentationDefinition.groups() {
 		if _, ok := availableGroups[group.Name]; !ok {
-			return nil, nil, fmt.Errorf("group %s is required but not available", group.Name)
+			return nil, nil, fmt.Errorf("group '%s' is required but not available", group.Name)
 		}
 	}
 

--- a/vcr/pe/presentation_submission.go
+++ b/vcr/pe/presentation_submission.go
@@ -21,6 +21,7 @@ package pe
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/PaesslerAG/jsonpath"
 	"github.com/google/uuid"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
@@ -168,4 +169,86 @@ func (b *PresentationSubmissionBuilder) Build(format string) (PresentationSubmis
 	}
 
 	return presentationSubmission, nonEmptySignInstructions, nil
+}
+
+// Resolve returns a map where each of the input descriptors is mapped to the corresponding VerifiableCredential.
+// If an input descriptor can't be mapped to a VC, an error is returned.
+// This function is specified by https://identity.foundation/presentation-exchange/#processing-of-submission-entries
+func (s PresentationSubmission) Resolve(presentations []vc.VerifiablePresentation) (map[string]vc.VerifiableCredential, error) {
+	var envelopeJSON []byte
+	if len(presentations) == 1 {
+		// TODO: This might not be right, caller might even use a JSON array as envelope with a single VP?
+		envelopeJSON, _ = json.Marshal(presentations[0])
+	} else {
+		envelopeJSON, _ = json.Marshal(presentations)
+	}
+	var envelope interface{}
+	if err := json.Unmarshal(envelopeJSON, &envelope); err != nil {
+		return nil, fmt.Errorf("unable to convert presentations to an interface: %w", err)
+	}
+
+	result := make(map[string]vc.VerifiableCredential)
+	for _, inputDescriptor := range s.DescriptorMap {
+		resolvedCredential, err := resolveCredential(inputDescriptor.Id, 0, inputDescriptor, envelope)
+		if err != nil {
+			return nil, fmt.Errorf("unable to resolve credential for input descriptor '%s': %w", inputDescriptor.Id, err)
+		}
+		result[inputDescriptor.Id] = *resolvedCredential
+	}
+	return result, nil
+}
+
+func resolveCredential(descriptorID string, level int, mapping InputDescriptorMappingObject, value interface{}) (*vc.VerifiableCredential, error) {
+	targetValueRaw, err := jsonpath.Get(mapping.Path, value)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get value for path %s: %w", mapping.Path, err)
+	}
+
+	var decodedTargetValue interface{}
+	switch targetValue := targetValueRaw.(type) {
+	case string:
+		// must be JWT VC or VP
+		if mapping.Format == vc.JWTCredentialProofFormat {
+			decodedTargetValue, err = vc.ParseVerifiableCredential(targetValue)
+			if err != nil {
+				return nil, fmt.Errorf("invalid JWT credential at path '%s': %w", mapping.Path, err)
+			}
+		} else if mapping.Format == vc.JWTPresentationProofFormat {
+			decodedTargetValue, err = vc.ParseVerifiablePresentation(targetValue)
+			if err != nil {
+				return nil, fmt.Errorf("invalid JWT presentation at path '%s': %w", mapping.Path, err)
+			}
+		}
+	case map[string]interface{}:
+		// must be JSON-LD
+		targetValueAsJSON, _ := json.Marshal(targetValue)
+		if mapping.Format == vc.JSONLDCredentialProofFormat {
+			decodedTargetValue, err = vc.ParseVerifiableCredential(string(targetValueAsJSON))
+			if err != nil {
+				return nil, fmt.Errorf("invalid JSON-LD credential at path '%s' (level %d): %w", mapping.Path, level, err)
+			}
+		} else if mapping.Format == vc.JSONLDPresentationProofFormat {
+			decodedTargetValue, err = vc.ParseVerifiablePresentation(string(targetValueAsJSON))
+			if err != nil {
+				return nil, fmt.Errorf("invalid JSON-LD presentation at path '%s' (level %d): %w", mapping.Path, level, err)
+			}
+		}
+	}
+	if decodedTargetValue == nil {
+		return nil, fmt.Errorf("value of Go type '%T' at path '%s' (level %d) can't be decoded using format '%s'", targetValueRaw, mapping.Path, level, mapping.Format)
+	}
+	if mapping.PathNested == nil {
+		if decodedCredential, ok := decodedTargetValue.(*vc.VerifiableCredential); ok {
+			return decodedCredential, nil
+		} else {
+			return nil, fmt.Errorf("path '%s' (level %d) does not reference a credential", mapping.Path, level)
+		}
+	} else {
+		// path_nested implies the credential is not found at the evaluated JSON path, but further down.
+		// We need to decode the value at the path (could be a credential or presentation in JWT or VP format) and evaluate the nested path.
+		decodedValueJSON, _ := json.Marshal(decodedTargetValue)
+		var decodedValueMap map[string]interface{}
+		_ = json.Unmarshal(decodedValueJSON, &decodedValueMap)
+		return resolveCredential(descriptorID, level+1, *mapping.PathNested, decodedValueMap)
+	}
 }

--- a/vcr/pe/presentation_submission_test.go
+++ b/vcr/pe/presentation_submission_test.go
@@ -310,7 +310,7 @@ func TestPresentationSubmission_Resolve(t *testing.T) {
 
 		credentials, err := submission.Resolve([]vc.VerifiablePresentation{vp})
 
-		require.EqualError(t, err, "unable to resolve credential for input descriptor '1': path '$.verifiableCredential' (level 0) does not reference a credential")
+		require.EqualError(t, err, "unable to resolve credential for input descriptor '1': path '$.verifiableCredential' does not reference a credential")
 		assert.Nil(t, credentials)
 	})
 	t.Run("invalid JSON-LD credential", func(t *testing.T) {
@@ -379,7 +379,7 @@ func TestPresentationSubmission_Resolve(t *testing.T) {
 
 		credentials, err := submission.Resolve([]vc.VerifiablePresentation{vp})
 
-		assert.EqualError(t, err, "unable to resolve credential for input descriptor '1': value of Go type 'string' at path '$.verifiableCredential.expirationDate' (level 0) can't be decoded using format 'ldp_vc'")
+		assert.EqualError(t, err, "unable to resolve credential for input descriptor '1': value of Go type 'string' at path '$.verifiableCredential.expirationDate' can't be decoded using format 'ldp_vc'")
 		assert.Nil(t, credentials)
 	})
 }

--- a/vcr/pe/presentation_submission_test.go
+++ b/vcr/pe/presentation_submission_test.go
@@ -172,11 +172,8 @@ func TestPresentationSubmissionBuilder_Build(t *testing.T) {
 }
 
 func TestPresentationSubmission_Resolve(t *testing.T) {
-	//holder1 := did.MustParseDID("did:example:1")
-	//holder2 := did.MustParseDID("did:example:2")
 	id1 := ssi.MustParseURI("1")
 	id2 := ssi.MustParseURI("2")
-	//id3 := ssi.MustParseURI("3")
 	now := time.Now()
 	vc1 := credentialToJSONLD(vc.VerifiableCredential{
 		ID:             &id1,


### PR DESCRIPTION
`PresentationSubmission.Resolve()` yields a map of input descriptor IDs to mapped credential.

