### PR TITLE
StatusList2021: add e2e test

### DIFF
--- a/e2e-tests/oauth-flow/run-tests.sh
+++ b/e2e-tests/oauth-flow/run-tests.sh
@@ -22,3 +22,10 @@ echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 pushd openid4vp
 ./run-test.sh
 popd
+
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo "!! Running test: StatusList2021 !!"
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+pushd statuslist2021
+./run-test.sh
+popd

--- a/e2e-tests/oauth-flow/statuslist2021/docker-compose.yml
+++ b/e2e-tests/oauth-flow/statuslist2021/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.7"
+services:
+  nodeA:
+    image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"
+    ports:
+      - "10443:443"
+      - "11323:1323"
+    environment:
+      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
+    volumes:
+      - "./node-A/nuts.yaml:/opt/nuts/nuts.yaml:ro"
+      - "./node-A/data:/opt/nuts/data:rw"
+      - "../../tls-certs/nodeA-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
+      - "../../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
+    healthcheck:
+      interval: 1s # Make test run quicker by checking health status more often
+  nodeB:
+    image: "${IMAGE_NODE_B:-nutsfoundation/nuts-node:master}"
+    ports:
+      - "20443:443"
+      - "21323:1323"
+    environment:
+      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
+    volumes:
+      - "./node-B/data:/opt/nuts/data:rw"
+      - "./node-B/nuts.yaml:/opt/nuts/nuts.yaml:ro"
+      - "../../tls-certs/nodeB-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
+      - "../../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
+    healthcheck:
+      interval: 1s # Make test run quicker by checking health status more often

--- a/e2e-tests/oauth-flow/statuslist2021/node-A/nuts.yaml
+++ b/e2e-tests/oauth-flow/statuslist2021/node-A/nuts.yaml
@@ -1,0 +1,24 @@
+url: https://nodeA
+verbosity: debug
+strictmode: false
+internalratelimiter: false
+datadir: /opt/nuts/data
+http:
+  default:
+    address: :1323
+    log: metadata-and-body
+  alt:
+    iam:
+      address: :443
+      log: metadata-and-body
+      tls: server
+auth:
+  v2apienabled: true
+  contractvalidators:
+    - dummy
+  irma:
+    autoupdateschemas: false
+tls:
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem

--- a/e2e-tests/oauth-flow/statuslist2021/node-B/nuts.yaml
+++ b/e2e-tests/oauth-flow/statuslist2021/node-B/nuts.yaml
@@ -1,0 +1,24 @@
+url: https://nodeB
+verbosity: debug
+strictmode: false
+internalratelimiter: false
+datadir: /opt/nuts/data
+http:
+  default:
+    address: :1323
+    log: metadata-and-body
+  alt:
+    iam:
+      address: :443
+      log: metadata-and-body
+      tls: server
+auth:
+  v2apienabled: true
+  contractvalidators:
+    - dummy
+  irma:
+    autoupdateschemas: false
+tls:
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem

--- a/e2e-tests/oauth-flow/statuslist2021/run-test.sh
+++ b/e2e-tests/oauth-flow/statuslist2021/run-test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+source ../../util.sh
+
+echo "------------------------------------"
+echo "Cleaning up running Docker containers and volumes, and key material..."
+echo "------------------------------------"
+docker compose down
+docker compose rm -f -v
+rm -rf ./node-*/data
+mkdir ./node-A/data ./node-B/data  # 'data' dirs will be created with root owner by docker if they do not exit. This creates permission issues on CI.
+
+echo "------------------------------------"
+echo "Starting Docker containers..."
+echo "------------------------------------"
+docker compose up -d --remove-orphans
+docker compose up --wait nodeA nodeB
+
+echo "------------------------------------"
+echo "Registering vendors..."
+echo "------------------------------------"
+
+# Register Party A
+PARTY_A_DIDDOC=$(curl -s -X POST http://localhost:11323/internal/vdr/v2/did)
+PARTY_A_DID=$(echo $PARTY_A_DIDDOC | jq -r .id)
+echo "  Vendor A DID: $PARTY_A_DID"
+
+# Register Vendor B
+PARTY_B_DIDDOC=$(curl -s -X POST http://localhost:21323/internal/vdr/v2/did)
+PARTY_B_DID=$(echo $PARTY_B_DIDDOC | jq -r .id)
+echo "  Vendor B DID: $PARTY_B_DID"
+
+echo "---------------------------------------"
+echo "Issuing NutsOrganizationCredential..."
+echo "---------------------------------------"
+
+# Issue NutsOrganizationCredential for Vendor B with a revocable StatusList2021Entry in VC.credentialStatus
+REQUEST="{\"type\":\"NutsOrganizationCredential\",\"issuer\":\"${PARTY_B_DID}\", \"credentialSubject\": {\"id\":\"${PARTY_B_DID}\", \"organization\":{\"name\":\"Caresoft B.V.\", \"city\":\"Caretown\"}},\"withStatusList2021Revocation\": true}"
+RESPONSE=$(echo $REQUEST | curl -s -X POST --data-binary @- http://localhost:21323/internal/vcr/v2/issuer/vc -H "Content-Type:application/json")
+if echo $RESPONSE | grep -q "VerifiableCredential"; then
+  CREDENTIAL_ID=$( echo $RESPONSE | jq .id  | sed "s/\"//g" )
+  echo "  VC issued: $CREDENTIAL_ID"
+else
+  echo "  FAILED: Could not issue NutsOrganizationCredential to node-B" 1>&2
+  echo $RESPONSE
+  exitWithDockerLogs 1
+fi
+
+VALIDATION_REQUEST="{\"verifiableCredential\": ${RESPONSE}}"
+
+echo "---------------------------------------"
+echo "Validating credential pt 1..."
+echo "---------------------------------------"
+
+RESPONSE=$(echo $VALIDATION_REQUEST | curl -s -X POST --data-binary @- http://localhost:21323/internal/vcr/v2/verifier/vc -H "Content-Type:application/json")
+if [[ $( echo $RESPONSE | jq -r .validity ) ==  "true" ]]; then
+  echo "  VC considered valid by node-B"
+else
+  echo "  FAILED: Could not validate NutsOrganizationCredential in node-B wallet" 1>&2
+  echo $RESPONSE
+  exitWithDockerLogs 1
+fi
+
+echo "---------------------------------------"
+echo "Revoking NutsOrganizationCredential..."
+echo "---------------------------------------"
+
+revokeCredential "http://localhost:21323" "${CREDENTIAL_ID}"
+
+echo "---------------------------------------"
+echo "Validating credential pt 2..."
+echo "---------------------------------------"
+
+# confirm revoked by StatusList2021Credential on node-B, uses internal store
+RESPONSE=$(echo $VALIDATION_REQUEST | curl -s -X POST --data-binary @- http://localhost:21323/internal/vcr/v2/verifier/vc -H "Content-Type:application/json")
+if [[ $( echo $RESPONSE | jq -r .validity ) ==  "false" ]]; then
+  echo "  VC considered revoked by node-B"
+else
+  echo "  FAILED: Credential not revoked on node-B" 1>&2
+  echo $RESPONSE
+  exitWithDockerLogs 1
+fi
+
+# confirm revoked by StatusList2021Credential on node-A, fetches StatusList2021Credential from node-B using APIs
+RESPONSE=$(echo $VALIDATION_REQUEST | curl -s -X POST --data-binary @- http://localhost:11323/internal/vcr/v2/verifier/vc -H "Content-Type:application/json")
+if [[ $( echo $RESPONSE | jq -r .validity ) ==  "false" ]]; then
+  echo "  VC considered revoked by node-A"
+else
+  echo "  FAILED: Credential not revoked on node-A" 1>&2
+  echo $RESPONSE
+  exitWithDockerLogs 1
+fi
+
+echo "------------------------------------"
+echo "Stopping Docker containers..."
+echo "------------------------------------"
+docker compose stop

--- a/vcr/issuer/issuer_test.go
+++ b/vcr/issuer/issuer_test.go
@@ -152,16 +152,16 @@ func Test_issuer_buildAndSignVC(t *testing.T) {
 		})
 	})
 	t.Run("credentialStatus", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		keyResolverMock := NewMockkeyResolver(ctrl)
+		keyResolverMock.EXPECT().ResolveAssertionKey(ctx, gomock.Any()).Return(signingKey, nil).AnyTimes()
 		t.Run("ok", func(t *testing.T) {
 			issuerDID := did.MustParseDID("did:web:example.com:iam:123")
 			slTemplate := template
 			slTemplate.Issuer = issuerDID.URI() // does not overwrite template
 
-			ctrl := gomock.NewController(t)
-			keyResolverMock := NewMockkeyResolver(ctrl)
-			keyResolverMock.EXPECT().ResolveAssertionKey(ctx, gomock.Any()).Return(signingKey, nil)
 			jsonldManager := jsonld.NewTestJSONLDManager(t)
-			sut := issuer{keyResolver: keyResolverMock, jsonldManager: jsonldManager, keyStore: keyStore, statusList: NewTestStatusList2021(t, issuerDID)}
+			sut := issuer{keyResolver: keyResolverMock, jsonldManager: jsonldManager, keyStore: keyStore, statusList: newTestStatusList2021(t, signingKey, issuerDID)}
 
 			result, err := sut.buildAndSignVC(ctx, slTemplate, CredentialOptions{WithStatusListRevocation: true})
 
@@ -176,7 +176,7 @@ func Test_issuer_buildAndSignVC(t *testing.T) {
 			assert.Equal(t, revocation.StatusList2021EntryType, statuses[0].Type)
 		})
 		t.Run("error - did:nuts", func(t *testing.T) {
-			sut := issuer{keyStore: keyStore, statusList: NewTestStatusList2021(t)}
+			sut := issuer{keyResolver: keyResolverMock, keyStore: keyStore, statusList: newTestStatusList2021(t, signingKey, did.MustParseDID(template.Issuer.String()))}
 
 			result, err := sut.buildAndSignVC(ctx, template, CredentialOptions{WithStatusListRevocation: true})
 
@@ -800,8 +800,15 @@ func TestIssuer_revokeStatusList(t *testing.T) {
 		return store, credentialID
 	}
 
+	ctx := audit.TestContext()
+	keyStore := crypto.NewMemoryCryptoInstance()
+	signingKey, err := keyStore.New(ctx, func(key crypt.PublicKey) (string, error) {
+		return issuerDID.String() + "#abc", nil
+	})
+	require.NoError(t, err)
+
 	t.Run("ok", func(t *testing.T) {
-		status := NewTestStatusList2021(t, issuerDID)
+		status := newTestStatusList2021(t, signingKey, issuerDID)
 		entry, err := status.Entry(context.Background(), issuerDID, revocation.StatusPurposeRevocation)
 		require.NoError(t, err)
 		issuerStore, credentialID := storeWithCred(gomock.NewController(t), *entry)
@@ -816,7 +823,7 @@ func TestIssuer_revokeStatusList(t *testing.T) {
 		assert.Nil(t, revCred)
 	})
 	t.Run("error - double revocation", func(t *testing.T) {
-		status := NewTestStatusList2021(t, issuerDID)
+		status := newTestStatusList2021(t, signingKey, issuerDID)
 		entry, err := status.Entry(context.Background(), issuerDID, revocation.StatusPurposeRevocation)
 		require.NoError(t, err)
 		issuerStore, credentialID := storeWithCred(gomock.NewController(t), *entry)
@@ -842,7 +849,7 @@ func TestIssuer_revokeStatusList(t *testing.T) {
 		assert.Nil(t, result)
 	})
 	t.Run("error - statuslist credential not found", func(t *testing.T) {
-		status := NewTestStatusList2021(t, issuerDID)
+		status := newTestStatusList2021(t, signingKey, issuerDID)
 		entry, err := status.Entry(context.Background(), issuerDID, revocation.StatusPurposeRevocation)
 		require.NoError(t, err)
 		entry.StatusListCredential = "unknown status list"
@@ -934,17 +941,13 @@ func TestIssuer_StatusList(t *testing.T) {
 	jsonldManager := jsonld.NewTestJSONLDManager(t)
 	trustConfig := trust.NewConfig(path.Join(io.TestDirectory(t), "trust.config"))
 	t.Run("ok", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		keyResolverMock := NewMockkeyResolver(ctrl)
-		keyResolverMock.EXPECT().ResolveAssertionKey(ctx, gomock.Any()).Return(signingKey, nil)
 		sut := issuer{
-			keyResolver:   keyResolverMock,
 			jsonldManager: jsonldManager,
 			keyStore:      keyStore,
 			trustConfig:   trustConfig,
-			statusList:    NewTestStatusList2021(t, issuerDID),
+			statusList:    newTestStatusList2021(t, signingKey, issuerDID),
 		}
-		sut.statusList.(*revocation.StatusList2021).Sign = sut.signVC
+		sut.statusList.(*revocation.StatusList2021).Sign = sut.buildJSONLDCredential
 		_, err = sut.statusList.Entry(ctx, issuerDID, revocation.StatusPurposeRevocation)
 		require.NoError(t, err)
 
@@ -972,6 +975,7 @@ func TestIssuer_StatusList(t *testing.T) {
 		assert.NotEmpty(t, subjects[0].EncodedList, "")
 
 		// verify credential -> trust is not added automatically
+		ctrl := gomock.NewController(t)
 		vStoreMock := verifier.NewMockStore(ctrl)
 		vStoreMock.EXPECT().GetRevocations(gomock.Any()).Return(nil, verifier.ErrNotFound)
 		vDIDResolverMock := resolver.NewMockDIDResolver(ctrl)
@@ -982,38 +986,15 @@ func TestIssuer_StatusList(t *testing.T) {
 		assert.NoError(t, verif.Verify(*result, true, true, nil))
 	})
 	t.Run("error - unknown status list credential", func(t *testing.T) {
-		sut := issuer{statusList: NewTestStatusList2021(t, issuerDID)}
+		sut := issuer{statusList: newTestStatusList2021(t, signingKey, issuerDID)}
 
 		result, err := sut.StatusList(ctx, issuerDID, 1)
 
 		assert.ErrorIs(t, err, vcr.ErrNotFound)
 		assert.Nil(t, result)
 	})
-	t.Run("error - issuance failed", func(t *testing.T) {
-		db := storage.NewTestStorageEngine(t).GetSQLDatabase()
-		storage.AddDIDtoSQLDB(t, db, issuerDID)
-		status := revocation.NewStatusList2021(db, nil)
-		status.Sign = func(_ context.Context, unsignedCredential vc.VerifiableCredential, _ string) (*vc.VerifiableCredential, error) {
-			return &unsignedCredential, nil
-		}
-		_, err = status.Entry(ctx, issuerDID, revocation.StatusPurposeRevocation)
-		require.NoError(t, err)
-		db.Exec("DROP TABLE status_list_credential")
-
-		sut := issuer{
-			jsonldManager: jsonldManager,
-			keyStore:      keyStore,
-			trustConfig:   trustConfig,
-			statusList:    status,
-		}
-
-		result, err := sut.StatusList(ctx, issuerDID, 1)
-
-		assert.Nil(t, result)
-		assert.Error(t, err, "issuance failed")
-	})
 	t.Run("error - did:nuts", func(t *testing.T) {
-		sut := issuer{statusList: NewTestStatusList2021(t)}
+		sut := issuer{statusList: newTestStatusList2021(t, signingKey)}
 		issuerNuts := did.MustParseDID("did:nuts:123")
 
 		result, err := sut.StatusList(ctx, issuerNuts, 1)
@@ -1023,12 +1004,12 @@ func TestIssuer_StatusList(t *testing.T) {
 	})
 }
 
-func NewTestStatusList2021(t testing.TB, dids ...did.DID) *revocation.StatusList2021 {
+func newTestStatusList2021(t testing.TB, signingKey crypto.Key, dids ...did.DID) *revocation.StatusList2021 {
 	storageEngine := storage.NewTestStorageEngine(t)
 	db := storageEngine.GetSQLDatabase()
 	storage.AddDIDtoSQLDB(t, db, dids...)
 	cs := revocation.NewStatusList2021(db, nil)
-	cs.Sign = func(_ context.Context, unsignedCredential vc.VerifiableCredential, _ string) (*vc.VerifiableCredential, error) {
+	cs.Sign = func(_ context.Context, unsignedCredential vc.VerifiableCredential, _ crypto.Key) (*vc.VerifiableCredential, error) {
 		unsignedCredential.ID, _ = ssi.ParseURI("test-credential")
 		bs, err := json.Marshal(unsignedCredential)
 		require.NoError(t, err)
@@ -1036,6 +1017,10 @@ func NewTestStatusList2021(t testing.TB, dids ...did.DID) *revocation.StatusList
 		require.NoError(t, json.Unmarshal(bs, unsignedWithRawField))
 		return unsignedWithRawField, nil
 	}
+	ctrl := gomock.NewController(t)
+	keyResolverMock := NewMockkeyResolver(ctrl)
+	keyResolverMock.EXPECT().ResolveAssertionKey(gomock.Any(), gomock.Any()).Return(signingKey, nil).AnyTimes()
+	cs.ResolveKey = keyResolverMock.ResolveAssertionKey
 	return cs
 }
 

--- a/vcr/issuer/issuer_test.go
+++ b/vcr/issuer/issuer_test.go
@@ -974,7 +974,7 @@ func TestIssuer_StatusList(t *testing.T) {
 		assert.Equal(t, subjects[0].StatusPurpose, revocation.StatusPurposeRevocation)
 		assert.NotEmpty(t, subjects[0].EncodedList, "")
 
-		// verify credential -> trust is not added automatically
+		// verify credential; revocation.StatusList2021 does not test signatures on StatusList2021Credentials it produces
 		ctrl := gomock.NewController(t)
 		vStoreMock := verifier.NewMockStore(ctrl)
 		vStoreMock.EXPECT().GetRevocations(gomock.Any()).Return(nil, verifier.ErrNotFound)

--- a/vcr/revocation/statuslist2021_issuer_test.go
+++ b/vcr/revocation/statuslist2021_issuer_test.go
@@ -48,7 +48,7 @@ func Test_TableNames(t *testing.T) {
 	assert.Equal(t, revocationRecord{}.TableName(), "status_list_entry")
 }
 
-func TestSqlStore_Create(t *testing.T) {
+func TestStatusList2021_Entry(t *testing.T) {
 	s := newTestStatusList2021(t, aliceDID, bobDID) // NOTE: most tests re-use the same store, so they will fail when tests run out of order.
 	testCtx := context.Background()
 
@@ -206,7 +206,7 @@ func TestSqlStore_Create(t *testing.T) {
 	})
 }
 
-func TestSqlStore_Revoke(t *testing.T) {
+func TestStatusList2021_Revoke(t *testing.T) {
 	s := newTestStatusList2021(t, aliceDID, bobDID)
 
 	entryP, err := s.Entry(nil, aliceDID, StatusPurposeRevocation)
@@ -269,7 +269,7 @@ func TestSqlStore_Revoke(t *testing.T) {
 	})
 }
 
-func TestCredentialStatus_Credential(t *testing.T) {
+func TestStatusList2021_Credential(t *testing.T) {
 	s := newTestStatusList2021(t, aliceDID, bobDID)
 	auditCtx := audit.TestContext()
 
@@ -356,7 +356,7 @@ func TestCredentialStatus_Credential(t *testing.T) {
 	})
 }
 
-func TestCredentialStatus_buildAndSignVC(t *testing.T) {
+func TestStatusList2021_buildAndSignVC(t *testing.T) {
 	cs := &StatusList2021{Sign: noopSign}
 
 	subjectID, err := toStatusListCredential(aliceDID, 1)

--- a/vcr/revocation/statuslist2021_issuer_test.go
+++ b/vcr/revocation/statuslist2021_issuer_test.go
@@ -338,7 +338,7 @@ func TestCredentialStatus_buildAndSignVC(t *testing.T) {
 		EncodedList:   encodedList,
 	}
 
-	cred, err := cs.buildAndSignVC(nil, aliceDID, expectedCS)
+	cred, err := cs.buildAndSignVC(nil, aliceDID, expectedCS, nil)
 
 	require.NoError(t, err)
 	assert.True(t, cred.ContainsContext(vc.VCContextV1URI()))

--- a/vcr/revocation/statuslist2021_verifier_test.go
+++ b/vcr/revocation/statuslist2021_verifier_test.go
@@ -127,7 +127,7 @@ func TestCredentialStatus_statusList(t *testing.T) {
 				StatusListIndex:      1,
 			}},
 		}
-		_, cr, err := (&StatusList2021{Sign: noopSign}).updateCredential(nil, &cir)
+		_, cr, err := (&StatusList2021{Sign: noopSign}).updateCredential(nil, &cir, nil)
 		require.NoError(t, err)
 		return *cr, cir
 	}

--- a/vcr/revocation/statuslist2021_verifier_test.go
+++ b/vcr/revocation/statuslist2021_verifier_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCredentialStatus_Verify(t *testing.T) {
+func TestStatusList2021_Verify(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		cs, entry, _ := testSetup(t, false)
 		cred := test.ValidNutsOrganizationCredential(t)
@@ -116,7 +116,7 @@ func TestCredentialStatus_Verify(t *testing.T) {
 	})
 }
 
-func TestCredentialStatus_statusList(t *testing.T) {
+func TestStatusList2021_statusList(t *testing.T) {
 	makeRecords := func(subjectID string) (credentialRecord, credentialIssuerRecord) {
 		cir := credentialIssuerRecord{
 			SubjectID: subjectID,
@@ -222,7 +222,7 @@ func TestCredentialStatus_statusList(t *testing.T) {
 
 }
 
-func TestCredentialStatus_update(t *testing.T) {
+func TestStatusList2021_update(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		cs, entry, ts := testSetup(t, false)
 
@@ -296,7 +296,7 @@ func TestCredentialStatus_update(t *testing.T) {
 	})
 }
 
-func TestCredentialStatus_download(t *testing.T) {
+func TestStatusList2021_download(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		cred := test.ValidStatusList2021Credential(t) // has bit 1 set
 		expected, err := json.Marshal(cred)
@@ -350,7 +350,7 @@ func TestCredentialStatus_download(t *testing.T) {
 	})
 }
 
-func TestCredentialStatus_verify(t *testing.T) {
+func TestStatusList2021_verify(t *testing.T) {
 	credentialStatusNoSignCheck := &StatusList2021{
 		client: nil,
 		VerifySignature: func(credentialToVerify vc.VerifiableCredential, validateAt *time.Time) error {
@@ -394,7 +394,7 @@ func TestCredentialStatus_verify(t *testing.T) {
 	})
 }
 
-func TestCredentialStatus_validate(t *testing.T) {
+func TestStatusList2021_validate(t *testing.T) {
 	cs := StatusList2021{
 		VerifySignature: func(credentialToVerify vc.VerifiableCredential, validateAt *time.Time) error { return nil },
 	}

--- a/vcr/revocation/types.go
+++ b/vcr/revocation/types.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/core"
+	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/jsonld"
 	"github.com/nuts-foundation/nuts-node/vcr/types"
 	"gorm.io/gorm"
@@ -89,7 +90,11 @@ type StatusList2021Verifier interface {
 type VerifySignFn func(credentialToVerify vc.VerifiableCredential, validateAt *time.Time) error
 
 // SignFn signs a VC according to the specified format. The vcr.issuer injects its signVC method here.
-type SignFn func(ctx context.Context, unsignedCredential vc.VerifiableCredential, credentialFormat string) (*vc.VerifiableCredential, error)
+type SignFn func(ctx context.Context, unsignedCredential vc.VerifiableCredential, key crypto.Key) (*vc.VerifiableCredential, error)
+
+// ResolveKeyFn resolves the key used SignFn to sign the StatusList2021Credential.
+// The vcr.issuer injects its keyResolver.ResolveAssertionKey here.
+type ResolveKeyFn func(ctx context.Context, issuerDID did.DID) (crypto.Key, error)
 
 var _ StatusList2021Issuer = (*StatusList2021)(nil)
 var _ StatusList2021Verifier = (*StatusList2021)(nil)
@@ -102,6 +107,7 @@ type StatusList2021 struct {
 	db              *gorm.DB
 	VerifySignature VerifySignFn // injected by verifier
 	Sign            SignFn       // injected by issuer, context must contain an audit log
+	ResolveKey      ResolveKeyFn // injected by issuer
 }
 
 // NewStatusList2021 returns a StatusList2021 without a Sign or VerifySignature method.

--- a/vcr/revocation/types_test.go
+++ b/vcr/revocation/types_test.go
@@ -21,13 +21,12 @@ package revocation
 import (
 	"context"
 	"encoding/json"
-	"github.com/nuts-foundation/nuts-node/crypto"
 	"testing"
 	"time"
 
-	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
+	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/stretchr/testify/assert"
 )
@@ -43,7 +42,6 @@ func newTestStatusList2021(t testing.TB, dids ...did.DID) *StatusList2021 {
 }
 
 func noopSign(_ context.Context, unsignedCredential vc.VerifiableCredential, _ crypto.Key) (*vc.VerifiableCredential, error) {
-	unsignedCredential.ID, _ = ssi.ParseURI("test-id")
 	// marshal-unmarshal credential to set the .raw field
 	bs, err := json.Marshal(unsignedCredential)
 	if err != nil {

--- a/vcr/verifier/verifier_test.go
+++ b/vcr/verifier/verifier_test.go
@@ -153,11 +153,12 @@ func TestVerifier_Verify(t *testing.T) {
 		db := storage.NewTestStorageEngine(t).GetSQLDatabase()
 		ctx.verifier.credentialStatus = revocation.NewStatusList2021(db, ts.Client())
 		ctx.verifier.credentialStatus.(*revocation.StatusList2021).VerifySignature = func(_ vc.VerifiableCredential, _ *time.Time) error { return nil } // don't check signatures on 'downloaded' StatusList2021Credentials
-		ctx.verifier.credentialStatus.(*revocation.StatusList2021).Sign = func(_ context.Context, unsignedCredential vc.VerifiableCredential, _ string) (*vc.VerifiableCredential, error) {
+		ctx.verifier.credentialStatus.(*revocation.StatusList2021).Sign = func(_ context.Context, unsignedCredential vc.VerifiableCredential, _ crypto.Key) (*vc.VerifiableCredential, error) {
 			bs, err := json.Marshal(unsignedCredential)
 			require.NoError(t, err)
 			return &unsignedCredential, json.Unmarshal(bs, &unsignedCredential)
 		}
+		ctx.verifier.credentialStatus.(*revocation.StatusList2021).ResolveKey = func(ctx context.Context, issuerDID did.DID) (crypto.Key, error) { return nil, nil } // ctx.verifier.credentialStatus.Sign ignores the key
 
 		cred := test.ValidNutsOrganizationCredential(t)
 		cred.Context = append(cred.Context, ssi.MustParseURI(jsonld.W3cStatusList2021Context))


### PR DESCRIPTION
closes #2880 

This PR adds an e2e test. 
The e2e test revealed an issue where using a SQLite db would deadlock when trying to resolve an issuers signing key (loading did doc). Key resolving is now done outside the transactions that needs the key.

The fix above also allows partially reverting  #2827 to merge the `issuers.buildAndSignVC` and `.signVC` methods; This means key checking to moved back to the top which is probably sufficient to fix #2856. This time I added a comment on the check to keep key resolving at the top.