### PR TITLE
set primary key for did service and vm to id

### DIFF
--- a/storage/sql_migrations/003_did.sql
+++ b/storage/sql_migrations/003_did.sql
@@ -17,7 +17,7 @@ create table did_verificationmethod
     -- data is a JSON object containing the verification method data, e.g. the public key.
     -- When producing the verificationMethod, data is used as JSON base object and the id and type are added.
     data text         not null,
-    primary key (did, id),
+    primary key (id),
     foreign key (did) references did (did) on delete cascade
 );
 
@@ -31,7 +31,7 @@ create table did_service
     -- data is a JSON object containing the service data, e.g. the serviceEndpoint.
     -- When producing the service, data is used as JSON base object and the id and type are added.
     data text         not null,
-    primary key (did, id),
+    primary key (id),
     foreign key (did) references did (did) on delete cascade
 );
 

--- a/vdr/didweb/store.go
+++ b/vdr/didweb/store.go
@@ -59,7 +59,7 @@ var _ schema.Tabler = (*sqlVerificationMethod)(nil)
 
 type sqlVerificationMethod struct {
 	ID   string `gorm:"primaryKey"`
-	Did  string `gorm:"primaryKey"`
+	Did  string
 	Data []byte
 }
 
@@ -71,7 +71,7 @@ var _ schema.Tabler = (*sqlService)(nil)
 
 type sqlService struct {
 	ID   string `gorm:"primaryKey"`
-	Did  string `gorm:"primaryKey"`
+	Did  string
 	Data []byte
 }
 


### PR DESCRIPTION
according to DID spec, the id always contains the DID, no need to have a primary key consist of both the did and id

also it would be too long (3140 bytes)