### PR TITLE
Add Delete function to vcr wallet

### DIFF
--- a/vcr/holder/interface.go
+++ b/vcr/holder/interface.go
@@ -56,6 +56,9 @@ type Wallet interface {
 
 	// IsEmpty returns true if the wallet contains no credentials at all (for all holder DIDs).
 	IsEmpty() (bool, error)
+
+	// Delete deletes a credential from the wallet
+	Delete(ctx context.Context, subjectDID did.DID, id ssi.URI) error
 }
 
 // PresentationOptions contains parameters used to create the right VerifiablePresentation

--- a/vcr/holder/wallet.go
+++ b/vcr/holder/wallet.go
@@ -289,7 +289,7 @@ func (h wallet) Delete(ctx context.Context, subjectDID did.DID, id ssi.URI) erro
 		if err != nil {
 			return fmt.Errorf("unable to read wallet credential count: %w", err)
 		}
-		return stats.Put(credentialCountStatsKey, binary.BigEndian.AppendUint32([]byte{}, currentCount+1))
+		return stats.Put(credentialCountStatsKey, binary.BigEndian.AppendUint32([]byte{}, currentCount-1))
 	}, stoabs.WithWriteLock()) // lock required for stats consistency
 	if err != nil {
 		return fmt.Errorf("unable to delete credential: %w", err)

--- a/vcr/holder/wallet_test.go
+++ b/vcr/holder/wallet_test.go
@@ -545,3 +545,37 @@ func Test_wallet_IsEmpty(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func Test_wallet_Delete(t *testing.T) {
+	t.Run("put 1 credential, delete 1 credential", func(t *testing.T) {
+		storageEngine := storage.NewTestStorageEngine(t)
+		store, _ := storageEngine.GetProvider("test").GetKVStore("credentials", storage.PersistentStorageClass)
+		sut := New(nil, nil, nil, nil, store)
+		expected := createCredential(vdr.TestMethodDIDA.String())
+
+		err := sut.Put(context.Background(), expected)
+		require.NoError(t, err)
+
+		list, err := sut.List(context.Background(), vdr.TestDIDA)
+		require.NoError(t, err)
+		require.Len(t, list, 1)
+		assert.Equal(t, expected.ID.String(), list[0].ID.String())
+
+		verifiableCredential := list[0]
+
+		subjectDID, err := verifiableCredential.SubjectDID()
+		require.NoError(t, err)
+		err = sut.Delete(context.Background(), *subjectDID, *verifiableCredential.ID)
+		require.NoError(t, err)
+
+		list, err = sut.List(context.Background(), vdr.TestDIDA)
+		require.NoError(t, err)
+		require.Len(t, list, 0)
+
+		empty, err := sut.IsEmpty()
+		require.NoError(t, err)
+		assert.True(t, empty)
+
+	})
+
+}


### PR DESCRIPTION
A new Delete function is added to the wallet in the vcr/holder/wallet.go file. This function allows a credential to be removed from the wallet. Additionally, an interface in the vcr/holder/interface.go file has been updated to include this Delete function. Proper error handling and stats consistency are ensured in this implementation.