### PR TITLE
IAM: fix OAuth2 error handling

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -138,7 +138,7 @@ func middleware(ctx echo.Context, operationID string) {
 	ctx.SetRequest(ctx.Request().WithContext(requestCtx))
 	if strings.HasPrefix(ctx.Request().URL.Path, "/oauth2/") {
 		ctx.Set(core.ErrorWriterContextKey, &oauth.Oauth2ErrorWriter{
-			HtmlPageTemplate: assets.Template("error.html"),
+			HtmlPageTemplate: assets.ErrorTemplate,
 		})
 	}
 }

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -767,14 +767,14 @@ func TestWrapper_middleware(t *testing.T) {
 	t.Run("OAuth2 error handling", func(t *testing.T) {
 		var handler strictServerCallCapturer
 		t.Run("OAuth2 path", func(t *testing.T) {
-			ctx := server.NewContext(httptest.NewRequest("GET", "/iam/foo", nil), httptest.NewRecorder())
-			_, _ = Wrapper{auth: authService}.middleware(ctx, nil, "Test", handler.handle)
+			ctx := server.NewContext(httptest.NewRequest("GET", "/oauth2/foo", nil), httptest.NewRecorder())
+			_, _ = Wrapper{auth: authService}.strictMiddleware(ctx, nil, "Test", handler.handle)
 
 			assert.IsType(t, &oauth.Oauth2ErrorWriter{}, ctx.Get(core.ErrorWriterContextKey))
 		})
 		t.Run("other path", func(t *testing.T) {
 			ctx := server.NewContext(httptest.NewRequest("GET", "/internal/foo", nil), httptest.NewRecorder())
-			_, _ = Wrapper{auth: authService}.middleware(ctx, nil, "Test", handler.handle)
+			_, _ = Wrapper{auth: authService}.strictMiddleware(ctx, nil, "Test", handler.handle)
 
 			assert.Nil(t, ctx.Get(core.ErrorWriterContextKey))
 		})

--- a/auth/api/iam/assets/error.html
+++ b/auth/api/iam/assets/error.html
@@ -1,0 +1,14 @@
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Authorization error</title>
+</head>
+<body>
+    <h1>Authorization error</h1>
+    <p>Couldn't fulfill the request. You can try again, or contact your service provider if the error persists.</p>
+    <p>You should provide them with the error details shown below.</p>
+    <pre style="margin: 5px; padding: 10px; background-color: #eff1f5">
+{{ if .Code }}Code: {{ .Code }}{{ end }}
+{{ if .Description }}Description: {{ .Description }}{{ end }}</pre>
+</body>
+</html>

--- a/auth/api/iam/assets/templates.go
+++ b/auth/api/iam/assets/templates.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2024 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package assets
 
 import (

--- a/auth/api/iam/assets/templates.go
+++ b/auth/api/iam/assets/templates.go
@@ -8,12 +8,10 @@ import (
 //go:embed *.html
 var assets embed.FS
 
-var Templates *template.Template
+// ErrorTemplate is the template used to render error pages.
+var ErrorTemplate *template.Template
 
 func init() {
-	Templates = template.Must(template.ParseFS(assets, "*.html"))
-}
-
-func Template(name string) *template.Template {
-	return Templates.Lookup(name)
+	templates := template.Must(template.ParseFS(assets, "*.html"))
+	ErrorTemplate = templates.Lookup("error.html")
 }

--- a/auth/api/iam/assets/templates.go
+++ b/auth/api/iam/assets/templates.go
@@ -1,0 +1,19 @@
+package assets
+
+import (
+	"embed"
+	"html/template"
+)
+
+//go:embed *.html
+var assets embed.FS
+
+var Templates *template.Template
+
+func init() {
+	Templates = template.Must(template.ParseFS(assets, "*.html"))
+}
+
+func Template(name string) *template.Template {
+	return Templates.Lookup(name)
+}

--- a/auth/api/iam/assets/templates_test.go
+++ b/auth/api/iam/assets/templates_test.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2024 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package assets
 
 import (

--- a/auth/api/iam/assets/templates_test.go
+++ b/auth/api/iam/assets/templates_test.go
@@ -1,0 +1,12 @@
+package assets
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestTemplateLoading(t *testing.T) {
+	// This test is here to make sure the templates are loaded correctly.
+	// It doesn't test the actual content of the templates.
+	assert.NotNil(t, ErrorTemplate)
+}

--- a/auth/api/iam/user.go
+++ b/auth/api/iam/user.go
@@ -46,7 +46,7 @@ const (
 	oAuthFlowTimeout = time.Minute
 	// userRedirectTimeout is the timeout for the user redirect session.
 	// This is the maximum time between the creation of the redirect for the user and the actual GET request to the user/wallet page.
-	userRedirectTimeout = time.Second * 10
+	userRedirectTimeout = time.Second * 5
 	// userSessionTimeout is the timeout for the user session.
 	// This is the TTL of the server side state and the cookie.
 	userSessionTimeout = time.Hour

--- a/auth/api/iam/user.go
+++ b/auth/api/iam/user.go
@@ -46,7 +46,7 @@ const (
 	oAuthFlowTimeout = time.Minute
 	// userRedirectTimeout is the timeout for the user redirect session.
 	// This is the maximum time between the creation of the redirect for the user and the actual GET request to the user/wallet page.
-	userRedirectTimeout = time.Second * 5
+	userRedirectTimeout = time.Second * 10
 	// userSessionTimeout is the timeout for the user session.
 	// This is the TTL of the server side state and the cookie.
 	userSessionTimeout = time.Hour


### PR DESCRIPTION
Was broken due to the OAuth2 path remapping (endpoints moved from `/iam` to `/oauth2`).

Also, if the user agent can't be redirected, it  now renders as text/html with:

```
invalid_request - no credentials available
```
(example)