### PR TITLE
Add conditional for storageClassName in nuts-data-pv.yaml

### DIFF
--- a/charts/nuts-node/templates/nuts-data-pv.yaml
+++ b/charts/nuts-node/templates/nuts-data-pv.yaml
@@ -9,7 +9,9 @@ metadata:
     "helm.sh/resource-policy": keep
 spec:
   persistentVolumeReclaimPolicy: Retain
+  {{ if .Values.nuts.data.persistedVolume.storageClassName }}
   storageClassName: {{ .Values.nuts.data.persistedVolume.storageClassName | default "" }}
+  {{ end }}
   capacity:
     storage: {{ .Values.nuts.data.persistedVolume.capacity | default "100Mi" }}
   accessModes: {{ required "Please define `nuts.data.persistedVolume.accessModes` in `values.yaml`" .Values.nuts.data.persistedVolume.accessModes }}
@@ -25,7 +27,9 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
 spec:
+  {{ if .Values.nuts.data.persistedVolume.storageClassName }}
   storageClassName: {{ .Values.nuts.data.persistedVolumeClaim.storageClassName | default "" }}
+  {{ end }}
   accessModes: {{ required "Please define `nuts.data.persistedVolumeClaim.accessModes` in `values.yaml`" .Values.nuts.data.persistedVolumeClaim.accessModes }}
   resources:
     requests:


### PR DESCRIPTION
Incorporated a conditional that checks if 'storageClassName' exists under .Values.nuts.data.persistedVolume in nuts-data-pv.yaml. The GKE platform sets the storageClassName to its own value after creation. When Helm runs a diff on the upgrade command, the change of the value of the storageClassName is detected. Helm than tries to patch the PVC, causing an error as it is immutable. This causes the upgrade command to fail. This solution only sets the storageClassName if the values.yaml explicitly does so, preventing this error condition to happen.