### PR TITLE
Audit log StatusList2021Credential renewal against system

### DIFF
--- a/vcr/revocation/statuslist2021_verifier.go
+++ b/vcr/revocation/statuslist2021_verifier.go
@@ -109,7 +109,7 @@ func (cs *StatusList2021) statusList(statusListCredential string) (*credentialRe
 		return cs.update(statusListCredential)
 	}
 
-	// managed StatusList2021Credentials are always up-to-date, does not matter that it is expired
+	// managed StatusList2021Credentials are always up-to-date, does not matter if it is expired
 	if cs.isManaged(statusListCredential) {
 		return cr, nil
 	}


### PR DESCRIPTION
closes #3026 
StatusList2021Credential renewal after expiration is a system operation and should not be logged against the party requesting the credential 