### PR TITLE
Fix govulncheck: revert go-version to stable

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -25,6 +25,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          # use go version from go.mod.
-          go-version-file: 'go.mod'
+          go-version-input: 'stable'
           go-package: ./...


### PR DESCRIPTION
partially reverts #2862

`go-version-input: 'stable'` uses the latest patch version
`go-version-file: 'go.mod'` does not domain a patch version resulting in all current failures. 

We always build with the latest patch version asap, so using version 'stable' should be fine