### PR TITLE
HTTP: change landing page on / to describe the public interface

### DIFF
--- a/core/landingpage.html
+++ b/core/landingpage.html
@@ -5,11 +5,8 @@
 <body>
 <h1>Your Nuts Node is running!</h1>
 <p>
-    Warning: if you see this message, it means you haven't properly secured your environment for production usage.<br />
-    See <a href="https://nuts-node.readthedocs.io/en/latest/pages/deployment/production-configuration.html" target="_blank">Configuring for Production</a> for more information on this topic.
-</p>
-<p>
-    <a href="status/diagnostics">Node Diagnostics</a>
+    But, there is nothing to see here. This HTTP service is used to resolve did:web DIDs and access OAuth2 endpoints.
+    See <a href="https://nuts-node.readthedocs.io/en/latest/pages/deployment/recommended-deployment.html#public-endpoints" target="_blank">Recommended Deployment</a> for which endpoints should be exposed.
 </p>
 </body>
 </html>


### PR DESCRIPTION
Fixes https://github.com/nuts-foundation/nuts-node/issues/3030

The internal API does not have a landing page.