### PR TITLE
fix test name

### DIFF
--- a/auth/api/iam/openid4vp_test.go
+++ b/auth/api/iam/openid4vp_test.go
@@ -194,10 +194,9 @@ func TestWrapper_handleAuthorizeRequestFromVerifier(t *testing.T) {
 
 		require.NoError(t, err)
 	})
-	t.Run("invalid presentation_definition_uri", func(t *testing.T) {
+	t.Run("fetching client metadata failed", func(t *testing.T) {
 		ctx := newTestClient(t)
 		params := defaultParams()
-		params[presentationDefUriParam] = "://example.com"
 		ctx.iamClient.EXPECT().ClientMetadata(gomock.Any(), "https://example.com/.well-known/authorization-server/iam/verifier").Return(nil, assert.AnError)
 		expectPostError(t, ctx, oauth.ServerError, "failed to get client metadata (verifier)", responseURI, "state")
 


### PR DESCRIPTION
there are 2 tests with the same name `"invalid presentation_definition_uri"`, the second then gets a number appended by the standard library `"invalid presentation_definition_uri#01"`. This is then also used by the test to generate a TempDir. 

The `#` in the name of the TempDir sometimes causes problems on consecutive runs of the same test on my laptop.