### PR TITLE
GoldenHammer: only work on did:nuts documents

### DIFF
--- a/golden_hammer/module.go
+++ b/golden_hammer/module.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/vcr"
 	"github.com/nuts-foundation/nuts-node/vcr/openid4vci"
 	"github.com/nuts-foundation/nuts-node/vdr"
+	"github.com/nuts-foundation/nuts-node/vdr/didnuts"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 	"net/url"
 	"sort"
@@ -187,6 +188,10 @@ func (h *GoldenHammer) listDocumentToFix() ([]did.Document, error) {
 	}
 	var documents []did.Document
 	for _, id := range dids {
+		if id.Method != didnuts.MethodName {
+			// Not a Nuts DID, skip
+			continue
+		}
 		if h.fixedDocumentDIDs[id.String()] {
 			// Already fixed
 			continue

--- a/golden_hammer/module_test.go
+++ b/golden_hammer/module_test.go
@@ -105,6 +105,19 @@ func TestGoldenHammer_Fix(t *testing.T) {
 	openid4vci.SetTLSIdentifierResolverPort(t, serverPort)
 	defer tlsServer.Close()
 
+	t.Run("DID methods other than did:nuts are ignored", func(t *testing.T) {
+		ctx := newMockContext(t)
+		otherDID := did.MustParseDID("did:example:123")
+		ctx.vdr.EXPECT().ListOwned(gomock.Any()).Return([]did.DID{otherDID}, nil)
+		service := ctx.hammer
+		service.tlsConfig = tlsServer.TLS
+		service.tlsConfig.InsecureSkipVerify = true
+		service.tlsConfig.Certificates = []tls.Certificate{pki.Certificate()}
+
+		err := service.registerServiceBaseURLs()
+
+		assert.NoError(t, err)
+	})
 	t.Run("nothing to fix", func(t *testing.T) {
 		// vendor and care organization DIDs already have the required service, so there's nothing to fix
 		ctx := newMockContext(t)


### PR DESCRIPTION
Might have to go altogether, but for now at least it should only look at `did:nuts` DIDs.