### PR TITLE
add PKCE to OAuth2 authorization code flow

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -72,18 +72,18 @@ const userSessionCookieName = "__Host-SID"
 
 // Wrapper handles OAuth2 flows.
 type Wrapper struct {
-	vcr           vcr.VCR
-	vdr           vdr.VDR
 	auth          auth.AuthenticationServices
 	policyBackend policy.PDPBackend
 	storageEngine storage.Engine
+	vcr           vcr.VCR
+	vdr           vdr.VDR
 }
 
 func New(authInstance auth.AuthenticationServices, vcrInstance vcr.VCR, vdrInstance vdr.VDR, storageEngine storage.Engine, policyBackend policy.PDPBackend) *Wrapper {
 	return &Wrapper{
-		storageEngine: storageEngine,
 		auth:          authInstance,
 		policyBackend: policyBackend,
+		storageEngine: storageEngine,
 		vcr:           vcrInstance,
 		vdr:           vdrInstance,
 	}
@@ -137,7 +137,8 @@ func (r Wrapper) HandleTokenRequest(ctx context.Context, request HandleTokenRequ
 		// Options:
 		// - OpenID4VCI
 		// - OpenID4VP
-		return r.handleAccessTokenRequest(ctx, *ownDID, request.Body.Code, request.Body.RedirectUri, request.Body.ClientId)
+		// verifier DID is taken from code->oauthSession storage
+		return r.handleAccessTokenRequest(ctx, *request.Body)
 	case "urn:ietf:params:oauth:grant-type:pre-authorized_code":
 		// Options:
 		// - OpenID4VCI
@@ -306,7 +307,6 @@ func (r Wrapper) HandleAuthorizeRequest(ctx context.Context, request HandleAutho
 		}
 	} // else, we'll allow for now, since other flows will break if we require JAR at this point.
 
-	// todo: store session in database? Isn't session specific for a particular flow?
 	session := createSession(params, *ownDID)
 
 	switch session.ResponseType {
@@ -611,6 +611,10 @@ func createSession(params oauthParameters, ownDID did.DID) *OAuthSession {
 	session.RedirectURI = params.get(oauth.RedirectURIParam)
 	session.OwnDID = &ownDID
 	session.ResponseType = params.get(oauth.ResponseTypeParam)
+	session.PKCEParams = PKCEParams{
+		Challenge:       params.get(oauth.CodeChallengeParam),
+		ChallengeMethod: params.get(oauth.CodeChallengeMethodParam),
+	}
 
 	return &session
 }

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -336,6 +336,8 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 		_ = request.Set(oauth.ResponseTypeParam, responseTypeCode)
 		_ = request.Set(oauth.ScopeParam, "test")
 		_ = request.Set(oauth.StateParam, "state")
+		_ = request.Set(oauth.CodeChallengeParam, "code_challenge")
+		_ = request.Set(oauth.CodeChallengeMethodParam, "S256")
 		headers := jws.NewHeaders()
 		headers.Set(jws.KeyIDKey, kid)
 		bytes, err := jwt.Sign(request, jwt.WithKey(jwa.ES256, key.Private(), jws.WithProtectedHeaders(headers)))
@@ -451,14 +453,16 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 		})
 
 		res, err := ctx.client.HandleAuthorizeRequest(requestContext(map[string]interface{}{
-			jwt.AudienceKey:         verifierDID.String(),
-			jwt.IssuerKey:           holderDID.String(),
-			oauth.ClientIDParam:     holderDID.String(),
-			oauth.NonceParam:        "nonce",
-			oauth.RedirectURIParam:  "https://example.com",
-			oauth.ResponseTypeParam: responseTypeCode,
-			oauth.ScopeParam:        "test",
-			oauth.StateParam:        "state",
+			jwt.AudienceKey:                verifierDID.String(),
+			jwt.IssuerKey:                  holderDID.String(),
+			oauth.ClientIDParam:            holderDID.String(),
+			oauth.NonceParam:               "nonce",
+			oauth.RedirectURIParam:         "https://example.com",
+			oauth.ResponseTypeParam:        responseTypeCode,
+			oauth.ScopeParam:               "test",
+			oauth.StateParam:               "state",
+			oauth.CodeChallengeParam:       "code_challenge",
+			oauth.CodeChallengeMethodParam: "S256",
 		}), HandleAuthorizeRequestRequestObject{
 			Did: verifierDID.String(),
 		})
@@ -567,8 +571,9 @@ func TestWrapper_Callback(t *testing.T) {
 		ctx := newTestClient(t)
 		putState(ctx, state)
 		putToken(ctx, token)
+		codeVerifier := getState(ctx, state).PKCEParams.Verifier
 		ctx.vdr.EXPECT().IsOwner(gomock.Any(), webDID).Return(true, nil).Times(2)
-		ctx.iamClient.EXPECT().AccessToken(gomock.Any(), code, verifierDID, "https://example.com/oauth2/did:web:example.com:iam:123/callback", holderDID).Return(&oauth.TokenResponse{AccessToken: "access"}, nil)
+		ctx.iamClient.EXPECT().AccessToken(gomock.Any(), code, verifierDID, "https://example.com/oauth2/did:web:example.com:iam:123/callback", holderDID, codeVerifier).Return(&oauth.TokenResponse{AccessToken: "access"}, nil)
 
 		res, err := ctx.client.Callback(nil, CallbackRequestObject{
 			Did: webDID.String(),
@@ -1059,9 +1064,9 @@ func statusCodeFrom(err error) int {
 }
 
 type testCtx struct {
+	authnServices *auth.MockAuthenticationServices
 	ctrl          *gomock.Controller
 	client        *Wrapper
-	authnServices *auth.MockAuthenticationServices
 	iamClient     *iam.MockClient
 	policy        *policy.MockPDPBackend
 	resolver      *resolver.MockDIDResolver

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -154,9 +154,9 @@ type HandleTokenRequestFormdataBody struct {
 	Assertion              *string `form:"assertion,omitempty" json:"assertion,omitempty"`
 	ClientId               *string `form:"client_id,omitempty" json:"client_id,omitempty"`
 	Code                   *string `form:"code,omitempty" json:"code,omitempty"`
+	CodeVerifier           *string `form:"code_verifier,omitempty" json:"code_verifier,omitempty"`
 	GrantType              string  `form:"grant_type" json:"grant_type"`
 	PresentationSubmission *string `form:"presentation_submission,omitempty" json:"presentation_submission,omitempty"`
-	RedirectUri            *string `form:"redirect_uri,omitempty" json:"redirect_uri,omitempty"`
 	Scope                  *string `form:"scope,omitempty" json:"scope,omitempty"`
 }
 
@@ -1240,22 +1240,13 @@ func (response HandleTokenRequest200JSONResponse) VisitHandleTokenRequestRespons
 	return json.NewEncoder(w).Encode(response)
 }
 
-type HandleTokenRequestdefaultApplicationProblemPlusJSONResponse struct {
-	Body struct {
-		// Detail A human-readable explanation specific to this occurrence of the problem.
-		Detail string `json:"detail"`
-
-		// Status HTTP statuscode
-		Status float32 `json:"status"`
-
-		// Title A short, human-readable summary of the problem type.
-		Title string `json:"title"`
-	}
+type HandleTokenRequestdefaultJSONResponse struct {
+	Body       ErrorResponse
 	StatusCode int
 }
 
-func (response HandleTokenRequestdefaultApplicationProblemPlusJSONResponse) VisitHandleTokenRequestResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
+func (response HandleTokenRequestdefaultJSONResponse) VisitHandleTokenRequestResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(response.StatusCode)
 
 	return json.NewEncoder(w).Encode(response.Body)

--- a/auth/api/iam/pkce_util.go
+++ b/auth/api/iam/pkce_util.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package iam
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
+)
+
+// PKCEParams contains the PKCE parameters so they can be stored in both the client and server side session.
+type PKCEParams struct {
+	Challenge       string
+	ChallengeMethod string
+	Verifier        string
+}
+
+func generatePKCEParams() PKCEParams {
+	verifier := nutsCrypto.GenerateNonce()
+	sha := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sha[:])
+	return PKCEParams{
+		Challenge:       challenge,
+		ChallengeMethod: "S256",
+		Verifier:        verifier,
+	}
+}
+
+func validatePKCEParams(params PKCEParams) bool {
+	switch params.ChallengeMethod {
+	case "S256":
+		sha := sha256.Sum256([]byte(params.Verifier))
+		challenge := base64.RawURLEncoding.EncodeToString(sha[:])
+		return challenge == params.Challenge
+	default:
+		return false
+	}
+}

--- a/auth/api/iam/pkce_util_test.go
+++ b/auth/api/iam/pkce_util_test.go
@@ -1,6 +1,5 @@
 /*
- * Nuts node
- * Copyright (C) 2023 Nuts community
+ * Copyright (C) 2024 Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,21 +13,17 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
  */
 
-package crypto
+package iam
 
 import (
-	"crypto/rand"
-	"encoding/base64"
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
-// GenerateNonce creates a 256 bit secure random
-func GenerateNonce() string {
-	buf := make([]byte, 256/8)
-	_, err := rand.Read(buf)
-	if err != nil {
-		panic(err)
-	}
-	return base64.RawURLEncoding.EncodeToString(buf)
+func TestPKCEParams(t *testing.T) {
+	params := generatePKCEParams()
+	assert.True(t, validatePKCEParams(params))
 }

--- a/auth/api/iam/session.go
+++ b/auth/api/iam/session.go
@@ -41,6 +41,7 @@ type OAuthSession struct {
 	RedirectURI            string
 	ServerState            ServerState
 	ResponseType           string
+	PKCEParams             PKCEParams
 	PresentationDefinition PresentationDefinition
 	VerifierDID            *did.DID
 

--- a/auth/api/iam/user.go
+++ b/auth/api/iam/user.go
@@ -122,7 +122,6 @@ func (r Wrapper) handleUserLanding(echoCtx echo.Context) error {
 		PKCEParams:  generatePKCEParams(),
 		RedirectURI: accessTokenRequest.Body.RedirectUri,
 		SessionID:   redirectSession.SessionID,
-		UserDetails: *accessTokenRequest.Body.PreauthorizedUser,
 		VerifierDID: verifier,
 	}
 	// store user session in session store under sessionID and clientState

--- a/auth/client/iam/interface.go
+++ b/auth/client/iam/interface.go
@@ -30,7 +30,7 @@ import (
 // Client defines OpenID4VP client methods using the IAM OpenAPI Spec.
 type Client interface {
 	// AccessToken requests an access token at the oauth2 token endpoint.
-	AccessToken(ctx context.Context, code string, verifier did.DID, callbackURI string, clientID did.DID) (*oauth.TokenResponse, error)
+	AccessToken(ctx context.Context, code string, verifier did.DID, callbackURI string, clientID did.DID, codeVerifier string) (*oauth.TokenResponse, error)
 	// AuthorizationServerMetadata returns the metadata of the remote wallet.
 	AuthorizationServerMetadata(ctx context.Context, webdid did.DID) (*oauth.AuthorizationServerMetadata, error)
 	// ClientMetadata returns the metadata of the remote verifier.

--- a/auth/client/iam/mock.go
+++ b/auth/client/iam/mock.go
@@ -45,18 +45,18 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // AccessToken mocks base method.
-func (m *MockClient) AccessToken(ctx context.Context, code string, verifier did.DID, callbackURI string, clientID did.DID) (*oauth.TokenResponse, error) {
+func (m *MockClient) AccessToken(ctx context.Context, code string, verifier did.DID, callbackURI string, clientID did.DID, codeVerifier string) (*oauth.TokenResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AccessToken", ctx, code, verifier, callbackURI, clientID)
+	ret := m.ctrl.Call(m, "AccessToken", ctx, code, verifier, callbackURI, clientID, codeVerifier)
 	ret0, _ := ret[0].(*oauth.TokenResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AccessToken indicates an expected call of AccessToken.
-func (mr *MockClientMockRecorder) AccessToken(ctx, code, verifier, callbackURI, clientID any) *gomock.Call {
+func (mr *MockClientMockRecorder) AccessToken(ctx, code, verifier, callbackURI, clientID, codeVerifier any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccessToken", reflect.TypeOf((*MockClient)(nil).AccessToken), ctx, code, verifier, callbackURI, clientID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccessToken", reflect.TypeOf((*MockClient)(nil).AccessToken), ctx, code, verifier, callbackURI, clientID, codeVerifier)
 }
 
 // AuthorizationServerMetadata mocks base method.

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -132,7 +132,7 @@ func (c *OpenID4VPClient) AuthorizationServerMetadata(ctx context.Context, webdi
 	return metadata, nil
 }
 
-func (c *OpenID4VPClient) AccessToken(ctx context.Context, code string, verifier did.DID, callbackURI string, clientID did.DID) (*oauth.TokenResponse, error) {
+func (c *OpenID4VPClient) AccessToken(ctx context.Context, code string, verifier did.DID, callbackURI string, clientID did.DID, codeVerifier string) (*oauth.TokenResponse, error) {
 	iamClient := c.httpClient
 	metadata, err := iamClient.OAuthAuthorizationServerMetadata(ctx, verifier)
 	if err != nil {
@@ -147,6 +147,7 @@ func (c *OpenID4VPClient) AccessToken(ctx context.Context, code string, verifier
 	data.Set(oauth.GrantTypeParam, oauth.AuthorizationCodeGrantType)
 	data.Set(oauth.CodeParam, code)
 	data.Set(oauth.RedirectURIParam, callbackURI)
+	data.Set(oauth.CodeVerifierParam, codeVerifier)
 	token, err := iamClient.AccessToken(ctx, metadata.TokenEndpoint, data)
 	if err != nil {
 		return nil, fmt.Errorf("remote server: error creating access token: %w", err)

--- a/auth/client/iam/openid4vp_test.go
+++ b/auth/client/iam/openid4vp_test.go
@@ -50,11 +50,12 @@ func TestIAMClient_AccessToken(t *testing.T) {
 	code := "code"
 	callbackURI := "https://test.test/iam/123/callback"
 	clientID := did.MustParseDID("did:web:test.test:iam:123")
+	codeVerifier := "code_verifier"
 
 	t.Run("ok", func(t *testing.T) {
 		ctx := createClientServerTestContext(t)
 
-		response, err := ctx.client.AccessToken(context.Background(), code, ctx.verifierDID, callbackURI, clientID)
+		response, err := ctx.client.AccessToken(context.Background(), code, ctx.verifierDID, callbackURI, clientID, codeVerifier)
 
 		require.NoError(t, err)
 		require.NotNil(t, response)
@@ -65,7 +66,7 @@ func TestIAMClient_AccessToken(t *testing.T) {
 		ctx := createClientServerTestContext(t)
 		ctx.token = nil
 
-		response, err := ctx.client.AccessToken(context.Background(), code, ctx.verifierDID, callbackURI, clientID)
+		response, err := ctx.client.AccessToken(context.Background(), code, ctx.verifierDID, callbackURI, clientID, codeVerifier)
 
 		assert.EqualError(t, err, "remote server: error creating access token: server returned HTTP 404 (expected: 200)")
 		assert.Nil(t, response)

--- a/auth/oauth/error.go
+++ b/auth/oauth/error.go
@@ -33,6 +33,8 @@ import (
 type ErrorCode string
 
 const (
+	// InvalidGrant is returned when the authorization grant or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.
+	InvalidGrant ErrorCode = "invalid_grant"
 	// InvalidRequest is returned when the request is missing a required parameter, includes an invalid parameter value,
 	// includes a parameter more than once, or is otherwise malformed.
 	InvalidRequest ErrorCode = "invalid_request"

--- a/auth/oauth/types.go
+++ b/auth/oauth/types.go
@@ -58,6 +58,12 @@ const (
 	AuthorizationCodeGrantType = "authorization_code"
 	// ClientIDParam is the parameter name for the client_id parameter
 	ClientIDParam = "client_id"
+	// CodeChallengeParam is the parameter name for the code_challenge parameter
+	CodeChallengeParam = "code_challenge"
+	// CodeChallengeMethodParam is the parameter name for the code_challenge_method parameter
+	CodeChallengeMethodParam = "code_challenge_method"
+	// CodeVerifierParam is the parameter name for the code_verifier parameter
+	CodeVerifierParam = "code_verifier"
 	// CodeParam is the parameter name for the code parameter
 	CodeParam = "code"
 	// GrantTypeParam is the parameter name for the grant_type parameter

--- a/codegen/configs/auth_iam.yaml
+++ b/codegen/configs/auth_iam.yaml
@@ -16,3 +16,4 @@ output-options:
     - VerifiablePresentation
     - VerifiableCredential
     - WalletOwnerType
+    - ErrorResponse

--- a/crypto/api/v1/api_test.go
+++ b/crypto/api/v1/api_test.go
@@ -468,7 +468,6 @@ func TestWrapper_DecryptJwe(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "unencrypted", string(resp.(DecryptJwe200JSONResponse).Body))
 	})
-
 }
 
 type mockContext struct {

--- a/crypto/random_test.go
+++ b/crypto/random_test.go
@@ -29,5 +29,5 @@ func TestRandom(t *testing.T) {
 	nonce := GenerateNonce()
 	decoded, _ := base64.RawURLEncoding.DecodeString(nonce)
 
-	assert.Len(t, decoded, 16)
+	assert.Len(t, decoded, 32)
 }

--- a/docs/_static/auth/iam.yaml
+++ b/docs/_static/auth/iam.yaml
@@ -86,9 +86,9 @@ paths:
                   type: string
                 presentation_submission:
                   type: string
-                redirect_uri:
-                  type: string
                 scope:
+                  type: string
+                code_verifier:
                   type: string
       responses:
         "200":
@@ -98,7 +98,11 @@ paths:
               schema:
                 "$ref": "#/components/schemas/TokenResponse"
         "default":
-          $ref: '../common/error_response.yaml'
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   "/oauth2/{did}/authorize":
     get:
       summary: Used by resource owners to initiate the authorization code flow.
@@ -748,7 +752,11 @@ components:
         error:
           type: string
           description: Code identifying the error that occurred.
-          example: "invalid_request"
+          example: invalid_request
+        error_description:
+          type: string
+          description: Human-readable description of the error.
+          example: The request is missing a required parameter.
     TokenIntrospectionRequest:
       description: >
         Token introspection request as described in RFC7662 section 2.1


### PR DESCRIPTION
part of #3012

checking PKCE verifier requires storing oauth request at the authorization server (based on state param). Also changed error returns for /token which used the redirect_uri. /token is a backchannel call so no redirects possible

- [x] remove redirect_uri from /token params