### PR TITLE
Fix for #3040: Update podSecurityContext and securityContext settings…

### DIFF
--- a/charts/nuts-node/values.yaml
+++ b/charts/nuts-node/values.yaml
@@ -25,10 +25,12 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+ fsGroup: 18081
 
-securityContext: {}
+securityContext:
+  runAsUser: 18081
+  runAsGroup: 18081
   # capabilities:
   #   drop:
   #   - ALL


### PR DESCRIPTION
… to changes from: "Docker: don't run as root user (#2917)"

Security settings for the nuts-node have been updated in the values.yaml file. The fsGroup value under podSecurityContext has been changed to 18081 and the runAsUser and runAsGroup have been added under securityContext, both set to 18081.