### PR TITLE
PEX: Allow VP format per submission wallet

### DIFF
--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -138,8 +138,8 @@ func (r *Wrapper) handlePresentationRequest(params map[string]string, session *S
 	}
 
 	submissionBuilder := presentationDefinition.PresentationSubmissionBuilder()
-	submissionBuilder.AddWallet(session.OwnDID, ownCredentials)
-	_, signInstructions, err := submissionBuilder.Build("ldp_vp")
+	submissionBuilder.AddWallet(session.OwnDID, ownCredentials, "ldp_vp")
+	_, signInstructions, err := submissionBuilder.Build()
 	if err != nil {
 		return nil, fmt.Errorf("unable to match presentation definition: %w", err)
 	}
@@ -210,8 +210,8 @@ func (r *Wrapper) handlePresentationRequestAccept(c echo.Context) error {
 	// TODO: Options (including format)
 	resultParams := map[string]string{}
 	submissionBuilder := presentationDefinition.PresentationSubmissionBuilder()
-	submissionBuilder.AddWallet(session.OwnDID, credentials)
-	submission, signInstructions, err := submissionBuilder.Build("ldp_vp")
+	submissionBuilder.AddWallet(session.OwnDID, credentials, "ldp_vp")
+	submission, signInstructions, err := submissionBuilder.Build()
 	if err != nil {
 		return err
 	}

--- a/auth/services/oauth/relying_party.go
+++ b/auth/services/oauth/relying_party.go
@@ -153,13 +153,13 @@ func (s *relyingParty) RequestRFC021AccessToken(ctx context.Context, requester d
 	// if there's a match, create a VP and call the token endpoint
 	// If the token endpoint succeeds, return the access token
 	// If no presentation definition matches, return a 412 "no matching credentials" error
-	builder := presentationDefinition.PresentationSubmissionBuilder()
-	builder.AddWallet(requester, walletCredentials)
 	format, err := determineFormat(metadata.VPFormats)
 	if err != nil {
 		return nil, err
 	}
-	submission, signInstructions, err := builder.Build(format)
+	builder := presentationDefinition.PresentationSubmissionBuilder()
+	builder.AddWallet(requester, walletCredentials, format)
+	submission, signInstructions, err := builder.Build()
 	if err != nil {
 		return nil, fmt.Errorf("failed to match presentation definition: %w", err)
 	}

--- a/vcr/pe/presentation_submission_test.go
+++ b/vcr/pe/presentation_submission_test.go
@@ -73,9 +73,9 @@ func TestPresentationSubmissionBuilder_Build(t *testing.T) {
 		presentationDefinition := PresentationDefinition{}
 		_ = json.Unmarshal([]byte(test.All), &presentationDefinition)
 		builder := presentationDefinition.PresentationSubmissionBuilder()
-		builder.AddWallet(holder1, []vc.VerifiableCredential{vc1, vc2})
+		builder.AddWallet(holder1, []vc.VerifiableCredential{vc1, vc2}, "ldp_vc")
 
-		submission, signInstructions, err := builder.Build("ldp_vp")
+		submission, signInstructions, err := builder.Build()
 
 		require.NoError(t, err)
 		require.NotNil(t, signInstructions)
@@ -104,7 +104,7 @@ func TestPresentationSubmissionBuilder_Build(t *testing.T) {
       }
     },
     {
-      "format": "ldp_vp",
+      "format": "jwt_vp",
       "id": "Match ID=2",
       "path": "$[1]",
       "path_nested": {
@@ -119,14 +119,18 @@ func TestPresentationSubmissionBuilder_Build(t *testing.T) {
 		presentationDefinition := PresentationDefinition{}
 		_ = json.Unmarshal([]byte(test.All), &presentationDefinition)
 		builder := presentationDefinition.PresentationSubmissionBuilder()
-		builder.AddWallet(holder1, []vc.VerifiableCredential{vc1})
-		builder.AddWallet(holder2, []vc.VerifiableCredential{vc2})
+		builder.AddWallet(holder1, []vc.VerifiableCredential{vc1}, "ldp_vp")
+		builder.AddWallet(holder2, []vc.VerifiableCredential{vc2}, "jwt_vp")
 
-		submission, signInstructions, err := builder.Build("ldp_vp")
+		submission, signInstructions, err := builder.Build()
 
 		require.NoError(t, err)
 		require.NotNil(t, signInstructions)
 		assert.Len(t, signInstructions, 2)
+		assert.Equal(t, holder1, signInstructions[0].Holder)
+		assert.Equal(t, "ldp_vp", signInstructions[0].Format)
+		assert.Equal(t, holder2, signInstructions[1].Holder)
+		assert.Equal(t, "jwt_vp", signInstructions[1].Format)
 		assert.Len(t, submission.DescriptorMap, 2)
 
 		submission.Id = "for-test" // easier assertion
@@ -154,10 +158,10 @@ func TestPresentationSubmissionBuilder_Build(t *testing.T) {
 		presentationDefinition := PresentationDefinition{}
 		_ = json.Unmarshal([]byte(test.All), &presentationDefinition)
 		builder := presentationDefinition.PresentationSubmissionBuilder()
-		builder.AddWallet(holder1, []vc.VerifiableCredential{vc1, vc2})
-		builder.AddWallet(holder2, []vc.VerifiableCredential{vc3})
+		builder.AddWallet(holder1, []vc.VerifiableCredential{vc1, vc2}, "ldp_vp")
+		builder.AddWallet(holder2, []vc.VerifiableCredential{vc3}, "jwt_vp")
 
-		submission, signInstructions, err := builder.Build("ldp_vp")
+		submission, signInstructions, err := builder.Build()
 
 		require.NoError(t, err)
 		require.NotNil(t, signInstructions)


### PR DESCRIPTION
Each wallet potentially maps to a sign instruction, which each could have their own VP format.

Found this requirement when validating submissions with a list of VPs (requires rebuilding the presentation submission).