### PR TITLE
PEX: Documentation on how a Policy maps Constraint Field IDs

### DIFF
--- a/docs/pages/deployment/pex.rst
+++ b/docs/pages/deployment/pex.rst
@@ -84,12 +84,14 @@ The ``wallet_owner_type`` field is used to determine the audience type of the pr
 OAuth2 Token Introspection field mapping
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The fields that contain an ``id`` property (e.g., ``example_credential_type`` in the example above) are returned in the OAuth2 Token Introspection response.
-The value of the Verifiable Credential that the matched field constraint are included in the response as claims.
+The input descriptor constraint fields that contain an ``id`` property (``input_descriptor.contraints.field.id``) are returned in the OAuth2 Token Introspection response.
+The value of the Verifiable Credential that the matched field is included in the response as claims.
+E.g., in the example above, a claim named ``example_credential_type`` is added to the introspection response, containing the Verifiable Credential ``type`` property.
+
 Writer of policies should take into consideration:
 - fields that are intended to be used for logging or authorization decisions should have a distinct identifier.
-- claims ideally map a registered claim name.
-- overwriting properties already defined in the token introspection endpoint response is forbidden.
+- claims ideally map a registered claim name (e.g. `IANA JWT claims <>https://www.iana.org/assignments/jwt/jwt.xhtml#claims>`_)
+- overwriting properties already defined in the token introspection endpoint response is forbidden. These are: ``iss``, ``sub``, ``exp``, ``iat``, ``active``, ``client_id``, ``scope``.
 
 Policy backend API definition
 *****************************

--- a/docs/pages/deployment/pex.rst
+++ b/docs/pages/deployment/pex.rst
@@ -61,12 +61,18 @@ JSON documents used for policies must have the following structure:
               "constraints": {
                 "fields": [
                   {
-                    "id": "example_credential_type",
                     "path": ["$.type"],
                     "filter": {
                       "type": "string",
-                      "const": "ExampleCredential"
+                      "const": "HumanCredential"
                     }
+                  },
+                  {
+                      "id": "fullName",
+                      "path": ["$.credentialSubject.fullName"],
+                      "filter": {
+                        "type": "string",
+                      }
                   }
                 ]
               }
@@ -86,7 +92,18 @@ OAuth2 Token Introspection field mapping
 
 The input descriptor constraint fields that contain an ``id`` property (``input_descriptor.contraints.field.id``) are returned in the OAuth2 Token Introspection response.
 The value of the Verifiable Credential that the matched field is included in the response as claims.
-E.g., in the example above, a claim named ``example_credential_type`` is added to the introspection response, containing the Verifiable Credential ``type`` property.
+E.g., in the example above, a claim named ``fullName`` is added to the introspection response, containing the Verifiable Credential ``type`` property.
+The following is an example OAuth2 Token Introspection response containing the ``fullName`` claim from the Presentation Definition
+(some fields are omitted for brevity):
+
+```json
+{
+  "iss": "did:web:example.com",
+  "active": true,
+  "scope": "example_scope",
+  "fullName": "John Doe"
+}
+```
 
 Writer of policies should take into consideration:
 - fields that are intended to be used for logging or authorization decisions should have a distinct identifier.

--- a/docs/pages/deployment/pex.rst
+++ b/docs/pages/deployment/pex.rst
@@ -92,7 +92,7 @@ OAuth2 Token Introspection field mapping
 
 The input descriptor constraint fields that contain an ``id`` property (``input_descriptor.contraints.field.id``) are returned in the OAuth2 Token Introspection response.
 The value of the Verifiable Credential that the matched field is included in the response as claims.
-E.g., in the example above, a claim named ``fullName`` is added to the introspection response, containing the Verifiable Credential ``type`` property.
+E.g., in the example above, a claim named ``fullName`` is added to the introspection response, containing the value of the ``credentialSubject.fullName`` property in the Verifiable Credential.
 The following is an example OAuth2 Token Introspection response containing the ``fullName`` claim from the Presentation Definition
 (some fields are omitted for brevity):
 

--- a/docs/pages/deployment/pex.rst
+++ b/docs/pages/deployment/pex.rst
@@ -22,7 +22,7 @@ To use file-based configuration, you need to define the path to a directory that
 .. code-block:: yaml
 
     policy:
-        directory: /path/to/directory
+      directory: /path/to/directory
 
 All JSON files in the directory will be loaded and used to define the mapping between scopes and presentation definitions.
 
@@ -30,55 +30,66 @@ To use a policy backend, you need to add the address of the policy backend to th
 
 .. code-block:: yaml
 
-	policy:
-		address: http://localhost:8080
+    policy:
+	  address: http://localhost:8080
 
 You cannot define both the directory and the address in the configuration. If both are defined, an error will be raised at startup.
 
-File-based configuration
-************************
+Policy Structure
+****************
 
-JSON files used for file-based configuration must have the following structure:
+JSON documents used for policies must have the following structure:
 
 .. code-block:: json
 
-	{
-		"example_scope": {
-			"organization": {
-				"id": "example",
-				"format": {
-					"ldp_vc": {
-						"proof_type": ["JsonWebSignature2020"]
-					},
-					"ldp_vp": {
-						"proof_type": ["JsonWebSignature2020"]
-					}
-				},
-				"definition": {
-					"input_descriptors": [
-						{
-							"id": "1",
-							"constraints": {
-								"fields": [
-									{
-										"path": ["$.type"],
-										"filter": {
-											"type": "string",
-											"const": "ExampleCredential"
-										}
-									}
-								]
-							}
-						}
-					]
-				}
-			}
-		}
-	}
+  {
+    "example_scope": {
+      "organization": {
+        "id": "example",
+        "format": {
+          "ldp_vc": {
+            "proof_type": ["JsonWebSignature2020"]
+          },
+          "ldp_vp": {
+            "proof_type": ["JsonWebSignature2020"]
+          }
+        },
+        "definition": {
+          "input_descriptors": [
+            {
+              "id": "1",
+              "constraints": {
+                "fields": [
+                  {
+                    "id": "example_credential_type",
+                    "path": ["$.type"],
+                    "filter": {
+                      "type": "string",
+                      "const": "ExampleCredential"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
 
-Where `example_scope` is the scope that the presentation definition is associated with.
-The `presentation_definition` object contains the presentation definition that should be used for the given scope.
-The `wallet_owner_type` field is used to determine the audience type of the presentation definition, valid values are `organization` and `user`.
+Where ``example_scope`` is the scope that the presentation definition is associated with.
+The ``presentation_definition`` object contains the presentation definition that should be used for the given scope.
+The ``wallet_owner_type`` field is used to determine the audience type of the presentation definition, valid values are ``organization`` and ``user``.
+
+OAuth2 Token Introspection field mapping
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The fields that contain an ``id`` property (e.g., ``example_credential_type`` in the example above) are returned in the OAuth2 Token Introspection response.
+The value of the Verifiable Credential that the matched field constraint are included in the response as claims.
+Writer of policies should take into consideration:
+- fields that are intended to be used for logging or authorization decisions should have a distinct identifier.
+- claims ideally map a registered claim name.
+- overwriting properties already defined in the token introspection endpoint response is forbidden.
 
 Policy backend API definition
 *****************************
@@ -86,7 +97,7 @@ Policy backend API definition
 The policy backend API is defined in the `OpenAPI 3.x <https://spec.openapis.org/oas/latest.html>`_ format.
 The API must have the following endpoint:
 
-- `GET /presentation_definitions?scope=X&authorizer=Y`: Get the presentation definition for a given scope and tenant.
+- ``GET /presentation_definitions?scope=X&authorizer=Y``: Get the presentation definition for a given scope and tenant.
 
 The full API definition can be downloaded `here <../../_static/policy/v1.yaml>`_.
 


### PR DESCRIPTION
For the token introspection response.

Also fixed styling issues (2 spaces instead of tabs to keep code blocks a bit more condensed).