### PR TITLE
VDR: Group all DID Document management funcs in a new interface

### DIFF
--- a/vcr/test/openid4vci_integration_test.go
+++ b/vcr/test/openid4vci_integration_test.go
@@ -274,7 +274,7 @@ func testCredential() vc.VerifiableCredential {
 func registerDID(t *testing.T, system *core.System) did.DID {
 	vdrService := system.FindEngineByName("vdr").(vdr.VDR)
 	ctx := audit.TestContext()
-	didDocument, _, err := vdrService.Create(ctx, didnuts.MethodName, didnuts.DefaultCreationOptions())
+	didDocument, _, err := vdrService.Create(ctx, didnuts.DefaultCreationOptions())
 	require.NoError(t, err)
 	return didDocument.ID
 

--- a/vdr/api/v1/api.go
+++ b/vdr/api/v1/api.go
@@ -130,7 +130,7 @@ func (a *Wrapper) CreateDID(ctx context.Context, request CreateDIDRequestObject)
 		options.SelfControl = *request.Body.SelfControl
 	}
 
-	doc, _, err := a.VDR.Create(ctx, didnuts.MethodName, options)
+	doc, _, err := a.VDR.Create(ctx, options)
 	// if this operation leads to an error, it may return a 500
 	if err != nil {
 		return nil, err

--- a/vdr/api/v1/api_test.go
+++ b/vdr/api/v1/api_test.go
@@ -48,7 +48,7 @@ func TestWrapper_CreateDID(t *testing.T) {
 	t.Run("ok - defaults", func(t *testing.T) {
 		ctx := newMockContext(t)
 		request := DIDCreateRequest{}
-		ctx.vdr.EXPECT().Create(gomock.Any(), didnuts.MethodName, gomock.Any()).Return(didDoc, nil, nil)
+		ctx.vdr.EXPECT().Create(gomock.Any(), didnuts.DefaultCreationOptions()).Return(didDoc, nil, nil)
 
 		response, err := ctx.client.CreateDID(nil, CreateDIDRequestObject{Body: &request})
 
@@ -71,7 +71,7 @@ func TestWrapper_CreateDID(t *testing.T) {
 			SelfControl: new(bool),
 			Controllers: &controllers,
 		}
-		ctx.vdr.EXPECT().Create(gomock.Any(), didnuts.MethodName, gomock.Any()).Return(didDoc, nil, nil)
+		ctx.vdr.EXPECT().Create(gomock.Any(), gomock.Any()).Return(didDoc, nil, nil)
 
 		response, err := ctx.client.CreateDID(nil, CreateDIDRequestObject{Body: &request})
 
@@ -96,7 +96,7 @@ func TestWrapper_CreateDID(t *testing.T) {
 	t.Run("error - create fails", func(t *testing.T) {
 		ctx := newMockContext(t)
 		request := DIDCreateRequest{}
-		ctx.vdr.EXPECT().Create(gomock.Any(), didnuts.MethodName, gomock.Any()).Return(nil, nil, errors.New("b00m!"))
+		ctx.vdr.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil, nil, errors.New("b00m!"))
 
 		response, err := ctx.client.CreateDID(nil, CreateDIDRequestObject{Body: &request})
 

--- a/vdr/api/v2/api.go
+++ b/vdr/api/v2/api.go
@@ -68,11 +68,12 @@ func (a *Wrapper) Routes(router core.EchoRouter) {
 
 func (w Wrapper) CreateDID(ctx context.Context, _ CreateDIDRequestObject) (CreateDIDResponseObject, error) {
 	options := management.DIDCreationOptions{
+		Method:      didweb.MethodName,
 		KeyFlags:    management.AssertionMethodUsage | management.CapabilityInvocationUsage | management.KeyAgreementUsage | management.AuthenticationUsage | management.CapabilityDelegationUsage,
 		SelfControl: true,
 	}
 
-	doc, _, err := w.VDR.Create(ctx, didweb.MethodName, options)
+	doc, _, err := w.VDR.Create(ctx, options)
 	// if this operation leads to an error, it may return a 500
 	if err != nil {
 		return nil, err

--- a/vdr/api/v2/api_test.go
+++ b/vdr/api/v2/api_test.go
@@ -22,6 +22,7 @@ package v2
 import (
 	"context"
 	"github.com/nuts-foundation/nuts-node/vdr/didweb"
+	"github.com/nuts-foundation/nuts-node/vdr/management"
 	"testing"
 
 	"github.com/nuts-foundation/go-did/did"
@@ -41,7 +42,12 @@ func TestWrapper_CreateDID(t *testing.T) {
 
 	t.Run("ok - defaults", func(t *testing.T) {
 		ctx := newMockContext(t)
-		ctx.vdr.EXPECT().Create(gomock.Any(), didweb.MethodName, gomock.Any()).Return(didDoc, nil, nil)
+		opts := management.DIDCreationOptions{
+			Method:      didweb.MethodName,
+			KeyFlags:    management.AssertionMethodUsage | management.CapabilityInvocationUsage | management.KeyAgreementUsage | management.AuthenticationUsage | management.CapabilityDelegationUsage,
+			SelfControl: true,
+		}
+		ctx.vdr.EXPECT().Create(gomock.Any(), opts).Return(didDoc, nil, nil)
 
 		response, err := ctx.client.CreateDID(nil, CreateDIDRequestObject{})
 
@@ -51,7 +57,7 @@ func TestWrapper_CreateDID(t *testing.T) {
 
 	t.Run("error - create fails", func(t *testing.T) {
 		ctx := newMockContext(t)
-		ctx.vdr.EXPECT().Create(gomock.Any(), didweb.MethodName, gomock.Any()).Return(nil, nil, assert.AnError)
+		ctx.vdr.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil, nil, assert.AnError)
 
 		response, err := ctx.client.CreateDID(nil, CreateDIDRequestObject{})
 

--- a/vdr/didnuts/creator.go
+++ b/vdr/didnuts/creator.go
@@ -68,6 +68,7 @@ type Creator struct {
 // DefaultCreationOptions returns the default DIDCreationOptions when creating DID Documents.
 func DefaultCreationOptions() management.DIDCreationOptions {
 	return management.DIDCreationOptions{
+		Method:      MethodName,
 		Controllers: []did.DID{},
 		KeyFlags:    management.AssertionMethodUsage | management.CapabilityInvocationUsage | management.KeyAgreementUsage,
 		SelfControl: true,

--- a/vdr/didnuts/manager.go
+++ b/vdr/didnuts/manager.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2024 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package didnuts
+
+import (
+	"context"
+	"fmt"
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/crypto"
+	"github.com/nuts-foundation/nuts-node/vdr/management"
+	"github.com/nuts-foundation/nuts-node/vdr/resolver"
+)
+
+// NewManager creates a new Manager instance.
+func NewManager(creator management.DocCreator, owner management.DocumentOwner) *Manager {
+	return &Manager{
+		Creator:       creator,
+		DocumentOwner: owner,
+	}
+}
+
+var _ management.DocumentManager = (*Manager)(nil)
+
+type Manager struct {
+	Creator       management.DocCreator
+	DocumentOwner management.DocumentOwner
+}
+
+func (m Manager) Create(ctx context.Context, options management.DIDCreationOptions) (*did.Document, crypto.Key, error) {
+	return m.Creator.Create(ctx, options)
+}
+
+func (m Manager) IsOwner(ctx context.Context, did did.DID) (bool, error) {
+	return m.DocumentOwner.IsOwner(ctx, did)
+}
+
+func (m Manager) ListOwned(ctx context.Context) ([]did.DID, error) {
+	return m.DocumentOwner.ListOwned(ctx)
+}
+
+func (m Manager) Resolve(_ did.DID, _ *resolver.ResolveMetadata) (*did.Document, *resolver.DocumentMetadata, error) {
+	return nil, nil, fmt.Errorf("Resolve() is not supported for did:%s", MethodName)
+}

--- a/vdr/didnuts/manager_test.go
+++ b/vdr/didnuts/manager_test.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package didnuts
+
+import (
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/vdr/management"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"testing"
+)
+
+func TestManager_Create(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	creator := management.NewMockDocCreator(ctrl)
+	owner := management.NewMockDocumentOwner(ctrl)
+	manager := NewManager(creator, owner)
+	creator.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil, nil, nil)
+
+	_, _, err := manager.Create(nil, management.DIDCreationOptions{})
+
+	assert.NoError(t, err)
+}
+
+func TestManager_IsOwner(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	creator := management.NewMockDocCreator(ctrl)
+	owner := management.NewMockDocumentOwner(ctrl)
+	manager := NewManager(creator, owner)
+	owner.EXPECT().IsOwner(gomock.Any(), gomock.Any()).Return(false, nil)
+
+	_, err := manager.IsOwner(nil, did.MustParseDID("did:nuts:example.com"))
+
+	assert.NoError(t, err)
+}
+
+func TestManager_ListOwned(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	creator := management.NewMockDocCreator(ctrl)
+	owner := management.NewMockDocumentOwner(ctrl)
+	manager := NewManager(creator, owner)
+	owner.EXPECT().ListOwned(gomock.Any()).Return(nil, nil)
+
+	_, err := manager.ListOwned(nil)
+
+	assert.NoError(t, err)
+}
+
+func TestManager_Resolve(t *testing.T) {
+	_, _, err := Manager{}.Resolve(did.DID{}, nil)
+	assert.EqualError(t, err, "Resolve() is not supported for did:nuts")
+}

--- a/vdr/didweb/manager.go
+++ b/vdr/didweb/manager.go
@@ -34,8 +34,7 @@ import (
 	"net/url"
 )
 
-var _ management.DocCreator = (*Manager)(nil)
-var _ resolver.DIDResolver = (*Manager)(nil)
+var _ management.DocumentManager = (*Manager)(nil)
 
 // NewManager creates a new Manager to create and update did:web DID documents.
 func NewManager(baseURL url.URL, keyStore crypto.KeyStore, db *gorm.DB) *Manager {

--- a/vdr/integration_test.go
+++ b/vdr/integration_test.go
@@ -54,7 +54,7 @@ func TestVDRIntegration_Test(t *testing.T) {
 	ctx := setup(t)
 
 	// Start with a first and fresh document named DocumentA.
-	docA, _, err := ctx.vdr.Create(ctx.audit, didnuts.MethodName, didnuts.DefaultCreationOptions())
+	docA, _, err := ctx.vdr.Create(ctx.audit, didnuts.DefaultCreationOptions())
 	require.NoError(t, err)
 	assert.NotNil(t, docA)
 
@@ -89,7 +89,7 @@ func TestVDRIntegration_Test(t *testing.T) {
 		"expected updated docA to have a service")
 
 	// Create a new DID Document we name DocumentB
-	docB, _, err := ctx.vdr.Create(ctx.audit, didnuts.MethodName, didnuts.DefaultCreationOptions())
+	docB, _, err := ctx.vdr.Create(ctx.audit, didnuts.DefaultCreationOptions())
 	require.NoError(t, err, "unexpected error while creating DocumentB")
 	assert.NotNil(t, docB,
 		"a new document should have been created")
@@ -160,7 +160,7 @@ func TestVDRIntegration_ConcurrencyTest(t *testing.T) {
 	ctx := setup(t)
 
 	// Start with a first and fresh document named DocumentA.
-	initialDoc, _, err := ctx.vdr.Create(ctx.audit, didnuts.MethodName, didnuts.DefaultCreationOptions())
+	initialDoc, _, err := ctx.vdr.Create(ctx.audit, didnuts.DefaultCreationOptions())
 	require.NoError(t, err)
 	assert.NotNil(t, initialDoc)
 
@@ -301,7 +301,7 @@ func setup(t *testing.T) testContext {
 	return testContext{
 		vdr:             vdr,
 		eventPublisher:  eventPublisher,
-		docCreator:      vdr.creators[didnuts.MethodName],
+		docCreator:      vdr.documentManagers[didnuts.MethodName],
 		didStore:        didStore,
 		cryptoInstance:  cryptoInstance,
 		audit:           audit.TestContext(),

--- a/vdr/interface.go
+++ b/vdr/interface.go
@@ -19,20 +19,16 @@
 package vdr
 
 import (
-	"context"
 	"github.com/nuts-foundation/go-did/did"
-	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/vdr/management"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 )
 
 // VDR defines the public end facing methods for the Verifiable Data Registry.
 type VDR interface {
-	management.DocumentOwner
 	management.DocUpdater
+	management.DocumentManager
 
-	// Create creates a new DID document according to the given DID method and returns it.
-	Create(ctx context.Context, method string, options management.DIDCreationOptions) (*did.Document, crypto.Key, error)
 	// ResolveManaged resolves a DID document that is managed by the local node.
 	ResolveManaged(id did.DID) (*did.Document, error)
 	// Resolver returns the resolver for getting the DID document for a DID.

--- a/vdr/management/management.go
+++ b/vdr/management/management.go
@@ -22,7 +22,15 @@ import (
 	"context"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/crypto"
+	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 )
+
+// DocumentManager is the interface that groups several higher level methods to create and update DID documents.
+type DocumentManager interface {
+	DocCreator
+	DocumentOwner
+	resolver.DIDResolver
+}
 
 // DocCreator is the interface that wraps the Create method
 type DocCreator interface {
@@ -34,6 +42,7 @@ type DocCreator interface {
 }
 
 // DocUpdater is the interface that defines functions that alter the state of a DID document
+// Deprecated: only did:nuts implements it, new methods should implement DocumentManager
 type DocUpdater interface {
 	// Update replaces the DID document identified by DID with the nextVersion
 	// If the DID Document is not found, ErrNotFound is returned
@@ -70,6 +79,9 @@ type DocManipulator interface {
 
 // DIDCreationOptions defines options for creating a DID Document.
 type DIDCreationOptions struct {
+	// Method specifies the DID method the new DID should use
+	Method string
+
 	// Controllers lists the DIDs that can control the new DID Document. If selfControl = true and controllers is not empty,
 	// the newly generated DID will be added to the list of controllers.
 	Controllers []did.DID

--- a/vdr/management/management_mock.go
+++ b/vdr/management/management_mock.go
@@ -15,8 +15,94 @@ import (
 
 	did "github.com/nuts-foundation/go-did/did"
 	crypto "github.com/nuts-foundation/nuts-node/crypto"
+	resolver "github.com/nuts-foundation/nuts-node/vdr/resolver"
 	gomock "go.uber.org/mock/gomock"
 )
+
+// MockDocumentManager is a mock of DocumentManager interface.
+type MockDocumentManager struct {
+	ctrl     *gomock.Controller
+	recorder *MockDocumentManagerMockRecorder
+}
+
+// MockDocumentManagerMockRecorder is the mock recorder for MockDocumentManager.
+type MockDocumentManagerMockRecorder struct {
+	mock *MockDocumentManager
+}
+
+// NewMockDocumentManager creates a new mock instance.
+func NewMockDocumentManager(ctrl *gomock.Controller) *MockDocumentManager {
+	mock := &MockDocumentManager{ctrl: ctrl}
+	mock.recorder = &MockDocumentManagerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockDocumentManager) EXPECT() *MockDocumentManagerMockRecorder {
+	return m.recorder
+}
+
+// Create mocks base method.
+func (m *MockDocumentManager) Create(ctx context.Context, options DIDCreationOptions) (*did.Document, crypto.Key, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, options)
+	ret0, _ := ret[0].(*did.Document)
+	ret1, _ := ret[1].(crypto.Key)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockDocumentManagerMockRecorder) Create(ctx, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockDocumentManager)(nil).Create), ctx, options)
+}
+
+// IsOwner mocks base method.
+func (m *MockDocumentManager) IsOwner(arg0 context.Context, arg1 did.DID) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsOwner", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsOwner indicates an expected call of IsOwner.
+func (mr *MockDocumentManagerMockRecorder) IsOwner(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOwner", reflect.TypeOf((*MockDocumentManager)(nil).IsOwner), arg0, arg1)
+}
+
+// ListOwned mocks base method.
+func (m *MockDocumentManager) ListOwned(ctx context.Context) ([]did.DID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListOwned", ctx)
+	ret0, _ := ret[0].([]did.DID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListOwned indicates an expected call of ListOwned.
+func (mr *MockDocumentManagerMockRecorder) ListOwned(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOwned", reflect.TypeOf((*MockDocumentManager)(nil).ListOwned), ctx)
+}
+
+// Resolve mocks base method.
+func (m *MockDocumentManager) Resolve(id did.DID, metadata *resolver.ResolveMetadata) (*did.Document, *resolver.DocumentMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Resolve", id, metadata)
+	ret0, _ := ret[0].(*did.Document)
+	ret1, _ := ret[1].(*resolver.DocumentMetadata)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Resolve indicates an expected call of Resolve.
+func (mr *MockDocumentManagerMockRecorder) Resolve(id, metadata any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockDocumentManager)(nil).Resolve), id, metadata)
+}
 
 // MockDocCreator is a mock of DocCreator interface.
 type MockDocCreator struct {

--- a/vdr/mock.go
+++ b/vdr/mock.go
@@ -60,9 +60,9 @@ func (mr *MockVDRMockRecorder) ConflictedDocuments() *gomock.Call {
 }
 
 // Create mocks base method.
-func (m *MockVDR) Create(ctx context.Context, method string, options management.DIDCreationOptions) (*did.Document, crypto.Key, error) {
+func (m *MockVDR) Create(ctx context.Context, options management.DIDCreationOptions) (*did.Document, crypto.Key, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", ctx, method, options)
+	ret := m.ctrl.Call(m, "Create", ctx, options)
 	ret0, _ := ret[0].(*did.Document)
 	ret1, _ := ret[1].(crypto.Key)
 	ret2, _ := ret[2].(error)
@@ -70,9 +70,9 @@ func (m *MockVDR) Create(ctx context.Context, method string, options management.
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockVDRMockRecorder) Create(ctx, method, options any) *gomock.Call {
+func (mr *MockVDRMockRecorder) Create(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockVDR)(nil).Create), ctx, method, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockVDR)(nil).Create), ctx, options)
 }
 
 // IsOwner mocks base method.
@@ -103,6 +103,22 @@ func (m *MockVDR) ListOwned(ctx context.Context) ([]did.DID, error) {
 func (mr *MockVDRMockRecorder) ListOwned(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOwned", reflect.TypeOf((*MockVDR)(nil).ListOwned), ctx)
+}
+
+// Resolve mocks base method.
+func (m *MockVDR) Resolve(id did.DID, metadata *resolver.ResolveMetadata) (*did.Document, *resolver.DocumentMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Resolve", id, metadata)
+	ret0, _ := ret[0].(*did.Document)
+	ret1, _ := ret[1].(*resolver.DocumentMetadata)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Resolve indicates an expected call of Resolve.
+func (mr *MockVDRMockRecorder) Resolve(id, metadata any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockVDR)(nil).Resolve), id, metadata)
 }
 
 // ResolveManaged mocks base method.


### PR DESCRIPTION
To produce a DID document of a certain type, you need to implement the `DocumentManager` interface. This is in preparation of extending the functionality of updating `did:web` documents; after this PR, https://github.com/nuts-foundation/nuts-node/pull/2734 will add CRUD for services. Later on, Verification Method CRUD might be added as well.

The goal is to have VDR only delegate calls to supported DID methods.

When `did:nuts` support is removed, many of the "old" (current) interfaces can be removed, this one will remain.