### PR TITLE
VDR: Fix resolving keys for did:web DIDs with port

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/nats-io/nats-server/v2 v2.10.10
 	github.com/nats-io/nats.go v1.32.0
 	github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b
-	github.com/nuts-foundation/go-did v0.11.0
+	github.com/nuts-foundation/go-did v0.12.0
 	github.com/nuts-foundation/go-leia/v4 v4.0.1
 	github.com/nuts-foundation/go-stoabs v1.9.0
 	// check the oapi-codegen tool version in the makefile when upgrading the runtime

--- a/go.sum
+++ b/go.sum
@@ -457,8 +457,8 @@ github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatR
 github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
 github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b h1:80icUxWHwE1MrIOOEK5rxrtyKOgZeq5Iu1IjAEkggTY=
 github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b/go.mod h1:6YUioYirD6/8IahZkoS4Ypc8xbeJW76Xdk1QKcziNTM=
-github.com/nuts-foundation/go-did v0.11.0 h1:RTem1MlVoOOoLa/Y2miYRy70Jex0/kJBTCPH5RtUmrY=
-github.com/nuts-foundation/go-did v0.11.0/go.mod h1:2e2H2Hqk0SWrrGZEg97dbK/ZFIkkFB65hNWdOSbylrg=
+github.com/nuts-foundation/go-did v0.12.0 h1:XmttEpFOxrUXzdXHj2x9h8KlhhPgyr02vgtygWg8xnY=
+github.com/nuts-foundation/go-did v0.12.0/go.mod h1:cZiOP2Is9hgIsP5g1FqkfhBDi8f6ktxkP6K4iTX9qns=
 github.com/nuts-foundation/go-leia/v4 v4.0.1 h1:+Sbk3Bew1QnRUqRXSOwomMw3nIZgncmTX425J7U5Q34=
 github.com/nuts-foundation/go-leia/v4 v4.0.1/go.mod h1:eaZuWIolpU61TMvTMcen85+SOEOnHiALdg5SxqLXzz8=
 github.com/nuts-foundation/go-stoabs v1.9.0 h1:zK+ugfolaJYyBvGwsRuavLVdycXk4Yw/1gI+tz17lWQ=

--- a/vdr/resolver/did_test.go
+++ b/vdr/resolver/did_test.go
@@ -95,8 +95,11 @@ func Test_deactivatedError_Is(t *testing.T) {
 }
 
 func newDidDoc() did.Document {
+	return newDidDocWithDID(did.MustParseDID("did:example:sakjsakldjsakld"))
+}
+
+func newDidDocWithDID(id did.DID) did.Document {
 	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	id := did.MustParseDID("did:example:sakjsakldjsakld")
 	keyID := did.DIDURL{DID: id}
 	keyID.Fragment = "key-1"
 	vm, _ := did.NewVerificationMethod(keyID, ssi.JsonWebKey2020, id, privateKey.Public())


### PR DESCRIPTION
When resolving keys, `DID.URI()` caused percent-encoded characters to be encoded again, causing private keys not be found.