### PR TITLE
Discovery: fix API of Client.Search()

### DIFF
--- a/discovery/api/v1/api.go
+++ b/discovery/api/v1/api.go
@@ -27,10 +27,13 @@ import (
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/discovery"
 	"net/http"
+	"net/url"
 )
 
 var _ StrictServerInterface = (*Wrapper)(nil)
 var _ core.ErrorStatusCodeResolver = (*Wrapper)(nil)
+
+const requestQueryContextKey = "request.url.query"
 
 type Wrapper struct {
 	Server discovery.Server
@@ -55,6 +58,12 @@ func (w *Wrapper) Routes(router core.EchoRouter) {
 				ctx.Set(core.OperationIDContextKey, operationID)
 				ctx.Set(core.ModuleNameContextKey, discovery.ModuleName)
 				ctx.Set(core.StatusCodeResolverContextKey, w)
+				// deepmap/openapi codegen does not support dynamic query parameters ("exploded form parameters"),
+				// so we expose the request URL query parameters to the request context,
+				// so the API handler can use them directly.
+				newContext := context.WithValue(ctx.Request().Context(), requestQueryContextKey, ctx.Request().URL.Query())
+				newRequest := ctx.Request().WithContext(newContext)
+				ctx.SetRequest(newRequest)
 				return f(ctx, request)
 			}
 		},
@@ -89,8 +98,14 @@ func (w *Wrapper) RegisterPresentation(_ context.Context, request RegisterPresen
 	return RegisterPresentation201Response{}, nil
 }
 
-func (w *Wrapper) SearchPresentations(_ context.Context, request SearchPresentationsRequestObject) (SearchPresentationsResponseObject, error) {
-	searchResults, err := w.Client.Search(request.ServiceID, request.Params.Query)
+func (w *Wrapper) SearchPresentations(ctx context.Context, request SearchPresentationsRequestObject) (SearchPresentationsResponseObject, error) {
+	// Use query parameters provided in request context (see Routes())
+	queryValues := ctx.Value(requestQueryContextKey).(url.Values)
+	query := make(map[string]string)
+	for key, values := range queryValues {
+		query[key] = values[0]
+	}
+	searchResults, err := w.Client.Search(request.ServiceID, query)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/_static/discovery/v1.yaml
+++ b/docs/_static/discovery/v1.yaml
@@ -71,7 +71,7 @@ paths:
           $ref: "../common/error_response.yaml"
         default:
           $ref: "../common/error_response.yaml"
-  /discovery/{serviceID}/search:
+  /internal/discovery/v1/{serviceID}:
     parameters:
       - name: serviceID
         in: path
@@ -82,7 +82,7 @@ paths:
       # See https://stackoverflow.com/questions/49582559/how-to-document-dynamic-query-parameter-names-in-openapi-swagger
       - in: query
         name: query
-        required: true
+        required: false
         schema:
           type: object
           additionalProperties:


### PR DESCRIPTION
Found these issues while fixing the e2e test.

Fixes:

- Endpoint was intended as an internal endpoint, moved it to `/internal/discovery/v1`
- Use of dynamic query parameters isn't supported by codegen, workaround