### PR TITLE
storage.sql.connection string redaction

### DIFF
--- a/core/server_config.go
+++ b/core/server_config.go
@@ -49,6 +49,7 @@ var redactedConfigKeys = []string{
 	"crypto.vault.token",
 	"storage.redis.password",
 	"storage.redis.sentinel.password",
+	"storage.sql.connection",
 }
 
 // ServerConfig has global server settings.

--- a/storage/config.go
+++ b/storage/config.go
@@ -18,8 +18,6 @@
 
 package storage
 
-import "strings"
-
 // Config specifies config for the storage engine.
 type Config struct {
 	BBolt BBoltConfig `koanf:"bbolt"`
@@ -35,26 +33,6 @@ func DefaultConfig() Config {
 // SQLConfig specifies config for the SQL storage engine.
 type SQLConfig struct {
 	// ConnectionString is the connection string for the SQL database.
-	// This string may contain secrets (user:password), so should never be logged. User RedactedConnectionString.
+	// This string may contain secrets (user:password), so should never be logged.
 	ConnectionString string `koanf:"connection"`
-}
-
-// RedactedConnectionString sanitizes the configured connection string so that is can be logged.
-func RedactedConnectionString(connection string) string {
-	if strings.HasPrefix(connection, "sqlite:") {
-		// this may still contain userauth, but this is not supported by nuts node
-		return connection
-	}
-	rest, url, found := strings.Cut(connection, "@")
-	if !found {
-		// does not contain user:pw
-		return connection
-	}
-	result := "<redacted>@" + url
-	protocol, _, found := strings.Cut(rest, "://")
-	if found {
-		// invalid if not found, but try to return as accurate as possible
-		result = protocol + "://" + result
-	}
-	return result
 }

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -170,7 +170,6 @@ func (e *engine) GetSQLDatabase() *gorm.DB {
 
 // initSQLDatabase initializes the SQL database connection.
 // If the connection string is not configured, it defaults to a SQLite database, stored in the node's data directory.
-// Note: only SQLite is supported for now
 func (e *engine) initSQLDatabase() error {
 	connectionString := e.config.SQL.ConnectionString
 	if len(connectionString) == 0 {
@@ -206,7 +205,7 @@ func (e *engine) initSQLDatabase() error {
 		}
 	}
 	if adapter == nil {
-		return fmt.Errorf("unsupported SQL database connection: %s", connectionString)
+		return fmt.Errorf("unsupported SQL database connection: %s", RedactedConnectionString(connectionString))
 	}
 
 	// Open connection and migrate
@@ -242,7 +241,7 @@ func (e *engine) initSQLDatabase() error {
 	dbMigrator.AutoDumpSchema = false
 	dbMigrator.Log = sqlMigrationLogger{}
 	if err = dbMigrator.CreateAndMigrate(); err != nil {
-		return fmt.Errorf("failed to migrate database: %w on %s", err, connectionString)
+		return fmt.Errorf("failed to migrate database: %w on %s", err, RedactedConnectionString(connectionString))
 	}
 
 	e.sqlDB, err = gorm.Open(adapter.connector(sqlDB), &gorm.Config{

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -205,7 +205,7 @@ func (e *engine) initSQLDatabase() error {
 		}
 	}
 	if adapter == nil {
-		return fmt.Errorf("unsupported SQL database connection: %s", RedactedConnectionString(connectionString))
+		return errors.New("unsupported SQL database")
 	}
 
 	// Open connection and migrate
@@ -241,7 +241,7 @@ func (e *engine) initSQLDatabase() error {
 	dbMigrator.AutoDumpSchema = false
 	dbMigrator.Log = sqlMigrationLogger{}
 	if err = dbMigrator.CreateAndMigrate(); err != nil {
-		return fmt.Errorf("failed to migrate database: %w on %s", err, RedactedConnectionString(connectionString))
+		return fmt.Errorf("failed to migrate database: %w", err)
 	}
 
 	e.sqlDB, err = gorm.Open(adapter.connector(sqlDB), &gorm.Config{

--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -169,4 +169,12 @@ func Test_engine_sqlDatabase(t *testing.T) {
 		assert.NoError(t, row.Scan(&count))
 		assert.Equal(t, len(sqlFiles), count)
 	})
+	t.Run("fails on unsupported database", func(t *testing.T) {
+		dataDir := io.TestDirectory(t)
+		require.NoError(t, os.Remove(dataDir))
+		e := New()
+		e.(*engine).config.SQL.ConnectionString = "fake://user:password@example.com:123/db"
+		err := e.Configure(core.ServerConfig{Datadir: dataDir})
+		assert.ErrorContains(t, err, "failed to initialize SQL database: unsupported SQL database connection: fake://<redacted>@example.com:123/db")
+	})
 }

--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -169,12 +169,13 @@ func Test_engine_sqlDatabase(t *testing.T) {
 		assert.NoError(t, row.Scan(&count))
 		assert.Equal(t, len(sqlFiles), count)
 	})
-	t.Run("fails on unsupported database", func(t *testing.T) {
+	t.Run("unsupported protocol doesn't log secrets", func(t *testing.T) {
 		dataDir := io.TestDirectory(t)
 		require.NoError(t, os.Remove(dataDir))
 		e := New()
 		e.(*engine).config.SQL.ConnectionString = "fake://user:password@example.com:123/db"
 		err := e.Configure(core.ServerConfig{Datadir: dataDir})
-		assert.ErrorContains(t, err, "failed to initialize SQL database: unsupported SQL database connection: fake://<redacted>@example.com:123/db")
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "user:password")
 	})
 }


### PR DESCRIPTION
closes #2971 

I figured we might want to provide some useful info in the error, so this PR tries to redact the secret:

``` yaml
storage:
  sql:
    connection: "fake://user:password@example.com:123/db"
```

fails with

```
"unable to configure Storage: failed to initialize SQL database: unsupported SQL database connection: fake://<redacted>@example.com:123/db"
```

This might still fail, so just not logging the string ever is the safest option.

What do you think? If this is preferred I will add tests etc.