### PR TITLE
Docker: drop 'v' prefix from versions

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -49,8 +49,6 @@ jobs:
             type=ref,event=branch,enable={{is_default_branch}},prefix=
             # generate 5.2.1 tag
             type=semver,pattern={{version}}
-            # generate 5 tag
-            type=semver,pattern={{major}}
           flavor: |
             latest=${{ steps.version.outputs.git_version == steps.get-latest-tag.outputs.tag }}
 

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -47,13 +47,12 @@ jobs:
           tags: |
             # generate 'master' tag for the master branch
             type=ref,event=branch,enable={{is_default_branch}},prefix=
-            # generate v5.2.1 tag
+            # generate 5.2.1 tag
             type=semver,pattern={{version}}
-            # generate v5 tag
+            # generate 5 tag
             type=semver,pattern={{major}}
           flavor: |
             latest=${{ steps.version.outputs.git_version == steps.get-latest-tag.outputs.tag }}
-            prefix=v,onlatest=false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
closes #1629 

this drops the tag `v` prefix for docker images, so tag `v6.0.0` creates docker image `nutsfoundation/nuts-node:6.0.0`

it also removes the major version tag (`nutsfoundation/nuts-node:6`). This is currently broken as tagging 6.0.1 will set this version as 6, even if tag 6.1.0 already exists.

Maybe wait to merge this until we are sure there will not be a v5.5.*