### PR TITLE
allow local issuance for did:web

### DIFF
--- a/vcr/issuer/interface.go
+++ b/vcr/issuer/interface.go
@@ -85,13 +85,6 @@ type CredentialSearcher interface {
 	SearchCredential(credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error)
 }
 
-const (
-	JSONLDCredentialFormat   = vc.JSONLDCredentialProofFormat
-	JWTCredentialFormat      = vc.JWTCredentialProofFormat
-	JSONLDPresentationFormat = vc.JSONLDPresentationProofFormat
-	JWTPresentationFormat    = vc.JWTPresentationProofFormat
-)
-
 // CredentialOptions specifies options for issuing a credential.
 type CredentialOptions struct {
 	// Format specifies the proof format for the issued credential. If not set, it defaults to JSON-LD.

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -261,17 +261,19 @@ func (c *vcr) Configure(config core.ServerConfig) error {
 		c.walletHttpClient = core.NewStrictHTTPClient(config.Strictmode, c.config.OpenID4VCI.Timeout, tlsConfig)
 		c.openidSessionStore = c.storageClient.GetSessionDatabase()
 	}
-	c.issuer = issuer.NewIssuer(c.issuerStore, c, networkPublisher, openidHandlerFn, didResolver, c.keyStore, c.jsonldManager, c.trustConfig)
+	// verifier, wallet and issuer order is important!
+	// verifier
 	c.verifier = verifier.NewVerifier(c.verifierStore, didResolver, c.keyResolver, c.jsonldManager, c.trustConfig)
-
-	c.ambassador = NewAmbassador(c.network, c, c.verifier, c.eventManager)
-
 	// Create holder/wallet
 	c.walletStore, err = c.storageClient.GetProvider(ModuleName).GetKVStore("wallet", storage.PersistentStorageClass)
 	if err != nil {
 		return err
 	}
 	c.wallet = holder.New(c.keyResolver, c.keyStore, c.verifier, c.jsonldManager, c.walletStore)
+	// issuer
+	c.issuer = issuer.NewIssuer(c.issuerStore, c, networkPublisher, openidHandlerFn, didResolver, c.keyStore, c.jsonldManager, c.trustConfig, c.vdrInstance, c.wallet)
+
+	c.ambassador = NewAmbassador(c.network, c, c.verifier, c.eventManager)
 
 	if err = c.store.HandleRestore(); err != nil {
 		return err

--- a/vcr/verifier/interface.go
+++ b/vcr/verifier/interface.go
@@ -20,12 +20,12 @@ package verifier
 
 import (
 	"errors"
-	"github.com/nuts-foundation/nuts-node/core"
 	"io"
 	"time"
 
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/vc"
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 )
 

--- a/vcr/verifier/verifier.go
+++ b/vcr/verifier/verifier.go
@@ -23,22 +23,21 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/lestrrat-go/jwx/v2/jwt"
-	"github.com/nuts-foundation/nuts-node/crypto"
-	"github.com/nuts-foundation/nuts-node/vcr/issuer"
-	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 	"strings"
 	"time"
 
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
+	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/jsonld"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/signature"
 	"github.com/nuts-foundation/nuts-node/vcr/signature/proof"
 	"github.com/nuts-foundation/nuts-node/vcr/trust"
 	"github.com/nuts-foundation/nuts-node/vcr/types"
+	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 )
 
 var timeFunc = time.Now
@@ -118,9 +117,9 @@ func (v *verifier) Validate(credentialToVerify vc.VerifiableCredential, at *time
 	}
 
 	switch credentialToVerify.Format() {
-	case issuer.JSONLDCredentialFormat:
+	case vc.JSONLDCredentialProofFormat:
 		return v.validateJSONLDCredential(credentialToVerify, at)
-	case issuer.JWTCredentialFormat:
+	case vc.JWTCredentialProofFormat:
 		return v.validateJWTCredential(credentialToVerify, at)
 	default:
 		return errors.New("unsupported credential proof format")
@@ -316,9 +315,9 @@ func (v verifier) VerifyVP(vp vc.VerifiablePresentation, verifyVCs bool, allowUn
 func (v verifier) doVerifyVP(vcVerifier Verifier, presentation vc.VerifiablePresentation, verifyVCs bool, allowUntrustedVCs bool, validAt *time.Time) ([]vc.VerifiableCredential, error) {
 	var err error
 	switch presentation.Format() {
-	case issuer.JSONLDPresentationFormat:
+	case vc.JSONLDPresentationProofFormat:
 		err = v.validateJSONLDPresentation(presentation, validAt)
-	case issuer.JWTPresentationFormat:
+	case vc.JWTPresentationProofFormat:
 		err = v.validateJWTPresentation(presentation, validAt)
 	default:
 		err = errors.New("unsupported presentation proof format")


### PR DESCRIPTION
closes #2640 

this allows an issuer to issue to a wallet within the same node. This only happend when the VC is not public, not published, the receiver is a did:web and when it's owned by the node.