### PR TITLE
SQL: specify lengths for VARCHAR columns 

### DIFF
--- a/storage/sql_migrations/001_discoveryservice.sql
+++ b/storage/sql_migrations/001_discoveryservice.sql
@@ -14,15 +14,15 @@ create table discovery_service
 -- discovery_presentation contains the presentations of the discovery services
 create table discovery_presentation
 (
-    id                      varchar(36) not null primary key,
-    service_id              varchar(36) not null,
+    id                      varchar(36)  not null primary key,
+    service_id              varchar(36)  not null,
     -- lamport_timestamp is the lamport clock of the presentation, converted to a tag and then returned to the client.
     -- It is only populated if the node is server for this service.
-    lamport_timestamp       integer     null,
-    credential_subject_id   varchar     not null,
-    presentation_id         varchar     not null,
-    presentation_raw        varchar     not null,
-    presentation_expiration integer     not null,
+    lamport_timestamp       integer      null,
+    credential_subject_id   varchar(500) not null,
+    presentation_id         varchar(500) not null,
+    presentation_raw        text         not null,
+    presentation_expiration integer      not null,
     unique (service_id, credential_subject_id),
     constraint fk_discovery_presentation_service_id foreign key (service_id) references discovery_service (id) on delete cascade
 );
@@ -34,16 +34,16 @@ create index idx_discovery_presentation_expiration on discovery_presentation (pr
 -- Then we don't need rows in the properties table for them (having a column for those is faster than having a row in the properties table which needs to be joined).
 create table discovery_credential
 (
-    id                    varchar(36) not null primary key,
+    id                    varchar(36)  not null primary key,
     -- presentation_id is NOT the ID of the presentation (VerifiablePresentation.ID), but refers to the presentation record in the discovery_presentation table.
-    presentation_id       varchar(36) not null,
-    credential_id         varchar     not null,
-    credential_issuer     varchar     not null,
-    credential_subject_id varchar     not null,
+    presentation_id       varchar(36)  not null,
+    credential_id         varchar(500) not null,
+    credential_issuer     varchar(500) not null,
+    credential_subject_id varchar(500) not null,
     -- for now, credentials with at most 2 types are supported.
     -- The type stored in the type column will be the 'other' type, not being 'VerifiableCredential'.
     -- When credentials with 3 or more types appear, we could have to use a separate table for the types.
-    credential_type       varchar,
+    credential_type       varchar(100),
     constraint fk_discovery_credential_presentation foreign key (presentation_id) references discovery_presentation (id) on delete cascade
 );
 
@@ -51,9 +51,9 @@ create table discovery_credential
 -- It is used by clients to search for presentations.
 create table discovery_credential_prop
 (
-    credential_id varchar(36) not null,
-    key           varchar     not null,
-    value         varchar,
+    credential_id varchar(36)  not null,
+    key           varchar(100) not null,
+    value         varchar(500),
     PRIMARY KEY (credential_id, key),
     -- cascading delete: if the presentation gets deleted, the properties get deleted as well
     constraint fk_discovery_credential_id foreign key (credential_id) references discovery_credential (id) on delete cascade


### PR DESCRIPTION
To avoid different behavior with different RDBMS's, default length might differ. The actual length are somewhat arbitrary (e.g., what will be the largest DID we'll encounter? Sidetree longform DIDs might be quite long)