### PR TITLE
remove references to deprecated purposeOfUseClaim

### DIFF
--- a/auth/services/oauth/authz_server.go
+++ b/auth/services/oauth/authz_server.go
@@ -49,7 +49,6 @@ const errInvalidSubjectFmt = "invalid jwt.subject: %w"
 const errInvalidVCClaim = "invalid jwt.vcs: %w"
 
 const vcClaim = "vcs"
-const purposeOfUseClaimDeprecated = "purposeOfUseClaim"
 const purposeOfUseClaim = "purposeOfUse"
 const userIdentityClaim = "usi"
 
@@ -314,10 +313,7 @@ func (s *authzServer) validateRequester(context *validationContext) error {
 func (s *authzServer) validatePurposeOfUse(context *validationContext) error {
 	purposeOfUse := context.stringVal(purposeOfUseClaim)
 	if purposeOfUse == nil {
-		purposeOfUse = context.stringVal(purposeOfUseClaimDeprecated)
-		if purposeOfUse == nil {
-			return errors.New("no purposeOfUse given")
-		}
+		return errors.New("no purposeOfUse given")
 	}
 
 	context.purposeOfUse = *purposeOfUse

--- a/auth/services/oauth/authz_server_test.go
+++ b/auth/services/oauth/authz_server_test.go
@@ -403,7 +403,6 @@ func TestService_validatePurposeOfUse(t *testing.T) {
 	t.Run("error - no purposeOfUse", func(t *testing.T) {
 		ctx := createContext(t)
 		tokenCtx := validContext(t)
-		tokenCtx.jwtBearerToken.Remove(purposeOfUseClaimDeprecated)
 		tokenCtx.jwtBearerToken.Remove(purposeOfUseClaim)
 
 		err := ctx.oauthService.validatePurposeOfUse(tokenCtx)
@@ -411,20 +410,9 @@ func TestService_validatePurposeOfUse(t *testing.T) {
 		assert.EqualError(t, err, "no purposeOfUse given")
 	})
 
-	t.Run("ok - only deprecated claim", func(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
 		ctx := createContext(t)
 		tokenCtx := validContext(t)
-		tokenCtx.jwtBearerToken.Remove(purposeOfUseClaim)
-
-		err := ctx.oauthService.validatePurposeOfUse(tokenCtx)
-
-		assert.NoError(t, err)
-	})
-
-	t.Run("ok - only correct claim", func(t *testing.T) {
-		ctx := createContext(t)
-		tokenCtx := validContext(t)
-		tokenCtx.jwtBearerToken.Remove(purposeOfUseClaimDeprecated)
 
 		err := ctx.oauthService.validatePurposeOfUse(tokenCtx)
 
@@ -783,17 +771,16 @@ func validContext(t *testing.T) *validationContext {
 	_ = json.Unmarshal(credString, &credMap)
 
 	claims := map[string]interface{}{
-		jwt.AudienceKey:             expectedAudience,
-		jwt.ExpirationKey:           time.Now().Add(5 * time.Second).Unix(),
-		jwt.JwtIDKey:                "a005e81c-6749-4967-b01c-495228fcafb4",
-		jwt.IssuedAtKey:             time.Now().UTC(),
-		jwt.IssuerKey:               requesterDID.String(),
-		jwt.NotBeforeKey:            0,
-		jwt.SubjectKey:              authorizerDID.String(),
-		userIdentityClaim:           usi,
-		purposeOfUseClaimDeprecated: expectedService,
-		purposeOfUseClaim:           expectedService,
-		vcClaim:                     []interface{}{credMap},
+		jwt.AudienceKey:   expectedAudience,
+		jwt.ExpirationKey: time.Now().Add(5 * time.Second).Unix(),
+		jwt.JwtIDKey:      "a005e81c-6749-4967-b01c-495228fcafb4",
+		jwt.IssuedAtKey:   time.Now().UTC(),
+		jwt.IssuerKey:     requesterDID.String(),
+		jwt.NotBeforeKey:  0,
+		jwt.SubjectKey:    authorizerDID.String(),
+		userIdentityClaim: usi,
+		purposeOfUseClaim: expectedService,
+		vcClaim:           []interface{}{credMap},
 	}
 	token := jwt.New()
 	for k, v := range claims {
@@ -812,16 +799,15 @@ func validAccessToken() *validationContext {
 	usi := vc.VerifiablePresentation{Type: []ssi.URI{ssi.MustParseURI("TestPresentation")}}
 
 	claims := map[string]interface{}{
-		jwt.AudienceKey:             expectedAudience,
-		jwt.ExpirationKey:           time.Now().Add(5 * time.Second).Unix(),
-		jwt.JwtIDKey:                "a005e81c-6749-4967-b01c-495228fcafb4",
-		jwt.IssuedAtKey:             time.Now().UTC(),
-		jwt.SubjectKey:              requesterDID.String(),
-		jwt.NotBeforeKey:            0,
-		jwt.IssuerKey:               authorizerDID.String(),
-		userIdentityClaim:           usi,
-		purposeOfUseClaimDeprecated: expectedService,
-		vcClaim:                     []string{"credential"},
+		jwt.AudienceKey:   expectedAudience,
+		jwt.ExpirationKey: time.Now().Add(5 * time.Second).Unix(),
+		jwt.JwtIDKey:      "a005e81c-6749-4967-b01c-495228fcafb4",
+		jwt.IssuedAtKey:   time.Now().UTC(),
+		jwt.SubjectKey:    requesterDID.String(),
+		jwt.NotBeforeKey:  0,
+		jwt.IssuerKey:     authorizerDID.String(),
+		userIdentityClaim: usi,
+		vcClaim:           []string{"credential"},
 	}
 	token := jwt.New()
 	for k, v := range claims {

--- a/auth/services/oauth/relying_party.go
+++ b/auth/services/oauth/relying_party.go
@@ -138,7 +138,6 @@ func claimsFromRequest(request services.CreateJwtGrantRequest, audience string) 
 	result[jwt.IssuerKey] = request.Requester
 	result[jwt.NotBeforeKey] = 0
 	result[jwt.SubjectKey] = request.Authorizer
-	result[purposeOfUseClaimDeprecated] = request.Service
 	result[purposeOfUseClaim] = request.Service
 	if request.IdentityVP != nil {
 		result[userIdentityClaim] = *request.IdentityVP

--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -4,6 +4,14 @@ Release notes
 #############
 
 ************************
+Peanut (v6.0.0)
+************************
+
+Release date: ?
+
+- removed usage of deprecated `purposeOfUseClaim` from NutsAuthorizationCredential
+
+************************
 Hazelnut update (v5.4.6)
 ************************
 


### PR DESCRIPTION
closes #2204 

removed reading `purposeOfUseClaim` from authorization credential.
this field is not referenced in v1 of the specs, so it has been long enough.