### PR TITLE
Tweaked strict mode checks to allow running without TLS

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -142,11 +142,6 @@ func (auth *Auth) Configure(config core.ServerConfig) error {
 		StrictMode:            config.Strictmode,
 	}, auth.vcr, resolver.DIDKeyResolver{Resolver: auth.vdrInstance.Resolver()}, auth.keyStore, auth.jsonldManager, auth.pkiProvider)
 
-	tlsEnabled := config.TLS.Enabled()
-	if config.Strictmode && !tlsEnabled {
-		return errors.New("in strictmode TLS must be enabled")
-	}
-
 	auth.tlsConfig, err = auth.pkiProvider.CreateTLSConfig(config.TLS) // returns nil if TLS is disabled
 	if err != nil {
 		return err

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -94,13 +94,6 @@ func TestAuth_Configure(t *testing.T) {
 		assert.EqualError(t, err, "in strictmode the only valid irma-scheme-manager is 'pbdf'")
 	})
 
-	t.Run("error - TLS required in strict mode", func(t *testing.T) {
-		authCfg := TestConfig()
-		i := testInstance(t, authCfg)
-		err := i.Configure(core.TestServerConfig())
-		assert.EqualError(t, err, "in strictmode TLS must be enabled")
-	})
-
 	t.Run("error - TLS config provider returns error", func(t *testing.T) {
 		i := testInstance(t, TestConfig())
 		pkiProvider := pki.NewMockProvider(gomock.NewController(t))

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -1104,8 +1104,11 @@ func startNode(t *testing.T, name string, testDirectory string, opts ...func(ser
 	}
 
 	instance := &Network{
-		config:          config,
-		didStore:        didStore,
+		config:   config,
+		didStore: didStore,
+		didDocumentFinder: &didstore.Finder{
+			Store: didStore,
+		},
 		keyStore:        keyStore,
 		keyResolver:     resolver.DIDKeyResolver{Resolver: didStore},
 		serviceResolver: resolver.DIDServiceResolver{Resolver: didStore},

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -249,11 +249,12 @@ func TestNetwork_Configure(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("error - TLS disabled in strict mode", func(t *testing.T) {
+	t.Run("error - TLS disabled in strict mode (and there are bootstrap nodes configured)", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		ctx := createNetwork(t, ctrl)
 		ctx.protocol.EXPECT().Configure(gomock.Any())
 		ctx.network.connectionManager = nil
+		ctx.network.config.BootstrapNodes = []string{"localhost:5555"}
 
 		err := ctx.network.Configure(core.TestServerConfig(func(config *core.ServerConfig) {
 			config.Datadir = io.TestDirectory(t)
@@ -266,7 +267,6 @@ func TestNetwork_Configure(t *testing.T) {
 		ctx := createNetwork(t, ctrl)
 		ctx.protocol.EXPECT().Configure(gomock.Any())
 		ctx.network.connectionManager = nil
-		ctx.network.assumeNewNode = true
 
 		err := ctx.network.Configure(core.TestServerConfig(func(config *core.ServerConfig) {
 			config.Datadir = io.TestDirectory(t)


### PR DESCRIPTION
When deploying my Discovery Server, I came across the issue that I must configure TLS (truststore, certificate and key) when strict mode is enabled.

This Nuts node only acts as Discovery Server; it only uses did:web and does not participate in a did:nuts network, meaning it does not need a client certificate (it does not connect to other node over gRPC or HTTP endpoints that require a client certificate).

This PR fixes the following:
- fixes the existing lenient check in the `network` module to allow TLS to be disabled when no bootstrap nodes are configured and there are no discovered nodes. The intended leniency is broken because `assumeNewNode` is initialized after the said check
- remove TLS enabled check in strict mode in the auth module; the strict HTTP client already checks whether the endpoints it connects to are HTTPS in strict mode, so this check does not add extra security.