### PR TITLE
cancel superseded docker build actions

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -11,6 +11,11 @@ on:
     branches:
       - master
 
+# cancel build action if superseded by new commit on same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
closes #2890

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency