### PR TITLE
ignore whitespace when storing VCs

### DIFF
--- a/vcr/credential/store/sql.go
+++ b/vcr/credential/store/sql.go
@@ -117,10 +117,17 @@ func (c CredentialStore) Store(db *gorm.DB, credential vc.VerifiableCredential) 
 		FirstOrCreate(&existingCredential).Error; err != nil {
 		return nil, err
 	}
-	if existingCredential.Raw != newCredential.Raw {
+	// compare with all whitespace and linebreaks removed
+	// todo: replace with correct canonicalization from VC spec, once it's available. Should be implemented in go-did.
+	if stripWhitespaceAndLinebreaks(existingCredential.Raw) != stripWhitespaceAndLinebreaks(newCredential.Raw) {
 		return nil, fmt.Errorf("credential with this ID already exists with different contents: %s", newCredential.ID)
 	}
 	return &newCredential, nil
+}
+
+// stripWhitespaceAndLinebreaks removes all whitespace and linebreaks from a string.
+func stripWhitespaceAndLinebreaks(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, " ", ""), "\n", "")
 }
 
 // BuildSearchStatement enriches a Gorm query to search for Verifiable Credentials in the SQL database.

--- a/vcr/credential/store/sql_test.go
+++ b/vcr/credential/store/sql_test.go
@@ -88,6 +88,20 @@ func TestCredentialStore_Store(t *testing.T) {
 		_, err = CredentialStore{}.Store(storageEngine.GetSQLDatabase(), vcEve2)
 		require.EqualError(t, err, "credential with this ID already exists with different contents: 66")
 	})
+	t.Run("duplicate credential with different whitespace", func(t *testing.T) {
+		setupStore(t, storageEngine.GetSQLDatabase())
+		vcEve := createPersonCredential("66", "did:example:eve", map[string]interface{}{
+			"givenName":  "Evil",
+			"familyName": "Mastermind",
+		})
+		vcEve2Str, _ := json.MarshalIndent(vcEve, "", "  ")
+		vcEve2, _ := vc.ParseVerifiableCredential(string(vcEve2Str))
+
+		_, err := CredentialStore{}.Store(storageEngine.GetSQLDatabase(), vcEve)
+		require.NoError(t, err)
+		_, err = CredentialStore{}.Store(storageEngine.GetSQLDatabase(), *vcEve2)
+		require.NoError(t, err)
+	})
 	t.Run("with indexable properties in credential", func(t *testing.T) {
 		setupStore(t, storageEngine.GetSQLDatabase())
 		_, err := CredentialStore{}.Store(storageEngine.GetSQLDatabase(), vcAlice)


### PR DESCRIPTION
fixes #2925

This is a simple fix that strips whitespace before comparing.

A better solution is to use the canonicalised form to compare. Created #2928 for that.