### PR TITLE
Discovery: 1 background process for refreshing Discovery Service

### DIFF
--- a/discovery/cmd/cmd.go
+++ b/discovery/cmd/cmd.go
@@ -33,11 +33,10 @@ func FlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("discovery.server.definition_ids", defs.Server.DefinitionIDs,
 		"IDs of the Discovery Service Definitions for which to act as server. "+
 			"If an ID does not map to a loaded service definition, the node will fail to start.")
-	flagSet.Duration("discovery.client.registration_refresh_interval", defs.Client.RegistrationRefreshInterval,
-		"Interval at which the client should refresh checks for registrations to refresh on the configured Discovery Services,"+
-			"in Golang time.Duration string format (e.g. 1s). "+
-			"Note that it only will actually refresh registrations that about to expire (less than 1/4th of their lifetime left).")
-	flagSet.Duration("discovery.client.refresh_interval", defs.Client.RefreshInterval, "How often to check for new Verifiable Presentations on the Discovery Services to update the local copy. "+
-		"Specified as Golang duration (e.g. 1m, 1h30m).")
+	flagSet.Duration("discovery.client.refresh_interval", defs.Client.RefreshInterval,
+		"Interval at which the client synchronizes with the Discovery Server; "+
+			"refreshing Verifiable Presentations of local DIDs and loading changes, updating the local copy. "+
+			"It only will actually refresh registrations of local DIDs that about to expire (less than 1/4th of their lifetime left). "+
+			"Specified as Golang duration (e.g. 1m, 1h30m).")
 	return flagSet
 }

--- a/discovery/config.go
+++ b/discovery/config.go
@@ -42,9 +42,6 @@ type ServerConfig struct {
 type ClientConfig struct {
 	// RefreshInterval specifies how often the client should refresh the Discovery Services.
 	RefreshInterval time.Duration `koanf:"refresh_interval"`
-	// RegistrationRefreshInterval specifies how often the client should refresh its registrations on Discovery Services.
-	// At the same interval, failed registrations are refreshed.
-	RegistrationRefreshInterval time.Duration `koanf:"registration_refresh_interval"`
 }
 
 // DefaultConfig returns the default configuration.
@@ -52,8 +49,7 @@ func DefaultConfig() Config {
 	return Config{
 		Server: ServerConfig{},
 		Client: ClientConfig{
-			RefreshInterval:             10 * time.Minute,
-			RegistrationRefreshInterval: 10 * time.Minute,
+			RefreshInterval: 10 * time.Minute,
 		},
 	}
 }

--- a/discovery/config_test.go
+++ b/discovery/config_test.go
@@ -24,5 +24,5 @@ import (
 )
 
 func TestDefaultConfig(t *testing.T) {
-	assert.NotEmpty(t, DefaultConfig().Client.RegistrationRefreshInterval)
+	assert.NotEmpty(t, DefaultConfig().Client.RefreshInterval)
 }

--- a/discovery/module.go
+++ b/discovery/module.go
@@ -401,11 +401,11 @@ func (m *Module) update() {
 		// Refresh registrations first, to make sure we have (our own) latest presentations when we load them from the Discovery Service
 		err := m.registrationManager.refresh(ctx, time.Now())
 		if err != nil {
-			log.Logger().WithError(err).Errorf("Failed to refresh service registrations on Discovery Server")
+			log.Logger().WithError(err).Errorf("Failed to refresh own Verifiable Presentations on Discovery Service")
 		}
 		err = m.clientUpdater.update(m.ctx)
 		if err != nil {
-			log.Logger().WithError(err).Errorf("Failed to refresh Verifiable Presentations from Discovery Server")
+			log.Logger().WithError(err).Errorf("Failed to load latest Verifiable Presentations from Discovery Service")
 		}
 	}
 	do()

--- a/discovery/module.go
+++ b/discovery/module.go
@@ -25,6 +25,7 @@ import (
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
+	"github.com/nuts-foundation/nuts-node/audit"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/discovery/api/v1/client"
 	"github.com/nuts-foundation/nuts-node/discovery/log"
@@ -128,17 +129,14 @@ func (m *Module) Start() error {
 		return err
 	}
 	m.clientUpdater = newClientUpdater(m.allDefinitions, m.store, m.verifyRegistration, m.httpClient)
-	m.routines.Add(1)
-	go func() {
-		defer m.routines.Done()
-		m.clientUpdater.update(m.ctx, m.config.Client.RefreshInterval)
-	}()
 	m.registrationManager = newRegistrationManager(m.allDefinitions, m.store, m.httpClient, m.vcrInstance)
-	m.routines.Add(1)
-	go func() {
-		defer m.routines.Done()
-		m.registrationManager.refresh(m.ctx, m.config.Client.RegistrationRefreshInterval)
-	}()
+	if m.config.Client.RefreshInterval > 0 {
+		m.routines.Add(1)
+		go func() {
+			defer m.routines.Done()
+			m.update()
+		}()
+	}
 	return nil
 }
 
@@ -288,6 +286,7 @@ func (m *Module) ActivateServiceForDID(ctx context.Context, serviceID string, su
 		log.Logger().WithError(err).Warnf("Presentation registration failed, will be retried later (did=%s,service=%s)", subjectDID, serviceID)
 	} else if err == nil {
 		log.Logger().Infof("Successfully activated service for DID (did=%s,service=%s)", subjectDID, serviceID)
+		_ = m.clientUpdater.updateService(ctx, m.allDefinitions[serviceID])
 	}
 	return err
 }
@@ -392,6 +391,32 @@ func (m *Module) Search(serviceID string, query map[string]string) ([]SearchResu
 		})
 	}
 	return result, nil
+}
+
+func (m *Module) update() {
+	ticker := time.NewTicker(m.config.Client.RefreshInterval)
+	defer ticker.Stop()
+	ctx := audit.Context(m.ctx, "app", ModuleName, "RefreshDiscoveryClient")
+	do := func() {
+		// Refresh registrations first, to make sure we have (our own) latest presentations when we load them from the Discovery Service
+		err := m.registrationManager.refresh(ctx, time.Now())
+		if err != nil {
+			log.Logger().WithError(err).Errorf("Failed to refresh service registrations on Discovery Server")
+		}
+		err = m.clientUpdater.update(m.ctx)
+		if err != nil {
+			log.Logger().WithError(err).Errorf("Failed to refresh Verifiable Presentations from Discovery Server")
+		}
+	}
+	do()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			do()
+		}
+	}
 }
 
 // validateAudience checks if the given audience of the presentation matches the service ID.


### PR DESCRIPTION
We had 2 background processes for refreshing Verifiable Presentations and fetching the latest changes from the Discovery Service. Simplified this to 1 process managed directly from the module, since there's no need to control the interval at which these run independently.

This also enabled putting the loading of changed/new Verifiable Presentations from the server directly after the refresh job, which causes refreshed VPs (of owned DIDs) to be immediately be in effect on the local copy of the Discovery Service. Otherwise, the client would see "stale" data.

This was still the case after `activate()` is called, so we now explicitly update the Discovery Service after successful registration.