### PR TITLE
allow for empty VPs to be build when no credentials are requested

### DIFF
--- a/auth/api/iam/validation.go
+++ b/auth/api/iam/validation.go
@@ -33,6 +33,9 @@ import (
 // validatePresentationSigner checks if the presenter of the VP is the same as the subject of the VCs being presented.
 // All returned errors can be used as description in an OAuth2 error.
 func validatePresentationSigner(presentation vc.VerifiablePresentation, expectedCredentialSubjectDID did.DID) (*did.DID, error) {
+	if len(presentation.VerifiableCredential) == 0 {
+		return credential.PresentationSigner(presentation)
+	}
 	subjectDID, err := credential.PresenterIsCredentialSubject(presentation)
 	if err != nil {
 		return nil, err

--- a/auth/api/iam/validation_test.go
+++ b/auth/api/iam/validation_test.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package iam
+
+import (
+	"testing"
+
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/go-did/vc"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_validatePresentationSigner(t *testing.T) {
+	signer := did.MustParseDID("did:example:123")
+	vp, _ := vc.ParseVerifiablePresentation(`{"proof":[{"verificationMethod":"did:example:123#first-vm"}]}`)
+	t.Run("ok - empty presentation", func(t *testing.T) {
+		subjectDID, err := validatePresentationSigner(*vp, signer)
+
+		assert.Nil(t, err)
+		assert.NotNil(t, subjectDID)
+	})
+}

--- a/vcr/holder/wallet.go
+++ b/vcr/holder/wallet.go
@@ -114,7 +114,17 @@ func (h wallet) BuildSubmission(ctx context.Context, walletDID did.DID, presenta
 		return nil, nil, fmt.Errorf("failed to build presentation submission: %w", err)
 	}
 	if signInstructions.Empty() {
-		return nil, nil, ErrNoCredentials
+		// we'll allow empty if no credentials are required
+		if len(presentationDefinition.InputDescriptors) > 0 {
+			return nil, nil, ErrNoCredentials
+		}
+		// add empty sign instruction
+		signInstructions = append(signInstructions, pe.SignInstruction{Holder: walletDID})
+		presentationSubmission = pe.PresentationSubmission{
+			Id:            uuid.NewString(),
+			DefinitionId:  presentationDefinition.Id,
+			DescriptorMap: make([]pe.InputDescriptorMappingObject, 0),
+		}
 	}
 
 	// todo: support multiple wallets

--- a/vcr/holder/wallet_test.go
+++ b/vcr/holder/wallet_test.go
@@ -371,6 +371,19 @@ func TestWallet_BuildSubmission(t *testing.T) {
 		assert.Nil(t, vp)
 		assert.Nil(t, submission)
 	})
+	t.Run("ok - empty presentation", func(t *testing.T) {
+		resetStore(t, storageEngine.GetSQLDatabase())
+		ctrl := gomock.NewController(t)
+		keyResolver := resolver.NewMockKeyResolver(ctrl)
+		keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.NutsSigningKeyType).Return(ssi.MustParseURI(key.KID()), key.Public(), nil)
+		w := New(keyResolver, keyStore, nil, jsonldManager, storageEngine)
+
+		vp, submission, err := w.BuildSubmission(ctx, walletDID, pe.PresentationDefinition{}, vpFormats, BuildParams{Audience: verifierDID.String(), Expires: time.Now().Add(time.Second), Nonce: ""})
+
+		assert.Nil(t, err)
+		assert.NotNil(t, vp)
+		assert.NotNil(t, submission)
+	})
 }
 
 func Test_wallet_Put(t *testing.T) {

--- a/vcr/pe/presentation_submission.go
+++ b/vcr/pe/presentation_submission.go
@@ -278,7 +278,7 @@ func (s PresentationSubmission) Validate(envelope Envelope, definition Presentat
 	if err != nil {
 		return nil, err
 	}
-	if len(signInstructions) == 0 {
+	if len(signInstructions) == 0 && len(definition.InputDescriptors) > 0 {
 		return nil, errors.New("presentation submission doesn't match presentation definition")
 	}
 	// Build a input descriptor -> credential map for comparison

--- a/vcr/pe/presentation_submission_test.go
+++ b/vcr/pe/presentation_submission_test.go
@@ -444,7 +444,17 @@ func TestPresentationSubmission_Validate(t *testing.T) {
 			proof.LDProof{VerificationMethod: vcID},
 		},
 	}
+	t.Run("ok - empty presentation and submission", func(t *testing.T) {
+		emptyVP := vc.VerifiablePresentation{
+			Proof: []interface{}{
+				proof.LDProof{VerificationMethod: vcID},
+			},
+		}
+		credentials, err := PresentationSubmission{}.Validate(toEnvelope(t, emptyVP), PresentationDefinition{})
 
+		require.NoError(t, err)
+		assert.Empty(t, credentials)
+	})
 	t.Run("ok - 1 presentation", func(t *testing.T) {
 		constant := vcID.String()
 		definition := PresentationDefinition{


### PR DESCRIPTION
closes #2800

needed changes to allow for empty VPs to be built when requested so by an empty presentation definition.
This makes testing without any credentials easier when still conforming to specs.