### PR TITLE
Discovery: API to list configured Discovery Services

### DIFF
--- a/codegen/configs/discovery_v1.yaml
+++ b/codegen/configs/discovery_v1.yaml
@@ -9,3 +9,4 @@ output-options:
   exclude-schemas:
     - VerifiablePresentation
     - PresentationsResponse
+    - ServiceDefinition

--- a/discovery/api/v1/api.go
+++ b/discovery/api/v1/api.go
@@ -156,3 +156,8 @@ func (w *Wrapper) DeactivateServiceForDID(ctx context.Context, request Deactivat
 	}
 	return DeactivateServiceForDID200Response{}, nil
 }
+
+func (w *Wrapper) GetServices(_ context.Context, _ GetServicesRequestObject) (GetServicesResponseObject, error) {
+	result := GetServices200JSONResponse(w.Client.Services())
+	return &result, nil
+}

--- a/discovery/api/v1/types.go
+++ b/discovery/api/v1/types.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"github.com/nuts-foundation/go-did/vc"
+	"github.com/nuts-foundation/nuts-node/discovery"
 	"github.com/nuts-foundation/nuts-node/discovery/api/v1/model"
 )
 
@@ -28,3 +29,6 @@ type VerifiablePresentation = vc.VerifiablePresentation
 
 // PresentationsResponse is a type alias
 type PresentationsResponse = model.PresentationsResponse
+
+// ServiceDefinition is a type alias
+type ServiceDefinition = discovery.ServiceDefinition

--- a/discovery/interface.go
+++ b/discovery/interface.go
@@ -113,6 +113,9 @@ type Client interface {
 	// DeactivateServiceForDID removes the registration of a DID on a Discovery Service.
 	// It returns an error if the service or DID is invalid/unknown.
 	DeactivateServiceForDID(ctx context.Context, serviceID string, subjectDID did.DID) error
+
+	// Services returns the list of services that are registered on this client.
+	Services() []ServiceDefinition
 }
 
 // SearchResult is a single result of a search operation.

--- a/discovery/mock.go
+++ b/discovery/mock.go
@@ -136,3 +136,17 @@ func (mr *MockClientMockRecorder) Search(serviceID, query any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockClient)(nil).Search), serviceID, query)
 }
+
+// Services mocks base method.
+func (m *MockClient) Services() []ServiceDefinition {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Services")
+	ret0, _ := ret[0].([]ServiceDefinition)
+	return ret0
+}
+
+// Services indicates an expected call of Services.
+func (mr *MockClientMockRecorder) Services() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Services", reflect.TypeOf((*MockClient)(nil).Services))
+}

--- a/discovery/module.go
+++ b/discovery/module.go
@@ -284,6 +284,14 @@ func (m *Module) DeactivateServiceForDID(ctx context.Context, serviceID string, 
 	return m.registrationManager.deactivate(ctx, serviceID, subjectDID)
 }
 
+func (m *Module) Services() []ServiceDefinition {
+	result := make([]ServiceDefinition, 0, len(m.allDefinitions))
+	for _, definition := range m.allDefinitions {
+		result = append(result, definition)
+	}
+	return result
+}
+
 func loadDefinitions(directory string) (map[string]ServiceDefinition, error) {
 	entries, err := os.ReadDir(directory)
 	if err != nil {

--- a/discovery/module_test.go
+++ b/discovery/module_test.go
@@ -345,3 +345,14 @@ func TestModule_ActivateServiceForDID(t *testing.T) {
 		require.ErrorIs(t, err, ErrPresentationRegistrationFailed)
 	})
 }
+
+func TestModule_Services(t *testing.T) {
+	storageEngine := storage.NewTestStorageEngine(t)
+	require.NoError(t, storageEngine.Start())
+	t.Run("ok", func(t *testing.T) {
+		services := (&Module{
+			allDefinitions: testDefinitions(),
+		}).Services()
+		assert.Len(t, services, 2)
+	})
+}

--- a/docs/_static/discovery/v1.yaml
+++ b/docs/_static/discovery/v1.yaml
@@ -71,6 +71,25 @@ paths:
           $ref: "../common/error_response.yaml"
         default:
           $ref: "../common/error_response.yaml"
+  /internal/discovery/v1:
+    get:
+      summary: Retrieves the list of Discovery Services.
+      description: |
+        An API provided by the Discovery Client that retrieves the list of configured Discovery Services.
+      operationId: getServices
+      tags:
+        - discovery
+      responses:
+        "200":
+          description:
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ServiceDefinition"
+        default:
+          $ref: "../common/error_response.yaml"
   /internal/discovery/v1/{serviceID}:
     parameters:
       - name: serviceID
@@ -239,6 +258,26 @@ components:
         fields:
           type: object
           description: Input descriptor IDs and their mapped values that from the Verifiable Credential.
+    ServiceDefinition:
+      type: object
+      required:
+          - id
+          - endpoint
+          - presentation_definition
+          - presentation_max_validity
+      properties:
+        id:
+          type: string
+          description: The ID of the Discovery Service.
+        endpoint:
+          type: string
+          description: The endpoint of the Discovery Service.
+        presentation_definition:
+          type: object
+          description: The Presentation Definition of the Discovery Service.
+        presentation_max_validity:
+          type: integer
+          description: The maximum validity (in seconds) of a Verifiable Presentation of the Discovery Service.
   securitySchemes:
     jwtBearerAuth:
       type: http


### PR DESCRIPTION
Required for future "Nuts Admin"-applications that want to show which Discovery Services are available.