### PR TITLE
load a VC into a wallet via the internal API

### DIFF
--- a/docs/_static/vcr/vcr_v2.yaml
+++ b/docs/_static/vcr/vcr_v2.yaml
@@ -420,7 +420,7 @@ paths:
     post:
       summary: Load a VerifiableCredential into the holders wallet.
       description: |
-        If a VerifiableCredential is obtained in another way or when it's created without publishing, this API allows to add it to a wallet.
+        If a VerifiableCredential is not directly issued to the wallet through e.g. OpenID4VCI, this API allows to add it to a wallet.
         The DID of the holder has to be provided in the path.
         It's assumed that the credentialSubject.id equals the holder DID.
 

--- a/docs/_static/vcr/vcr_v2.yaml
+++ b/docs/_static/vcr/vcr_v2.yaml
@@ -416,7 +416,39 @@ paths:
                 $ref: "#/components/schemas/VerifiablePresentation"
         default:
           $ref: '../common/error_response.yaml'
+  /internal/vcr/v2/holder/{did}/vc:
+    post:
+      summary: Load a VerifiableCredential into the holders wallet.
+      description: |
+        If a VerifiableCredential is obtained in another way or when it's created without publishing, this API allows to add it to a wallet.
+        The DID of the holder has to be provided in the path.
+        It's assumed that the credentialSubject.id equals the holder DID.
 
+        error returns:
+        * 400 - Invalid credential
+        * 500 - An error occurred while processing the request
+      operationId: loadVC
+      tags:
+        - credential
+      parameters:
+        - name: did
+          in: path
+          description: URL encoded DID.
+          required: true
+          example: "did:web:example.com:iam:123"
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VerifiableCredential"
+      responses:
+        "204":
+          description: The credential will not be altered in any way, so no need to return it.
+        default:
+          $ref: '../common/error_response.yaml'
 components:
   schemas:
     VerifiableCredential:

--- a/vcr/api/vcr/v2/api.go
+++ b/vcr/api/vcr/v2/api.go
@@ -327,7 +327,7 @@ func (w *Wrapper) LoadVC(ctx context.Context, request LoadVCRequestObject) (Load
 	if err != nil {
 		return nil, core.InvalidInputError("invalid holder did: %w", err)
 	}
-	// VCs can only be added to the wallet of the credentialSubject.ID
+	
 	if request.Body == nil {
 		return nil, core.InvalidInputError("missing credential in body")
 	}

--- a/vcr/api/vcr/v2/api.go
+++ b/vcr/api/vcr/v2/api.go
@@ -321,6 +321,23 @@ func (w *Wrapper) VerifyVP(ctx context.Context, request VerifyVPRequestObject) (
 	return VerifyVP200JSONResponse(result), nil
 }
 
+func (w *Wrapper) LoadVC(ctx context.Context, request LoadVCRequestObject) (LoadVCResponseObject, error) {
+	// the actual holder is ignored for now, since we only support a single wallet...
+	_, err := did.ParseDID(request.Did)
+	if err != nil {
+		return nil, core.InvalidInputError("invalid holder did: %w", err)
+	}
+	// VCs can only be added to the wallet of the credentialSubject.ID
+	if request.Body == nil {
+		return nil, core.InvalidInputError("missing credential in body")
+	}
+	err = w.VCR.Wallet().Put(ctx, *request.Body)
+	if err != nil {
+		return nil, err
+	}
+	return LoadVC204Response{}, nil
+}
+
 // TrustIssuer handles API request to start trusting an issuer of a Verifiable Credential.
 func (w *Wrapper) TrustIssuer(ctx context.Context, request TrustIssuerRequestObject) (TrustIssuerResponseObject, error) {
 	if err := changeTrust(*request.Body, w.VCR.Trust); err != nil {


### PR DESCRIPTION
closes #2642 

primary use case is to load a VC into the wallet when issued to a web:did.