### PR TITLE
HTTP client: clip response body to log at 200 characters instead of 100

### DIFF
--- a/auth/client/iam/client.go
+++ b/auth/client/iam/client.go
@@ -156,8 +156,8 @@ func (hb HTTPClient) AccessToken(ctx context.Context, tokenEndpoint string, data
 	if err = json.Unmarshal(responseData, &token); err != nil {
 		// Cut off the response body to 100 characters max to prevent logging of large responses
 		responseBodyString := string(responseData)
-		if len(responseBodyString) > 100 {
-			responseBodyString = responseBodyString[:100] + "...(clipped)"
+		if len(responseBodyString) > core.HttpResponseBodyLogClipAt {
+			responseBodyString = responseBodyString[:core.HttpResponseBodyLogClipAt] + "...(clipped)"
 		}
 		return token, fmt.Errorf("unable to unmarshal response: %w, %s", err, string(responseData))
 	}

--- a/core/http_client.go
+++ b/core/http_client.go
@@ -30,6 +30,10 @@ import (
 	"time"
 )
 
+// HttpResponseBodyLogClipAt is the maximum length of a response body to log.
+// If the response body is longer than this, it will be truncated.
+const HttpResponseBodyLogClipAt = 200
+
 // HttpError describes an error returned when invoking a remote server.
 type HttpError struct {
 	error
@@ -51,8 +55,8 @@ func TestResponseCodeWithLog(expectedStatusCode int, response *http.Response, lo
 		if log != nil {
 			// Cut off the response body to 100 characters max to prevent logging of large responses
 			responseBodyString := string(responseData)
-			if len(responseBodyString) > 100 {
-				responseBodyString = responseBodyString[:100] + "...(clipped)"
+			if len(responseBodyString) > HttpResponseBodyLogClipAt {
+				responseBodyString = responseBodyString[:HttpResponseBodyLogClipAt] + "...(clipped)"
 			}
 			log.WithField("http_request_path", response.Request.URL.Path).
 				Infof("Unexpected HTTP response (len=%d): %s", len(responseData), responseBodyString)

--- a/core/http_client_test.go
+++ b/core/http_client_test.go
@@ -44,7 +44,6 @@ func TestHTTPClient(t *testing.T) {
 	defer server.Close()
 
 	t.Run("no auth token", func(t *testing.T) {
-
 		authToken = ""
 		client, err := CreateHTTPClient(ClientConfig{}, nil)
 		require.NoError(t, err)
@@ -145,8 +144,8 @@ func TestTestResponseCodeWithLog(t *testing.T) {
 		assert.Equal(t, logrus.InfoLevel, hook.LastEntry().Level)
 		assert.Equal(t, "Unexpected HTTP response (len=13): hello, world!", hook.LastEntry().Message)
 	})
-	t.Run("large response body (>100), clipped", func(t *testing.T) {
-		data := strings.Repeat("a", 101)
+	t.Run("large response body (>200), clipped", func(t *testing.T) {
+		data := strings.Repeat("a", 201)
 		status := stdHttp.StatusUnauthorized
 		logger := logrus.New()
 		hook := test.NewLocal(logger)
@@ -155,7 +154,7 @@ func TestTestResponseCodeWithLog(t *testing.T) {
 
 		_ = TestResponseCodeWithLog(stdHttp.StatusOK, &stdHttp.Response{StatusCode: status, Body: readCloser(data), Request: request}, logger.WithFields(nil))
 
-		assert.Equal(t, "Unexpected HTTP response (len=101): "+strings.Repeat("a", 100)+"...(clipped)", hook.LastEntry().Message)
+		assert.Equal(t, "Unexpected HTTP response (len=201): "+strings.Repeat("a", HttpResponseBodyLogClipAt)+"...(clipped)", hook.LastEntry().Message)
 	})
 }
 


### PR DESCRIPTION
I've noticed several times that 100 characters is just not enough for most genuine errors  that the Nuts node returns. 200 should probably cut it.