### PR TITLE
Remove deprecated 'version' from docker-compose.yaml files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,5 @@ Dockerfile*
 makefile
 nuts-node
 development
+data
+e2e-tests

--- a/development/network/docker-compose.yaml
+++ b/development/network/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   node1:
     image: &image nutsfoundation/nuts-node:latest

--- a/docs/pages/getting-started/1-running-docker.rst
+++ b/docs/pages/getting-started/1-running-docker.rst
@@ -56,7 +56,6 @@ Copy the following YAML file and save it as ``docker-compose.yaml`` in the worki
 
 .. code-block:: yaml
 
-  version: "3.7"
   services:
     nuts:
       image: nutsfoundation/nuts-node:latest

--- a/e2e-tests/auth/selfsigned/docker-compose.yml
+++ b/e2e-tests/auth/selfsigned/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   node:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/denylist/defaults/docker-compose.yml
+++ b/e2e-tests/denylist/defaults/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nuts-node:
     container_name: denylist-nuts-node-defaults

--- a/e2e-tests/denylist/github/docker-compose.yml
+++ b/e2e-tests/denylist/github/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nuts-node-github:
     container_name: denylist-nuts-node-github

--- a/e2e-tests/discovery/docker-compose.yml
+++ b/e2e-tests/discovery/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA:
     image: nginx

--- a/e2e-tests/nuts-network/direct-wan/docker-compose.yml
+++ b/e2e-tests/nuts-network/direct-wan/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/nuts-network/gossip-overflow/docker-compose.yml
+++ b/e2e-tests/nuts-network/gossip-overflow/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/nuts-network/gossip/docker-compose.yml
+++ b/e2e-tests/nuts-network/gossip/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/nuts-network/private-transactions/docker-compose.yml
+++ b/e2e-tests/nuts-network/private-transactions/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/nuts-network/ssl-offloading/haproxy/docker-compose.yml
+++ b/e2e-tests/nuts-network/ssl-offloading/haproxy/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA-backend:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/nuts-network/ssl-offloading/nginx/docker-compose.yml
+++ b/e2e-tests/nuts-network/ssl-offloading/nginx/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA-backend:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/nuts-network/ssl-pass-through/docker-compose.yml
+++ b/e2e-tests/nuts-network/ssl-pass-through/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA-backend:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/oauth-flow/openid4vp/docker-compose.yml
+++ b/e2e-tests/oauth-flow/openid4vp/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA-backend:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/oauth-flow/rfc002/docker-compose.yml
+++ b/e2e-tests/oauth-flow/rfc002/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA-backend:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/oauth-flow/rfc021/docker-compose.yml
+++ b/e2e-tests/oauth-flow/rfc021/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA-backend:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/oauth-flow/rfc021/mysql.yml
+++ b/e2e-tests/oauth-flow/rfc021/mysql.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA-backend:
     environment:

--- a/e2e-tests/oauth-flow/rfc021/postgres.yml
+++ b/e2e-tests/oauth-flow/rfc021/postgres.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA-backend:
     environment:

--- a/e2e-tests/oauth-flow/statuslist2021/docker-compose.yml
+++ b/e2e-tests/oauth-flow/statuslist2021/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA-backend:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/openid4vci/issuer-initiated/docker-compose.yml
+++ b/e2e-tests/openid4vci/issuer-initiated/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA-backend:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/openid4vci/network-issuance/docker-compose.yml
+++ b/e2e-tests/openid4vci/network-issuance/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA-backend:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/ops/key-rotation/docker-compose.yml
+++ b/e2e-tests/ops/key-rotation/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/storage/backup-restore/docker-compose.yml
+++ b/e2e-tests/storage/backup-restore/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/storage/redis/docker-compose.yml
+++ b/e2e-tests/storage/redis/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nodeA:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"

--- a/e2e-tests/storage/vault/docker-compose.yml
+++ b/e2e-tests/storage/vault/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   node:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"


### PR DESCRIPTION
`version` is deprecated since the compose spec has merged versions 2 and 3: https://docs.docker.com/compose/compose-file/compose-versioning/

fixing this because deprecation warnings are complicating debugging on the rootless docker user feature
