### PR TITLE
Issue #2755 An access_token request does not work for VCs with jwt_vc_json because https://identity.foundation/claim-format-registry/ expects jwt_vc.

### DIFF
--- a/vcr/credential/formats.go
+++ b/vcr/credential/formats.go
@@ -26,6 +26,10 @@ func DIFClaimFormats(formats map[string]map[string][]string) Formats {
 		ParamAliases: map[string]string{
 			// no aliases for this type
 		},
+		FormatAliases: map[string]string{
+			"jwt_vp_json": "jwt_vp",
+			"jwt_vc_json": "jwt_vc",
+		},
 	}
 }
 
@@ -43,8 +47,9 @@ func OpenIDSupportedFormats(formats map[string]map[string][]string) Formats {
 // Formats is a map of supported formats and their parameters according to https://identity.foundation/claim-format-registry/
 // E.g., ldp_vp: {proof_type: [Ed25519Signature2018, JsonWebSignature2020]}
 type Formats struct {
-	Map          map[string]map[string][]string
-	ParamAliases map[string]string
+	Map           map[string]map[string][]string
+	ParamAliases  map[string]string
+	FormatAliases map[string]string
 }
 
 // Match takes the other supports formats and returns the formats that are supported by both sets.
@@ -58,7 +63,8 @@ func (f Formats) Match(other Formats) Formats {
 	}
 
 	for thisFormat, thisFormatParams := range f.Map {
-		otherFormatParams := other.normalizeParameters(other.Map[thisFormat])
+		otherFormat := other.normalizeFormat(thisFormat)
+		otherFormatParams := other.normalizeParameters(other.Map[otherFormat])
 		if otherFormatParams == nil {
 			// format not supported by other
 			continue
@@ -98,6 +104,13 @@ func (f Formats) normalizeParameter(param string) string {
 		return alias
 	}
 	return param
+}
+
+func (f Formats) normalizeFormat(format string) string {
+	if alias, ok := f.FormatAliases[format]; ok {
+		return alias
+	}
+	return format
 }
 
 // normalizeParameters normalizes the parameter map to the names used in the DIF spec.

--- a/vcr/credential/formats.go
+++ b/vcr/credential/formats.go
@@ -57,9 +57,14 @@ type Formats struct {
 // If a format is supported by both sets, but parameters overlap (e.g. supported cryptographic algorithms),
 // the format is not included in the result.
 func (f Formats) Match(other Formats) Formats {
+	aliases := f.FormatAliases
+	if aliases == nil {
+		aliases = other.FormatAliases
+	}
 	result := Formats{
-		Map:          map[string]map[string][]string{},
-		ParamAliases: map[string]string{},
+		Map:           map[string]map[string][]string{},
+		ParamAliases:  map[string]string{},
+		FormatAliases: aliases,
 	}
 
 	for thisFormat, thisFormatParams := range f.Map {

--- a/vcr/credential/formats.go
+++ b/vcr/credential/formats.go
@@ -49,6 +49,7 @@ func OpenIDSupportedFormats(formats map[string]map[string][]string) Formats {
 type Formats struct {
 	Map           map[string]map[string][]string
 	ParamAliases  map[string]string
+	// FormatAliases allows aliasing the VP and VC formats. This feature can be removed when https://identity.foundation/claim-format-registry/ and the OpenID4VC specifications have agreed on the format designators.
 	FormatAliases map[string]string
 }
 


### PR DESCRIPTION
Issue #2755 An access_token request does not work for VCs with jwt_vc_json because https://identity.foundation/claim-format-registry/ expects jwt_vc.

- Add format aliases to credential formats. Updated the Formats struct and associated methods in the vcr/credential/formats.go file to include the handling of format aliases. This provides additional flexibility in mapping equivalent format names. Also created a new method "normalizeFormat" to facilitate the normalization of these format aliases.