### PR TITLE
Fix for #2953: Handle nil credentials in GetCredentialsInWallet

### DIFF
--- a/vcr/api/vcr/v2/api.go
+++ b/vcr/api/vcr/v2/api.go
@@ -404,6 +404,9 @@ func (w *Wrapper) GetCredentialsInWallet(ctx context.Context, request GetCredent
 	if err != nil {
 		return nil, err
 	}
+	if credentials == nil {
+		credentials = []vc.VerifiableCredential{}
+	}
 	return GetCredentialsInWallet200JSONResponse(credentials), nil
 }
 


### PR DESCRIPTION
This PR ensures that in the function GetCredentialsInWallet, a nil slice of credentials is replaced with an empty slice.