### PR TITLE
Issuer: split builder and signer

### DIFF
--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -196,17 +196,15 @@ func (i issuer) buildAndSignVC(ctx context.Context, template vc.VerifiableCreden
 		return nil, core.InvalidInputError("can only issue credential with 1 type")
 	}
 
-	unsignedCredential := template // TODO: why are we copying the template?
-	//unsignedCredential := vc.VerifiableCredential{
-	//	Context:           template.Context,
-	//	//ID:                &credentialID, // set during signing
-	//	Type:              template.Type,
-	//	CredentialSubject: template.CredentialSubject,
-	//	Issuer:            template.Issuer,
-	//	ExpirationDate:    template.ExpirationDate,
-	//	IssuanceDate:      template.IssuanceDate,
-	//	//CredentialStatus:  template.CredentialStatus, // not allowed for now since it requires API changes to be able to determine what status to revoke.
-	//}
+	unsignedCredential := vc.VerifiableCredential{
+		Context: template.Context,
+		//ID:                &credentialID, // set during signing
+		Type:              template.Type,
+		CredentialSubject: template.CredentialSubject,
+		Issuer:            template.Issuer,
+		ExpirationDate:    template.ExpirationDate,
+		//CredentialStatus:  template.CredentialStatus, // not allowed for now since it requires API changes to be able to determine what status to revoke.
+	}
 
 	if options.WithStatusListRevocation {
 		issuerDID, err := did.ParseDID(unsignedCredential.Issuer.String())
@@ -228,6 +226,7 @@ func (i issuer) buildAndSignVC(ctx context.Context, template vc.VerifiableCreden
 
 	issuanceDate := TimeFunc()
 	unsignedCredential.IssuanceDate = &issuanceDate
+
 	if !unsignedCredential.ContainsContext(vc.VCContextV1URI()) {
 		unsignedCredential.Context = append(unsignedCredential.Context, vc.VCContextV1URI())
 	}

--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -196,33 +196,23 @@ func (i issuer) buildAndSignVC(ctx context.Context, template vc.VerifiableCreden
 		return nil, core.InvalidInputError("can only issue credential with 1 type")
 	}
 
-	issuerDID, err := did.ParseDID(template.Issuer.String())
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse issuer: %w", err)
-	}
+	unsignedCredential := template // TODO: why are we copying the template?
+	//unsignedCredential := vc.VerifiableCredential{
+	//	Context:           template.Context,
+	//	//ID:                &credentialID, // set during signing
+	//	Type:              template.Type,
+	//	CredentialSubject: template.CredentialSubject,
+	//	Issuer:            template.Issuer,
+	//	ExpirationDate:    template.ExpirationDate,
+	//	IssuanceDate:      template.IssuanceDate,
+	//	//CredentialStatus:  template.CredentialStatus, // not allowed for now since it requires API changes to be able to determine what status to revoke.
+	//}
 
-	key, err := i.keyResolver.ResolveAssertionKey(ctx, *issuerDID)
-	if err != nil {
-		const errString = "failed to sign credential: could not resolve an assertionKey for issuer: %w"
-		// Differentiate between a DID document not found and some other error:
-		if resolver.IsFunctionalResolveError(err) {
-			return nil, core.InvalidInputError(errString, err)
-		}
-		return nil, fmt.Errorf(errString, err)
-	}
-
-	credentialID := ssi.MustParseURI(fmt.Sprintf("%s#%s", issuerDID.String(), uuid.New().String()))
-	unsignedCredential := vc.VerifiableCredential{
-		Context:           template.Context,
-		ID:                &credentialID,
-		Type:              template.Type,
-		CredentialSubject: template.CredentialSubject,
-		Issuer:            template.Issuer,
-		ExpirationDate:    template.ExpirationDate,
-		IssuanceDate:      template.IssuanceDate,
-		//CredentialStatus:  template.CredentialStatus, // not allowed for now since it requires API changes to be able to determine what status to revoke.
-	}
 	if options.WithStatusListRevocation {
+		issuerDID, err := did.ParseDID(unsignedCredential.Issuer.String())
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse issuer: %w", err)
+		}
 		// add credential status
 		credentialStatusEntry, err := i.statusListStore.Create(ctx, *issuerDID, statuslist2021.StatusPurposeRevocation)
 		if err != nil {
@@ -235,10 +225,9 @@ func (i issuer) buildAndSignVC(ctx context.Context, template vc.VerifiableCreden
 			unsignedCredential.Context = append(unsignedCredential.Context, statusList2021ContextURI)
 		}
 	}
-	if unsignedCredential.IssuanceDate == nil {
-		issuanceDate := TimeFunc()
-		unsignedCredential.IssuanceDate = &issuanceDate
-	}
+
+	issuanceDate := TimeFunc()
+	unsignedCredential.IssuanceDate = &issuanceDate
 	if !unsignedCredential.ContainsContext(vc.VCContextV1URI()) {
 		unsignedCredential.Context = append(unsignedCredential.Context, vc.VCContextV1URI())
 	}
@@ -247,8 +236,31 @@ func (i issuer) buildAndSignVC(ctx context.Context, template vc.VerifiableCreden
 	if !unsignedCredential.IsType(defaultType) {
 		unsignedCredential.Type = append(unsignedCredential.Type, defaultType)
 	}
+	return i.signVC(ctx, unsignedCredential, options.Format)
+}
 
-	switch options.Format {
+// signVC signs the credential according to the requested proofFormat. It adds the credentialID, but no other fields are set/validated.
+func (i issuer) signVC(ctx context.Context, unsignedCredential vc.VerifiableCredential, proofFormat string) (*vc.VerifiableCredential, error) {
+	issuerDID, err := did.ParseDID(unsignedCredential.Issuer.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse issuer: %w", err)
+	}
+
+	// set credentialID
+	credentialID := ssi.MustParseURI(fmt.Sprintf("%s#%s", issuerDID.String(), uuid.New().String()))
+	unsignedCredential.ID = &credentialID
+
+	key, err := i.keyResolver.ResolveAssertionKey(ctx, *issuerDID)
+	if err != nil {
+		const errString = "failed to sign credential: could not resolve an assertionKey for issuer: %w"
+		// Differentiate between a DID document not found and some other error:
+		if resolver.IsFunctionalResolveError(err) {
+			return nil, core.InvalidInputError(errString, err)
+		}
+		return nil, fmt.Errorf(errString, err)
+	}
+
+	switch proofFormat {
 	case vc.JWTCredentialProofFormat:
 		return vc.CreateJWTVerifiableCredential(ctx, unsignedCredential, func(ctx context.Context, claims map[string]interface{}, headers map[string]interface{}) (string, error) {
 			return i.keyStore.SignJWT(ctx, claims, headers, key)
@@ -267,7 +279,17 @@ func (i issuer) buildJSONLDCredential(ctx context.Context, unsignedCredential vc
 	b, _ := json.Marshal(unsignedCredential)
 	_ = json.Unmarshal(b, &credentialAsMap)
 
-	proofOptions := proof.ProofOptions{Created: *unsignedCredential.IssuanceDate}
+	// get issuance timestamp. statuslist2021 uses 'validFrom', everything else uses 'issuanceDate'.
+	// IssuanceDate and ValidFrom are mutually exclusive, but this is untested.
+	var created *time.Time
+	if unsignedCredential.ValidFrom != nil && !unsignedCredential.ValidFrom.IsZero() {
+		created = unsignedCredential.ValidFrom
+	}
+	if unsignedCredential.IssuanceDate != nil && !unsignedCredential.IssuanceDate.IsZero() {
+		created = unsignedCredential.IssuanceDate
+	}
+
+	proofOptions := proof.ProofOptions{Created: *created}
 
 	webSig := signature.JSONWebSignature2020{ContextLoader: i.jsonldManager.DocumentLoader(), Signer: i.keyStore}
 	signingResult, err := proof.NewLDProof(proofOptions).Sign(ctx, credentialAsMap, webSig, key)
@@ -448,18 +470,18 @@ func (i issuer) StatusList(ctx context.Context, issuerDID did.DID, page int) (*v
 			statusList2021ContextURI,
 		},
 		Type: []ssi.URI{
-			// vc.VerifiableCredentialTypeV1URI(), // automatically added
+			vc.VerifiableCredentialTypeV1URI(),
 			statusList2021CredentialTypeURI,
 		},
 		CredentialSubject: []any{credSubject},
 		Issuer:            issuerDID.URI(),
-		IssuanceDate:      &iss,
-		ExpirationDate:    &exp,
+		ValidFrom:         &iss,
+		ValidUntil:        &exp,
 	}
 
 	// build and sign the VC.
 	// All content is validated and these credentials should not be in the issuer store, so don't use i.Issue()
-	statusListCredential, err := i.buildAndSignVC(ctx, template, CredentialOptions{Format: vc.JSONLDCredentialProofFormat})
+	statusListCredential, err := i.signVC(ctx, template, vc.JSONLDCredentialProofFormat)
 	if err != nil {
 		return nil, err
 	}

--- a/vcr/issuer/issuer_test.go
+++ b/vcr/issuer/issuer_test.go
@@ -948,7 +948,7 @@ func TestIssuer_StatusList(t *testing.T) {
 		_, err = sut.statusListStore.Create(ctx, issuerDID, statuslist2021.StatusPurposeRevocation)
 		require.NoError(t, err)
 
-		issuance, _ := time.Parse(time.RFC3339, "2022-01-02T12:00:00Z")
+		issuance := time.Now()
 		expiration := issuance.Add(statusListValidity)
 		TimeFunc = func() time.Time { return issuance }
 		defer func() { TimeFunc = time.Now }()
@@ -963,8 +963,8 @@ func TestIssuer_StatusList(t *testing.T) {
 		assert.True(t, result.IsType(ssi.MustParseURI(statuslist2021.CredentialType)))
 		assert.Nil(t, result.IssuanceDate)
 		assert.Nil(t, result.ExpirationDate)
-		assert.Equal(t, *result.ValidFrom, issuance)
-		assert.Equal(t, *result.ValidUntil, expiration)
+		assert.Equal(t, result.ValidFrom.Local(), issuance.Local())
+		assert.Equal(t, result.ValidUntil.Local(), expiration.Local())
 
 		// credential subject
 		var subjects []statuslist2021.CredentialSubject

--- a/vcr/issuer/issuer_test.go
+++ b/vcr/issuer/issuer_test.go
@@ -68,13 +68,14 @@ func Test_issuer_buildAndSignVC(t *testing.T) {
 	schemaOrgContext := ssi.MustParseURI("https://schema.org")
 	issuance, err := time.Parse(time.RFC3339, "2022-01-02T12:00:00Z")
 	require.NoError(t, err)
+	TimeFunc = func() time.Time { return issuance }
+	defer func() { TimeFunc = time.Now }()
 
 	expirationDate := issuance.Add(time.Hour)
 	template := vc.VerifiableCredential{
 		Context:        []ssi.URI{schemaOrgContext},
 		Type:           []ssi.URI{credentialType},
 		Issuer:         issuerID,
-		IssuanceDate:   &issuance,
 		ExpirationDate: &expirationDate,
 		CredentialSubject: []interface{}{map[string]interface{}{
 			"id": subjectDID,
@@ -137,7 +138,7 @@ func Test_issuer_buildAndSignVC(t *testing.T) {
 			assert.Contains(t, result.Type, credentialType, "expected vc to be of right type")
 			assert.Contains(t, result.Context, schemaOrgContext)
 			assert.Contains(t, result.Context, vc.VCContextV1URI())
-			assert.Equal(t, template.IssuanceDate.Local(), result.IssuanceDate.Local())
+			assert.Equal(t, issuance.Local(), result.IssuanceDate.Local())
 			assert.Equal(t, template.ExpirationDate.Local(), result.ExpirationDate.Local())
 			assert.Equal(t, template.Issuer, result.Issuer)
 			assert.Equal(t, template.CredentialSubject, result.CredentialSubject)
@@ -175,11 +176,8 @@ func Test_issuer_buildAndSignVC(t *testing.T) {
 			assert.Equal(t, statuslist2021.EntryType, statuses[0].Type)
 		})
 		t.Run("error - did:nuts", func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			keyResolverMock := NewMockkeyResolver(ctrl)
-			keyResolverMock.EXPECT().ResolveAssertionKey(ctx, gomock.Any()).Return(signingKey, nil)
 			jsonldManager := jsonld.NewTestJSONLDManager(t)
-			sut := issuer{keyResolver: keyResolverMock, jsonldManager: jsonldManager, keyStore: keyStore, statusListStore: NewTestStatusListStore(t)}
+			sut := issuer{jsonldManager: jsonldManager, keyStore: keyStore, statusListStore: NewTestStatusListStore(t)}
 
 			result, err := sut.buildAndSignVC(ctx, template, CredentialOptions{WithStatusListRevocation: true})
 
@@ -950,6 +948,11 @@ func TestIssuer_StatusList(t *testing.T) {
 		_, err = sut.statusListStore.Create(ctx, issuerDID, statuslist2021.StatusPurposeRevocation)
 		require.NoError(t, err)
 
+		issuance := time.Now().Truncate(time.Second)
+		expiration := issuance.Add(statusListValidity)
+		TimeFunc = func() time.Time { return issuance }
+		defer func() { TimeFunc = time.Now }()
+
 		result, err := sut.StatusList(ctx, issuerDID, 1)
 
 		// credential
@@ -958,6 +961,10 @@ func TestIssuer_StatusList(t *testing.T) {
 		assert.Contains(t, result.Context, statusList2021ContextURI)
 		assert.Equal(t, result.Issuer.String(), issuerDID.String())
 		assert.True(t, result.IsType(ssi.MustParseURI(statuslist2021.CredentialType)))
+		assert.Nil(t, result.IssuanceDate)
+		assert.Nil(t, result.ExpirationDate)
+		assert.Equal(t, *result.ValidFrom, issuance)
+		assert.Equal(t, *result.ValidUntil, expiration)
 
 		// credential subject
 		var subjects []statuslist2021.CredentialSubject

--- a/vcr/issuer/issuer_test.go
+++ b/vcr/issuer/issuer_test.go
@@ -948,7 +948,7 @@ func TestIssuer_StatusList(t *testing.T) {
 		_, err = sut.statusListStore.Create(ctx, issuerDID, statuslist2021.StatusPurposeRevocation)
 		require.NoError(t, err)
 
-		issuance := time.Now().Truncate(time.Second)
+		issuance, _ := time.Parse(time.RFC3339, "2022-01-02T12:00:00Z")
 		expiration := issuance.Add(statusListValidity)
 		TimeFunc = func() time.Time { return issuance }
 		defer func() { TimeFunc = time.Now }()


### PR DESCRIPTION
PR contains
- split VC signing from building (needed for statuslist2021)
- issue statuslist2021 credentials with `validFrom`/`validUntil` fields (bug fix)
- always set `issuanceDate` in builder function. The API does not allow setting the issuanceDate, and we have an exported `TimeFunc()` to set a value for testing.