### PR TITLE
Restrict SQLite driver to 1 DB connection

### DIFF
--- a/vcr/credential/store/sql_test.go
+++ b/vcr/credential/store/sql_test.go
@@ -276,11 +276,11 @@ func TestCredentialStore_BuildSearchStatement(t *testing.T) {
 			setupStore(t, storageEngine.GetSQLDatabase())
 			for _, credential := range tc.inputVCs {
 				err := db.Transaction(func(tx *gorm.DB) error {
-					credentialRecord, err := store.Store(db, credential)
+					credentialRecord, err := store.Store(tx, credential)
 					if err != nil {
 						return err
 					}
-					return db.Create(&testCredential{
+					return tx.Create(&testCredential{
 						ID: credentialRecord.ID,
 					}).Error
 				})

--- a/vcr/statuslist2021/store_test.go
+++ b/vcr/statuslist2021/store_test.go
@@ -189,9 +189,6 @@ func TestSqlStore_Create(t *testing.T) {
 			t.SkipNow() // requires generation of postgres DB
 			// create store with postgres DB
 			var storePG *sqlStore
-			// set lock to make sure it isn't used
-			storePG.writeLock.Lock()
-			defer storePG.writeLock.Unlock()
 			raceFn(storePG)
 			// To confirm there was a race condition on the page creation (can't happen with SQLite), check the logs for:
 			//		2024/02/12 19:53:20 .../nuts-node/vcr/statuslist2021/store.go:196 duplicated key not allowed


### PR DESCRIPTION
by limiting SQLite to 1 connection there is no need to have write locks in code to simulate SELECT FOR UPDATE.

this results in a deadlock when a new transaction is started from within a transaction, but this will fail during development.