### PR TITLE
Refactor nuts-node chart for separate internal and external services

### DIFF
--- a/charts/nuts-node/README.md
+++ b/charts/nuts-node/README.md
@@ -21,10 +21,11 @@ there are `nuts` config properties. This contains 3 sections:
 NUTS allows binding to specific interfaces on the host machines. In the case of Kubernetes, this is already taken care 
 of. However, we do need to expose the `http` and `gRPC` ports. This is extracted from the following properties:
 
-| Property                                                        | Value (default) |
-|-----------------------------------------------------------------|-----------------|
-| `http.default.address` (must align with `service.internalPort`) | :1323 |
-| `network.grpcaddr`                                              | :5555    | 
+| Property                                                                  | Value (default) |
+|---------------------------------------------------------------------------|-----------------|
+| `http.external.address` (must align with `service.external.internalPort`) | :8080           |
+| `http.internal.address` (must align with `service.internal.internalPort`) | :8081           |
+| `network.grpcaddr`                                                        | :5555           | 
 
 For the `nuts-node` port, the `service.internalPort` can simply be used. For gRPC, the Helm chart filters out all digits 
 after the last `:` character. If not set, defaults will be used.

--- a/charts/nuts-node/templates/NOTES.txt
+++ b/charts/nuts-node/templates/NOTES.txt
@@ -1,22 +1,46 @@
-1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
+1. Get the external application URL by running these commands:
+{{- if .Values.ingress.external.enabled }}
+{{- range $host := .Values.ingress.external.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  http{{ if $.Values.ingress.external.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
+{{- else if contains "NodePort" .Values.service.external.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "chart.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if contains "LoadBalancer" .Values.service.external.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "chart.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "chart.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
+  echo http://$SERVICE_IP:{{ .Values.service.external.port }}
+{{- else if contains "ClusterIP" .Values.service.external.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:{{ .Values.service.internalPort }}/status to view the node status"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.internalPort }}:$CONTAINER_PORT
+  echo "Visit http://127.0.0.1:{{ .Values.service.external.internalPort }}/status to view the node status"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.external.internalPort }}:$CONTAINER_PORT
+{{- end }}
+
+
+2. Get the internal application URL by running these commands:
+{{- if .Values.ingress.internal.enabled }}
+{{- range $host := .Values.ingress.internal.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.internal.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.internal.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "chart.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.internal.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "chart.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "chart.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.internal.port }}
+{{- else if contains "ClusterIP" .Values.service.internal.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:{{ .Values.service.internal.internalPort }}/status to view the node status"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.internal.internalPort }}:$CONTAINER_PORT
 {{- end }}

--- a/charts/nuts-node/templates/deployment.yaml
+++ b/charts/nuts-node/templates/deployment.yaml
@@ -77,8 +77,11 @@ spec:
             - name: nuts-data-pv
               mountPath: /opt/nuts/data
           ports:
-            - name: http
-              containerPort: {{ .Values.service.internalPort | default 1323 }}
+            - name: http-internal
+              containerPort: {{ .Values.service.internal.internalPort | default 8081 }}
+              protocol: TCP
+            - name: http-external
+              containerPort: {{ .Values.service.external.internalPort | default 8080 }}
               protocol: TCP
             - name: grpc
               containerPort: {{ template "grpcPort" . }}
@@ -86,15 +89,15 @@ spec:
           livenessProbe:
             httpGet:
               path: /status
-              port: http
+              port: http-internal
           readinessProbe:
             httpGet:
               path: /status
-              port: http
+              port: http-internal
           startupProbe:
             httpGet:
               path: /status
-              port: http
+              port: http-internal
             failureThreshold: 300
             periodSeconds: 10
           resources:

--- a/charts/nuts-node/templates/ingress.yaml
+++ b/charts/nuts-node/templates/ingress.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.ingress.external.enabled -}}
 {{- $fullName := include "chart.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+{{- $svcPort := .Values.service.external.port -}}
+{{- if and .Values.ingress.external.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.external.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.external.annotations "kubernetes.io/ingress.class" .Values.ingress.external.className}}
   {{- end }}
 {{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -15,20 +15,20 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: "{{ $fullName }}-external"
   labels:
     {{- include "chart.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- with .Values.ingress.external.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- if and .Values.ingress.external.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.external.className }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if .Values.ingress.external.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    {{- range .Values.ingress.external.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -37,7 +37,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
+    {{- range .Values.ingress.external.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
@@ -49,11 +49,73 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ $fullName }}
+                name: "{{ $fullName }}-external"
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ $fullName }}
+              serviceName: "{{ $fullName }}-external"
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+---
+{{- if .Values.ingress.external.enabled -}}
+{{- $fullName := include "chart.fullname" . -}}
+{{- $svcPort := .Values.service.external.port -}}
+{{- if and .Values.ingress.external.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.external.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.external.annotations "kubernetes.io/ingress.class" .Values.ingress.external.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: "{{ $fullName }}-external"
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  {{- with .Values.ingress.external.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.external.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.external.className }}
+  {{- end }}
+  {{- if .Values.ingress.external.tls }}
+  tls:
+    {{- range .Values.ingress.external.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.external.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: "{{ $fullName }}-external"
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: "{{ $fullName }}-external"
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}

--- a/charts/nuts-node/templates/ingress.yaml
+++ b/charts/nuts-node/templates/ingress.yaml
@@ -60,12 +60,12 @@ spec:
     {{- end }}
 {{- end }}
 ---
-{{- if .Values.ingress.external.enabled -}}
+{{- if .Values.ingress.internal.enabled -}}
 {{- $fullName := include "chart.fullname" . -}}
-{{- $svcPort := .Values.service.external.port -}}
-{{- if and .Values.ingress.external.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.external.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.external.annotations "kubernetes.io/ingress.class" .Values.ingress.external.className}}
+{{- $svcPort := .Values.service.internal.port -}}
+{{- if and .Values.ingress.internal.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.internal.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.internal.annotations "kubernetes.io/ingress.class" .Values.ingress.internal.className}}
   {{- end }}
 {{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -77,20 +77,20 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: "{{ $fullName }}-external"
+  name: "{{ $fullName }}-internal"
   labels:
     {{- include "chart.labels" . | nindent 4 }}
-  {{- with .Values.ingress.external.annotations }}
+  {{- with .Values.ingress.internal.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.external.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.external.className }}
+  {{- if and .Values.ingress.internal.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.internal.className }}
   {{- end }}
-  {{- if .Values.ingress.external.tls }}
+  {{- if .Values.ingress.internal.tls }}
   tls:
-    {{- range .Values.ingress.external.tls }}
+    {{- range .Values.ingress.internal.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -99,7 +99,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.external.hosts }}
+    {{- range .Values.ingress.internal.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
@@ -111,11 +111,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: "{{ $fullName }}-external"
+                name: "{{ $fullName }}-internal"
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: "{{ $fullName }}-external"
+              serviceName: "{{ $fullName }}-internal"
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}

--- a/charts/nuts-node/templates/service.yaml
+++ b/charts/nuts-node/templates/service.yaml
@@ -1,16 +1,32 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "chart.fullname" . }}
+  name: "{{ include "chart.fullname" . }}-internal"
   labels:
     {{- include "chart.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.service.internal.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
+    - port: {{ .Values.service.internal.port }}
+      targetPort: http-internal
       protocol: TCP
-      name: http
+      name: http-internal
+  selector:
+    {{- include "chart.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ include "chart.fullname" . }}-external"
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.external.type }}
+  ports:
+    - port: {{ .Values.service.external.port }}
+      targetPort: http-external
+      protocol: TCP
+      name: http-external
     - port: {{ template "grpcPort" . }}
       targetPort: {{ template "grpcPort" . }}
       protocol: TCP

--- a/charts/nuts-node/templates/tests/test-connection.yaml
+++ b/charts/nuts-node/templates/tests/test-connection.yaml
@@ -8,8 +8,12 @@ metadata:
     "helm.sh/hook": test
 spec:
   containers:
-    - name: wget
+    - name: wget-internal
       image: busybox
       command: ['wget']
-      args: ['{{ include "chart.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "chart.fullname" . }}:{{ .Values.service.internal.port }}']
+    - name: wget-external
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "chart.fullname" . }}:{{ .Values.service.external.port }}']
   restartPolicy: Never

--- a/charts/nuts-node/values.yaml
+++ b/charts/nuts-node/values.yaml
@@ -124,9 +124,6 @@ nuts:
         address: :8081
       external:
         address: :8080
-      default:
-        cors:
-          origin: "https://chart-example.local"
     verbosity: debug
     tls:
       truststorefile: /opt/nuts/ssl/ca.pem

--- a/charts/nuts-node/values.yaml
+++ b/charts/nuts-node/values.yaml
@@ -56,7 +56,7 @@ ingress:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     hosts:
-      - host: chart-example.external
+      - host: chart-example.internal
         paths:
           - path: /
             pathType: ImplementationSpecific
@@ -71,7 +71,7 @@ ingress:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     hosts:
-      - host: chart-example.local
+      - host: chart-example.external
         paths:
           - path: /
             pathType: ImplementationSpecific

--- a/charts/nuts-node/values.yaml
+++ b/charts/nuts-node/values.yaml
@@ -39,25 +39,46 @@ securityContext:
   # runAsUser: 1000
 
 service:
-  type: ClusterIP
-  internalPort: 1323
-  port: 1323
+  internal:
+    type: ClusterIP
+    internalPort: 8081
+    port: 8081
+  external:
+    type: ClusterIP
+    internalPort: 8080
+    port: 8080
 
 ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+  internal:
+    enabled: false
+    className: ""
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: chart-example.external
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: []
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
+  external:
+    enabled: false
+    className: ""
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: []
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -99,8 +120,11 @@ nuts:
     # Everything below `nuts.config` will be placed into the `nuts.yaml` config file of the Pods
     datadir: /opt/nuts/data
     http:
+      internal:
+        address: :8081
+      external:
+        address: :8080
       default:
-        address: :1323
         cors:
           origin: "https://chart-example.local"
     verbosity: debug


### PR DESCRIPTION
This revision refactors nuts-node charts to support separate internal and external services. It provides different ingress classes, annotations, hosts, and rules for external and internal services. It also adjusts `service.yaml` to accommodate these changes and provides different application URLs for internal and external services. Configurations in `values.yaml` have been altered to reflect these changes as well.