### PR TITLE
VDR: Resolve did:web from database first, then HTTP

### DIFF
--- a/vcr/test.go
+++ b/vcr/test.go
@@ -61,7 +61,7 @@ func NewTestVCRContext(t *testing.T, keyStore crypto.KeyStore) TestVCRContext {
 	networkInstance := network.NewTestNetworkInstance(t)
 	eventManager := events.NewTestManager(t)
 	vdrInstance := vdr.NewVDR(keyStore, networkInstance, didStore, eventManager, storageEngine)
-	err := vdrInstance.Configure(core.ServerConfig{URL: "http://nuts.test"})
+	err := vdrInstance.Configure(core.TestServerConfig())
 	require.NoError(t, err)
 	newInstance := NewVCRInstance(
 		ctx.KeyStore,
@@ -97,7 +97,6 @@ func NewTestVCRInstance(t *testing.T) *vcr {
 	networkInstance := network.NewNetworkInstance(network.TestNetworkConfig(), didStore, keyStore, eventManager, storageEngine.GetProvider("network"), nil)
 	serverCfg := core.TestServerConfig(func(config *core.ServerConfig) {
 		config.Datadir = testDirectory
-		config.URL = "http://nuts.test"
 	})
 	_ = networkInstance.Configure(serverCfg)
 	vdrInstance := vdr.NewVDR(keyStore, networkInstance, didStore, eventManager, storageEngine)
@@ -130,7 +129,7 @@ func NewTestVCRInstanceInDir(t *testing.T, testDirectory string) *vcr {
 	networkInstance := network.NewTestNetworkInstance(t)
 	eventManager := events.NewTestManager(t)
 	vdrInstance := vdr.NewVDR(nil, networkInstance, didStore, eventManager, storageEngine)
-	err := vdrInstance.Configure(core.ServerConfig{})
+	err := vdrInstance.Configure(core.TestServerConfig())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vdr/integration_test.go
+++ b/vdr/integration_test.go
@@ -238,10 +238,11 @@ type testContext struct {
 func setup(t *testing.T) testContext {
 	// === Setup ===
 	testDir := io.TestDirectory(t)
-	nutsConfig := *core.NewServerConfig()
-	nutsConfig.Strictmode = false
-	nutsConfig.Verbosity = "debug"
-	nutsConfig.Datadir = testDir
+	nutsConfig := core.TestServerConfig(func(config *core.ServerConfig) {
+		config.Strictmode = false
+		config.Verbosity = "debug"
+		config.Datadir = testDir
+	})
 
 	// Configure the logger:
 	var lvl log.Level

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -112,12 +112,6 @@ func (r *Module) Name() string {
 func (r *Module) Configure(config core.ServerConfig) error {
 	r.networkAmbassador = didnuts.NewAmbassador(r.network, r.store, r.eventManager)
 
-	// Register DID methods we can resolve
-	r.didResolver.Register(didnuts.MethodName, &didnuts.Resolver{Store: r.store})
-	r.didResolver.Register(didweb.MethodName, didweb.NewResolver())
-	r.didResolver.Register(didjwk.MethodName, didjwk.NewResolver())
-	r.didResolver.Register(didkey.MethodName, didkey.NewResolver())
-
 	// Methods we can produce from the Nuts node
 	// did:nuts
 	r.documentManagers = map[string]management.DocumentManager{
@@ -132,9 +126,26 @@ func (r *Module) Configure(config core.ServerConfig) error {
 	}
 	// did:web
 	publicURL, err := config.ServerURL()
+	var webResolver resolver.DIDResolver
 	if err == nil {
-		r.documentManagers[didweb.MethodName] = didweb.NewManager(*publicURL.JoinPath("iam"), r.keyStore, r.storageInstance.GetSQLDatabase())
+		manager := didweb.NewManager(*publicURL.JoinPath("iam"), r.keyStore, r.storageInstance.GetSQLDatabase())
+		r.documentManagers[didweb.MethodName] = manager
+		// did:web resolver should first look in own database, then resolve over the web
+		webResolver = resolver.ChainedDIDResolver{
+			Resolvers: []resolver.DIDResolver{
+				manager,
+				didweb.NewResolver(),
+			},
+		}
+	} else {
+		webResolver = didweb.NewResolver()
 	}
+
+	// Register DID methods we can resolve
+	r.didResolver.Register(didnuts.MethodName, &didnuts.Resolver{Store: r.store})
+	r.didResolver.Register(didweb.MethodName, webResolver)
+	r.didResolver.Register(didjwk.MethodName, didjwk.NewResolver())
+	r.didResolver.Register(didkey.MethodName, didkey.NewResolver())
 
 	// Initiate the routines for auto-updating the data.
 	r.networkAmbassador.Configure()

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -126,19 +126,17 @@ func (r *Module) Configure(config core.ServerConfig) error {
 	}
 	// did:web
 	publicURL, err := config.ServerURL()
-	var webResolver resolver.DIDResolver
-	if err == nil {
-		manager := didweb.NewManager(*publicURL.JoinPath("iam"), r.keyStore, r.storageInstance.GetSQLDatabase())
-		r.documentManagers[didweb.MethodName] = manager
-		// did:web resolver should first look in own database, then resolve over the web
-		webResolver = resolver.ChainedDIDResolver{
-			Resolvers: []resolver.DIDResolver{
-				manager,
-				didweb.NewResolver(),
-			},
-		}
-	} else {
-		webResolver = didweb.NewResolver()
+	if err != nil {
+		return err
+	}
+	manager := didweb.NewManager(*publicURL.JoinPath("iam"), r.keyStore, r.storageInstance.GetSQLDatabase())
+	r.documentManagers[didweb.MethodName] = manager
+	// did:web resolver should first look in own database, then resolve over the web
+	webResolver := resolver.ChainedDIDResolver{
+		Resolvers: []resolver.DIDResolver{
+			manager,
+			didweb.NewResolver(),
+		},
 	}
 
 	// Register DID methods we can resolve

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -259,7 +259,7 @@ func TestVDR_ConflictingDocuments(t *testing.T) {
 			keyID.Fragment = "1"
 			_, _ = client.New(audit.TestContext(), crypto.StringNamingFunc(keyID.String()))
 			vdr := NewVDR(client, nil, didstore.NewTestStore(t), nil, storage.NewTestStorageEngine(t))
-			_ = vdr.Configure(*core.NewServerConfig())
+			_ = vdr.Configure(core.TestServerConfig())
 			//vdr.didResolver.Register(didnuts.MethodName, didnuts.Resolver{Store: vdr.store})
 			didDocument := did.Document{ID: TestDIDA}
 
@@ -486,7 +486,7 @@ func TestVDR_Configure(t *testing.T) {
 		require.NoError(t, err)
 
 		instance := NewVDR(nil, nil, nil, nil, storageInstance)
-		err = instance.Configure(core.ServerConfig{})
+		err = instance.Configure(core.TestServerConfig())
 		require.NoError(t, err)
 
 		doc, md, err := instance.Resolver().Resolve(*inputDID, nil)
@@ -500,7 +500,7 @@ func TestVDR_Configure(t *testing.T) {
 	})
 	t.Run("it can resolve using did:key", func(t *testing.T) {
 		instance := NewVDR(nil, nil, nil, nil, storageInstance)
-		err := instance.Configure(core.ServerConfig{})
+		err := instance.Configure(core.TestServerConfig())
 		require.NoError(t, err)
 
 		doc, md, err := instance.Resolver().Resolve(did.MustParseDID("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"), nil)

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts"
 	"github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
+	"github.com/nuts-foundation/nuts-node/vdr/didweb"
 	"github.com/nuts-foundation/nuts-node/vdr/management"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 	"io"
@@ -441,23 +442,38 @@ func TestVDR_IsOwner(t *testing.T) {
 func TestVDR_Configure(t *testing.T) {
 	storageInstance := storage.NewTestStorageEngine(t)
 	t.Run("it can resolve using did:web", func(t *testing.T) {
-		http.DefaultTransport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-			return &http.Response{
-				Header:     map[string][]string{"Content-Type": {"application/json"}},
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(`{"id": "did:web:example.com"}`)),
-			}, nil
+		t.Run("not in database", func(t *testing.T) {
+			http.DefaultTransport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					Header:     map[string][]string{"Content-Type": {"application/json"}},
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"id": "did:web:example.com"}`)),
+				}, nil
+			})
+
+			instance := NewVDR(nil, nil, nil, nil, storageInstance)
+			err := instance.Configure(core.ServerConfig{URL: "https://nuts.nl"})
+			require.NoError(t, err)
+
+			doc, md, err := instance.Resolver().Resolve(did.MustParseDID("did:web:example.com"), nil)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, doc)
+			assert.NotNil(t, md)
 		})
+		t.Run("resolves local DID from database", func(t *testing.T) {
+			instance := NewVDR(crypto.NewMemoryCryptoInstance(), nil, nil, nil, storageInstance)
+			err := instance.Configure(core.ServerConfig{URL: "https://example.com"})
+			require.NoError(t, err)
+			_, _, err = instance.Create(audit.TestContext(), management.Create("web").With(didweb.UserPath("root")))
+			require.NoError(t, err)
 
-		instance := NewVDR(nil, nil, nil, nil, storageInstance)
-		err := instance.Configure(core.ServerConfig{URL: "https://nuts.nl"})
-		require.NoError(t, err)
+			doc, md, err := instance.Resolver().Resolve(did.MustParseDID("did:web:example.com:iam:root"), nil)
 
-		doc, md, err := instance.Resolver().Resolve(did.MustParseDID("did:web:example.com"), nil)
-
-		assert.NoError(t, err)
-		assert.NotNil(t, doc)
-		assert.NotNil(t, md)
+			assert.NoError(t, err)
+			assert.NotNil(t, doc)
+			assert.NotNil(t, md)
+		})
 	})
 	t.Run("it can resolve using did:jwk", func(t *testing.T) {
 		privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)


### PR DESCRIPTION
Owned DIDs don't need to be fetched "remotely" from the own node.

Fixes https://github.com/nuts-foundation/nuts-node/issues/2639