### PR TITLE
fix ignored db migration error in tests

### DIFF
--- a/storage/test.go
+++ b/storage/test.go
@@ -32,9 +32,12 @@ func NewTestStorageEngineInDir(t testing.TB, dir string) Engine {
 	result := New().(*engine)
 
 	result.config.SQL = SQLConfig{ConnectionString: sqliteConnectionString(dir)}
-	_ = result.Configure(core.TestServerConfig(func(config *core.ServerConfig) {
+	err := result.Configure(core.TestServerConfig(func(config *core.ServerConfig) {
 		config.Datadir = dir + "/data"
 	}))
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Cleanup(func() {
 		_ = result.Shutdown()
 	})


### PR DESCRIPTION
invalid migration files return an error from storage.Configure that was ignored