### PR TITLE
PEX: ldp_vp submission with 1 VC should not index credential property

### DIFF
--- a/vcr/pe/presentation_submission.go
+++ b/vcr/pe/presentation_submission.go
@@ -147,6 +147,16 @@ func (b *PresentationSubmissionBuilder) Build(format string) (PresentationSubmis
 		}
 	}
 
+	// the verifiableCredential property in Verifiable Presentations can be a single VC or an array of VCs when represented in JSON.
+	// go-did always marshals a single VC as a single VC for JSON-LD VPs. So we might need to fix the mapping paths.
+	if format == vc.JSONLDPresentationProofFormat {
+		for _, signInstruction := range nonEmptySignInstructions {
+			if len(signInstruction.Mappings) == 1 {
+				signInstruction.Mappings[0].Path = "$.verifiableCredential"
+			}
+		}
+	}
+
 	index := 0
 	// last we create the descriptor map for the presentation submission
 	// If there's only one sign instruction the Path will be $.

--- a/vcr/pe/presentation_submission_test.go
+++ b/vcr/pe/presentation_submission_test.go
@@ -198,7 +198,6 @@ func TestPresentationSubmissionBuilder_Build(t *testing.T) {
 
 		submission.Id = "for-test" // easier assertion
 		actualJSON, _ := json.MarshalIndent(submission, "", "  ")
-		println(string(actualJSON))
 		assert.JSONEq(t, expectedJSON, string(actualJSON))
 	})
 }

--- a/vcr/pe/test/test_definitions.go
+++ b/vcr/pe/test/test_definitions.go
@@ -30,6 +30,7 @@ const PickOne = `
   ],
   "input_descriptors": [
 	{
+      "id": "Match ID=1",
 	  "name": "Pick 1",
       "group": ["A"],
 	  "constraints": {
@@ -47,6 +48,7 @@ const PickOne = `
 	  }
     },
     {
+      "id": "Match ID=2",
 	  "name": "Pick 2",
       "group": ["A"],
 	  "constraints": {


### PR DESCRIPTION
go-did marshals `verifiableCredential` to a JSON object instead of an array in that case.