### PR TITLE
SQL: Redirect GORM logging to logrus

### DIFF
--- a/storage/engine.go
+++ b/storage/engine.go
@@ -45,6 +45,10 @@ import (
 
 const storeShutdownTimeout = 5 * time.Second
 
+// sqlSlowQueryThreshold specifies the threshold for logging slow SQL queries.
+// If SQL queries take longer than this threshold, they will be logged as warnings.
+const sqlSlowQueryThreshold = 200 * time.Millisecond
+
 //go:embed sql_migrations/*.sql
 var sqlMigrationsFS embed.FS
 
@@ -205,10 +209,11 @@ func (e *engine) initSQLDatabase() error {
 
 	// Open connection and migrate
 	var err error
+
 	e.sqlDB, err = gorm.Open(adapter.connector(adapter.gormConnectionString(trimmedConnectionString)), &gorm.Config{
 		Logger: gormLogrusLogger{
 			underlying:    log.Logger(),
-			slowThreshold: 200 * time.Millisecond,
+			slowThreshold: sqlSlowQueryThreshold,
 		},
 	})
 	if err != nil {

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -205,7 +205,12 @@ func (e *engine) initSQLDatabase() error {
 
 	// Open connection and migrate
 	var err error
-	e.sqlDB, err = gorm.Open(adapter.connector(adapter.gormConnectionString(trimmedConnectionString)), &gorm.Config{})
+	e.sqlDB, err = gorm.Open(adapter.connector(adapter.gormConnectionString(trimmedConnectionString)), &gorm.Config{
+		Logger: gormLogrusLogger{
+			underlying:    log.Logger(),
+			slowThreshold: 200 * time.Millisecond,
+		},
+	})
 	if err != nil {
 		return err
 	}

--- a/storage/gorm_logger.go
+++ b/storage/gorm_logger.go
@@ -1,0 +1,52 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+	"time"
+)
+
+var _ logger.Interface = (*gormLogrusLogger)(nil)
+var nowFunc = time.Now
+
+// gormLogrusLogger is a logger that uses logrus as underlying logger for gorm
+type gormLogrusLogger struct {
+	underlying    *logrus.Entry
+	slowThreshold time.Duration
+}
+
+func (g gormLogrusLogger) LogMode(level logger.LogLevel) logger.Interface {
+	// Ignored, level determined by underlying logger
+	return g
+}
+
+func (g gormLogrusLogger) Info(_ context.Context, msg string, args ...interface{}) {
+	g.underlying.Infof(msg, args...)
+}
+
+func (g gormLogrusLogger) Warn(ctx context.Context, msg string, args ...interface{}) {
+	g.underlying.Warnf(msg, args...)
+}
+
+func (g gormLogrusLogger) Error(ctx context.Context, msg string, args ...interface{}) {
+	g.underlying.Errorf(msg, args...)
+}
+
+func (g gormLogrusLogger) Trace(_ context.Context, begin time.Time, fn func() (sql string, rowsAffected int64), err error) {
+	// If time since begin is greater than slowThreshold, log as warning
+	// Otherwise, log on DEBUG
+	elapsed := nowFunc().Sub(begin)
+	sql, _ := fn()
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		g.underlying.WithError(err).Warnf("Query failed (took %s): %s", elapsed, sql)
+		return
+	}
+	if elapsed >= g.slowThreshold {
+		g.underlying.Warnf("Slow query (took %s): %s", elapsed, sql)
+	} else {
+		g.underlying.Debugf("Query (took %s): %s", elapsed, sql)
+	}
+}

--- a/storage/gorm_logger_test.go
+++ b/storage/gorm_logger_test.go
@@ -1,0 +1,58 @@
+package storage
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"testing"
+	"time"
+)
+
+func Test_gormLogrusLogger_Trace(t *testing.T) {
+	hook := &test.Hook{}
+	underlying := logrus.New()
+	underlying.SetLevel(logrus.TraceLevel)
+	underlying.AddHook(hook)
+	logger := gormLogrusLogger{
+		underlying:    underlying.WithFields(nil),
+		slowThreshold: 10 * time.Second,
+	}
+	now := time.Now()
+	nowFunc = func() time.Time {
+		return now
+	}
+	t.Run("execution error", func(t *testing.T) {
+		defer hook.Reset()
+		logger.Trace(nil, now.Add(-time.Second), func() (sql string, rowsAffected int64) {
+			return "SELECT 1", 0
+		}, assert.AnError)
+		require.Len(t, hook.Entries, 1)
+		assert.Equal(t, hook.LastEntry().Message, "Query failed (took 1s): SELECT 1")
+	})
+	t.Run("normal query", func(t *testing.T) {
+		defer hook.Reset()
+		logger.Trace(nil, now.Add(-time.Second), func() (sql string, rowsAffected int64) {
+			return "SELECT 1", 0
+		}, nil)
+		require.Len(t, hook.Entries, 1)
+		assert.Equal(t, hook.LastEntry().Message, "Query (took 1s): SELECT 1")
+	})
+	t.Run("record not found (error is ignored)", func(t *testing.T) {
+		defer hook.Reset()
+		logger.Trace(nil, now.Add(-time.Second), func() (sql string, rowsAffected int64) {
+			return "SELECT 1", 0
+		}, gorm.ErrRecordNotFound)
+		require.Len(t, hook.Entries, 1)
+		assert.Equal(t, hook.LastEntry().Message, "Query (took 1s): SELECT 1")
+	})
+	t.Run("slow query", func(t *testing.T) {
+		defer hook.Reset()
+		logger.Trace(nil, now.Add(-20*time.Second), func() (sql string, rowsAffected int64) {
+			return "SELECT 1", 0
+		}, nil)
+		require.Len(t, hook.Entries, 1)
+		assert.Equal(t, hook.LastEntry().Message, "Slow query (took 20s): SELECT 1")
+	})
+}


### PR DESCRIPTION
By default, GORM writes logs in a custom format to stdout. GORM currently triggered on errornous SQL (also "record not found") and when queries take longer than 200ms.

This PR introduces a GORM logger that pipes the logging to logrus.

The implementation (and the slow SQL threshold) of `Trace()` is reflects its default implementation in GORM (although a bit simplified).