### PR TITLE
Enable iam api by default

### DIFF
--- a/auth/api/auth/v1/api_test.go
+++ b/auth/api/auth/v1/api_test.go
@@ -68,10 +68,6 @@ type mockAuthClient struct {
 	relyingParty   *oauth.MockRelyingParty
 }
 
-func (m *mockAuthClient) V2APIEnabled() bool {
-	return true
-}
-
 func (m *mockAuthClient) AuthzServer() oauth.AuthorizationServer {
 	return m.authzServer
 }

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -119,11 +119,7 @@ func (r Wrapper) Routes(router core.EchoRouter) {
 func (r Wrapper) middleware(ctx echo.Context, request interface{}, operationID string, f StrictHandlerFunc) (interface{}, error) {
 	ctx.Set(core.OperationIDContextKey, operationID)
 	ctx.Set(core.ModuleNameContextKey, apiModuleName)
-
-	if !r.auth.V2APIEnabled() {
-		return nil, core.Error(http.StatusForbidden, "Access denied")
-	}
-
+	
 	// Add http.Request to context, to allow reading URL query parameters
 	requestCtx := context.WithValue(ctx.Request().Context(), httpRequestContextKey, ctx.Request())
 	ctx.SetRequest(ctx.Request().WithContext(requestCtx))

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -657,29 +657,6 @@ func TestWrapper_middleware(t *testing.T) {
 	server := echo.New()
 	ctrl := gomock.NewController(t)
 	authService := auth.NewMockAuthenticationServices(ctrl)
-	authService.EXPECT().V2APIEnabled().Return(true).AnyTimes()
-
-	t.Run("API enabling", func(t *testing.T) {
-		t.Run("enabled", func(t *testing.T) {
-			var called strictServerCallCapturer
-
-			ctx := server.NewContext(httptest.NewRequest("GET", "/iam/foo", nil), httptest.NewRecorder())
-			_, _ = Wrapper{auth: authService}.middleware(ctx, nil, "Test", called.handle)
-
-			assert.True(t, bool(called))
-		})
-		t.Run("disabled", func(t *testing.T) {
-			var called strictServerCallCapturer
-
-			authService := auth.NewMockAuthenticationServices(ctrl)
-			authService.EXPECT().V2APIEnabled().Return(false).AnyTimes()
-
-			ctx := server.NewContext(httptest.NewRequest("GET", "/iam/foo", nil), httptest.NewRecorder())
-			_, _ = Wrapper{auth: authService}.middleware(ctx, nil, "Test", called.handle)
-
-			assert.False(t, bool(called))
-		})
-	})
 
 	t.Run("OAuth2 error handling", func(t *testing.T) {
 		var handler strictServerCallCapturer

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -72,11 +72,6 @@ func (auth *Auth) Config() interface{} {
 	return &auth.config
 }
 
-// V2APIEnabled returns true if the v2 API is enabled
-func (auth *Auth) V2APIEnabled() bool {
-	return auth.config.V2APIEnabled
-}
-
 // PublicURL returns the public URL of the node.
 func (auth *Auth) PublicURL() *url.URL {
 	return auth.publicURL

--- a/auth/cmd/cmd.go
+++ b/auth/cmd/cmd.go
@@ -41,9 +41,6 @@ const ConfHTTPTimeout = "auth.http.timeout"
 // ConfAccessTokenLifeSpan defines how long (in seconds) an access token is valid
 const ConfAccessTokenLifeSpan = "auth.accesstokenlifespan"
 
-// ConfV2APIEnabled enables experimental v2 API endpoints
-const ConfV2APIEnabled = "auth.v2apienabled"
-
 // FlagSet returns the configuration flags supported by this module.
 func FlagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("auth", pflag.ContinueOnError)
@@ -55,8 +52,6 @@ func FlagSet() *pflag.FlagSet {
 	flags.Int(ConfClockSkew, defs.ClockSkew, "allowed JWT Clock skew in milliseconds")
 	flags.Int(ConfAccessTokenLifeSpan, defs.AccessTokenLifeSpan, "defines how long (in seconds) an access token is valid. Uses default in strict mode.")
 	flags.StringSlice(ConfContractValidators, defs.ContractValidators, "sets the different contract validators to use")
-	flags.Bool(ConfV2APIEnabled, defs.V2APIEnabled, "enables experimental v2 API endpoints")
-	_ = flags.MarkHidden(ConfV2APIEnabled)
 	_ = flags.MarkDeprecated("auth.http.timeout", "use httpclient.timeout instead")
 
 	return flags

--- a/auth/cmd/cmd_test.go
+++ b/auth/cmd/cmd_test.go
@@ -48,7 +48,6 @@ func TestFlagSet(t *testing.T) {
 		ConfHTTPTimeout,
 		ConfAutoUpdateIrmaSchemas,
 		ConfIrmaSchemeManager,
-		ConfV2APIEnabled,
 	}, keys)
 }
 

--- a/auth/config.go
+++ b/auth/config.go
@@ -32,7 +32,6 @@ type Config struct {
 	ClockSkew           int        `koanf:"clockskew"`
 	ContractValidators  []string   `koanf:"contractvalidators"`
 	AccessTokenLifeSpan int        `koanf:"accesstokenlifespan"`
-	V2APIEnabled        bool       `koanf:"v2apienabled"`
 }
 
 type IrmaConfig struct {

--- a/auth/interface.go
+++ b/auth/interface.go
@@ -38,9 +38,6 @@ type AuthenticationServices interface {
 	RelyingParty() oauth.RelyingParty
 	// ContractNotary returns an instance of ContractNotary
 	ContractNotary() services.ContractNotary
-	// V2APIEnabled returns true if the V2 API is enabled.
-	// It is disabled by default, since it's still in development.
-	V2APIEnabled() bool
 	// PublicURL returns the public URL of the node.
 	PublicURL() *url.URL
 }

--- a/auth/mock.go
+++ b/auth/mock.go
@@ -111,17 +111,3 @@ func (mr *MockAuthenticationServicesMockRecorder) RelyingParty() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelyingParty", reflect.TypeOf((*MockAuthenticationServices)(nil).RelyingParty))
 }
-
-// V2APIEnabled mocks base method.
-func (m *MockAuthenticationServices) V2APIEnabled() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "V2APIEnabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// V2APIEnabled indicates an expected call of V2APIEnabled.
-func (mr *MockAuthenticationServicesMockRecorder) V2APIEnabled() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V2APIEnabled", reflect.TypeOf((*MockAuthenticationServices)(nil).V2APIEnabled))
-}

--- a/e2e-tests/discovery/node-B/nuts.yaml
+++ b/e2e-tests/discovery/node-B/nuts.yaml
@@ -13,7 +13,6 @@ discovery:
     refresh_interval: 500ms
     registration_refresh_interval: 500ms
 auth:
-  v2apienabled: true
   contractvalidators:
     - dummy
   irma:

--- a/e2e-tests/oauth-flow/openid4vp/node-A/nuts.yaml
+++ b/e2e-tests/oauth-flow/openid4vp/node-A/nuts.yaml
@@ -8,7 +8,6 @@ http:
   internal:
     address: :8081
 auth:
-  v2apienabled: true
   contractvalidators:
     - dummy
   irma:

--- a/e2e-tests/oauth-flow/openid4vp/node-B/nuts.yaml
+++ b/e2e-tests/oauth-flow/openid4vp/node-B/nuts.yaml
@@ -7,7 +7,6 @@ http:
   internal:
     address: :8081
 auth:
-  v2apienabled: true
   contractvalidators:
     - dummy
   irma:

--- a/e2e-tests/oauth-flow/rfc021/node-A/nuts.yaml
+++ b/e2e-tests/oauth-flow/rfc021/node-A/nuts.yaml
@@ -7,7 +7,6 @@ http:
   internal:
     address: :8081
 auth:
-  v2apienabled: true
   contractvalidators:
     - dummy
   irma:

--- a/e2e-tests/oauth-flow/rfc021/node-B/nuts.yaml
+++ b/e2e-tests/oauth-flow/rfc021/node-B/nuts.yaml
@@ -8,7 +8,6 @@ http:
     address: :8081
 auth:
   tlsenabled: true
-  v2apienabled: true
   contractvalidators:
     - dummy
   irma:

--- a/e2e-tests/oauth-flow/statuslist2021/node-A/nuts.yaml
+++ b/e2e-tests/oauth-flow/statuslist2021/node-A/nuts.yaml
@@ -8,7 +8,6 @@ http:
   internal:
     address: :8081
 auth:
-  v2apienabled: true
   contractvalidators:
     - dummy
   irma:

--- a/e2e-tests/oauth-flow/statuslist2021/node-B/nuts.yaml
+++ b/e2e-tests/oauth-flow/statuslist2021/node-B/nuts.yaml
@@ -8,7 +8,6 @@ http:
   internal:
     address: :8081
 auth:
-  v2apienabled: true
   contractvalidators:
     - dummy
   irma:


### PR DESCRIPTION
closes #2907 

removes `auth.v2apienabled` option