### PR TITLE
HTTP: correct status code logging for errors

### DIFF
--- a/core/echo_errors.go
+++ b/core/echo_errors.go
@@ -64,7 +64,7 @@ func CreateHTTPErrorHandler() echo.HTTPErrorHandler {
 		if operationID != nil {
 			title = fmt.Sprintf("%s failed", fmt.Sprintf("%s", operationID))
 		}
-		statusCode := getHTTPStatusCode(err, ctx)
+		statusCode := GetHTTPStatusCode(err, ctx)
 		logger := getContextLogger(ctx)
 		logMsg := logger.
 			WithField("operationID", operationID).
@@ -186,13 +186,16 @@ func ResolveStatusCode(err error, mapping map[error]int) int {
 	return unmappedStatusCode
 }
 
-// getHTTPStatusCode resolves the HTTP Status Code to be returned from the given error, in this order:
+// GetHTTPStatusCode resolves the HTTP Status Code to be returned from the given error, in this order:
 // - errors with a predefined status code (HTTPStatusCodeError, echo.HTTPError)
 // - from handler
 // - if none of the above criteria match, HTTP 500 Internal Server Error is returned.
-func getHTTPStatusCode(err error, ctx echo.Context) int {
+func GetHTTPStatusCode(err error, ctx echo.Context) int {
 	if predefined, ok := err.(HTTPStatusCodeError); ok {
 		return predefined.StatusCode()
+	}
+	if predefined, ok := err.(*echo.HTTPError); ok {
+		return predefined.Code
 	}
 
 	statusCodeResolverInterf := ctx.Get(StatusCodeResolverContextKey)

--- a/http/requestlogger.go
+++ b/http/requestlogger.go
@@ -21,9 +21,9 @@ package http
 import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/sirupsen/logrus"
 	"mime"
-	"net/http"
 )
 
 // requestLoggerMiddleware returns middleware that logs metadata of HTTP requests.
@@ -39,15 +39,7 @@ func requestLoggerMiddleware(skipper middleware.Skipper, logger *logrus.Entry) e
 		LogValuesFunc: func(c echo.Context, values middleware.RequestLoggerValues) error {
 			status := values.Status
 			if values.Error != nil {
-				// In case the error provides `func StatusCode() int`
-				// (e.g. core.HTTPStatusCodeError)
-				if x, ok := values.Error.(interface{ StatusCode() int }); ok {
-					status = x.StatusCode()
-				} else if x, ok := values.Error.(*echo.HTTPError); ok {
-					status = x.Code
-				} else {
-					status = http.StatusInternalServerError
-				}
+				status = core.GetHTTPStatusCode(values.Error, c)
 			}
 
 			logger.WithFields(logrus.Fields{

--- a/http/requestlogger_test.go
+++ b/http/requestlogger_test.go
@@ -104,6 +104,7 @@ func Test_requestLoggerMiddleware(t *testing.T) {
 		echoMock.EXPECT().Request().Return(&http.Request{})
 		echoMock.EXPECT().Response().Return(&echo.Response{Status: http.StatusOK})
 		echoMock.EXPECT().RealIP().Return("::1")
+		echoMock.EXPECT().Get(core.StatusCodeResolverContextKey)
 
 		logger, hook := test.NewNullLogger()
 		logFunc := requestLoggerMiddleware(func(_ echo.Context) bool {


### PR DESCRIPTION
They always default to 500, because the HTTP request logger used its own status code resolver. It now re-uses the one used by the error handler.

Fixes https://github.com/nuts-foundation/nuts-node/issues/2274