### PR TITLE
Auth: create session and validate signatures perform the same checks

### DIFF
--- a/auth/api/auth/v1/api.go
+++ b/auth/api/auth/v1/api.go
@@ -125,7 +125,7 @@ func (w Wrapper) VerifySignature(_ context.Context, request VerifySignatureReque
 		vpType := validationResult.VPType()
 		response.VpType = &vpType
 	} else {
-		log.Logger().Warn("Signature verification failed, reason: %s", validationResult.Reason())
+		log.Logger().Warnf("Signature verification failed, reason: %s", validationResult.Reason())
 		response.Validity = false
 	}
 	return VerifySignature200JSONResponse(response), nil

--- a/auth/api/auth/v1/api.go
+++ b/auth/api/auth/v1/api.go
@@ -125,6 +125,7 @@ func (w Wrapper) VerifySignature(_ context.Context, request VerifySignatureReque
 		vpType := validationResult.VPType()
 		response.VpType = &vpType
 	} else {
+		log.Logger().Warn("Signature verification failed, reason: %s", validationResult.Reason())
 		response.Validity = false
 	}
 	return VerifySignature200JSONResponse(response), nil

--- a/auth/services/selfsigned/signer.go
+++ b/auth/services/selfsigned/signer.go
@@ -227,20 +227,19 @@ func checkSessionParams(params map[string]interface{}) error {
 	if !ok {
 		return fmt.Errorf("employee should be an object")
 	}
-	_, ok = employeeMap["identifier"]
-	if !ok {
-		return fmt.Errorf("missing employee identifier")
+	identifier, _ := employeeMap["identifier"].(string)
+	if len(identifier) == 0 {
+		return fmt.Errorf("missing/invalid employee identifier")
 	}
-	_, ok = employeeMap["initials"]
-	if !ok {
-		return fmt.Errorf("missing employee initials")
+	initials, _ := employeeMap["initials"].(string)
+	if len(initials) == 0 {
+		return fmt.Errorf("missing/invalid employee initials")
 	}
-	_, ok = employeeMap["familyName"]
-	if !ok {
-		return fmt.Errorf("missing employee familyName")
+	familyName, _ := employeeMap["familyName"].(string)
+	if len(familyName) == 0 {
+		return fmt.Errorf("missing/invalid employee familyName")
 	}
 	return nil
-
 }
 
 func (v *signer) Routes(router core.EchoRouter) {

--- a/auth/services/selfsigned/signer_test.go
+++ b/auth/services/selfsigned/signer_test.go
@@ -109,6 +109,52 @@ func TestSessionStore_StartSigningSession(t *testing.T) {
 
 		require.Error(t, err)
 	})
+
+	t.Run("empty employee familyName", func(t *testing.T) {
+		params := map[string]interface{}{
+			"employer": employer.String(),
+			"employee": map[string]interface{}{
+				"identifier": identifier,
+				"roleName":   roleName,
+				"initials":   initials,
+				"familyName": "",
+			},
+		}
+
+		ss := NewSigner(nil, "").(*signer)
+		_, err := ss.StartSigningSession(contract.Contract{RawContractText: testContract}, params)
+		require.ErrorContains(t, err, "missing/invalid employee familyName")
+	})
+	t.Run("empty employee initials", func(t *testing.T) {
+		params := map[string]interface{}{
+			"employer": employer.String(),
+			"employee": map[string]interface{}{
+				"identifier": identifier,
+				"roleName":   roleName,
+				"initials":   "",
+				"familyName": familyName,
+			},
+		}
+
+		ss := NewSigner(nil, "").(*signer)
+		_, err := ss.StartSigningSession(contract.Contract{RawContractText: testContract}, params)
+		require.ErrorContains(t, err, "missing/invalid employee initials")
+	})
+	t.Run("empty employee identifier", func(t *testing.T) {
+		params := map[string]interface{}{
+			"employer": employer.String(),
+			"employee": map[string]interface{}{
+				"identifier": "",
+				"roleName":   roleName,
+				"initials":   initials,
+				"familyName": familyName,
+			},
+		}
+
+		ss := NewSigner(nil, "").(*signer)
+		_, err := ss.StartSigningSession(contract.Contract{RawContractText: testContract}, params)
+		require.ErrorContains(t, err, "missing/invalid employee identifier")
+	})
 }
 
 func TestSessionStore_SigningSessionStatus(t *testing.T) {


### PR DESCRIPTION
Signature verification performed more elaborate checks (employee details non-empty strings) than on session creation, which allows EmployeeID sessions to fail on input that was deemed valid earlier. That causes confusion, so should be the same.

Also, validation failure reason isn't logged or returned. Ideally it's returned to the client, but then we have to alter (extend) the OpenAPI spec. So for now, only log it.

Or should we still return it?