### PR TITLE
StatusList: issuance

### DIFF
--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -22,8 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/nuts-foundation/nuts-node/auth/client/iam"
-	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -31,10 +29,12 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/audit"
 	"github.com/nuts-foundation/nuts-node/auth"
+	"github.com/nuts-foundation/nuts-node/auth/client/iam"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	oauthServices "github.com/nuts-foundation/nuts-node/auth/services/oauth"
 	"github.com/nuts-foundation/nuts-node/core"
@@ -42,7 +42,10 @@ import (
 	"github.com/nuts-foundation/nuts-node/policy"
 	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/nuts-foundation/nuts-node/vcr"
+	"github.com/nuts-foundation/nuts-node/vcr/holder"
+	"github.com/nuts-foundation/nuts-node/vcr/issuer"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
+	"github.com/nuts-foundation/nuts-node/vcr/types"
 	"github.com/nuts-foundation/nuts-node/vcr/verifier"
 	"github.com/nuts-foundation/nuts-node/vdr"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
@@ -680,6 +683,34 @@ func TestWrapper_RequestUserAccessToken(t *testing.T) {
 	})
 }
 
+func TestWrapper_StatusList(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		ctx := newTestClient(t)
+		page := 1
+		id := "123"
+		issuerDID := did.MustParseDID("did:web:example.com:iam:" + id)
+		slCred := VerifiableCredential{Issuer: ssi.MustParseURI(issuerDID.String())}
+		ctx.vcIssuer.EXPECT().StatusList(nil, issuerDID, page).Return(&slCred, nil)
+
+		res, err := ctx.client.StatusList(nil, StatusListRequestObject{
+			Id:   id,
+			Page: page,
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, StatusList200JSONResponse(slCred), res)
+	})
+	t.Run("error - not found", func(t *testing.T) {
+		ctx := newTestClient(t)
+		ctx.vcIssuer.EXPECT().StatusList(nil, gomock.Any(), gomock.Any()).Return(nil, types.ErrNotFound)
+
+		res, err := ctx.client.StatusList(nil, StatusListRequestObject{})
+
+		assert.ErrorIs(t, err, types.ErrNotFound)
+		assert.Nil(t, res)
+	})
+}
+
 type strictServerCallCapturer bool
 
 func (s *strictServerCallCapturer) handle(_ echo.Context, _ interface{}) (response interface{}, err error) {
@@ -735,6 +766,7 @@ type testCtx struct {
 	relyingParty  *oauthServices.MockRelyingParty
 	vcr           *vcr.MockVCR
 	vdr           *vdr.MockVDR
+	vcIssuer      *issuer.MockIssuer
 	vcVerifier    *verifier.MockVerifier
 	wallet        *holder.MockWallet
 }
@@ -749,6 +781,7 @@ func newTestClient(t testing.TB) *testCtx {
 	policyInstance := policy.NewMockPDPBackend(ctrl)
 	mockResolver := resolver.NewMockDIDResolver(ctrl)
 	relyingPary := oauthServices.NewMockRelyingParty(ctrl)
+	vcIssuer := issuer.NewMockIssuer(ctrl)
 	vcVerifier := verifier.NewMockVerifier(ctrl)
 	iamClient := iam.NewMockClient(ctrl)
 	mockVDR := vdr.NewMockVDR(ctrl)
@@ -757,6 +790,7 @@ func newTestClient(t testing.TB) *testCtx {
 
 	authnServices.EXPECT().PublicURL().Return(publicURL).AnyTimes()
 	authnServices.EXPECT().RelyingParty().Return(relyingPary).AnyTimes()
+	mockVCR.EXPECT().Issuer().Return(vcIssuer).AnyTimes()
 	mockVCR.EXPECT().Verifier().Return(vcVerifier).AnyTimes()
 	mockVCR.EXPECT().Wallet().Return(mockWallet).AnyTimes()
 	authnServices.EXPECT().IAMClient().Return(iamClient).AnyTimes()
@@ -767,6 +801,7 @@ func newTestClient(t testing.TB) *testCtx {
 		authnServices: authnServices,
 		policy:        policyInstance,
 		relyingParty:  relyingPary,
+		vcIssuer:      vcIssuer,
 		vcVerifier:    vcVerifier,
 		resolver:      mockResolver,
 		vdr:           mockVDR,

--- a/auth/api/iam/types.go
+++ b/auth/api/iam/types.go
@@ -36,6 +36,9 @@ type DIDDocumentMetadata = resolver.DocumentMetadata
 // VerifiablePresentation is an alias
 type VerifiablePresentation = vc.VerifiablePresentation
 
+// VerifiableCredential is an alias
+type VerifiableCredential = vc.VerifiableCredential
+
 // ErrorResponse is an alias
 type ErrorResponse = oauth.OAuth2Error
 

--- a/codegen/configs/auth_iam.yaml
+++ b/codegen/configs/auth_iam.yaml
@@ -14,3 +14,4 @@ output-options:
     - RedirectResponse
     - TokenResponse
     - VerifiablePresentation
+    - VerifiableCredential

--- a/docs/_static/auth/iam.yaml
+++ b/docs/_static/auth/iam.yaml
@@ -528,6 +528,40 @@ paths:
           description: |
             This is returned when an OAuth2 Client is unauthorized to talk to the introspection endpoint.
             Note: introspection of an invalid or malformed token returns a 200 where with field 'active'=false
+  /iam/{id}/statuslist/{page}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: The ID part of the web DID
+        schema:
+          type: string
+          example: EwVMYK2ugaMvRHUbGFBhuyF423JuNQbtpes35eHhkQic
+      - name: page
+        in: path
+        required: true
+        description: StatusListCredential page number for this DID
+        schema:
+          type: integer
+          example: 1
+    get:
+      summary: Get the StatusList2021Credential for the given DID and page
+      description: >
+        Returns the StatusList2021Credential as specified in https://www.w3.org/TR/2023/WD-vc-status-list-20230427/
+  
+        error returns:
+        * 404 - id or page not found; possibly be non-existing, deactivated, or not managed by this node
+        * 500 - internal server error
+      operationId: statusList
+      responses:
+        "200":
+          description: OK, StatusList2021Credential found and returned
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/VerifiableCredential"
+        default:
+          $ref: '../common/error_response.yaml'
 components:
   schemas:
     DIDDocument:
@@ -558,6 +592,8 @@ components:
           type: string
           description: The session ID that can be used to retrieve the access token by the calling application.
           example: "eyJhbGciOiJSUzI1NiIsI"
+    VerifiableCredential:
+      $ref: '../common/ssi_types.yaml#/components/schemas/VerifiableCredential'
     TokenResponse:
       type: object
       description: |

--- a/docs/_static/vcr/vcr_v2.yaml
+++ b/docs/_static/vcr/vcr_v2.yaml
@@ -191,9 +191,12 @@ paths:
       summary: "Revoke an issued credential"
       description: |
         Revoke a credential.
+        For a credential issued by did:nuts a revocation credential is published to the network
+        For a credential issued by did:web the revocation bit is set on the status list referenced in VC.credentialStatus
 
         error returns:
-        * 400 - Credential can't be revoked. Most likely due to a missing private key.
+        * 400 - Credential can't be revoked. Most likely due to a missing private key. Or credential contains no credentialStatus.
+        * 404 - Credential not found
         * 409 - Credential has already been revoked
         * 500 - An error occurred while processing the request
       operationId: "revokeVC"
@@ -201,11 +204,13 @@ paths:
         - credential
       responses:
         "200":
-          description: Revocation has been processed locally. It has also been published to the network.
+          description: Revocation for did:nuts VC has been published to the network.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Revocation'
+        "204":
+          description: Revocation for did:web VC has been processed. It is accessible in the StatusList bitstring
         default:
           $ref: '../common/error_response.yaml'
   /internal/vcr/v2/verifier/vc:
@@ -503,6 +508,19 @@ components:
           description: RFC3339 time string until when the credential is valid.
           type: string
           example: "2012-01-02T12:00:00Z"
+        credentialSubject:
+          $ref: '#/components/schemas/CredentialSubject'
+        withStatusList2021Revocation:
+          description: |
+            Add a credentialStatus with statusPurpose 'revocation' to the issued credential. This allows a credential to 
+            be revoked using the referenced StatusList2021Credential. StatusPurpose 'suspension' is not supported (yet). 
+            See https://www.w3.org/TR/2023/WD-vc-status-list-20230427/
+            
+            Credentials with a short lifespan (expiry) are preferred over adding a credentialStatus.
+            This is a required field for credentials without an expirationDate.
+            Only valid for did:web issuers.
+          type: boolean
+          default: false
         format:
           description: Proof format for the credential (ldp_vc for JSON-LD or jwt_vc for JWT). If not set, it defaults to JSON-LD.
           default: ldp_vc
@@ -516,17 +534,17 @@ components:
             When set to false, the caller is responsible for distributing the VC to a holder. When the issuer is
             also the holder, it then can be used to directly create a presentation (self issued).
             Note: a not published credential can still be publicly revoked.
+            Only valid for did:nuts issuers.
           type: boolean
           default: true
         visibility:
-            description: |
-              When publishToNetwork is true, the credential can be published publicly or privately to the holder.
-              This field is mandatory if publishToNetwork is true to prevent accidents. It defaults to "private".
-            type: string
-            enum: [ public, private ]
-            default: private
-        credentialSubject:
-          $ref: '#/components/schemas/CredentialSubject'
+          description: |
+            When publishToNetwork is true, the credential can be published publicly or privately to the holder.
+            This field is mandatory if publishToNetwork is true to prevent accidents. It defaults to "private".
+            Only valid for did:nuts issuers.
+          type: string
+          enum: [ public, private ]
+          default: private
     SearchVCRequest:
       type: object
       description: request body for searching VCs

--- a/e2e-tests/discovery/run-test.sh
+++ b/e2e-tests/discovery/run-test.sh
@@ -27,7 +27,7 @@ DIDDOC=$(docker compose exec nodeB nuts vdr create-did --v2)
 DID=$(echo $DIDDOC | jq -r .id)
 echo DID: $DID
 
-REQUEST="{\"type\":\"NutsOrganizationCredential\",\"issuer\":\"${DID}\", \"credentialSubject\": {\"id\":\"${DID}\", \"organization\":{\"name\":\"Caresoft B.V.\", \"city\":\"Caretown\"}},\"publishToNetwork\": false}"
+REQUEST="{\"type\":\"NutsOrganizationCredential\",\"issuer\":\"${DID}\", \"credentialSubject\": {\"id\":\"${DID}\", \"organization\":{\"name\":\"Caresoft B.V.\", \"city\":\"Caretown\"}},\"withStatusList2021Revocation\": false}"
 RESPONSE=$(echo $REQUEST | curl --insecure -s -X POST --data-binary @- http://localhost:21323/internal/vcr/v2/issuer/vc -H "Content-Type:application/json")
 if echo $RESPONSE | grep -q "VerifiableCredential"; then
   echo "VC issued"

--- a/e2e-tests/oauth-flow/openid4vp/run-test.sh
+++ b/e2e-tests/oauth-flow/openid4vp/run-test.sh
@@ -30,7 +30,7 @@ PARTY_B_DID=$(echo $PARTY_B_DIDDOC | jq -r .id)
 echo Vendor B DID: $PARTY_B_DID
 
 # Issue NutsOrganizationCredential for Vendor B
-REQUEST="{\"type\":\"NutsOrganizationCredential\",\"issuer\":\"${PARTY_B_DID}\", \"credentialSubject\": {\"id\":\"${PARTY_B_DID}\", \"organization\":{\"name\":\"Caresoft B.V.\", \"city\":\"Caretown\"}},\"publishToNetwork\": false}"
+REQUEST="{\"type\":\"NutsOrganizationCredential\",\"issuer\":\"${PARTY_B_DID}\", \"credentialSubject\": {\"id\":\"${PARTY_B_DID}\", \"organization\":{\"name\":\"Caresoft B.V.\", \"city\":\"Caretown\"}},\"withStatusList2021Revocation\": false}"
 RESPONSE=$(echo $REQUEST | curl -X POST --data-binary @- http://localhost:21323/internal/vcr/v2/issuer/vc -H "Content-Type:application/json")
 if echo $RESPONSE | grep -q "VerifiableCredential"; then
   echo "VC issued"

--- a/e2e-tests/oauth-flow/rfc021/run-test.sh
+++ b/e2e-tests/oauth-flow/rfc021/run-test.sh
@@ -29,7 +29,7 @@ VENDOR_B_DID=$(echo $VENDOR_B_DIDDOC | jq -r .id)
 echo Vendor B DID: $VENDOR_B_DID
 
 # Issue NutsOrganizationCredential for Vendor B
-REQUEST="{\"type\":\"NutsOrganizationCredential\",\"issuer\":\"${VENDOR_B_DID}\", \"credentialSubject\": {\"id\":\"${VENDOR_B_DID}\", \"organization\":{\"name\":\"Caresoft B.V.\", \"city\":\"Caretown\"}},\"publishToNetwork\": false}"
+REQUEST="{\"type\":\"NutsOrganizationCredential\",\"issuer\":\"${VENDOR_B_DID}\", \"credentialSubject\": {\"id\":\"${VENDOR_B_DID}\", \"organization\":{\"name\":\"Caresoft B.V.\", \"city\":\"Caretown\"}},\"withStatusList2021Revocation\": false}"
 RESPONSE=$(echo $REQUEST | curl -X POST --data-binary @- http://localhost:21323/internal/vcr/v2/issuer/vc -H "Content-Type:application/json")
 if echo $RESPONSE | grep -q "VerifiableCredential"; then
   echo "VC issued"

--- a/vcr/api/vcr/v2/generated.go
+++ b/vcr/api/vcr/v2/generated.go
@@ -129,6 +129,14 @@ type IssueVCRequest struct {
 	// Visibility When publishToNetwork is true, the credential can be published publicly or privately to the holder.
 	// This field is mandatory if publishToNetwork is true to prevent accidents. It defaults to "private".
 	Visibility *IssueVCRequestVisibility `json:"visibility,omitempty"`
+
+	// WithStatusList2021Revocation Add a credentialStatus with statusPurpose 'revocation' to the issued credential. This allows a credential to
+	// be revoked using the referenced StatusList2021Credential. StatusPurpose 'suspension' is not supported (yet).
+	// See https://www.w3.org/TR/2023/WD-vc-status-list-20230427/
+	//
+	// Credentials with a short lifespan (expiry) are preferred over adding a credentialStatus.
+	// A credentialStatus can only be added if publishToNetwork is false, and the issuer is not a did:nuts.
+	WithStatusList2021Revocation *bool `json:"withStatusList2021Revocation,omitempty"`
 }
 
 // IssueVCRequestFormat Proof format for the credential (ldp_vc for JSON-LD or jwt_vc for JWT). If not set, it defaults to JSON-LD.
@@ -3037,6 +3045,14 @@ func (response RevokeVC200JSONResponse) VisitRevokeVCResponse(w http.ResponseWri
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
+}
+
+type RevokeVC204Response struct {
+}
+
+func (response RevokeVC204Response) VisitRevokeVCResponse(w http.ResponseWriter) error {
+	w.WriteHeader(204)
+	return nil
 }
 
 type RevokeVCdefaultApplicationProblemPlusJSONResponse struct {

--- a/vcr/credential/statuslist2021/bitstring.go
+++ b/vcr/credential/statuslist2021/bitstring.go
@@ -27,7 +27,8 @@ import (
 
 var ErrIndexNotInBitstring = errors.New("index not in status list")
 
-var defaultBitstringLengthInBytes = 16 * 1024 // *8 = herd privacy of 16kB or 131072 bit
+const defaultBitstringLengthInBytes = 16 * 1024 // *8 = herd privacy of 16kB or 131072 bit
+const MaxBitstringIndex = defaultBitstringLengthInBytes*8 - 1
 
 // Bitstring is not thread-safe
 type Bitstring []byte

--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/vcr/openid4vci"
+	"github.com/nuts-foundation/nuts-node/vdr/didnuts"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 	"time"
 
@@ -53,8 +54,7 @@ var TimeFunc = time.Now
 // See https://github.com/nuts-foundation/nuts-node/issues/2063
 func NewIssuer(store Store, vcrStore types.Writer, networkPublisher Publisher,
 	openidHandlerFn func(ctx context.Context, id did.DID) (OpenIDHandler, error),
-	didResolver resolver.DIDResolver, keyStore crypto.KeyStore, jsonldManager jsonld.JSONLD, trustConfig *trust.Config,
-) Issuer {
+	didResolver resolver.DIDResolver, keyStore crypto.KeyStore, jsonldManager jsonld.JSONLD, trustConfig *trust.Config) Issuer {
 	keyResolver := vdrKeyResolver{
 		publicKeyResolver:  resolver.DIDKeyResolver{Resolver: didResolver},
 		privateKeyResolver: keyStore,
@@ -66,11 +66,12 @@ func NewIssuer(store Store, vcrStore types.Writer, networkPublisher Publisher,
 		walletResolver: openid4vci.DIDIdentifierResolver{
 			ServiceResolver: resolver.DIDServiceResolver{Resolver: didResolver},
 		},
-		keyResolver:   keyResolver,
-		keyStore:      keyStore,
-		jsonldManager: jsonldManager,
-		trustConfig:   trustConfig,
-		vcrStore:      vcrStore,
+		keyResolver:     keyResolver,
+		keyStore:        keyStore,
+		jsonldManager:   jsonldManager,
+		trustConfig:     trustConfig,
+		vcrStore:        vcrStore,
+		statusListStore: newStatusListMemoryStore(),
 	}
 }
 
@@ -85,6 +86,7 @@ type issuer struct {
 	jsonldManager    jsonld.JSONLD
 	vcrStore         types.Writer
 	walletResolver   openid4vci.IdentifierResolver
+	statusListStore  StatusList2021Store
 }
 
 // Issue creates a new credential, signs, stores it.
@@ -96,7 +98,7 @@ func (i issuer) Issue(ctx context.Context, template vc.VerifiableCredential, opt
 		return nil, errors.New("publishing VC JWTs is not supported")
 	}
 
-	createdVC, err := i.buildVC(ctx, template, options)
+	createdVC, err := i.buildAndSignVC(ctx, template, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +187,7 @@ func (i issuer) issueUsingOpenID4VCI(ctx context.Context, credential vc.Verifiab
 	return true, i.vcrStore.StoreCredential(credential, nil)
 }
 
-func (i issuer) buildVC(ctx context.Context, template vc.VerifiableCredential, options CredentialOptions) (*vc.VerifiableCredential, error) {
+func (i issuer) buildAndSignVC(ctx context.Context, template vc.VerifiableCredential, options CredentialOptions) (*vc.VerifiableCredential, error) {
 	if len(template.Type) != 1 {
 		return nil, core.InvalidInputError("can only issue credential with 1 type")
 	}
@@ -214,6 +216,20 @@ func (i issuer) buildVC(ctx context.Context, template vc.VerifiableCredential, o
 		Issuer:            template.Issuer,
 		ExpirationDate:    template.ExpirationDate,
 		IssuanceDate:      template.IssuanceDate,
+		CredentialStatus:  template.CredentialStatus, // TODO: needs api update for this to work. do we allow external issuers to revoke this credential?
+	}
+	if options.WithStatusListRevocation {
+		// add credential status
+		credentialStatusEntry, err := i.statusListStore.Create(ctx, *issuerDID, StatusPurposeRevocation)
+		if err != nil {
+			return nil, err
+		}
+		unsignedCredential.CredentialStatus = append(unsignedCredential.CredentialStatus, credentialStatusEntry)
+
+		// add status list context
+		if !unsignedCredential.ContainsContext(statusList2021ContextURI) {
+			unsignedCredential.Context = append(unsignedCredential.Context, statusList2021ContextURI)
+		}
 	}
 	if unsignedCredential.IssuanceDate == nil {
 		issuanceDate := TimeFunc()
@@ -259,6 +275,19 @@ func (i issuer) buildJSONLDCredential(ctx context.Context, unsignedCredential vc
 }
 
 func (i issuer) Revoke(ctx context.Context, credentialID ssi.URI) (*credential.Revocation, error) {
+	credentialDIDURL, err := did.ParseDIDURL(credentialID.String())
+
+	// revoke did:nuts credential. activating on err maintains existing behavior
+	if err != nil || credentialDIDURL.Method == didnuts.MethodName {
+		return i.revokeDIDNuts(ctx, credentialID)
+	}
+
+	// revoke a credential that has a revocable credentialStatus
+	return nil, i.revokeStatusList(ctx, credentialID)
+}
+
+// revokeDIDNuts revokes did:nuts credentials and publishes the revocation to the network
+func (i issuer) revokeDIDNuts(ctx context.Context, credentialID ssi.URI) (*credential.Revocation, error) {
 	// Previously we first tried to resolve the credential, but that's not necessary:
 	// if the credential doesn't actually exist the revocation doesn't apply to anything, no harm done.
 	// Although it is a bit ugly, it helps issuers to revoke credentials that they don't have anymore,
@@ -290,6 +319,37 @@ func (i issuer) Revoke(ctx context.Context, credentialID ssi.URI) (*credential.R
 		WithField(core.LogFieldCredentialID, credentialID).
 		Info("Verifiable Credential revoked")
 	return revocation, nil
+}
+
+// revokeStatusList revokes a credential through its credential status
+func (i issuer) revokeStatusList(ctx context.Context, credentialID ssi.URI) error {
+	cred, err := i.store.GetCredential(credentialID)
+	if err != nil {
+		return err
+	}
+
+	statuses, err := cred.CredentialStatuses()
+	if err != nil {
+		return err
+	}
+
+	// find the correct credentialStatus and revoke it on the relevant statuslist
+	for _, status := range statuses {
+		if status.Type == credential.StatusList2021EntryType {
+			var slEntry credential.StatusList2021Entry
+			err = json.Unmarshal(status.Raw(), &slEntry)
+			if err != nil {
+				return err
+			}
+			// TODO: make sure it is the correct entry when we allow other purposes, or VC issuance that include other credential statuses
+			if slEntry.StatusPurpose != StatusPurposeRevocation {
+				continue
+			}
+			return i.statusListStore.Revoke(ctx, credentialID, slEntry)
+		}
+	}
+
+	return types.ErrStatusNotFound
 }
 
 func (i issuer) buildRevocation(ctx context.Context, credentialID ssi.URI) (*credential.Revocation, error) {
@@ -340,6 +400,8 @@ func (i issuer) buildRevocation(ctx context.Context, credentialID ssi.URI) (*cre
 	return &signedRevocation, nil
 }
 
+// isRevoked returns false if no credential.Revocation can be found, all other cases default to true.
+// Only applies to did:nuts revocations.
 func (i issuer) isRevoked(credentialID ssi.URI) (bool, error) {
 	_, err := i.store.GetRevocation(credentialID)
 	switch err {
@@ -356,4 +418,48 @@ func (i issuer) isRevoked(credentialID ssi.URI) (bool, error) {
 
 func (i issuer) SearchCredential(credentialType ssi.URI, issuer did.DID, subject *ssi.URI) ([]vc.VerifiableCredential, error) {
 	return i.store.SearchCredential(credentialType, issuer, subject)
+}
+
+// statusListValidity is default validity of a statuslist credential. It should be
+const statusListValidity = 24 * time.Hour // TODO: make configurable
+
+var statusList2021ContextURI = ssi.MustParseURI(jsonld.W3cStatusList2021Context)
+var statusList2021CredentialTypeURI = ssi.MustParseURI(credential.StatusList2021CredentialType)
+
+func (i issuer) StatusList(ctx context.Context, issuerDID did.DID, page int) (*vc.VerifiableCredential, error) {
+	// todo: get cached credential if available
+
+	// get credential subject
+	credSubject, err := i.statusListStore.CredentialSubject(ctx, issuerDID, page)
+	if err != nil {
+		return nil, err
+	}
+
+	// create statuslist credential template
+	iss := TimeFunc()
+	exp := iss.Add(statusListValidity)
+	template := vc.VerifiableCredential{
+		Context: []ssi.URI{
+			vc.VCContextV1URI(),
+			statusList2021ContextURI,
+		},
+		Type: []ssi.URI{
+			// vc.VerifiableCredentialTypeV1URI(), // automatically added
+			statusList2021CredentialTypeURI,
+		},
+		CredentialSubject: []any{credSubject},
+		Issuer:            issuerDID.URI(),
+		IssuanceDate:      &iss,
+		ExpirationDate:    &exp,
+	}
+
+	// build and sign the VC.
+	// All content is validated and these credentials should not be in the issuer store, so don't use i.Issue()
+	statusListCredential, err := i.buildAndSignVC(ctx, template, CredentialOptions{Format: vc.JSONLDCredentialProofFormat})
+	if err != nil {
+		return nil, err
+	}
+	// TODO: cache result
+
+	return statusListCredential, nil
 }

--- a/vcr/issuer/issuer_test.go
+++ b/vcr/issuer/issuer_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/nuts-foundation/nuts-node/audit"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/vcr/openid4vci"
+	"github.com/nuts-foundation/nuts-node/vcr/verifier"
+	"github.com/nuts-foundation/nuts-node/vdr/didweb"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 	"github.com/stretchr/testify/require"
 	"path"
@@ -86,7 +88,7 @@ func Test_issuer_buildVC(t *testing.T) {
 			jsonldManager := jsonld.NewTestJSONLDManager(t)
 			sut := issuer{keyResolver: keyResolverMock, jsonldManager: jsonldManager, keyStore: keyStore}
 
-			result, err := sut.buildVC(ctx, template, CredentialOptions{Format: vc.JSONLDCredentialProofFormat})
+			result, err := sut.buildAndSignVC(ctx, template, CredentialOptions{Format: vc.JSONLDCredentialProofFormat})
 			require.NoError(t, err)
 			require.NotNil(t, result)
 			assert.Contains(t, result.Type, credentialType, "expected vc to be of right type")
@@ -107,7 +109,7 @@ func Test_issuer_buildVC(t *testing.T) {
 			jsonldManager := jsonld.NewTestJSONLDManager(t)
 			sut := issuer{keyResolver: keyResolverMock, jsonldManager: jsonldManager, keyStore: keyStore}
 
-			result, err := sut.buildVC(ctx, template, CredentialOptions{})
+			result, err := sut.buildAndSignVC(ctx, template, CredentialOptions{})
 			require.NoError(t, err)
 			require.NotNil(t, result)
 			assert.Equal(t, vc.JSONLDCredentialProofFormat, result.Format())
@@ -121,7 +123,7 @@ func Test_issuer_buildVC(t *testing.T) {
 			jsonldManager := jsonld.NewTestJSONLDManager(t)
 			sut := issuer{keyResolver: keyResolverMock, jsonldManager: jsonldManager, keyStore: keyStore}
 
-			result, err := sut.buildVC(ctx, template, CredentialOptions{Format: vc.JWTCredentialProofFormat})
+			result, err := sut.buildAndSignVC(ctx, template, CredentialOptions{Format: vc.JWTCredentialProofFormat})
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -142,6 +144,44 @@ func Test_issuer_buildVC(t *testing.T) {
 			assert.Equal(t, result.ID.String(), result.JWT().JwtID())
 		})
 	})
+	t.Run("credentialStatus", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			issuerDID := ssi.MustParseURI("did:web:example.com:iam:123")
+			slTemplate := template
+			slTemplate.Issuer = issuerDID // does not overwrite template
+
+			ctrl := gomock.NewController(t)
+			keyResolverMock := NewMockkeyResolver(ctrl)
+			keyResolverMock.EXPECT().ResolveAssertionKey(ctx, gomock.Any()).Return(signingKey, nil)
+			jsonldManager := jsonld.NewTestJSONLDManager(t)
+			sut := issuer{keyResolver: keyResolverMock, jsonldManager: jsonldManager, keyStore: keyStore, statusListStore: newStatusListMemoryStore()}
+
+			result, err := sut.buildAndSignVC(ctx, slTemplate, CredentialOptions{WithStatusListRevocation: true})
+
+			// only check fields relevant to credential status
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Contains(t, result.Context, statusList2021ContextURI)
+
+			statuses, err := result.CredentialStatuses()
+			require.NoError(t, err)
+			require.Len(t, statuses, 1)
+			assert.Equal(t, credential.StatusList2021EntryType, statuses[0].Type)
+		})
+		t.Run("error - did:nuts", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			keyResolverMock := NewMockkeyResolver(ctrl)
+			keyResolverMock.EXPECT().ResolveAssertionKey(ctx, gomock.Any()).Return(signingKey, nil)
+			jsonldManager := jsonld.NewTestJSONLDManager(t)
+			sut := issuer{keyResolver: keyResolverMock, jsonldManager: jsonldManager, keyStore: keyStore, statusListStore: newStatusListMemoryStore()}
+
+			result, err := sut.buildAndSignVC(ctx, template, CredentialOptions{WithStatusListRevocation: true})
+
+			// only check fields relevant to credential status
+			assert.ErrorContains(t, err, "unsupported DID method: nuts")
+			assert.Nil(t, result)
+		})
+	})
 
 	t.Run("it does not add the default context twice", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -159,7 +199,7 @@ func Test_issuer_buildVC(t *testing.T) {
 			IssuanceDate: &issuanceDate,
 		}
 
-		result, err := sut.buildVC(ctx, template, CredentialOptions{})
+		result, err := sut.buildAndSignVC(ctx, template, CredentialOptions{})
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -174,7 +214,7 @@ func Test_issuer_buildVC(t *testing.T) {
 			template := vc.VerifiableCredential{
 				Type: []ssi.URI{},
 			}
-			result, err := sut.buildVC(ctx, template, CredentialOptions{})
+			result, err := sut.buildAndSignVC(ctx, template, CredentialOptions{})
 
 			assert.ErrorIs(t, err, core.InvalidInputError("can only issue credential with 1 type"))
 			assert.Nil(t, result)
@@ -186,7 +226,7 @@ func Test_issuer_buildVC(t *testing.T) {
 			template := vc.VerifiableCredential{
 				Type: []ssi.URI{credentialType},
 			}
-			result, err := sut.buildVC(ctx, template, CredentialOptions{})
+			result, err := sut.buildAndSignVC(ctx, template, CredentialOptions{})
 
 			assert.ErrorIs(t, err, did.ErrInvalidDID)
 			assert.Nil(t, result)
@@ -199,7 +239,7 @@ func Test_issuer_buildVC(t *testing.T) {
 			jsonldManager := jsonld.NewTestJSONLDManager(t)
 			sut := issuer{keyResolver: keyResolverMock, jsonldManager: jsonldManager, keyStore: keyStore}
 
-			result, err := sut.buildVC(ctx, template, CredentialOptions{Format: "paper"})
+			result, err := sut.buildAndSignVC(ctx, template, CredentialOptions{Format: "paper"})
 
 			assert.EqualError(t, err, "unsupported credential proof format")
 			assert.Nil(t, result)
@@ -218,7 +258,7 @@ func Test_issuer_buildVC(t *testing.T) {
 				Type:   []ssi.URI{credentialType},
 				Issuer: issuerID,
 			}
-			_, err := sut.buildVC(ctx, template, CredentialOptions{})
+			_, err := sut.buildAndSignVC(ctx, template, CredentialOptions{})
 			assert.EqualError(t, err, "failed to sign credential: could not resolve an assertionKey for issuer: b00m!")
 		})
 
@@ -233,7 +273,7 @@ func Test_issuer_buildVC(t *testing.T) {
 				Type:   []ssi.URI{credentialType},
 				Issuer: issuerID,
 			}
-			_, err := sut.buildVC(ctx, template, CredentialOptions{})
+			_, err := sut.buildAndSignVC(ctx, template, CredentialOptions{})
 			assert.ErrorIs(t, err, core.InvalidInputError("failed to sign credential: could not resolve an assertionKey for issuer: unable to find the DID document"))
 		})
 	})
@@ -594,7 +634,7 @@ _:c14n0 <https://www.w3.org/2018/credentials#issuer> <did:nuts:123> .
 		})
 	})
 }
-func Test_issuer_Revoke(t *testing.T) {
+func Test_issuer_revokeNetwork(t *testing.T) {
 	credentialID := "did:nuts:123#38E90E8C-F7E5-4333-B63A-F9DD155A0272"
 	credentialURI := ssi.MustParseURI(credentialID)
 	issuerID := "did:nuts:123"
@@ -743,6 +783,91 @@ func Test_issuer_Revoke(t *testing.T) {
 	})
 }
 
+func TestIssuer_revokeStatusList(t *testing.T) {
+	issuerDID := did.MustParseDID("did:web:example.com:iam:123")
+	storeWithCred := func(c *gomock.Controller, entry credential.StatusList2021Entry) (*MockStore, ssi.URI) {
+		credentialID := ssi.MustParseURI(issuerDID.String() + "#identifier")
+		cred := &vc.VerifiableCredential{
+			ID:               &credentialID,
+			Issuer:           ssi.MustParseURI(issuerDID.String()),
+			CredentialStatus: []any{entry},
+		}
+		store := NewMockStore(c)
+		store.EXPECT().GetCredential(*cred.ID).Return(cred, nil).MinTimes(1)
+		return store, credentialID
+	}
+
+	t.Run("ok", func(t *testing.T) {
+		statuslist := newStatusListMemoryStore()
+		entry, err := statuslist.Create(context.Background(), issuerDID, StatusPurposeRevocation)
+		require.NoError(t, err)
+		issuerStore, credentialID := storeWithCred(gomock.NewController(t), *entry)
+		sut := issuer{
+			store:           issuerStore,
+			statusListStore: statuslist,
+		}
+
+		revCred, err := sut.Revoke(context.Background(), credentialID)
+
+		assert.NoError(t, err)
+		assert.Nil(t, revCred)
+	})
+	t.Run("error - double revocation", func(t *testing.T) {
+		statuslist := newStatusListMemoryStore()
+		entry, err := statuslist.Create(context.Background(), issuerDID, StatusPurposeRevocation)
+		require.NoError(t, err)
+		issuerStore, credentialID := storeWithCred(gomock.NewController(t), *entry)
+		sut := issuer{
+			store:           issuerStore,
+			statusListStore: statuslist,
+		}
+
+		_, err = sut.Revoke(context.Background(), credentialID)
+		require.NoError(t, err)
+		_, err = sut.Revoke(context.Background(), credentialID)
+
+		assert.ErrorIs(t, err, vcr.ErrRevoked)
+	})
+	t.Run("error - credential not found", func(t *testing.T) {
+		store := NewMockStore(gomock.NewController(t))
+		store.EXPECT().GetCredential(gomock.Any()).Return(nil, vcr.ErrNotFound)
+		sut := issuer{store: store}
+
+		result, err := sut.Revoke(context.Background(), ssi.MustParseURI("did:web:example.com:iam#not-found"))
+
+		assert.ErrorIs(t, err, vcr.ErrNotFound)
+		assert.Nil(t, result)
+	})
+	t.Run("error - statuslist credential not found", func(t *testing.T) {
+		statuslist := newStatusListMemoryStore()
+		entry, err := statuslist.Create(context.Background(), issuerDID, StatusPurposeRevocation)
+		require.NoError(t, err)
+		entry.StatusListCredential = "unknown status list"
+		issuerStore, credentialID := storeWithCred(gomock.NewController(t), *entry)
+		sut := issuer{
+			store:           issuerStore,
+			statusListStore: statuslist,
+		}
+
+		_, err = sut.Revoke(context.Background(), credentialID)
+
+		assert.ErrorIs(t, err, vcr.ErrNotFound)
+	})
+	t.Run("error - invalid credentialStatus", func(t *testing.T) {
+	})
+	t.Run("error - no revokable credential status", func(t *testing.T) {
+		issuerStore, credentialID := storeWithCred(gomock.NewController(t), credential.StatusList2021Entry{
+			Type:          credential.StatusList2021EntryType,
+			StatusPurpose: "not revocation",
+		})
+		sut := issuer{store: issuerStore}
+
+		_, err := sut.Revoke(context.Background(), credentialID)
+
+		assert.ErrorIs(t, err, vcr.ErrStatusNotFound)
+	})
+}
+
 func TestIssuer_isRevoked(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
@@ -788,4 +913,100 @@ func TestIssuer_isRevoked(t *testing.T) {
 		assert.True(t, isRevoked)
 	})
 
+}
+
+func TestIssuer_StatusList(t *testing.T) {
+	issuerDID := did.MustParseDID("did:web:example.com:iam:123")
+	issuerURL, err := didweb.DIDToURL(issuerDID)
+	require.NoError(t, err)
+
+	ctx := audit.TestContext()
+	const kid = "did:web:example.com:iam:123#abc"
+	keyStore := crypto.NewMemoryCryptoInstance()
+	signingKey, err := keyStore.New(ctx, func(key crypt.PublicKey) (string, error) {
+		return kid, nil
+	})
+	require.NoError(t, err)
+
+	jsonldManager := jsonld.NewTestJSONLDManager(t)
+	trustConfig := trust.NewConfig(path.Join(io.TestDirectory(t), "trust.config"))
+	t.Run("ok", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		keyResolverMock := NewMockkeyResolver(ctrl)
+		keyResolverMock.EXPECT().ResolveAssertionKey(ctx, gomock.Any()).Return(signingKey, nil)
+		sut := issuer{
+			keyResolver:     keyResolverMock,
+			jsonldManager:   jsonldManager,
+			keyStore:        keyStore,
+			trustConfig:     trustConfig,
+			statusListStore: newStatusListMemoryStore(),
+		}
+		_, err = sut.statusListStore.Create(ctx, issuerDID, StatusPurposeRevocation)
+		require.NoError(t, err)
+
+		result, err := sut.StatusList(ctx, issuerDID, 1)
+
+		// credential
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Contains(t, result.Context, statusList2021ContextURI)
+		assert.Equal(t, result.Issuer.String(), issuerDID.String())
+		assert.True(t, result.IsType(ssi.MustParseURI(credential.StatusList2021CredentialType)))
+
+		// credential subject
+		var subjects []credential.StatusList2021CredentialSubject
+		err = result.UnmarshalCredentialSubject(&subjects)
+		require.NoError(t, err)
+		require.Len(t, subjects, 1)
+		assert.Equal(t, subjects[0].Id, issuerURL.JoinPath("statuslist", "1").String())
+		assert.Equal(t, subjects[0].Type, credential.StatusList2021CredentialSubjectType)
+		assert.Equal(t, subjects[0].StatusPurpose, StatusPurposeRevocation)
+		assert.NotEmpty(t, subjects[0].EncodedList, "")
+
+		// verify credential -> trust is not added automatically
+		vStoreMock := verifier.NewMockStore(ctrl)
+		vStoreMock.EXPECT().GetRevocations(gomock.Any()).Return(nil, verifier.ErrNotFound)
+		vDIDResolverMock := resolver.NewMockDIDResolver(ctrl)
+		vDIDResolverMock.EXPECT().Resolve(gomock.Any(), gomock.Any())
+		vKeyResolverMock := resolver.NewMockKeyResolver(ctrl)
+		vKeyResolverMock.EXPECT().ResolveKeyByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(signingKey.Public(), nil)
+		verif := verifier.NewVerifier(vStoreMock, vDIDResolverMock, vKeyResolverMock, jsonldManager, trustConfig, nil)
+		assert.NoError(t, verif.Verify(*result, true, true, nil))
+	})
+	t.Run("error - unknown status list credential", func(t *testing.T) {
+		sut := issuer{statusListStore: newStatusListMemoryStore()}
+
+		result, err := sut.StatusList(ctx, issuerDID, 1)
+
+		assert.ErrorIs(t, err, vcr.ErrNotFound)
+		assert.Nil(t, result)
+	})
+	t.Run("error - issuance failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		keyResolverMock := NewMockkeyResolver(ctrl)
+		keyResolverMock.EXPECT().ResolveAssertionKey(ctx, gomock.Any()).Return(nil, errors.New("issuance failed"))
+		sut := issuer{
+			keyResolver:     keyResolverMock,
+			jsonldManager:   jsonldManager,
+			keyStore:        keyStore,
+			trustConfig:     trustConfig,
+			statusListStore: newStatusListMemoryStore(),
+		}
+		_, err = sut.statusListStore.Create(ctx, issuerDID, StatusPurposeRevocation)
+		require.NoError(t, err)
+
+		result, err := sut.StatusList(ctx, issuerDID, 1)
+
+		assert.Nil(t, result)
+		assert.Error(t, err, "issuance failed")
+	})
+	t.Run("error - did:nuts", func(t *testing.T) {
+		sut := issuer{statusListStore: newStatusListMemoryStore()}
+		issuerNuts := did.MustParseDID("did:nuts:123")
+
+		result, err := sut.StatusList(ctx, issuerNuts, 1)
+
+		assert.ErrorContains(t, err, "unsupported DID method: nuts")
+		assert.Nil(t, result)
+	})
 }

--- a/vcr/issuer/mock.go
+++ b/vcr/issuer/mock.go
@@ -179,6 +179,21 @@ func (mr *MockIssuerMockRecorder) SearchCredential(credentialType, issuer, subje
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchCredential", reflect.TypeOf((*MockIssuer)(nil).SearchCredential), credentialType, issuer, subject)
 }
 
+// StatusList mocks base method.
+func (m *MockIssuer) StatusList(ctx context.Context, issuer did.DID, page int) (*vc.VerifiableCredential, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StatusList", ctx, issuer, page)
+	ret0, _ := ret[0].(*vc.VerifiableCredential)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StatusList indicates an expected call of StatusList.
+func (mr *MockIssuerMockRecorder) StatusList(ctx, issuer, page any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusList", reflect.TypeOf((*MockIssuer)(nil).StatusList), ctx, issuer, page)
+}
+
 // MockStore is a mock of Store interface.
 type MockStore struct {
 	ctrl     *gomock.Controller

--- a/vcr/issuer/statuslist2021_store.go
+++ b/vcr/issuer/statuslist2021_store.go
@@ -1,0 +1,220 @@
+package issuer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/nuts-foundation/nuts-node/vcr/types"
+	"strconv"
+	"sync"
+
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/vcr/credential"
+	"github.com/nuts-foundation/nuts-node/vcr/credential/statuslist2021"
+	"github.com/nuts-foundation/nuts-node/vdr/didweb"
+)
+
+// errNotFound wraps types.ErrNotFound to clarify which credential is not found
+var errNotFound = fmt.Errorf("status list: %w", types.ErrNotFound)
+
+// errUnsupportedPurpose limits current usage to 'revocation'
+var errUnsupportedPurpose = errors.New("status list: purpose not supported")
+
+// errNotFound wraps types.ErrRevoked to clarify the source of the error
+var errRevoked = fmt.Errorf("status list: %w", types.ErrRevoked)
+
+type StatusPurpose string
+
+const (
+	StatusPurposeRevocation = "revocation"
+	statusPurposeSuspension = "suspension" // currently not supported
+)
+
+// StatusList2021Store keeps track of the number of credentials with a credential status per issuer, and allows revoking
+// them by setting the relevant bit on the StatusList.
+// Individual statuses should be derived from the StatusList2021Credential(s), not inspected here.
+type StatusList2021Store interface {
+	// CredentialSubject creates a StatusList2021CredentialSubject to incorporate in a StatusList2021Credential issued by issuer.
+	CredentialSubject(ctx context.Context, issuer did.DID, page int) (*credential.StatusList2021CredentialSubject, error)
+	// Create a credential.StatusList2021Entry that can be added to the credentialStatus of a VC.
+	// The corresponding credential will have a gap in the bitstring if the returned entry does not make it into a credential.
+	Create(ctx context.Context, issuer did.DID, purpose StatusPurpose) (*credential.StatusList2021Entry, error)
+	// Revoke by adding StatusList2021Entry to the list of revocations.
+	// The credentialID is only used to allow reverse search of revocations, its issuer is NOT compared to the entry issuer.
+	// Returns types.ErrRevoked if already revoked, or types.ErrNotFound when the entry.StatusListCredential is unknown.
+	Revoke(ctx context.Context, credentialID ssi.URI, entry credential.StatusList2021Entry) error
+}
+
+// lastIndex tracks the last Page + StatusListIndex combo issued for an Issuer
+type lastIndex struct {
+	Issuer          string // did:web:example.com:iam:id
+	Page            int    // >= 1
+	StatusListIndex int    // 0 <= statusListIndex < statuslist2021.MaxBitstringIndex
+}
+
+// revocation exists if the index on the statusListCredential is set
+type revocation struct {
+	StatusListCredential string // https://example.com/iam/id/status/page
+	CredentialID         string // did:web:example.com:iam:id#unique-identifier
+	Page                 int    // >= 1
+	StatusListIndex      int    // 0 <= statusListIndex <= statuslist2021.MaxBitstringIndex
+}
+
+var _ StatusList2021Store = (*statusListMemoryStore)(nil)
+
+func newStatusListMemoryStore() *statusListMemoryStore {
+	return &statusListMemoryStore{
+		revocations: make(map[string][]revocation),
+		issuers:     make(map[string]lastIndex),
+		mux:         sync.RWMutex{},
+	}
+}
+
+// statusListMemoryStore is an in-memory store for testing. It does not store anything and only works for did:web
+type statusListMemoryStore struct {
+	// revocations maps all revoked credentials to the relevant statusListCredential (so incl. page)
+	revocations map[string][]revocation
+	// issuers keeps track of known issuers and their last statusListIndex+Page combo
+	issuers map[string]lastIndex
+	mux     sync.RWMutex
+}
+
+func (s *statusListMemoryStore) CredentialSubject(_ context.Context, issuer did.DID, page int) (*credential.StatusList2021CredentialSubject, error) {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+
+	statusListCredential, err := toStatusListCredential(issuer, page)
+	if err != nil {
+		return nil, err
+	}
+
+	// get revocations
+	pageRevocations, ok := s.revocations[statusListCredential]
+	if !ok {
+		return nil, errNotFound
+	}
+
+	// make encodedList
+	bitstring := statuslist2021.NewBitstring()
+	for _, rev := range pageRevocations {
+		if err = bitstring.SetBit(rev.StatusListIndex, true); err != nil {
+			// can't happen
+			return nil, err
+		}
+	}
+	encodedList, err := statuslist2021.Compress(*bitstring)
+	if err != nil {
+		// can't happen
+		return nil, err
+	}
+
+	return &credential.StatusList2021CredentialSubject{
+		Id:            statusListCredential,
+		Type:          credential.StatusList2021CredentialSubjectType,
+		StatusPurpose: StatusPurposeRevocation,
+		EncodedList:   encodedList,
+	}, nil
+}
+
+func (s *statusListMemoryStore) Create(_ context.Context, issuer did.DID, purpose StatusPurpose) (*credential.StatusList2021Entry, error) {
+	if purpose != StatusPurposeRevocation {
+		return nil, errUnsupportedPurpose
+	}
+
+	// lock db after validating input
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	// last index
+	issuerIndex, ok := s.issuers[issuer.String()]
+
+	// new StatusList2021Credential issuer
+	if !ok {
+		issuerIndex = lastIndex{
+			Issuer:          issuer.String(),
+			Page:            1,
+			StatusListIndex: -1, // will be incremented before usage
+		}
+	}
+
+	// next index
+	issuerIndex.StatusListIndex++
+	if issuerIndex.StatusListIndex > statuslist2021.MaxBitstringIndex {
+		issuerIndex.StatusListIndex = 0
+		issuerIndex.Page++
+	}
+
+	// statusListCredential with correct page
+	statusListCredential, err := toStatusListCredential(issuer, issuerIndex.Page)
+	if err != nil {
+		return nil, err
+	}
+
+	// store new page
+	if issuerIndex.StatusListIndex == 0 {
+		s.revocations[statusListCredential] = []revocation{}
+	}
+
+	// store index
+	s.issuers[issuer.String()] = issuerIndex
+
+	return &credential.StatusList2021Entry{
+		ID:                   fmt.Sprintf("%s#%d", statusListCredential, issuerIndex.StatusListIndex),
+		Type:                 credential.StatusList2021EntryType,
+		StatusPurpose:        StatusPurposeRevocation,
+		StatusListIndex:      strconv.Itoa(issuerIndex.StatusListIndex),
+		StatusListCredential: statusListCredential,
+	}, nil
+}
+
+func (s *statusListMemoryStore) Revoke(_ context.Context, credentialID ssi.URI, entry credential.StatusList2021Entry) error {
+	// validate statusListIndex
+	indexToRevoke, err := strconv.Atoi(entry.StatusListIndex)
+	if err != nil {
+		return err
+	}
+	if indexToRevoke < 0 || indexToRevoke > statuslist2021.MaxBitstringIndex {
+		return statuslist2021.ErrIndexNotInBitstring
+	}
+
+	// lock db after validating input
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	// get revocations for this page. exists when a StatusList2021Entry with purpose 'revocation' was issued for the page
+	revokedIndices, ok := s.revocations[entry.StatusListCredential]
+	if !ok {
+		return errNotFound
+	}
+
+	// check if revoked
+	for _, rev := range revokedIndices {
+		if rev.StatusListIndex == indexToRevoke {
+			// already revoked
+			return errRevoked
+		}
+	}
+
+	// store revocation
+	newRevocation := revocation{
+		StatusListCredential: entry.StatusListCredential,
+		CredentialID:         credentialID.String(),
+		StatusListIndex:      indexToRevoke,
+	}
+	s.revocations[entry.StatusListCredential] = append(s.revocations[entry.StatusListCredential], newRevocation)
+
+	return nil
+}
+
+func toStatusListCredential(issuer did.DID, page int) (string, error) {
+	switch issuer.Method {
+	case "web":
+		issuerAsURL, err := didweb.DIDToURL(issuer) // https://example.com/iam/id
+		if err != nil {
+			return "", err
+		}
+		return issuerAsURL.JoinPath("statuslist", strconv.Itoa(page)).String(), nil // https://example.com/iam/id/status/page
+	}
+	return "", fmt.Errorf("status list: unsupported DID method: %s", issuer.Method)
+}

--- a/vcr/issuer/statuslist2021_store_test.go
+++ b/vcr/issuer/statuslist2021_store_test.go
@@ -1,0 +1,59 @@
+package issuer
+
+import (
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/nuts-node/vcr/credential"
+	"github.com/nuts-foundation/nuts-node/vcr/credential/statuslist2021"
+	"github.com/nuts-foundation/nuts-node/vdr/didweb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/url"
+	"testing"
+)
+
+func Test_InMemoryStore(t *testing.T) {
+	issuerURL, _ := url.Parse("https://example.com/iam/issuer/")
+	issuerDID, _ := didweb.URLToDID(*issuerURL)
+	page1 := 1
+	t.Run("ok", func(t *testing.T) {
+		store := newStatusListMemoryStore()
+		statusListCredential := issuerURL.JoinPath("statuslist", "1")
+
+		// add a revocation to the store
+		entry, err := store.Create(nil, *issuerDID, StatusPurposeRevocation)
+		require.NoError(t, err)
+		require.NoError(t, store.Revoke(nil, ssi.MustParseURI("credential id"), *entry))
+		bs := statuslist2021.NewBitstring()
+		require.NoError(t, bs.SetBit(0, true))
+		expectedList, err := statuslist2021.Compress(*bs)
+		require.NoError(t, err)
+
+		cs, err := store.CredentialSubject(nil, *issuerDID, page1)
+
+		require.NoError(t, err)
+		assert.Equal(t, statusListCredential.String(), cs.Id)
+		assert.Equal(t, credential.StatusList2021CredentialSubjectType, cs.Type)
+		assert.Equal(t, StatusPurposeRevocation, cs.StatusPurpose)
+		assert.Equal(t, expectedList, cs.EncodedList)
+	})
+
+	t.Run(" ok - not revoked", func(t *testing.T) {
+		store := newStatusListMemoryStore()
+		_, err := store.Create(nil, *issuerDID, StatusPurposeRevocation)
+		require.NoError(t, err)
+		expectedList, err := statuslist2021.Compress(*statuslist2021.NewBitstring())
+		require.NoError(t, err)
+
+		cs, err := store.CredentialSubject(nil, *issuerDID, page1)
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedList, cs.EncodedList)
+	})
+
+	t.Run("unknown statuslist", func(t *testing.T) {
+		nonExistingPage := 5
+		cs, err := newStatusListMemoryStore().CredentialSubject(nil, *issuerDID, nonExistingPage)
+		assert.ErrorIs(t, err, errNotFound)
+		assert.Nil(t, cs)
+	})
+}

--- a/vcr/types/constants.go
+++ b/vcr/types/constants.go
@@ -26,6 +26,9 @@ import (
 // ErrNotFound is returned when a credential can not be found based on its ID.
 var ErrNotFound = errors.New("credential not found")
 
+// ErrStatusNotFound is returned when the credential does not contain the desired credential status
+var ErrStatusNotFound = errors.New("credential contains no (relevant) status")
+
 // ErrMultipleFound is returned when multiple credentials or revocations are found for the same ID.
 var ErrMultipleFound = errors.New("multiple found")
 


### PR DESCRIPTION
closes #2690 

this PR adds
- option to add credentialStatus entry to a VC during issuance
- revoking credentials with a credentialStatus
- fetching StatusList2021Credentials for issuers that have issued credentials with a credentialStatus
`example.com/iam/123/statuslist/1`
- in memory store that will be replaced by a sql store in a follow-up PR
