### PR TITLE
Discovery: return subject ID in search results

### DIFF
--- a/discovery/api/v1/api.go
+++ b/discovery/api/v1/api.go
@@ -110,7 +110,7 @@ func (w *Wrapper) SearchPresentations(ctx context.Context, request SearchPresent
 	if err != nil {
 		return nil, err
 	}
-	result := make([]SearchResult, 0)
+	results := make([]SearchResult, 0)
 	for _, searchResult := range searchResults {
 		result := SearchResult{
 			Vp:     searchResult.Presentation,

--- a/discovery/api/v1/api.go
+++ b/discovery/api/v1/api.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/audit"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/discovery"
+	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"net/http"
 	"net/url"
 )
@@ -111,13 +112,18 @@ func (w *Wrapper) SearchPresentations(ctx context.Context, request SearchPresent
 	}
 	result := make([]SearchResult, 0)
 	for _, searchResult := range searchResults {
-		result = append(result, SearchResult{
+		result := SearchResult{
 			Vp:     searchResult.Presentation,
 			Id:     searchResult.Presentation.ID.String(),
 			Fields: searchResult.Fields,
-		})
+		}
+		subjectDID, _ := credential.PresentationSigner(searchResult.Presentation)
+		if subjectDID != nil {
+			result.SubjectId = subjectDID.String()
+		}
+		results = append(results, result)
 	}
-	return SearchPresentations200JSONResponse(result), nil
+	return SearchPresentations200JSONResponse(results), nil
 }
 
 func (w *Wrapper) ActivateServiceForDID(ctx context.Context, request ActivateServiceForDIDRequestObject) (ActivateServiceForDIDResponseObject, error) {

--- a/discovery/api/v1/generated.go
+++ b/discovery/api/v1/generated.go
@@ -30,6 +30,9 @@ type SearchResult struct {
 	// Id The ID of the Verifiable Presentation.
 	Id string `json:"id"`
 
+	// SubjectId The ID of the Verifiable Credential subject (holder), typically a DID.
+	SubjectId string `json:"subject_id"`
+
 	// Vp Verifiable Presentation
 	Vp VerifiablePresentation `json:"vp"`
 }

--- a/docs/_static/discovery/v1.yaml
+++ b/docs/_static/discovery/v1.yaml
@@ -277,12 +277,16 @@ components:
       type: object
       required:
         - id
+        - subject_id
         - vp
         - fields
       properties:
         id:
           type: string
           description: The ID of the Verifiable Presentation.
+        subject_id:
+          type: string
+          description: The ID of the Verifiable Credential subject (holder), typically a DID.
         vp:
           $ref: "#/components/schemas/VerifiablePresentation"
         fields:


### PR DESCRIPTION
So client application's don't need to parse the returned VPs