### PR TITLE
VCR: Allow VPs without credentials

### DIFF
--- a/auth/api/iam/s2s_vptoken_test.go
+++ b/auth/api/iam/s2s_vptoken_test.go
@@ -163,7 +163,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 	})
 	t.Run("missing presentation expiry date", func(t *testing.T) {
 		ctx := newTestClient(t)
-		presentation := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
+		presentation, _ := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
 			require.NoError(t, token.Remove(jwt.ExpirationKey))
 		}, verifiableCredential)
 
@@ -173,7 +173,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 	})
 	t.Run("missing presentation not before date", func(t *testing.T) {
 		ctx := newTestClient(t)
-		presentation := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
+		presentation, _ := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
 			require.NoError(t, token.Remove(jwt.NotBeforeKey))
 		}, verifiableCredential)
 
@@ -183,7 +183,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 	})
 	t.Run("missing presentation valid for too long", func(t *testing.T) {
 		ctx := newTestClient(t)
-		presentation := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
+		presentation, _ := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
 			require.NoError(t, token.Set(jwt.ExpirationKey, time.Now().Add(time.Hour)))
 		}, verifiableCredential)
 
@@ -193,7 +193,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 	})
 	t.Run("JWT VP", func(t *testing.T) {
 		ctx := newTestClient(t)
-		presentation := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
+		presentation, _ := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
 			require.NoError(t, token.Set(jwt.AudienceKey, issuerDID.String()))
 		}, verifiableCredential)
 		ctx.policy.EXPECT().PresentationDefinition(gomock.Any(), issuerDID, requestedScope).Return(&definition, nil)
@@ -269,7 +269,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		t.Run("JWT VP is missing nonce", func(t *testing.T) {
 			ctx := newTestClient(t)
 			ctx.policy.EXPECT().PresentationDefinition(gomock.Any(), issuerDID, requestedScope).Return(&definition, nil)
-			presentation := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
+			presentation, _ := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
 				_ = token.Set(jwt.AudienceKey, issuerDID.String())
 				_ = token.Remove("nonce")
 			}, verifiableCredential)
@@ -281,7 +281,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		t.Run("JWT VP has empty nonce", func(t *testing.T) {
 			ctx := newTestClient(t)
 			ctx.policy.EXPECT().PresentationDefinition(gomock.Any(), issuerDID, requestedScope).Return(&definition, nil)
-			presentation := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
+			presentation, _ := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
 				_ = token.Set(jwt.AudienceKey, issuerDID.String())
 				_ = token.Set("nonce", "")
 			}, verifiableCredential)
@@ -293,7 +293,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		t.Run("JWT VP nonce is not a string", func(t *testing.T) {
 			ctx := newTestClient(t)
 			ctx.policy.EXPECT().PresentationDefinition(gomock.Any(), issuerDID, requestedScope).Return(&definition, nil)
-			presentation := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
+			presentation, _ := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
 				_ = token.Set(jwt.AudienceKey, issuerDID.String())
 				_ = token.Set("nonce", true)
 			}, verifiableCredential)
@@ -306,7 +306,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 	t.Run("audience", func(t *testing.T) {
 		t.Run("missing", func(t *testing.T) {
 			ctx := newTestClient(t)
-			presentation := test.CreateJWTPresentation(t, *subjectDID, nil, verifiableCredential)
+			presentation, _ := test.CreateJWTPresentation(t, *subjectDID, nil, verifiableCredential)
 
 			resp, err := ctx.client.handleS2SAccessTokenRequest(context.Background(), issuerDID, requestedScope, submissionJSON, presentation.Raw())
 
@@ -315,7 +315,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		})
 		t.Run("not matching", func(t *testing.T) {
 			ctx := newTestClient(t)
-			presentation := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
+			presentation, _ := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
 				require.NoError(t, token.Set(jwt.AudienceKey, "did:example:other"))
 			}, verifiableCredential)
 

--- a/vcr/credential/util_test.go
+++ b/vcr/credential/util_test.go
@@ -182,7 +182,7 @@ func TestPresentationIssuanceDate(t *testing.T) {
 	presenterDID := did.MustParseDID("did:test:123")
 	expected := time.Now().In(time.UTC).Truncate(time.Second)
 	t.Run("JWT iat", func(t *testing.T) {
-		presentation := test.CreateJWTPresentation(t, presenterDID, func(token jwt.Token) {
+		presentation, _ := test.CreateJWTPresentation(t, presenterDID, func(token jwt.Token) {
 			_ = token.Remove(jwt.NotBeforeKey)
 			require.NoError(t, token.Set(jwt.IssuedAtKey, expected))
 		})
@@ -190,7 +190,7 @@ func TestPresentationIssuanceDate(t *testing.T) {
 		assert.Equal(t, expected, *actual)
 	})
 	t.Run("JWT nbf", func(t *testing.T) {
-		presentation := test.CreateJWTPresentation(t, presenterDID, func(token jwt.Token) {
+		presentation, _ := test.CreateJWTPresentation(t, presenterDID, func(token jwt.Token) {
 			_ = token.Remove(jwt.IssuedAtKey)
 			require.NoError(t, token.Set(jwt.NotBeforeKey, expected))
 		})
@@ -198,7 +198,7 @@ func TestPresentationIssuanceDate(t *testing.T) {
 		assert.Equal(t, expected, *actual)
 	})
 	t.Run("JWT nbf takes precedence over iat", func(t *testing.T) {
-		presentation := test.CreateJWTPresentation(t, presenterDID, func(token jwt.Token) {
+		presentation, _ := test.CreateJWTPresentation(t, presenterDID, func(token jwt.Token) {
 			require.NoError(t, token.Set(jwt.IssuedAtKey, expected.Add(time.Hour)))
 			require.NoError(t, token.Set(jwt.NotBeforeKey, expected))
 		})
@@ -206,7 +206,7 @@ func TestPresentationIssuanceDate(t *testing.T) {
 		assert.Equal(t, expected, *actual)
 	})
 	t.Run("JWT no iat or nbf", func(t *testing.T) {
-		presentation := test.CreateJWTPresentation(t, presenterDID, func(token jwt.Token) {
+		presentation, _ := test.CreateJWTPresentation(t, presenterDID, func(token jwt.Token) {
 			_ = token.Remove(jwt.IssuedAtKey)
 			_ = token.Remove(jwt.NotBeforeKey)
 		})
@@ -246,14 +246,14 @@ func TestPresentationExpirationDate(t *testing.T) {
 	presenterDID := did.MustParseDID("did:test:123")
 	expected := time.Now().In(time.UTC).Truncate(time.Second)
 	t.Run("JWT", func(t *testing.T) {
-		presentation := test.CreateJWTPresentation(t, presenterDID, func(token jwt.Token) {
+		presentation, _ := test.CreateJWTPresentation(t, presenterDID, func(token jwt.Token) {
 			require.NoError(t, token.Set(jwt.ExpirationKey, expected))
 		})
 		actual := PresentationExpirationDate(presentation)
 		assert.Equal(t, expected, *actual)
 	})
 	t.Run("JWT no exp", func(t *testing.T) {
-		presentation := test.CreateJWTPresentation(t, presenterDID, func(token jwt.Token) {
+		presentation, _ := test.CreateJWTPresentation(t, presenterDID, func(token jwt.Token) {
 			_ = token.Remove(jwt.ExpirationKey)
 		})
 		actual := PresentationExpirationDate(presentation)

--- a/vcr/pe/util_test.go
+++ b/vcr/pe/util_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestParseEnvelope(t *testing.T) {
 	t.Run("JWT", func(t *testing.T) {
-		presentation := test.CreateJWTPresentation(t, did.MustParseDID("did:example:1"), nil, credential.ValidNutsOrganizationCredential(t))
+		presentation, _ := test.CreateJWTPresentation(t, did.MustParseDID("did:example:1"), nil, credential.ValidNutsOrganizationCredential(t))
 		envelope, err := ParseEnvelope([]byte(presentation.Raw()))
 		require.NoError(t, err)
 		require.Equal(t, presentation.ID.String(), envelope.asInterface.(map[string]interface{})["id"])
@@ -59,7 +59,7 @@ func TestParseEnvelope(t *testing.T) {
 		require.Len(t, envelope.Presentations, 1)
 	})
 	t.Run("JSON array with JWTs", func(t *testing.T) {
-		presentation := test.CreateJWTPresentation(t, did.MustParseDID("did:example:1"), nil, credential.ValidNutsOrganizationCredential(t))
+		presentation, _ := test.CreateJWTPresentation(t, did.MustParseDID("did:example:1"), nil, credential.ValidNutsOrganizationCredential(t))
 		presentations := []string{presentation.Raw(), presentation.Raw()}
 		listJSON, _ := json.Marshal(presentations)
 		envelope, err := ParseEnvelope(listJSON)

--- a/vcr/test/test.go
+++ b/vcr/test/test.go
@@ -35,7 +35,7 @@ import (
 )
 
 // CreateJWTPresentation creates a JWT presentation with the given subject DID and credentials.
-func CreateJWTPresentation(t *testing.T, subjectDID did.DID, tokenVisitor func(token jwt.Token), credentials ...vc.VerifiableCredential) vc.VerifiablePresentation {
+func CreateJWTPresentation(t *testing.T, subjectDID did.DID, tokenVisitor func(token jwt.Token), credentials ...vc.VerifiableCredential) (vc.VerifiablePresentation, crypto.Key) {
 	headers := map[string]any{jws.TypeKey: "JWT"}
 	claims := map[string]interface{}{
 		jwt.SubjectKey:    subjectDID.String(),
@@ -62,7 +62,7 @@ func CreateJWTPresentation(t *testing.T, subjectDID did.DID, tokenVisitor func(t
 	signedToken, err := keyStore.SignJWT(audit.TestContext(), claims, headers, key.KID())
 	result, err := vc.ParseVerifiablePresentation(signedToken)
 	require.NoError(t, err)
-	return *result
+	return *result, key
 }
 
 // CreateJSONLDPresentation creates a JSON-LD presentation with the given subject DID and credentials.

--- a/vcr/verifier/interface.go
+++ b/vcr/verifier/interface.go
@@ -48,7 +48,12 @@ type Verifier interface {
 	RegisterRevocation(revocation credential.Revocation) error
 
 	// VerifyVP verifies the given Verifiable Presentation. If successful, it returns the credentials within the presentation.
-	// If verifyVCs is true, it will also verify the credentials inside the VP, checking their correctness, signature and trust status (unless allowUntrustedVCs is true).
+	// If verifyVCs is true, it will also verify the credentials inside the VP:
+	// - checking their correctness,
+	// - signature
+	// - trust status (unless allowUntrustedVCs is true).
+	// It always checks whether the signer of the presentation is the holder of the presented credentials,
+	// but only if there are credentials in the presentation.
 	VerifyVP(presentation vc.VerifiablePresentation, verifyVCs bool, allowUntrustedVCs bool, validAt *time.Time) ([]vc.VerifiableCredential, error)
 }
 

--- a/vcr/verifier/verifier.go
+++ b/vcr/verifier/verifier.go
@@ -252,7 +252,7 @@ func (v verifier) doVerifyVP(vcVerifier Verifier, presentation vc.VerifiablePres
 	// custom requirement: credentials may only be presented by subject
 	if subjectDID, err := credential.PresenterIsCredentialSubject(presentation); err != nil {
 		return nil, newVerificationError("presenter is credential subject: %w", err)
-	} else if subjectDID == nil {
+	} else if subjectDID == nil && len(presentation.VerifiableCredential) > 0 {
 		return nil, newVerificationError("credential(s) must be presented by subject")
 	}
 


### PR DESCRIPTION
Verification now fails as there are no credentials which's subject DID can be compared to the VP signer. Discovery Services use an empty VP to signal a deleted VP.