### PR TITLE
Discovery: improve test stability

### DIFF
--- a/discovery/client_test.go
+++ b/discovery/client_test.go
@@ -271,8 +271,8 @@ func Test_clientUpdater_update(t *testing.T) {
 		store := setupStore(t, storageEngine.GetSQLDatabase())
 		ctrl := gomock.NewController(t)
 		httpClient := client.NewMockHTTPClient(ctrl)
-		httpClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return([]vc.VerifiablePresentation{}, "test", nil)
-		httpClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, "", errors.New("test"))
+		httpClient.EXPECT().Get(gomock.Any(), "http://example.com/usecase", gomock.Any()).Return([]vc.VerifiablePresentation{}, "test", nil)
+		httpClient.EXPECT().Get(gomock.Any(), "http://example.com/other", gomock.Any()).Return(nil, "", errors.New("test"))
 		updater := newClientUpdater(testDefinitions(), store, alwaysOkVerifier, httpClient)
 
 		err := updater.update(context.Background())


### PR DESCRIPTION
Service Definitions is a map, which caused the call order of the mocked HTTP client to be undefined.

(I wonder why this didn't fail more often).