### PR TITLE
IAM: fix loading of server state

### DIFF
--- a/auth/api/iam/session.go
+++ b/auth/api/iam/session.go
@@ -19,6 +19,7 @@
 package iam
 
 import (
+	"encoding/json"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/http"
@@ -52,27 +53,42 @@ const (
 	submissionStateKey    = "presentationSubmission"
 )
 
+func (s ServerState) unmarshal(key string, target interface{}) bool {
+	if s[key] == nil {
+		return false
+	}
+	data, err := json.Marshal(s[key])
+	if err != nil {
+		return false
+	}
+	err = json.Unmarshal(data, &target)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
 // VerifiablePresentations returns the verifiable presentations from the server state.
 // If the server state does not contain a verifiable presentation, an empty slice is returned.
 func (s ServerState) VerifiablePresentations() []vc.VerifiablePresentation {
-	presentations := make([]vc.VerifiablePresentation, 0)
-	if val, ok := s[presentationsStateKey]; ok {
-		// each entry should be castable to a VerifiablePresentation
-		if arr, ok := val.([]interface{}); ok {
-			for _, v := range arr {
-				if vp, ok := v.(vc.VerifiablePresentation); ok {
-					presentations = append(presentations, vp)
-				}
-			}
-		}
+	if val, ok := s[presentationsStateKey].([]vc.VerifiablePresentation); ok {
+		return val
 	}
-	return presentations
+	var result []vc.VerifiablePresentation
+	if s.unmarshal(presentationsStateKey, &result) {
+		return result
+	}
+	return nil
 }
 
 // PresentationSubmission returns the Presentation Submission from the server state.
 func (s ServerState) PresentationSubmission() *pe.PresentationSubmission {
 	if val, ok := s[submissionStateKey].(pe.PresentationSubmission); ok {
 		return &val
+	}
+	var result pe.PresentationSubmission
+	if s.unmarshal(submissionStateKey, &result) {
+		return &result
 	}
 	return nil
 }
@@ -82,7 +98,11 @@ func (s ServerState) CredentialMap() map[string]vc.VerifiableCredential {
 	if mapped, ok := s[credentialMapStateKey].(map[string]vc.VerifiableCredential); ok {
 		return mapped
 	}
-	return map[string]vc.VerifiableCredential{}
+	var result map[string]vc.VerifiableCredential
+	if s.unmarshal(credentialMapStateKey, &result) {
+		return result
+	}
+	return nil
 }
 
 // RedirectSession is the session object that is used to redirect the user to a Nuts node website.

--- a/auth/api/iam/session_test.go
+++ b/auth/api/iam/session_test.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2024 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package iam
 
 import (

--- a/auth/api/iam/session_test.go
+++ b/auth/api/iam/session_test.go
@@ -1,0 +1,64 @@
+package iam
+
+import (
+	"encoding/json"
+	"github.com/nuts-foundation/go-did/vc"
+	"github.com/nuts-foundation/nuts-node/storage"
+	"github.com/nuts-foundation/nuts-node/vcr/pe"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestServerState(t *testing.T) {
+	vpStr := `{"type":"VerifiablePresentation", "id":"vp", "verifiableCredential":{"type":"VerifiableCredential", "id":"vc", "credentialSubject":{"id":"did:web:example.com:iam:holder"}}}`
+	expectedVP, err := vc.ParseVerifiablePresentation(vpStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, expectedVP.ID.String())
+	require.NotEmpty(t, expectedVP.VerifiableCredential[0].ID.String())
+	submissionAsStr := `{"id":"1", "definition_id":"1", "descriptor_map":[{"id":"1","format":"ldp_vc","path":"$.verifiableCredential"}]}`
+	var expectedSubmission pe.PresentationSubmission
+	err = json.Unmarshal([]byte(submissionAsStr), &expectedSubmission)
+	require.NoError(t, err)
+
+	state := ServerState{}
+	state[presentationsStateKey] = []vc.VerifiablePresentation{*expectedVP}
+	state[submissionStateKey] = expectedSubmission
+	state[credentialMapStateKey] = map[string]vc.VerifiableCredential{"1": expectedVP.VerifiableCredential[0]}
+
+	t.Run("before marshalling", func(t *testing.T) {
+		actualVPs := state.VerifiablePresentations()
+		require.Len(t, actualVPs, 1)
+		require.Equal(t, *expectedVP, actualVPs[0])
+
+		actualSubmission := state.PresentationSubmission()
+		require.NotNil(t, actualSubmission)
+		require.Equal(t, expectedSubmission, *actualSubmission)
+
+		actualCredentialMap := state.CredentialMap()
+		require.Len(t, actualCredentialMap, 1)
+		require.Equal(t, expectedVP.VerifiableCredential[0], actualCredentialMap["1"])
+	})
+	t.Run("after marshalling", func(t *testing.T) {
+		storageEngine := storage.NewTestStorageEngine(t)
+		store := storageEngine.GetSessionDatabase().GetStore(time.Minute, "session")
+
+		err := store.Put("state", state)
+		require.NoError(t, err)
+		var actualState ServerState
+		err = store.Get("state", &actualState)
+		require.NoError(t, err)
+
+		actualVPs := actualState.VerifiablePresentations()
+		require.Len(t, actualVPs, 1)
+		require.Equal(t, expectedVP.ID.String(), actualVPs[0].ID.String())
+
+		actualSubmission := actualState.PresentationSubmission()
+		require.NotNil(t, actualSubmission)
+		require.Equal(t, expectedSubmission, *actualSubmission)
+
+		actualCredentialMap := actualState.CredentialMap()
+		require.Len(t, actualCredentialMap, 1)
+		require.Equal(t, expectedVP.VerifiableCredential[0].ID.String(), actualCredentialMap["1"].ID.String())
+	})
+}


### PR DESCRIPTION
After loading the session from the store, the fields became typed as `[]interface{}` and `map[string]interface{}`, making them uncastable.

Should we consider making `ServerState` a struct instead of a map, instead?