### PR TITLE
VDR: Allow deactivation for did:web, added support to v2 API

### DIFF
--- a/vdr/api/v1/api.go
+++ b/vdr/api/v1/api.go
@@ -227,7 +227,7 @@ func (a *Wrapper) DeactivateDID(ctx context.Context, request DeactivateDIDReques
 	if err != nil {
 		return nil, err
 	}
-	err = a.DocManipulator.Deactivate(ctx, *id)
+	err = a.VDR.Deactivate(ctx, *id)
 	if err != nil {
 		return nil, err
 	}

--- a/vdr/api/v1/api_test.go
+++ b/vdr/api/v1/api_test.go
@@ -320,7 +320,7 @@ func TestWrapper_DeactivateDID(t *testing.T) {
 	did123, _ := did.ParseDID("did:nuts:123")
 	t.Run("ok", func(t *testing.T) {
 		ctx := newMockContext(t)
-		ctx.docUpdater.EXPECT().Deactivate(ctx.requestCtx, *did123).Return(nil)
+		ctx.vdr.EXPECT().Deactivate(ctx.requestCtx, *did123).Return(nil)
 
 		_, err := ctx.client.DeactivateDID(ctx.requestCtx, DeactivateDIDRequestObject{Did: did123.String()})
 

--- a/vdr/api/v2/api.go
+++ b/vdr/api/v2/api.go
@@ -84,8 +84,15 @@ func (w Wrapper) CreateDID(ctx context.Context, request CreateDIDRequestObject) 
 }
 
 func (w Wrapper) DeleteDID(ctx context.Context, request DeleteDIDRequestObject) (DeleteDIDResponseObject, error) {
-	//TODO implement me
-	panic("implement me")
+	targetDID, err := did.ParseDID(request.Did)
+	if err != nil {
+		return nil, err
+	}
+	err = w.VDR.Deactivate(ctx, *targetDID)
+	if err != nil {
+		return nil, err
+	}
+	return DeleteDID204Response{}, nil
 }
 
 func (w Wrapper) ResolveDID(_ context.Context, request ResolveDIDRequestObject) (ResolveDIDResponseObject, error) {

--- a/vdr/didnuts/manager.go
+++ b/vdr/didnuts/manager.go
@@ -41,6 +41,11 @@ var _ management.DocumentManager = (*Manager)(nil)
 type Manager struct {
 	Creator       management.DocCreator
 	DocumentOwner management.DocumentOwner
+	Manipulator   management.DocManipulator
+}
+
+func (m Manager) Deactivate(ctx context.Context, id did.DID) error {
+	return m.Manipulator.Deactivate(ctx, id)
 }
 
 func (m Manager) Create(ctx context.Context, options management.CreationOptions) (*did.Document, crypto.Key, error) {

--- a/vdr/didweb/manager.go
+++ b/vdr/didweb/manager.go
@@ -67,8 +67,9 @@ type Manager struct {
 	keyStore crypto.KeyStore
 }
 
-func (m Manager) Deactivate(_ context.Context, _ did.DID) error {
-	return errors.New("Deactivate() is not yet supported for did:web")
+func (m Manager) Deactivate(_ context.Context, subjectDID did.DID) error {
+	// TODO: Should we remove private keys as well?
+	return m.store.delete(subjectDID)
 }
 
 func (m Manager) RemoveVerificationMethod(ctx context.Context, id did.DID, keyID did.DIDURL) error {

--- a/vdr/didweb/store.go
+++ b/vdr/didweb/store.go
@@ -30,6 +30,7 @@ import (
 )
 
 type store interface {
+	delete(subjectDID did.DID) error
 	create(subjectDID did.DID, methods ...did.VerificationMethod) error
 	get(subjectDID did.DID) ([]did.VerificationMethod, []did.Service, error)
 	list() ([]did.DID, error)
@@ -135,6 +136,17 @@ func (s *sqlStore) get(id did.DID) ([]did.VerificationMethod, []did.Service, err
 	}
 
 	return verificationMethods, services, nil
+}
+
+func (s *sqlStore) delete(subjectDID did.DID) error {
+	result := s.db.Model(&sqlDID{}).Where("did = ?", subjectDID.String()).Delete(&sqlDID{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return resolver.ErrNotFound
+	}
+	return nil
 }
 
 // list returns all DIDs in the store.

--- a/vdr/didweb/store_mock.go
+++ b/vdr/didweb/store_mock.go
@@ -73,6 +73,20 @@ func (mr *MockstoreMockRecorder) createService(subjectDID, service any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "createService", reflect.TypeOf((*Mockstore)(nil).createService), subjectDID, service)
 }
 
+// delete mocks base method.
+func (m *Mockstore) delete(subjectDID did.DID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "delete", subjectDID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// delete indicates an expected call of delete.
+func (mr *MockstoreMockRecorder) delete(subjectDID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "delete", reflect.TypeOf((*Mockstore)(nil).delete), subjectDID)
+}
+
 // deleteService mocks base method.
 func (m *Mockstore) deleteService(subjectDID did.DID, id ssi.URI) error {
 	m.ctrl.T.Helper()

--- a/vdr/didweb/store_test.go
+++ b/vdr/didweb/store_test.go
@@ -87,6 +87,30 @@ func Test_sqlStore_create(t *testing.T) {
 	})
 }
 
+func Test_sqlStore_delete(t *testing.T) {
+	storageEngine := storage.NewTestStorageEngine(t)
+	require.NoError(t, storageEngine.Start())
+
+	store := &sqlStore{db: storageEngine.GetSQLDatabase()}
+
+	t.Run("DID does not exist", func(t *testing.T) {
+		resetStore(t, store.db)
+
+		err := store.delete(testDID)
+		require.ErrorIs(t, err, resolver.ErrNotFound)
+	})
+	t.Run("DID exists", func(t *testing.T) {
+		resetStore(t, store.db)
+		_ = store.create(testDID)
+
+		err := store.delete(testDID)
+		require.NoError(t, err)
+
+		_, _, err = store.get(testDID)
+		require.ErrorIs(t, err, resolver.ErrNotFound)
+	})
+}
+
 func Test_sqlStore_get(t *testing.T) {
 	storageEngine := storage.NewTestStorageEngine(t)
 	require.NoError(t, storageEngine.Start())

--- a/vdr/management/management.go
+++ b/vdr/management/management.go
@@ -39,6 +39,9 @@ type DocumentManager interface {
 	DocumentOwner
 	resolver.DIDResolver
 
+	// Deactivate deactivates a DID document, making it unusable for future interactions.
+	Deactivate(ctx context.Context, id did.DID) error
+
 	// CreateService creates a new service in the DID document identified by subjectDID.
 	// If the service DID is not provided, it will be generated.
 	CreateService(ctx context.Context, subjectDID did.DID, service did.Service) (*did.Service, error)

--- a/vdr/management/management_mock.go
+++ b/vdr/management/management_mock.go
@@ -74,6 +74,20 @@ func (mr *MockDocumentManagerMockRecorder) CreateService(ctx, subjectDID, servic
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateService", reflect.TypeOf((*MockDocumentManager)(nil).CreateService), ctx, subjectDID, service)
 }
 
+// Deactivate mocks base method.
+func (m *MockDocumentManager) Deactivate(ctx context.Context, id did.DID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Deactivate", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Deactivate indicates an expected call of Deactivate.
+func (mr *MockDocumentManagerMockRecorder) Deactivate(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deactivate", reflect.TypeOf((*MockDocumentManager)(nil).Deactivate), ctx, id)
+}
+
 // DeleteService mocks base method.
 func (m *MockDocumentManager) DeleteService(ctx context.Context, subjectDID did.DID, serviceID ssi.URI) error {
 	m.ctrl.T.Helper()
@@ -333,6 +347,94 @@ func (m *MockDocManipulator) UpdateService(ctx context.Context, subjectDID did.D
 func (mr *MockDocManipulatorMockRecorder) UpdateService(ctx, subjectDID, serviceID, service any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateService", reflect.TypeOf((*MockDocManipulator)(nil).UpdateService), ctx, subjectDID, serviceID, service)
+}
+
+// MockCreationOptions is a mock of CreationOptions interface.
+type MockCreationOptions struct {
+	ctrl     *gomock.Controller
+	recorder *MockCreationOptionsMockRecorder
+}
+
+// MockCreationOptionsMockRecorder is the mock recorder for MockCreationOptions.
+type MockCreationOptionsMockRecorder struct {
+	mock *MockCreationOptions
+}
+
+// NewMockCreationOptions creates a new mock instance.
+func NewMockCreationOptions(ctrl *gomock.Controller) *MockCreationOptions {
+	mock := &MockCreationOptions{ctrl: ctrl}
+	mock.recorder = &MockCreationOptionsMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockCreationOptions) EXPECT() *MockCreationOptionsMockRecorder {
+	return m.recorder
+}
+
+// All mocks base method.
+func (m *MockCreationOptions) All() []CreationOption {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "All")
+	ret0, _ := ret[0].([]CreationOption)
+	return ret0
+}
+
+// All indicates an expected call of All.
+func (mr *MockCreationOptionsMockRecorder) All() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "All", reflect.TypeOf((*MockCreationOptions)(nil).All))
+}
+
+// Method mocks base method.
+func (m *MockCreationOptions) Method() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Method")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Method indicates an expected call of Method.
+func (mr *MockCreationOptionsMockRecorder) Method() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Method", reflect.TypeOf((*MockCreationOptions)(nil).Method))
+}
+
+// With mocks base method.
+func (m *MockCreationOptions) With(option CreationOption) CreationOptions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "With", option)
+	ret0, _ := ret[0].(CreationOptions)
+	return ret0
+}
+
+// With indicates an expected call of With.
+func (mr *MockCreationOptionsMockRecorder) With(option any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "With", reflect.TypeOf((*MockCreationOptions)(nil).With), option)
+}
+
+// MockCreationOption is a mock of CreationOption interface.
+type MockCreationOption struct {
+	ctrl     *gomock.Controller
+	recorder *MockCreationOptionMockRecorder
+}
+
+// MockCreationOptionMockRecorder is the mock recorder for MockCreationOption.
+type MockCreationOptionMockRecorder struct {
+	mock *MockCreationOption
+}
+
+// NewMockCreationOption creates a new mock instance.
+func NewMockCreationOption(ctrl *gomock.Controller) *MockCreationOption {
+	mock := &MockCreationOption{ctrl: ctrl}
+	mock.recorder = &MockCreationOptionMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockCreationOption) EXPECT() *MockCreationOptionMockRecorder {
+	return m.recorder
 }
 
 // MockDocumentOwner is a mock of DocumentOwner interface.

--- a/vdr/mock.go
+++ b/vdr/mock.go
@@ -91,6 +91,20 @@ func (mr *MockVDRMockRecorder) CreateService(ctx, subjectDID, service any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateService", reflect.TypeOf((*MockVDR)(nil).CreateService), ctx, subjectDID, service)
 }
 
+// Deactivate mocks base method.
+func (m *MockVDR) Deactivate(ctx context.Context, id did.DID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Deactivate", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Deactivate indicates an expected call of Deactivate.
+func (mr *MockVDRMockRecorder) Deactivate(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deactivate", reflect.TypeOf((*MockVDR)(nil).Deactivate), ctx, id)
+}
+
 // DeleteService mocks base method.
 func (m *MockVDR) DeleteService(ctx context.Context, subjectDID did.DID, serviceID ssi.URI) error {
 	m.ctrl.T.Helper()

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -286,6 +286,24 @@ func (r *Module) Create(ctx context.Context, options management.CreationOptions)
 	return doc, key, nil
 }
 
+func (r *Module) Deactivate(ctx context.Context, id did.DID) error {
+	log.Logger().
+		WithField(core.LogFieldDID, id).
+		Debug("Deactivating DID Document")
+	manager := r.documentManagers[id.Method]
+	if manager == nil {
+		return fmt.Errorf("%w: %s", management.ErrUnsupportedDIDMethod, id.Method)
+	}
+	err := manager.Deactivate(ctx, id)
+	if err != nil {
+		return fmt.Errorf("could not deactivate DID document: %w", err)
+	}
+	log.Logger().
+		WithField(core.LogFieldDID, id).
+		Info("DID Document deactivated")
+	return nil
+}
+
 // Update updates a DID Document based on the DID.
 // It only works on did:nuts, so is subject for removal in the future.
 func (r *Module) Update(ctx context.Context, id did.DID, next did.Document) error {

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -526,6 +526,25 @@ func TestModule_Create(t *testing.T) {
 	})
 }
 
+func TestModule_Deactivate(t *testing.T) {
+	t.Run("unsupported DID method", func(t *testing.T) {
+		test := newVDRTestCtx(t)
+
+		err := test.vdr.Deactivate(context.Background(), did.MustParseDID("did:example:123"))
+
+		assert.EqualError(t, err, "unsupported DID method: example")
+	})
+	t.Run("manager returns error", func(t *testing.T) {
+		id := did.MustParseDID("did:nuts:123")
+		test := newVDRTestCtx(t)
+		test.mockDocumentManager.EXPECT().Deactivate(gomock.Any(), id).Return(assert.AnError)
+
+		err := test.vdr.Deactivate(context.Background(), id)
+
+		assert.EqualError(t, err, "could not deactivate DID document: "+assert.AnError.Error())
+	})
+}
+
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {


### PR DESCRIPTION
Added VDRv2 API support for `Deactivate()`, changed v1 API to use the same function to reduce complexity (and as side effect `did:web` DIDs can be deactivated using v1 API).