### PR TITLE
Discovery: search API for clients

### DIFF
--- a/discovery/api/v1/wrapper.go
+++ b/discovery/api/v1/wrapper.go
@@ -83,3 +83,19 @@ func (w *Wrapper) RegisterPresentation(_ context.Context, request RegisterPresen
 	}
 	return RegisterPresentation201Response{}, nil
 }
+
+func (w *Wrapper) SearchPresentations(_ context.Context, request SearchPresentationsRequestObject) (SearchPresentationsResponseObject, error) {
+	searchResults, err := w.Client.Search(request.ServiceID, request.Params.Query)
+	if err != nil {
+		return nil, err
+	}
+	var result []SearchResult
+	for _, searchResult := range searchResults {
+		result = append(result, SearchResult{
+			Vp:     searchResult.Presentation,
+			Id:     searchResult.Presentation.ID.String(),
+			Fields: searchResult.Fields,
+		})
+	}
+	return SearchPresentations200JSONResponse(result), nil
+}

--- a/discovery/api/v1/wrapper_test.go
+++ b/discovery/api/v1/wrapper_test.go
@@ -20,8 +20,10 @@ package v1
 
 import (
 	"errors"
+	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/discovery"
+	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -114,6 +116,50 @@ func TestWrapper_ResolveStatusCode(t *testing.T) {
 			assert.Equal(t, expectedCode, wrapper.ResolveStatusCode(err))
 		})
 	}
+}
+
+func TestWrapper_SearchPresentations(t *testing.T) {
+	query := map[string]string{
+		"foo": "bar",
+	}
+	id, _ := ssi.ParseURI("did:nuts:foo#1")
+	vp := vc.VerifiablePresentation{
+		ID:                   id,
+		VerifiableCredential: []vc.VerifiableCredential{credential.ValidNutsOrganizationCredential(t)},
+	}
+	t.Run("ok", func(t *testing.T) {
+		test := newMockContext(t)
+		results := []discovery.SearchResult{
+			{
+				Presentation: vp,
+				Fields:       nil,
+			},
+		}
+		test.client.EXPECT().Search(serviceID, query).Return(results, nil)
+
+		response, err := test.wrapper.SearchPresentations(nil, SearchPresentationsRequestObject{
+			ServiceID: serviceID,
+			Params:    SearchPresentationsParams{Query: query},
+		})
+
+		assert.NoError(t, err)
+		assert.IsType(t, SearchPresentations200JSONResponse{}, response)
+		actual := response.(SearchPresentations200JSONResponse)
+		require.Len(t, actual, 1)
+		assert.Equal(t, vp, actual[0].Vp)
+		assert.Equal(t, vp.ID.String(), actual[0].Id)
+	})
+	t.Run("error", func(t *testing.T) {
+		test := newMockContext(t)
+		test.client.EXPECT().Search(serviceID, query).Return(nil, discovery.ErrServiceNotFound)
+
+		_, err := test.wrapper.SearchPresentations(nil, SearchPresentationsRequestObject{
+			ServiceID: serviceID,
+			Params:    SearchPresentationsParams{Query: query},
+		})
+
+		assert.ErrorIs(t, err, discovery.ErrServiceNotFound)
+	})
 }
 
 type mockContext struct {

--- a/discovery/interface.go
+++ b/discovery/interface.go
@@ -27,6 +27,7 @@ import (
 )
 
 // Tag is value that references a point in the list.
+// It is used by clients to request new entries since their last query.
 // It is opaque for clients: they should not try to interpret it.
 // The server who issued the tag can interpret it as Lamport timestamp.
 type Tag string

--- a/discovery/interface.go
+++ b/discovery/interface.go
@@ -27,7 +27,6 @@ import (
 )
 
 // Tag is value that references a point in the list.
-// It is used by clients to request new entries since their last query.
 // It is opaque for clients: they should not try to interpret it.
 // The server who issued the tag can interpret it as Lamport timestamp.
 type Tag string
@@ -94,5 +93,17 @@ type Server interface {
 
 // Client defines the API for Discovery Clients.
 type Client interface {
-	Search(serviceID string, query map[string]string) ([]vc.VerifiablePresentation, error)
+	// Search searches for presentations which credential(s) match the given query.
+	// Query parameters are formatted as simple JSON paths, e.g. "issuer" or "credentialSubject.name".
+	Search(serviceID string, query map[string]string) ([]SearchResult, error)
+}
+
+// SearchResult is a single result of a search operation.
+type SearchResult struct {
+	// Presentation is the Verifiable Presentation that was matched.
+	Presentation vc.VerifiablePresentation `json:"vp"`
+	// Fields is a map of Input Descriptor Constraint Fields from the Discovery Service's Presentation Definition.
+	// The keys are the Input Descriptor IDs mapped to the values from the credential(s) inside the Presentation.
+	// It only includes constraint fields that have an ID.
+	Fields map[string]interface{} `json:"fields"`
 }

--- a/discovery/mock.go
+++ b/discovery/mock.go
@@ -93,10 +93,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Search mocks base method.
-func (m *MockClient) Search(serviceID string, query map[string]string) ([]vc.VerifiablePresentation, error) {
+func (m *MockClient) Search(serviceID string, query map[string]string) ([]SearchResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Search", serviceID, query)
-	ret0, _ := ret[0].([]vc.VerifiablePresentation)
+	ret0, _ := ret[0].([]SearchResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/discovery/test.go
+++ b/discovery/test.go
@@ -50,6 +50,7 @@ var testServiceID = "usecase_v1"
 
 func testDefinitions() map[string]ServiceDefinition {
 	issuerPattern := "did:example:*"
+	issuerFieldID := "issuer_field"
 	return map[string]ServiceDefinition{
 		testServiceID: {
 			ID:       testServiceID,
@@ -61,6 +62,7 @@ func testDefinitions() map[string]ServiceDefinition {
 						Constraints: &pe.Constraints{
 							Fields: []pe.Field{
 								{
+									Id:   &issuerFieldID,
 									Path: []string{"$.issuer"},
 									Filter: &pe.Filter{
 										Type:    "string",

--- a/docs/_static/discovery/v1.yaml
+++ b/docs/_static/discovery/v1.yaml
@@ -94,6 +94,8 @@ paths:
       description: |
         An API of the discovery client that searches for presentations on the discovery service,
         whose credentials match the given query parameter.
+        It queries the client's local copy of the Discovery Service which is periodically synchronized with the Discovery Server.
+        This means new registrations might not immediately show up, depending on the client refresh interval. 
         The query parameters are interpreted as JSON path expressions, evaluated on the verifiable credentials.
         The following features and limitations apply:
         - only simple child-selectors are supported (so no arrays selectors, script expressions etc).

--- a/docs/_static/discovery/v1.yaml
+++ b/docs/_static/discovery/v1.yaml
@@ -71,6 +71,60 @@ paths:
           $ref: "../common/error_response.yaml"
         default:
           $ref: "../common/error_response.yaml"
+  /discovery/{serviceID}/search:
+    parameters:
+      - name: serviceID
+        in: path
+        required: true
+        schema:
+          type: string
+      # Way to specify dynamic query parameters
+      # See https://stackoverflow.com/questions/49582559/how-to-document-dynamic-query-parameter-names-in-openapi-swagger
+      - in: query
+        name: query
+        required: true
+        schema:
+          type: object
+          additionalProperties:
+            type: string
+        style: form
+        explode: true
+    get:
+      summary: Searches for presentations registered on the discovery service.
+      description: |
+        An API of the discovery client that searches for presentations on the discovery service,
+        whose credentials match the given query parameter.
+        The query parameters are interpreted as JSON path expressions, evaluated on the verifiable credentials.
+        The following features and limitations apply:
+        - only simple child-selectors are supported (so no arrays selectors, script expressions etc).
+        - only JSON string values can be matched, no numbers, booleans, etc.
+        - wildcard (*) are supported at the start and end of the value
+        - a single wildcard (*) means: match any (non-nil) value
+        - matching is case-insensitive
+        - expressions must not include the '$.' prefix, which is added by the API.
+        - all expressions must match a single credential, for the credential to be included in the result.
+        - if there are multiple credentials in the presentation, the presentation is included in the result if any of the credentials match.
+        
+        Valid examples:
+        - `credentialSubject.givenName=John`
+        - `credentialSubject.organization.city=Arnhem`
+        - `credentialSubject.organization.name=Hospital*`
+        - `credentialSubject.organization.name=*clinic`
+        - `issuer=did:web:example.com`
+      operationId: searchPresentations
+      tags:
+        - discovery
+      responses:
+        "200":
+          description: Search results are returned, if any.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SearchResult"
+        default:
+          $ref: "../common/error_response.yaml"
 components:
   schemas:
     VerifiablePresentation:
@@ -87,6 +141,21 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/VerifiablePresentation"
+    SearchResult:
+      type: object
+      required:
+        - id
+        - vp
+        - fields
+      properties:
+        id:
+          type: string
+          description: The ID of the Verifiable Presentation.
+        vp:
+          $ref: "#/components/schemas/VerifiablePresentation"
+        fields:
+          type: object
+          description: Input descriptor IDs and their mapped values that from the Verifiable Credential.
   securitySchemes:
     jwtBearerAuth:
       type: http


### PR DESCRIPTION
PR adds `Discovery.Seach()` API that searches for presentations registered on a discovery service. The actual search functionality for the database already existed in the store implementation, this PR adds API exposure.

Alongside the matching VPs, it also returns a map with fields from the PEX definition mapped to credential fields, just like the OAuth2 token introspection API. This is useful for displaying search results (e.g. organization search like in Demo EHR).

Example output:

```json
[
  {
    "vp": "eyJhbGciOiJFUzI1NiIsImtpZCI6ImRpZDpleGFtcGxlOmFsaWNlIzAiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOlsidXNlY2FzZV92MSJdLCJleHAiOjE3MDQyMTI1MTksImlzcyI6ImRpZDpleGFtcGxlOmFsaWNlIiwianRpIjoiZGlkOmV4YW1wbGU6YWxpY2UjOGE5NWVlMTYtZmI1Ny00NjYzLThkZTctY2Y2NzJmMTRlNWQzIiwibmJmIjoxNzA0MTgzNzE5LCJzdWIiOiJkaWQ6ZXhhbXBsZTphbGljZSIsInZwIjp7IkBjb250ZXh0IjpudWxsLCJ0eXBlIjoiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiIsInZlcmlmaWFibGVDcmVkZW50aWFsIjoiZXlKaGJHY2lPaUpGVXpJMU5pSXNJbXRwWkNJNkltUnBaRHBsZUdGdGNHeGxPbUZzYVdObEl6QWlMQ0owZVhBaU9pSktWMVFpZlEuZXlKbGVIQWlPakUzTURReU56QXhNVGtzSW1semN5STZJbVJwWkRwbGVHRnRjR3hsT21GMWRHaHZjbWwwZVNJc0ltcDBhU0k2SW1ScFpEcGxlR0Z0Y0d4bE9tRjFkR2h2Y21sMGVTTXhZV05qTVdaaU5DMWhNREEyTFRReE4yWXRPR1psTWkwNU16UXlOamN5TmpBNU5ESWlMQ0p1WW1ZaU9qRTNNRFF4T0RNM01Ua3NJbk4xWWlJNkltUnBaRHBsZUdGdGNHeGxPbUZzYVdObElpd2lkbU1pT25zaVFHTnZiblJsZUhRaU9tNTFiR3dzSW1OeVpXUmxiblJwWVd4VGRXSnFaV04wSWpwYmV5SnBaQ0k2SW1ScFpEcGxlR0Z0Y0d4bE9tRnNhV05sSWl3aWNHVnljMjl1SWpwN0ltWmhiV2xzZVU1aGJXVWlPaUpLYjI1bGN5SXNJbWRwZG1WdVRtRnRaU0k2SWtGc2FXTmxJbjE5WFN3aWRIbHdaU0k2V3lKV1pYSnBabWxoWW14bFEzSmxaR1Z1ZEdsaGJDSXNJbFJsYzNSRGNtVmtaVzUwYVdGc0lsMTlmUS4wNUlWT2c0d3hTQl9DWGxXU0Rjby1BeVNRRDlOdGdBcUhsLWctQ0NLaElTOXFWNW9HWmEwcmVPaTFyVk9nSlp5c2RJVzd5NGdIMFNrY0tad0k3ZG1JQSJ9fQ.Bl3PmN6X5ESFTdwnrisx588ts1wKCkmgpnWegDQXBobeAc2myd4u8VZmIGtKPI3eVwI4gNQS8ZjjfozEEiyjrw",
    "fields": {
      "issuer_field": "did:example:authority"
    }
  }
]
```