### PR TITLE
VCR: Allow credentials to be passed when creating PEX submission

### DIFF
--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -455,7 +455,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 		ctx.vdr.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
 		ctx.iamClient.EXPECT().ClientMetadata(gomock.Any(), "https://example.com/.well-known/authorization-server/iam/verifier").Return(&clientMetadata, nil)
 		ctx.iamClient.EXPECT().PresentationDefinition(gomock.Any(), pdEndpoint).Return(&pe.PresentationDefinition{}, nil)
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), holderDID, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), nil, holderDID, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
 		ctx.iamClient.EXPECT().PostAuthorizationResponse(gomock.Any(), vc.VerifiablePresentation{}, pe.PresentationSubmission{}, "https://example.com/oauth2/did:web:example.com:iam:verifier/response", "state").Return("https://example.com/iam/holder/redirect", nil)
 
 		res, err := ctx.client.HandleAuthorizeRequest(requestContext(map[string]interface{}{

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -104,8 +104,7 @@ type TokenIntrospectionResponse struct {
 // TokenIntrospectionResponseAssuranceLevel Assurance level of the identity of the End-User.
 type TokenIntrospectionResponseAssuranceLevel string
 
-// UserDetails Claims about the user, when not using an OpenID Connect Identity Provider.
-// Specified according to https://www.iana.org/assignments/jwt/jwt.xhtml
+// UserDetails Claims about the authorized user.
 type UserDetails struct {
 	// Id Machine-readable identifier, uniquely identifying the user in the issuing system.
 	Id string `json:"id"`
@@ -126,8 +125,7 @@ type RequestServiceAccessTokenJSONBody struct {
 
 // RequestUserAccessTokenJSONBody defines parameters for RequestUserAccessToken.
 type RequestUserAccessTokenJSONBody struct {
-	// PreauthorizedUser Claims about the user, when not using an OpenID Connect Identity Provider.
-	// Specified according to https://www.iana.org/assignments/jwt/jwt.xhtml
+	// PreauthorizedUser Claims about the authorized user.
 	PreauthorizedUser *UserDetails `json:"preauthorized_user,omitempty"`
 
 	// RedirectUri The URL to which the user-agent will be redirected after the authorization request.

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -249,7 +249,7 @@ func (r Wrapper) handleAuthorizeRequestFromVerifier(ctx context.Context, walletD
 		Expires:  time.Now().Add(15 * time.Minute),
 		Nonce:    nonce,
 	}
-	vp, submission, err := r.vcr.Wallet().BuildSubmission(ctx, walletDID, *presentationDefinition, metadata.VPFormats, buildParams)
+	vp, submission, err := r.vcr.Wallet().BuildSubmission(ctx, nil, walletDID, *presentationDefinition, metadata.VPFormats, buildParams)
 	if err != nil {
 		if errors.Is(err, holder.ErrNoCredentials) {
 			return r.sendAndHandleDirectPostError(ctx, oauth.OAuth2Error{Code: oauth.InvalidRequest, Description: "no credentials available"}, responseURI, state)
@@ -544,7 +544,7 @@ func (r Wrapper) handleAccessTokenRequest(ctx context.Context, verifier did.DID,
 		return nil, withCallbackURI(oauthError(oauth.InvalidRequest, fmt.Sprintf("client_id does not match: %s vs %s", oauthSession.ClientID, *clientId)), callbackURI)
 	}
 
-  state := oauthSession.ServerState
+	state := oauthSession.ServerState
 	mapping, err := r.policyBackend.PresentationDefinitions(ctx, verifier, oauthSession.Scope)
 	if err != nil {
 		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("failed to fetch presentation definition: %s", err.Error())), callbackURI)

--- a/auth/api/iam/openid4vp_test.go
+++ b/auth/api/iam/openid4vp_test.go
@@ -248,7 +248,7 @@ func TestWrapper_handleAuthorizeRequestFromVerifier(t *testing.T) {
 		putState(ctx, "state")
 		ctx.iamClient.EXPECT().ClientMetadata(gomock.Any(), "https://example.com/.well-known/authorization-server/iam/verifier").Return(&clientMetadata, nil)
 		ctx.iamClient.EXPECT().PresentationDefinition(gomock.Any(), pdEndpoint).Return(&pe.PresentationDefinition{}, nil)
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), holderDID, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(nil, nil, assert.AnError)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), nil, holderDID, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(nil, nil, assert.AnError)
 		expectPostError(t, ctx, oauth.ServerError, assert.AnError.Error(), responseURI, "state")
 
 		_, err := ctx.client.handleAuthorizeRequestFromVerifier(context.Background(), holderDID, params)
@@ -261,7 +261,7 @@ func TestWrapper_handleAuthorizeRequestFromVerifier(t *testing.T) {
 		putState(ctx, "state")
 		ctx.iamClient.EXPECT().ClientMetadata(gomock.Any(), "https://example.com/.well-known/authorization-server/iam/verifier").Return(&clientMetadata, nil)
 		ctx.iamClient.EXPECT().PresentationDefinition(gomock.Any(), pdEndpoint).Return(&pe.PresentationDefinition{}, nil)
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), holderDID, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(nil, nil, holder.ErrNoCredentials)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), nil, holderDID, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(nil, nil, holder.ErrNoCredentials)
 		expectPostError(t, ctx, oauth.InvalidRequest, "no credentials available", responseURI, "state")
 
 		_, err := ctx.client.handleAuthorizeRequestFromVerifier(context.Background(), holderDID, params)

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -239,7 +239,7 @@ func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, requeste
 		Expires:  time.Now().Add(time.Second * 5),
 		Nonce:    nutsCrypto.GenerateNonce(),
 	}
-	vp, submission, err := c.wallet.BuildSubmission(ctx, requester, *presentationDefinition, metadata.VPFormats, params)
+	vp, submission, err := c.wallet.BuildSubmission(ctx, nil, requester, *presentationDefinition, metadata.VPFormats, params)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/client/iam/openid4vp_test.go
+++ b/auth/client/iam/openid4vp_test.go
@@ -307,7 +307,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		ctx := createClientServerTestContext(t)
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), walletDID, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), nil, walletDID, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
 
 		response, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierDID, scopes)
 
@@ -328,7 +328,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 			writer.WriteHeader(http.StatusBadRequest)
 			_, _ = writer.Write(oauthErrorBytes)
 		}
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), walletDID, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), nil, walletDID, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
 
 		_, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierDID, scopes)
 
@@ -371,7 +371,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 	t.Run("error - failed to build vp", func(t *testing.T) {
 		ctx := createClientServerTestContext(t)
 
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), walletDID, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(nil, nil, assert.AnError)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), nil, walletDID, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(nil, nil, assert.AnError)
 
 		_, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierDID, scopes)
 

--- a/vcr/holder/interface.go
+++ b/vcr/holder/interface.go
@@ -49,7 +49,9 @@ type Wallet interface {
 	BuildPresentation(ctx context.Context, credentials []vc.VerifiableCredential, options PresentationOptions, signerDID *did.DID, validateVC bool) (*vc.VerifiablePresentation, error)
 
 	// BuildSubmission builds a Verifiable Presentation based on the given presentation definition.
-	BuildSubmission(ctx context.Context, walletDID did.DID, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error)
+	// If credentials is nil, it will use credentials in the wallet for the given wallet DID.
+	// If credentials is not nil (len=0 is also considered not nil)
+	BuildSubmission(ctx context.Context, credentials []vc.VerifiableCredential, holderDID did.DID, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error)
 
 	// List returns all credentials in the wallet for the given holder.
 	// If the wallet does not contain any credentials for the given holder, it returns an empty list.

--- a/vcr/holder/mock.go
+++ b/vcr/holder/mock.go
@@ -60,9 +60,9 @@ func (mr *MockWalletMockRecorder) BuildPresentation(ctx, credentials, options, s
 }
 
 // BuildSubmission mocks base method.
-func (m *MockWallet) BuildSubmission(ctx context.Context, walletDID did.DID, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
+func (m *MockWallet) BuildSubmission(ctx context.Context, credentials []vc.VerifiableCredential, holderDID did.DID, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildSubmission", ctx, walletDID, presentationDefinition, acceptedFormats, params)
+	ret := m.ctrl.Call(m, "BuildSubmission", ctx, credentials, holderDID, presentationDefinition, acceptedFormats, params)
 	ret0, _ := ret[0].(*vc.VerifiablePresentation)
 	ret1, _ := ret[1].(*pe.PresentationSubmission)
 	ret2, _ := ret[2].(error)
@@ -70,9 +70,9 @@ func (m *MockWallet) BuildSubmission(ctx context.Context, walletDID did.DID, pre
 }
 
 // BuildSubmission indicates an expected call of BuildSubmission.
-func (mr *MockWalletMockRecorder) BuildSubmission(ctx, walletDID, presentationDefinition, acceptedFormats, params any) *gomock.Call {
+func (mr *MockWalletMockRecorder) BuildSubmission(ctx, credentials, holderDID, presentationDefinition, acceptedFormats, params any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildSubmission", reflect.TypeOf((*MockWallet)(nil).BuildSubmission), ctx, walletDID, presentationDefinition, acceptedFormats, params)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildSubmission", reflect.TypeOf((*MockWallet)(nil).BuildSubmission), ctx, credentials, holderDID, presentationDefinition, acceptedFormats, params)
 }
 
 // Diagnostics mocks base method.

--- a/vcr/holder/wallet.go
+++ b/vcr/holder/wallet.go
@@ -81,11 +81,14 @@ type BuildParams struct {
 	Nonce    string
 }
 
-func (h wallet) BuildSubmission(ctx context.Context, walletDID did.DID, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
-	// get VCs from own wallet
-	credentials, err := h.List(ctx, walletDID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to retrieve wallet credentials: %w", err)
+func (h wallet) BuildSubmission(ctx context.Context, credentials []vc.VerifiableCredential, walletDID did.DID, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
+	if credentials == nil {
+		// get VCs from own wallet
+		var err error
+		credentials, err = h.List(ctx, walletDID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to retrieve wallet credentials: %w", err)
+		}
 	}
 
 	// match against the wallet's credentials

--- a/vcr/holder/wallet_test.go
+++ b/vcr/holder/wallet_test.go
@@ -350,22 +350,35 @@ func TestWallet_BuildSubmission(t *testing.T) {
 		keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.NutsSigningKeyType).Return(ssi.MustParseURI(key.KID()), key.Public(), nil)
 
 		w := New(keyResolver, keyStore, nil, jsonldManager, storageEngine)
-		err := w.Put(context.Background(), credentials...)
-		require.NoError(t, err)
 
-		vp, submission, err := w.BuildSubmission(ctx, walletDID, presentationDefinition, vpFormats, BuildParams{Audience: verifierDID.String(), Expires: time.Now().Add(time.Second), Nonce: ""})
+		vp, submission, err := w.BuildSubmission(ctx, credentials, walletDID, presentationDefinition, vpFormats, BuildParams{Audience: verifierDID.String(), Expires: time.Now().Add(time.Second), Nonce: ""})
 
 		assert.NoError(t, err)
 		require.NotNil(t, vp)
 		require.NotNil(t, submission)
+	})
+	t.Run("credentials from wallet", func(t *testing.T) {
+		resetStore(t, storageEngine.GetSQLDatabase())
+		ctrl := gomock.NewController(t)
+		keyResolver := resolver.NewMockKeyResolver(ctrl)
+		keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.NutsSigningKeyType).Return(ssi.MustParseURI(key.KID()), key.Public(), nil)
 
+		w := New(keyResolver, keyStore, nil, jsonldManager, storageEngine)
+		err := w.Put(context.Background(), credentials...)
+		require.NoError(t, err)
+
+		vp, submission, err := w.BuildSubmission(ctx, credentials, walletDID, presentationDefinition, vpFormats, BuildParams{Audience: verifierDID.String(), Expires: time.Now().Add(time.Second), Nonce: ""})
+
+		assert.NoError(t, err)
+		require.NotNil(t, vp)
+		require.NotNil(t, submission)
 	})
 	t.Run("error - no matching credentials", func(t *testing.T) {
 		resetStore(t, storageEngine.GetSQLDatabase())
 
 		w := New(nil, keyStore, nil, jsonldManager, storageEngine)
 
-		vp, submission, err := w.BuildSubmission(ctx, walletDID, presentationDefinition, vpFormats, BuildParams{Audience: verifierDID.String(), Expires: time.Now().Add(time.Second), Nonce: ""})
+		vp, submission, err := w.BuildSubmission(ctx, []vc.VerifiableCredential{}, walletDID, presentationDefinition, vpFormats, BuildParams{Audience: verifierDID.String(), Expires: time.Now().Add(time.Second), Nonce: ""})
 
 		assert.Equal(t, ErrNoCredentials, err)
 		assert.Nil(t, vp)
@@ -378,7 +391,7 @@ func TestWallet_BuildSubmission(t *testing.T) {
 		keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.NutsSigningKeyType).Return(ssi.MustParseURI(key.KID()), key.Public(), nil)
 		w := New(keyResolver, keyStore, nil, jsonldManager, storageEngine)
 
-		vp, submission, err := w.BuildSubmission(ctx, walletDID, pe.PresentationDefinition{}, vpFormats, BuildParams{Audience: verifierDID.String(), Expires: time.Now().Add(time.Second), Nonce: ""})
+		vp, submission, err := w.BuildSubmission(ctx, []vc.VerifiableCredential{}, walletDID, pe.PresentationDefinition{}, vpFormats, BuildParams{Audience: verifierDID.String(), Expires: time.Now().Add(time.Second), Nonce: ""})
 
 		assert.Nil(t, err)
 		assert.NotNil(t, vp)


### PR DESCRIPTION
Allows matching on wallets other than the SQL wallet in VCR. Required for using user-session wallet with EmployeeCredential.

I tried refactoring `Wallet` into VC storage (`SQLWallet`) and building presentations (`Presenter`), but that just lead to another type that needed to be passed everywhere, where `Wallet` is also currently passed. So no real benefit, other than 2 smaller types instead of 1 larger.