### PR TITLE
VDR: Introduce DID method-specific creation options

### DIFF
--- a/vdr/api/v1/api.go
+++ b/vdr/api/v1/api.go
@@ -122,12 +122,12 @@ func (a *Wrapper) CreateDID(ctx context.Context, request CreateDIDRequestObject)
 			if err != nil {
 				return nil, core.InvalidInputError("controller entry (%s) could not be parsed: %w", c, err)
 			}
-			options.Controllers = append(options.Controllers, *id)
+			options.MethodSpecificOptions = append(options.MethodSpecificOptions, didnuts.Controllers(*id))
 		}
 	}
 	options.KeyFlags = request.Body.VerificationMethodRelationship.ToFlags(options.KeyFlags)
 	if request.Body.SelfControl != nil {
-		options.SelfControl = *request.Body.SelfControl
+		options.MethodSpecificOptions = append(options.MethodSpecificOptions, didnuts.SelfControl(*request.Body.SelfControl))
 	}
 
 	doc, _, err := a.VDR.Create(ctx, options)

--- a/vdr/api/v1/api.go
+++ b/vdr/api/v1/api.go
@@ -90,7 +90,7 @@ func (a *Wrapper) AddNewVerificationMethod(ctx context.Context, request AddNewVe
 		opts = &VerificationMethodRelationship{}
 	}
 
-	vm, err := a.DocManipulator.AddVerificationMethod(ctx, *d, opts.ToFlags(didnuts.DefaultCreationOptions().KeyFlags))
+	vm, err := a.DocManipulator.AddVerificationMethod(ctx, *d, opts.ToFlags(didnuts.DefaultKeyFlags()))
 	if err != nil {
 		return nil, err
 	}
@@ -117,17 +117,23 @@ func (a *Wrapper) Routes(router core.EchoRouter) {
 func (a *Wrapper) CreateDID(ctx context.Context, request CreateDIDRequestObject) (CreateDIDResponseObject, error) {
 	options := didnuts.DefaultCreationOptions()
 	if request.Body.Controllers != nil {
+		var controllers []did.DID
 		for _, c := range *request.Body.Controllers {
 			id, err := did.ParseDID(c)
 			if err != nil {
 				return nil, core.InvalidInputError("controller entry (%s) could not be parsed: %w", c, err)
 			}
-			options.AddOption(didnuts.Controllers(*id))
+			controllers = append(controllers, *id)
 		}
+		options = options.With(didnuts.Controllers(controllers...))
 	}
-	options.KeyFlags = request.Body.VerificationMethodRelationship.ToFlags(options.KeyFlags)
+	defaultKeyFlags := didnuts.DefaultKeyFlags()
+	keyFlags := request.Body.VerificationMethodRelationship.ToFlags(defaultKeyFlags)
+	if keyFlags != defaultKeyFlags {
+		options = options.With(keyFlags)
+	}
 	if request.Body.SelfControl != nil {
-		options.AddOption(didnuts.SelfControl(*request.Body.SelfControl))
+		options = options.With(didnuts.SelfControl(*request.Body.SelfControl))
 	}
 
 	doc, _, err := a.VDR.Create(ctx, options)

--- a/vdr/api/v1/api.go
+++ b/vdr/api/v1/api.go
@@ -122,12 +122,12 @@ func (a *Wrapper) CreateDID(ctx context.Context, request CreateDIDRequestObject)
 			if err != nil {
 				return nil, core.InvalidInputError("controller entry (%s) could not be parsed: %w", c, err)
 			}
-			options.MethodSpecificOptions = append(options.MethodSpecificOptions, didnuts.Controllers(*id))
+			options.AddOption(didnuts.Controllers(*id))
 		}
 	}
 	options.KeyFlags = request.Body.VerificationMethodRelationship.ToFlags(options.KeyFlags)
 	if request.Body.SelfControl != nil {
-		options.MethodSpecificOptions = append(options.MethodSpecificOptions, didnuts.SelfControl(*request.Body.SelfControl))
+		options.AddOption(didnuts.SelfControl(*request.Body.SelfControl))
 	}
 
 	doc, _, err := a.VDR.Create(ctx, options)

--- a/vdr/api/v1/api_test.go
+++ b/vdr/api/v1/api_test.go
@@ -376,7 +376,7 @@ func TestWrapper_AddNewVerificationMethod(t *testing.T) {
 
 	t.Run("ok - without key usage", func(t *testing.T) {
 		ctx := newMockContext(t)
-		ctx.docUpdater.EXPECT().AddVerificationMethod(ctx.requestCtx, *did123, didnuts.DefaultCreationOptions().KeyFlags).Return(newMethod, nil)
+		ctx.docUpdater.EXPECT().AddVerificationMethod(ctx.requestCtx, *did123, didnuts.DefaultKeyFlags()).Return(newMethod, nil)
 
 		response, err := ctx.client.AddNewVerificationMethod(ctx.requestCtx, AddNewVerificationMethodRequestObject{Did: did123.String()})
 
@@ -386,7 +386,7 @@ func TestWrapper_AddNewVerificationMethod(t *testing.T) {
 
 	t.Run("ok - with key usage", func(t *testing.T) {
 		ctx := newMockContext(t)
-		expectedKeyUsage := didnuts.DefaultCreationOptions().KeyFlags | management.AuthenticationUsage | management.CapabilityDelegationUsage
+		expectedKeyUsage := didnuts.DefaultKeyFlags() | management.AuthenticationUsage | management.CapabilityDelegationUsage
 		ctx.docUpdater.EXPECT().AddVerificationMethod(ctx.requestCtx, *did123, expectedKeyUsage).Return(newMethod, nil)
 		trueBool := true
 		request := AddNewVerificationMethodJSONRequestBody{

--- a/vdr/api/v2/api.go
+++ b/vdr/api/v2/api.go
@@ -67,12 +67,9 @@ func (a *Wrapper) Routes(router core.EchoRouter) {
 }
 
 func (w Wrapper) CreateDID(ctx context.Context, request CreateDIDRequestObject) (CreateDIDResponseObject, error) {
-	options := management.DIDCreationOptions{
-		Method:   didweb.MethodName,
-		KeyFlags: management.AssertionMethodUsage | management.CapabilityInvocationUsage | management.KeyAgreementUsage | management.AuthenticationUsage | management.CapabilityDelegationUsage,
-	}
+	options := management.Create(didweb.MethodName)
 	if request.Body.Id != nil && *request.Body.Id != "" {
-		options.AddOption(didweb.UserPath(*request.Body.Id))
+		options = options.With(didweb.UserPath(*request.Body.Id))
 	}
 
 	doc, _, err := w.VDR.Create(ctx, options)

--- a/vdr/api/v2/api.go
+++ b/vdr/api/v2/api.go
@@ -66,11 +66,13 @@ func (a *Wrapper) Routes(router core.EchoRouter) {
 	}))
 }
 
-func (w Wrapper) CreateDID(ctx context.Context, _ CreateDIDRequestObject) (CreateDIDResponseObject, error) {
+func (w Wrapper) CreateDID(ctx context.Context, request CreateDIDRequestObject) (CreateDIDResponseObject, error) {
 	options := management.DIDCreationOptions{
-		Method:      didweb.MethodName,
-		KeyFlags:    management.AssertionMethodUsage | management.CapabilityInvocationUsage | management.KeyAgreementUsage | management.AuthenticationUsage | management.CapabilityDelegationUsage,
-		SelfControl: true,
+		Method:   didweb.MethodName,
+		KeyFlags: management.AssertionMethodUsage | management.CapabilityInvocationUsage | management.KeyAgreementUsage | management.AuthenticationUsage | management.CapabilityDelegationUsage,
+	}
+	if request.Body.Id != nil && *request.Body.Id != "" {
+		options.MethodSpecificOptions = append(options.MethodSpecificOptions, didweb.UserPath(*request.Body.Id))
 	}
 
 	doc, _, err := w.VDR.Create(ctx, options)

--- a/vdr/api/v2/api.go
+++ b/vdr/api/v2/api.go
@@ -72,7 +72,7 @@ func (w Wrapper) CreateDID(ctx context.Context, request CreateDIDRequestObject) 
 		KeyFlags: management.AssertionMethodUsage | management.CapabilityInvocationUsage | management.KeyAgreementUsage | management.AuthenticationUsage | management.CapabilityDelegationUsage,
 	}
 	if request.Body.Id != nil && *request.Body.Id != "" {
-		options.MethodSpecificOptions = append(options.MethodSpecificOptions, didweb.UserPath(*request.Body.Id))
+		options.AddOption(didweb.UserPath(*request.Body.Id))
 	}
 
 	doc, _, err := w.VDR.Create(ctx, options)

--- a/vdr/api/v2/api_test.go
+++ b/vdr/api/v2/api_test.go
@@ -22,7 +22,6 @@ package v2
 import (
 	"context"
 	"github.com/nuts-foundation/nuts-node/vdr/didweb"
-	"github.com/nuts-foundation/nuts-node/vdr/management"
 	"testing"
 
 	"github.com/nuts-foundation/go-did/did"
@@ -42,11 +41,7 @@ func TestWrapper_CreateDID(t *testing.T) {
 
 	t.Run("ok - defaults", func(t *testing.T) {
 		ctx := newMockContext(t)
-		opts := management.DIDCreationOptions{
-			Method:   didweb.MethodName,
-			KeyFlags: management.AssertionMethodUsage | management.CapabilityInvocationUsage | management.KeyAgreementUsage | management.AuthenticationUsage | management.CapabilityDelegationUsage,
-		}
-		ctx.vdr.EXPECT().Create(gomock.Any(), opts).Return(didDoc, nil, nil)
+		ctx.vdr.EXPECT().Create(gomock.Any(), didweb.DefaultCreationOptions()).Return(didDoc, nil, nil)
 
 		response, err := ctx.client.CreateDID(nil, CreateDIDRequestObject{Body: &CreateDIDJSONRequestBody{}})
 
@@ -55,13 +50,7 @@ func TestWrapper_CreateDID(t *testing.T) {
 	})
 	t.Run("with user ID", func(t *testing.T) {
 		ctx := newMockContext(t)
-		opts := management.DIDCreationOptions{
-			Method:   didweb.MethodName,
-			KeyFlags: management.AssertionMethodUsage | management.CapabilityInvocationUsage | management.KeyAgreementUsage | management.AuthenticationUsage | management.CapabilityDelegationUsage,
-			MethodSpecificOptions: []management.DIDCreationOption{
-				didweb.UserPath("1"),
-			},
-		}
+		opts := didweb.DefaultCreationOptions().With(didweb.UserPath("1"))
 		ctx.vdr.EXPECT().Create(gomock.Any(), opts).Return(didDoc, nil, nil)
 
 		var userId = "1"

--- a/vdr/api/v2/api_test.go
+++ b/vdr/api/v2/api_test.go
@@ -43,9 +43,8 @@ func TestWrapper_CreateDID(t *testing.T) {
 	t.Run("ok - defaults", func(t *testing.T) {
 		ctx := newMockContext(t)
 		opts := management.DIDCreationOptions{
-			Method:      didweb.MethodName,
-			KeyFlags:    management.AssertionMethodUsage | management.CapabilityInvocationUsage | management.KeyAgreementUsage | management.AuthenticationUsage | management.CapabilityDelegationUsage,
-			SelfControl: true,
+			Method:   didweb.MethodName,
+			KeyFlags: management.AssertionMethodUsage | management.CapabilityInvocationUsage | management.KeyAgreementUsage | management.AuthenticationUsage | management.CapabilityDelegationUsage,
 		}
 		ctx.vdr.EXPECT().Create(gomock.Any(), opts).Return(didDoc, nil, nil)
 
@@ -54,7 +53,27 @@ func TestWrapper_CreateDID(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, id, response.(CreateDID200JSONResponse).ID)
 	})
+	t.Run("with user ID", func(t *testing.T) {
+		ctx := newMockContext(t)
+		opts := management.DIDCreationOptions{
+			Method:   didweb.MethodName,
+			KeyFlags: management.AssertionMethodUsage | management.CapabilityInvocationUsage | management.KeyAgreementUsage | management.AuthenticationUsage | management.CapabilityDelegationUsage,
+			MethodSpecificOptions: []management.DIDCreationOption{
+				didweb.UserPath("1"),
+			},
+		}
+		ctx.vdr.EXPECT().Create(gomock.Any(), opts).Return(didDoc, nil, nil)
 
+		var userId = "1"
+		response, err := ctx.client.CreateDID(nil, CreateDIDRequestObject{
+			Body: &CreateDIDJSONRequestBody{
+				Id: &userId,
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, id, response.(CreateDID200JSONResponse).ID)
+	})
 	t.Run("error - create fails", func(t *testing.T) {
 		ctx := newMockContext(t)
 		ctx.vdr.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil, nil, assert.AnError)

--- a/vdr/api/v2/api_test.go
+++ b/vdr/api/v2/api_test.go
@@ -48,7 +48,7 @@ func TestWrapper_CreateDID(t *testing.T) {
 		}
 		ctx.vdr.EXPECT().Create(gomock.Any(), opts).Return(didDoc, nil, nil)
 
-		response, err := ctx.client.CreateDID(nil, CreateDIDRequestObject{})
+		response, err := ctx.client.CreateDID(nil, CreateDIDRequestObject{Body: &CreateDIDJSONRequestBody{}})
 
 		require.NoError(t, err)
 		assert.Equal(t, id, response.(CreateDID200JSONResponse).ID)
@@ -78,7 +78,9 @@ func TestWrapper_CreateDID(t *testing.T) {
 		ctx := newMockContext(t)
 		ctx.vdr.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil, nil, assert.AnError)
 
-		response, err := ctx.client.CreateDID(nil, CreateDIDRequestObject{})
+		response, err := ctx.client.CreateDID(nil, CreateDIDRequestObject{
+			Body: &CreateDIDJSONRequestBody{},
+		})
 
 		assert.Error(t, err)
 		assert.Nil(t, response)

--- a/vdr/cmd/cmd.go
+++ b/vdr/cmd/cmd.go
@@ -117,7 +117,7 @@ func createCmd() *cobra.Command {
 	result.Flags().BoolVar(createRequest.CapabilityDelegation, "capabilityDelegation", defs.KeyFlags.Is(management.CapabilityDelegationUsage), setUsage(defs.KeyFlags.Is(management.CapabilityDelegationUsage), "Pass '%t' to %s capabilityDelegation capabilities."))
 	result.Flags().BoolVar(createRequest.CapabilityInvocation, "capabilityInvocation", defs.KeyFlags.Is(management.CapabilityInvocationUsage), setUsage(defs.KeyFlags.Is(management.CapabilityInvocationUsage), "Pass '%t' to %s capabilityInvocation capabilities."))
 	result.Flags().BoolVar(createRequest.KeyAgreement, "keyAgreement", defs.KeyFlags.Is(management.KeyAgreementUsage), setUsage(defs.KeyFlags.Is(management.KeyAgreementUsage), "Pass '%t' to %s keyAgreement capabilities."))
-	result.Flags().BoolVar(createRequest.SelfControl, "selfControl", defs.SelfControl, setUsage(defs.SelfControl, "Pass '%t' to %s DID Document control."))
+	result.Flags().BoolVar(createRequest.SelfControl, "selfControl", true, setUsage(true, "Pass '%t' to %s DID Document control."))
 	result.Flags().BoolVar(&useV2, "v2", false, "Pass 'true' to use the V2 API and create a did:web DID.")
 	result.Flags().StringSliceVar(createRequest.Controllers, "controllers", []string{}, "Comma-separated list of DIDs that can control the generated DID Document.")
 

--- a/vdr/cmd/cmd.go
+++ b/vdr/cmd/cmd.go
@@ -104,7 +104,7 @@ func createCmd() *cobra.Command {
 		},
 	}
 
-	defs := didnuts.DefaultCreationOptions()
+	defs := didnuts.DefaultKeyFlags()
 	setUsage := func(def bool, usage string) string {
 		opposite := "enable"
 		if def {
@@ -112,11 +112,11 @@ func createCmd() *cobra.Command {
 		}
 		return fmt.Sprintf(usage, !def, opposite)
 	}
-	result.Flags().BoolVar(createRequest.AssertionMethod, "assertionMethod", defs.KeyFlags.Is(management.AssertionMethodUsage), setUsage(defs.KeyFlags.Is(management.AssertionMethodUsage), "Pass '%t' to %s assertionMethod capabilities."))
-	result.Flags().BoolVar(createRequest.Authentication, "authentication", defs.KeyFlags.Is(management.AuthenticationUsage), setUsage(defs.KeyFlags.Is(management.AuthenticationUsage), "Pass '%t' to %s authentication capabilities."))
-	result.Flags().BoolVar(createRequest.CapabilityDelegation, "capabilityDelegation", defs.KeyFlags.Is(management.CapabilityDelegationUsage), setUsage(defs.KeyFlags.Is(management.CapabilityDelegationUsage), "Pass '%t' to %s capabilityDelegation capabilities."))
-	result.Flags().BoolVar(createRequest.CapabilityInvocation, "capabilityInvocation", defs.KeyFlags.Is(management.CapabilityInvocationUsage), setUsage(defs.KeyFlags.Is(management.CapabilityInvocationUsage), "Pass '%t' to %s capabilityInvocation capabilities."))
-	result.Flags().BoolVar(createRequest.KeyAgreement, "keyAgreement", defs.KeyFlags.Is(management.KeyAgreementUsage), setUsage(defs.KeyFlags.Is(management.KeyAgreementUsage), "Pass '%t' to %s keyAgreement capabilities."))
+	result.Flags().BoolVar(createRequest.AssertionMethod, "assertionMethod", defs.Is(management.AssertionMethodUsage), setUsage(defs.Is(management.AssertionMethodUsage), "Pass '%t' to %s assertionMethod capabilities."))
+	result.Flags().BoolVar(createRequest.Authentication, "authentication", defs.Is(management.AuthenticationUsage), setUsage(defs.Is(management.AuthenticationUsage), "Pass '%t' to %s authentication capabilities."))
+	result.Flags().BoolVar(createRequest.CapabilityDelegation, "capabilityDelegation", defs.Is(management.CapabilityDelegationUsage), setUsage(defs.Is(management.CapabilityDelegationUsage), "Pass '%t' to %s capabilityDelegation capabilities."))
+	result.Flags().BoolVar(createRequest.CapabilityInvocation, "capabilityInvocation", defs.Is(management.CapabilityInvocationUsage), setUsage(defs.Is(management.CapabilityInvocationUsage), "Pass '%t' to %s capabilityInvocation capabilities."))
+	result.Flags().BoolVar(createRequest.KeyAgreement, "keyAgreement", defs.Is(management.KeyAgreementUsage), setUsage(defs.Is(management.KeyAgreementUsage), "Pass '%t' to %s keyAgreement capabilities."))
 	result.Flags().BoolVar(createRequest.SelfControl, "selfControl", true, setUsage(true, "Pass '%t' to %s DID Document control."))
 	result.Flags().BoolVar(&useV2, "v2", false, "Pass 'true' to use the V2 API and create a did:web DID.")
 	result.Flags().StringSliceVar(createRequest.Controllers, "controllers", []string{}, "Comma-separated list of DIDs that can control the generated DID Document.")

--- a/vdr/didnuts/ambassador_test.go
+++ b/vdr/didnuts/ambassador_test.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/audit"
 	"github.com/nuts-foundation/nuts-node/network"
-	"github.com/nuts-foundation/nuts-node/vdr/management"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 	"testing"
 	"time"
@@ -389,7 +388,7 @@ func TestAmbassador_handleUpdateDIDDocument(t *testing.T) {
 		ctx := newMockContext(t)
 
 		controllerDoc, signingKey, _ := newDidDoc()
-		didDocument, _, _ := newDidDocWithOptions(management.DIDCreationOptions{Controllers: []did.DID{controllerDoc.ID}})
+		didDocument, _, _ := newDidDocWithOptions(false, controllerDoc.ID)
 
 		didDocPayload, _ := json.Marshal(didDocument)
 		payloadHash := hash.SHA256Sum(didDocPayload)
@@ -795,10 +794,10 @@ func Test_uniqueTransactions(t *testing.T) {
 	})
 }
 
-func newDidDocWithOptions(opts management.DIDCreationOptions) (did.Document, jwk.Key, error) {
+func newDidDocWithOptions(selfControl bool, controllers ...did.DID) (did.Document, jwk.Key, error) {
 	kc := &mockKeyCreator{}
 	docCreator := Creator{KeyStore: kc}
-	didDocument, key, err := docCreator.create(audit.TestContext(), opts)
+	didDocument, key, err := docCreator.create(audit.TestContext(), DefaultCreationOptions().KeyFlags, selfControl, controllers)
 	signingKey, _ := jwk.FromRaw(key.Public())
 	thumbStr, _ := crypto.Thumbprint(signingKey)
 	didDocument.ID = did.MustParseDID(fmt.Sprintf("did:nuts:%s", thumbStr))
@@ -818,7 +817,7 @@ func newDidDocWithOptions(opts management.DIDCreationOptions) (did.Document, jwk
 }
 
 func newDidDoc() (did.Document, jwk.Key, error) {
-	return newDidDocWithOptions(DefaultCreationOptions())
+	return newDidDocWithOptions(true)
 }
 
 type mockContext struct {

--- a/vdr/didnuts/ambassador_test.go
+++ b/vdr/didnuts/ambassador_test.go
@@ -797,7 +797,7 @@ func Test_uniqueTransactions(t *testing.T) {
 func newDidDocWithOptions(selfControl bool, controllers ...did.DID) (did.Document, jwk.Key, error) {
 	kc := &mockKeyCreator{}
 	docCreator := Creator{KeyStore: kc}
-	didDocument, key, err := docCreator.create(audit.TestContext(), DefaultCreationOptions().KeyFlags, selfControl, controllers)
+	didDocument, key, err := docCreator.create(audit.TestContext(), DefaultKeyFlags(), selfControl, controllers)
 	signingKey, _ := jwk.FromRaw(key.Public())
 	thumbStr, _ := crypto.Thumbprint(signingKey)
 	didDocument.ID = did.MustParseDID(fmt.Sprintf("did:nuts:%s", thumbStr))

--- a/vdr/didnuts/creator.go
+++ b/vdr/didnuts/creator.go
@@ -166,7 +166,7 @@ func (n Creator) Create(ctx context.Context, options management.DIDCreationOptio
 		case controllersCreationOption:
 			controllers = append(controllers, o.controllers...)
 		default:
-			return nil, nil, fmt.Errorf("unknown option type: %T", opt)
+			return nil, nil, fmt.Errorf("unknown option: %T", opt)
 		}
 	}
 

--- a/vdr/didnuts/creator.go
+++ b/vdr/didnuts/creator.go
@@ -77,11 +77,29 @@ type Creator struct {
 // DefaultCreationOptions returns the default DIDCreationOptions when creating DID Documents.
 func DefaultCreationOptions() management.DIDCreationOptions {
 	return management.DIDCreationOptions{
-		Method:      MethodName,
-		Controllers: []did.DID{},
-		KeyFlags:    management.AssertionMethodUsage | management.CapabilityInvocationUsage | management.KeyAgreementUsage,
-		SelfControl: true,
+		Method:                MethodName,
+		KeyFlags:              management.AssertionMethodUsage | management.CapabilityInvocationUsage | management.KeyAgreementUsage,
+		MethodSpecificOptions: []management.DIDCreationOption{SelfControl(true)},
 	}
+}
+
+type selfControlCreationOption struct {
+	selfControl bool
+}
+
+// SelfControl is a DID document creation option that indicates whether the generated DID Document can be altered with its own capabilityInvocation key.
+func SelfControl(value bool) management.DIDCreationOption {
+	return selfControlCreationOption{selfControl: value}
+}
+
+type controllersCreationOption struct {
+	controllers []did.DID
+}
+
+// Controllers is a DID document creation option that indicates which DIDs can control the generated DID Document.
+// If selfControl = true and controllers is not empty, the newly generated DID will be added to the list of controllers.
+func Controllers(controllers ...did.DID) management.DIDCreationOption {
+	return controllersCreationOption{controllers: controllers}
 }
 
 // didKIDNamingFunc is a function used to name a key used in newly generated DID Documents.
@@ -138,13 +156,27 @@ var ErrInvalidOptions = errors.New("create request has invalid combination of op
 // The key is added to the verificationMethod list and referred to from the Authentication list
 // It also publishes the DID Document to the network.
 func (n Creator) Create(ctx context.Context, options management.DIDCreationOptions) (*did.Document, nutsCrypto.Key, error) {
+	var selfControl bool
+	var controllers []did.DID
+
+	for _, opt := range options.MethodSpecificOptions {
+		switch o := opt.(type) {
+		case selfControlCreationOption:
+			selfControl = o.selfControl
+		case controllersCreationOption:
+			controllers = append(controllers, o.controllers...)
+		default:
+			return nil, nil, fmt.Errorf("unknown option type: %T", opt)
+		}
+	}
+
 	// for all controllers given in the options, we need to capture the metadata so the new transaction can reference to it
 	// holder for all metadata of the controllers
-	controllerMetadata := make([]resolver.DocumentMetadata, len(options.Controllers))
+	controllerMetadata := make([]resolver.DocumentMetadata, len(controllers))
 
 	// if any controllers have been added, check if they exist through the didResolver
-	if len(options.Controllers) > 0 {
-		for _, controller := range options.Controllers {
+	if len(controllers) > 0 {
+		for _, controller := range controllers {
 			_, meta, err := n.DIDResolver.Resolve(controller, nil)
 			if err != nil {
 				return nil, nil, fmt.Errorf("could not create DID document: could not resolve a controller: %w", err)
@@ -153,11 +185,11 @@ func (n Creator) Create(ctx context.Context, options management.DIDCreationOptio
 		}
 	}
 
-	if options.SelfControl && !options.KeyFlags.Is(management.CapabilityInvocationUsage) {
+	if selfControl && !options.KeyFlags.Is(management.CapabilityInvocationUsage) {
 		return nil, nil, ErrInvalidOptions
 	}
 
-	doc, key, err := n.create(ctx, options)
+	doc, key, err := n.create(ctx, options.KeyFlags, selfControl, controllers)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -169,7 +201,7 @@ func (n Creator) Create(ctx context.Context, options management.DIDCreationOptio
 	return doc, key, nil
 }
 
-func (n Creator) create(ctx context.Context, options management.DIDCreationOptions) (*did.Document, nutsCrypto.Key, error) {
+func (n Creator) create(ctx context.Context, flags management.DIDKeyFlags, selfControl bool, controllers []did.DID) (*did.Document, nutsCrypto.Key, error) {
 	// First, generate a new keyPair with the correct kid
 	// Currently, always keep the key in the keystore. This allows us to change the transaction format and regenerate transactions at a later moment.
 	// Relevant issue:
@@ -191,16 +223,16 @@ func (n Creator) create(ctx context.Context, options management.DIDCreationOptio
 	didID, _ := resolver.GetDIDFromURL(key.KID())
 	doc := CreateDocument()
 	doc.ID = didID
-	doc.Controller = options.Controllers
+	doc.Controller = controllers
 
 	var verificationMethod *did.VerificationMethod
-	if options.SelfControl {
+	if selfControl {
 		// Add VerificationMethod using generated key
 		verificationMethod, err = did.NewVerificationMethod(*keyID, ssi.JsonWebKey2020, did.DID{}, key.Public())
 		if err != nil {
 			return nil, nil, err
 		}
-		if len(options.Controllers) > 0 {
+		if len(controllers) > 0 {
 			// also set as controller
 			doc.Controller = append(doc.Controller, didID)
 		}
@@ -220,7 +252,7 @@ func (n Creator) create(ctx context.Context, options management.DIDCreationOptio
 		}
 	}
 
-	applyKeyUsage(&doc, verificationMethod, options.KeyFlags)
+	applyKeyUsage(&doc, verificationMethod, flags)
 	return &doc, key, nil
 }
 

--- a/vdr/didnuts/creator_test.go
+++ b/vdr/didnuts/creator_test.go
@@ -87,6 +87,15 @@ func TestCreator_Create(t *testing.T) {
 			assert.Empty(t, txTemplate.AdditionalPrevs)
 		})
 
+		t.Run("unknown option", func(t *testing.T) {
+			_, _, err := (&Creator{}).Create(nil, management.DIDCreationOptions{
+				MethodSpecificOptions: []management.DIDCreationOption{
+					"",
+				},
+			})
+			assert.EqualError(t, err, "unknown option: string")
+		})
+
 		t.Run("all keys", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			networkClient := network.NewMockTransactions(ctrl)

--- a/vdr/didnuts/creator_test.go
+++ b/vdr/didnuts/creator_test.go
@@ -225,7 +225,9 @@ func TestCreator_Create(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockKeyStore := nutsCrypto.NewMockKeyStore(ctrl)
 		creator := Creator{KeyStore: mockKeyStore}
-		ops := DefaultCreationOptions().With(KeyFlag(management.AssertionMethodUsage))
+		ops := DefaultCreationOptions().
+			With(KeyFlag(management.AssertionMethodUsage)).
+			With(SelfControl(false))
 		mockKeyStore.EXPECT().New(gomock.Any(), gomock.Any()).Return(nil, errors.New("b00m!"))
 
 		_, _, err := creator.Create(nil, ops)

--- a/vdr/didnuts/creator_test.go
+++ b/vdr/didnuts/creator_test.go
@@ -51,8 +51,7 @@ func TestDefaultCreationOptions(t *testing.T) {
 	assert.False(t, usage.Is(management.CapabilityDelegationUsage))
 	assert.True(t, usage.Is(management.CapabilityInvocationUsage))
 	assert.True(t, usage.Is(management.KeyAgreementUsage))
-	assert.True(t, ops.SelfControl)
-	assert.Empty(t, ops.Controllers)
+	assert.Contains(t, ops.MethodSpecificOptions, SelfControl(true))
 }
 
 func TestCreator_Create(t *testing.T) {
@@ -101,7 +100,9 @@ func TestCreator_Create(t *testing.T) {
 					management.CapabilityDelegationUsage |
 					management.CapabilityInvocationUsage |
 					management.KeyAgreementUsage,
-				SelfControl: true,
+				MethodSpecificOptions: []management.DIDCreationOption{
+					SelfControl(true),
+				},
 			}
 			doc, _, err := creator.Create(nil, ops)
 
@@ -117,9 +118,11 @@ func TestCreator_Create(t *testing.T) {
 		t.Run("extra controller", func(t *testing.T) {
 			c, _ := did.ParseDID("did:nuts:controller")
 			ops := management.DIDCreationOptions{
-				KeyFlags:    management.AssertionMethodUsage | management.CapabilityInvocationUsage,
-				SelfControl: true,
-				Controllers: []did.DID{*c},
+				KeyFlags: management.AssertionMethodUsage | management.CapabilityInvocationUsage,
+				MethodSpecificOptions: []management.DIDCreationOption{
+					SelfControl(true),
+					Controllers(*c),
+				},
 			}
 			controllerDoc := CreateDocument()
 			controllerDoc.ID = *c
@@ -148,9 +151,11 @@ func TestCreator_Create(t *testing.T) {
 		t.Run("error - unknown controllers", func(t *testing.T) {
 			c, _ := did.ParseDID("did:nuts:controller")
 			ops := management.DIDCreationOptions{
-				KeyFlags:    management.AssertionMethodUsage | management.CapabilityInvocationUsage,
-				SelfControl: true,
-				Controllers: []did.DID{*c},
+				KeyFlags: management.AssertionMethodUsage | management.CapabilityInvocationUsage,
+				MethodSpecificOptions: []management.DIDCreationOption{
+					SelfControl(true),
+					Controllers(*c),
+				},
 			}
 			controllerDoc := CreateDocument()
 			controllerDoc.ID = *c
@@ -184,8 +189,7 @@ func TestCreator_Create(t *testing.T) {
 			})
 
 			ops := management.DIDCreationOptions{
-				KeyFlags:    management.AssertionMethodUsage,
-				SelfControl: false,
+				KeyFlags: management.AssertionMethodUsage,
 			}
 			doc, docCreationKey, err := creator.Create(nil, ops)
 
@@ -210,7 +214,9 @@ func TestCreator_Create(t *testing.T) {
 	t.Run("error - invalid combination", func(t *testing.T) {
 		ops := management.DIDCreationOptions{
 			// CapabilityInvocation is not enabled, required when SelfControl = true
-			SelfControl: true,
+			MethodSpecificOptions: []management.DIDCreationOption{
+				SelfControl(true),
+			},
 		}
 		kc := &mockKeyCreator{}
 		creator := Creator{KeyStore: kc}
@@ -235,8 +241,7 @@ func TestCreator_Create(t *testing.T) {
 		mockKeyStore := nutsCrypto.NewMockKeyStore(ctrl)
 		creator := Creator{KeyStore: mockKeyStore}
 		ops := management.DIDCreationOptions{
-			KeyFlags:    management.AssertionMethodUsage,
-			SelfControl: false,
+			KeyFlags: management.AssertionMethodUsage,
 		}
 		mockKeyStore.EXPECT().New(gomock.Any(), gomock.Any()).Return(nil, errors.New("b00m!"))
 

--- a/vdr/didnuts/manager.go
+++ b/vdr/didnuts/manager.go
@@ -42,7 +42,7 @@ type Manager struct {
 	DocumentOwner management.DocumentOwner
 }
 
-func (m Manager) Create(ctx context.Context, options management.DIDCreationOptions) (*did.Document, crypto.Key, error) {
+func (m Manager) Create(ctx context.Context, options management.CreationOptions) (*did.Document, crypto.Key, error) {
 	return m.Creator.Create(ctx, options)
 }
 

--- a/vdr/didnuts/manager_test.go
+++ b/vdr/didnuts/manager_test.go
@@ -33,7 +33,7 @@ func TestManager_Create(t *testing.T) {
 	manager := NewManager(creator, owner)
 	creator.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil, nil, nil)
 
-	_, _, err := manager.Create(nil, management.DIDCreationOptions{})
+	_, _, err := manager.Create(nil, DefaultCreationOptions())
 
 	assert.NoError(t, err)
 }

--- a/vdr/didweb/manager.go
+++ b/vdr/didweb/manager.go
@@ -34,6 +34,10 @@ import (
 	"net/url"
 )
 
+func DefaultCreationOptions() management.CreationOptions {
+	return management.Create(MethodName)
+}
+
 var _ management.DocumentManager = (*Manager)(nil)
 
 // NewManager creates a new Manager to create and update did:web DID documents.
@@ -59,14 +63,14 @@ type userPathOption struct {
 // UserPath is an option to set a user for the did:web document.
 // It will be used as last path part of the DID.
 // If not set, a random UUID will be used.
-func UserPath(path string) management.DIDCreationOption {
+func UserPath(path string) management.CreationOption {
 	return userPathOption{path: path}
 }
 
 // Create creates a new did:web document.
-func (m Manager) Create(ctx context.Context, opts management.DIDCreationOptions) (*did.Document, crypto.Key, error) {
+func (m Manager) Create(ctx context.Context, opts management.CreationOptions) (*did.Document, crypto.Key, error) {
 	pathPart := uuid.NewString()
-	for _, opt := range opts.MethodSpecificOptions {
+	for _, opt := range opts.All() {
 		switch option := opt.(type) {
 		case userPathOption:
 			pathPart = option.path

--- a/vdr/didweb/manager_test.go
+++ b/vdr/didweb/manager_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/audit"
 	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/storage"
-	"github.com/nuts-foundation/nuts-node/vdr/management"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -114,11 +113,7 @@ func TestManager_Create(t *testing.T) {
 		}, nil)
 		m := NewManager(*baseURL, keyStore, storageEngine.GetSQLDatabase())
 
-		document, key, err := m.Create(audit.TestContext(), management.DIDCreationOptions{
-			MethodSpecificOptions: []management.DIDCreationOption{
-				UserPath("test"),
-			},
-		})
+		document, key, err := m.Create(audit.TestContext(), DefaultCreationOptions().With(UserPath("test")))
 		require.NoError(t, err)
 		require.NotNil(t, document)
 		require.NotNil(t, key)
@@ -130,11 +125,7 @@ func TestManager_Create(t *testing.T) {
 		keyStore := nutsCrypto.NewMockKeyStore(ctrl)
 		m := NewManager(*baseURL, keyStore, storageEngine.GetSQLDatabase())
 
-		_, _, err := m.Create(audit.TestContext(), management.DIDCreationOptions{
-			MethodSpecificOptions: []management.DIDCreationOption{
-				"",
-			},
-		})
+		_, _, err := m.Create(audit.TestContext(), DefaultCreationOptions().With(""))
 		require.EqualError(t, err, "unknown option: string")
 	})
 }
@@ -156,7 +147,7 @@ func TestManager_IsOwner(t *testing.T) {
 	t.Run("not owned (other DID)", func(t *testing.T) {
 		resetStore(t, storageEngine.GetSQLDatabase())
 		m := NewManager(*baseURL, nutsCrypto.NewMemoryCryptoInstance(), storageEngine.GetSQLDatabase())
-		_, _, err := m.Create(audit.TestContext(), management.DIDCreationOptions{})
+		_, _, err := m.Create(audit.TestContext(), DefaultCreationOptions())
 		require.NoError(t, err)
 
 		owned, err := m.IsOwner(audit.TestContext(), id)
@@ -166,7 +157,7 @@ func TestManager_IsOwner(t *testing.T) {
 	t.Run("owned", func(t *testing.T) {
 		resetStore(t, storageEngine.GetSQLDatabase())
 		m := NewManager(*baseURL, nutsCrypto.NewMemoryCryptoInstance(), storageEngine.GetSQLDatabase())
-		document, _, err := m.Create(audit.TestContext(), management.DIDCreationOptions{})
+		document, _, err := m.Create(audit.TestContext(), DefaultCreationOptions())
 		require.NoError(t, err)
 
 		owned, err := m.IsOwner(audit.TestContext(), document.ID)
@@ -191,7 +182,7 @@ func TestManager_ListOwned(t *testing.T) {
 	t.Run("single DID", func(t *testing.T) {
 		resetStore(t, storageEngine.GetSQLDatabase())
 		m := NewManager(*baseURL, nutsCrypto.NewMemoryCryptoInstance(), storageEngine.GetSQLDatabase())
-		document, _, err := m.Create(audit.TestContext(), management.DIDCreationOptions{})
+		document, _, err := m.Create(audit.TestContext(), DefaultCreationOptions())
 		require.NoError(t, err)
 
 		dids, err := m.ListOwned(audit.TestContext())
@@ -201,9 +192,9 @@ func TestManager_ListOwned(t *testing.T) {
 	t.Run("multiple DIDs", func(t *testing.T) {
 		resetStore(t, storageEngine.GetSQLDatabase())
 		m := NewManager(*baseURL, nutsCrypto.NewMemoryCryptoInstance(), storageEngine.GetSQLDatabase())
-		document1, _, err := m.Create(audit.TestContext(), management.DIDCreationOptions{})
+		document1, _, err := m.Create(audit.TestContext(), DefaultCreationOptions())
 		require.NoError(t, err)
-		document2, _, err := m.Create(audit.TestContext(), management.DIDCreationOptions{})
+		document2, _, err := m.Create(audit.TestContext(), DefaultCreationOptions())
 		require.NoError(t, err)
 
 		dids, err := m.ListOwned(audit.TestContext())
@@ -228,7 +219,7 @@ func TestManager_Resolve(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		resetStore(t, storageEngine.GetSQLDatabase())
 		m := NewManager(*baseURL, nutsCrypto.NewMemoryCryptoInstance(), storageEngine.GetSQLDatabase())
-		document, _, err := m.Create(audit.TestContext(), management.DIDCreationOptions{})
+		document, _, err := m.Create(audit.TestContext(), DefaultCreationOptions())
 		require.NoError(t, err)
 		expected, _ := document.MarshalJSON()
 

--- a/vdr/management/management.go
+++ b/vdr/management/management.go
@@ -82,16 +82,14 @@ type DIDCreationOptions struct {
 	// Method specifies the DID method the new DID should use
 	Method string
 
-	// Controllers lists the DIDs that can control the new DID Document. If selfControl = true and controllers is not empty,
-	// the newly generated DID will be added to the list of controllers.
-	Controllers []did.DID
-
 	// KeyFlags specifies for what purposes the generated key can be used
 	KeyFlags DIDKeyFlags
 
-	// SelfControl indicates whether the generated DID Document can be altered with its own capabilityInvocation key.
-	// Defaults to true when not given.
-	SelfControl bool
+	// MethodSpecificOptions contains creation options specific to the DID method.
+	MethodSpecificOptions []DIDCreationOption
+}
+
+type DIDCreationOption interface {
 }
 
 // DIDKeyFlags is a bitmask used for specifying for what purposes a key in a DID document can be used (a.k.a. Verification Method relationships).

--- a/vdr/management/management.go
+++ b/vdr/management/management.go
@@ -89,6 +89,12 @@ type DIDCreationOptions struct {
 	MethodSpecificOptions []DIDCreationOption
 }
 
+// AddOption adds a method-specific DID creation option.
+func (o *DIDCreationOptions) AddOption(opt DIDCreationOption) *DIDCreationOptions {
+	o.MethodSpecificOptions = append(o.MethodSpecificOptions, opt)
+	return o
+}
+
 type DIDCreationOption interface {
 }
 

--- a/vdr/management/management_mock.go
+++ b/vdr/management/management_mock.go
@@ -43,7 +43,7 @@ func (m *MockDocumentManager) EXPECT() *MockDocumentManagerMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockDocumentManager) Create(ctx context.Context, options DIDCreationOptions) (*did.Document, crypto.Key, error) {
+func (m *MockDocumentManager) Create(ctx context.Context, options CreationOptions) (*did.Document, crypto.Key, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", ctx, options)
 	ret0, _ := ret[0].(*did.Document)
@@ -128,7 +128,7 @@ func (m *MockDocCreator) EXPECT() *MockDocCreatorMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockDocCreator) Create(ctx context.Context, options DIDCreationOptions) (*did.Document, crypto.Key, error) {
+func (m *MockDocCreator) Create(ctx context.Context, options CreationOptions) (*did.Document, crypto.Key, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", ctx, options)
 	ret0, _ := ret[0].(*did.Document)

--- a/vdr/management/management_test.go
+++ b/vdr/management/management_test.go
@@ -56,10 +56,11 @@ func TestKeyUsage_Is(t *testing.T) {
 	})
 }
 
-func TestDIDCreationOptions_AddOption(t *testing.T) {
-	o := DIDCreationOptions{}
-	result := o.AddOption("test")
+func TestCreationOptions_With(t *testing.T) {
+	// make sure With() returns a mutated copy
+	o := defaultDIDCreationOptions{}
+	result := o.With("test")
 	require.NotNil(t, result)
-	assert.Contains(t, o.MethodSpecificOptions, "test")
-	assert.Same(t, result, &o)
+	assert.Contains(t, result.All(), "test")
+	assert.NotContains(t, o.All(), "test")
 }

--- a/vdr/management/management_test.go
+++ b/vdr/management/management_test.go
@@ -20,6 +20,7 @@ package management
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -53,4 +54,12 @@ func TestKeyUsage_Is(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestDIDCreationOptions_AddOption(t *testing.T) {
+	o := DIDCreationOptions{}
+	result := o.AddOption("test")
+	require.NotNil(t, result)
+	assert.Contains(t, o.MethodSpecificOptions, "test")
+	assert.Same(t, result, &o)
 }

--- a/vdr/mock.go
+++ b/vdr/mock.go
@@ -60,7 +60,7 @@ func (mr *MockVDRMockRecorder) ConflictedDocuments() *gomock.Call {
 }
 
 // Create mocks base method.
-func (m *MockVDR) Create(ctx context.Context, options management.DIDCreationOptions) (*did.Document, crypto.Key, error) {
+func (m *MockVDR) Create(ctx context.Context, options management.CreationOptions) (*did.Document, crypto.Key, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", ctx, options)
 	ret0, _ := ret[0].(*did.Document)

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -270,15 +270,15 @@ func (r *Module) Diagnostics() []core.DiagnosticResult {
 }
 
 // Create generates a new DID Document
-func (r *Module) Create(ctx context.Context, options management.DIDCreationOptions) (*did.Document, crypto.Key, error) {
+func (r *Module) Create(ctx context.Context, options management.CreationOptions) (*did.Document, crypto.Key, error) {
 	log.Logger().Debug("Creating new DID Document.")
-	manager := r.documentManagers[options.Method]
+	manager := r.documentManagers[options.Method()]
 	if manager == nil {
-		return nil, nil, fmt.Errorf("unsupported method: %s", options.Method)
+		return nil, nil, fmt.Errorf("unsupported method: %s", options.Method())
 	}
 	doc, key, err := manager.Create(ctx, options)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not create DID document (method %s): %w", options.Method, err)
+		return nil, nil, fmt.Errorf("could not create DID document (method %s): %w", options.Method(), err)
 	}
 	log.Logger().
 		WithField(core.LogFieldDID, doc.ID).

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -296,14 +296,11 @@ func TestVDR_ConflictingDocuments(t *testing.T) {
 			require.NoError(t, err)
 			didDocOrg.AddCapabilityInvocation(orgVM)
 			test.mockDocumentManager.EXPECT().Create(gomock.Any(), gomock.Any()).Return(didDocOrg, keyOrg, nil)
-			didDocOrg, keyOrg, err = test.vdr.Create(test.ctx, management.DIDCreationOptions{
-				KeyFlags: management.AssertionMethodUsage | management.KeyAgreementUsage,
-				Method:   didnuts.MethodName,
-				MethodSpecificOptions: []management.DIDCreationOption{
-					didnuts.Controllers(didDocVendor.ID),
-					didnuts.SelfControl(false),
-				},
-			})
+			didDocOrg, keyOrg, err = test.vdr.Create(test.ctx, didnuts.DefaultCreationOptions().
+				With(didnuts.KeyFlag(management.AssertionMethodUsage|management.KeyAgreementUsage)).
+				With(didnuts.Controllers(didDocVendor.ID)).
+				With(didnuts.SelfControl(false)),
+			)
 			require.NoError(t, err)
 
 			client := crypto.NewMemoryCryptoInstance()

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -297,10 +297,12 @@ func TestVDR_ConflictingDocuments(t *testing.T) {
 			didDocOrg.AddCapabilityInvocation(orgVM)
 			test.mockDocumentManager.EXPECT().Create(gomock.Any(), gomock.Any()).Return(didDocOrg, keyOrg, nil)
 			didDocOrg, keyOrg, err = test.vdr.Create(test.ctx, management.DIDCreationOptions{
-				Controllers: []did.DID{didDocVendor.ID},
-				KeyFlags:    management.AssertionMethodUsage | management.KeyAgreementUsage,
-				SelfControl: false,
-				Method:      didnuts.MethodName,
+				KeyFlags: management.AssertionMethodUsage | management.KeyAgreementUsage,
+				Method:   didnuts.MethodName,
+				MethodSpecificOptions: []management.DIDCreationOption{
+					didnuts.Controllers(didDocVendor.ID),
+					didnuts.SelfControl(false),
+				},
 			})
 			require.NoError(t, err)
 


### PR DESCRIPTION
DID methods have their own creation options, SelfControl and Controllers are `did:nuts` specific. `did:web` has (user) "id" (last path part in the DID).

This moves `did:nuts` options to the `didnuts` package and introduces an option for `did:web`.