### PR TITLE
set workdir in dev image

### DIFF
--- a/development/dev-image/Dockerfile
+++ b/development/dev-image/Dockerfile
@@ -13,5 +13,7 @@ RUN chmod +x /usr/bin/nuts
 HEALTHCHECK --start-period=60s --timeout=5s --interval=10s \
     CMD curl -f http://localhost:8081/status || exit 1
 
+WORKDIR /nuts
+
 EXPOSE 8080 8081 5555
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docs/pages/deployment/docker.rst
+++ b/docs/pages/deployment/docker.rst
@@ -17,7 +17,7 @@ If you want to run without Docker Compose you can use the following command from
 .. code-block:: shell
 
   docker run --name nuts -p 8080:8080 -p 8081:8081 \
-    -e NUTS_STRICTMODE=false -e NUTS_HTTP_INTERNAL_ADDRESS=":8081" -e URL="http://nuts" \
+    -e NUTS_STRICTMODE=false -e NUTS_HTTP_INTERNAL_ADDRESS=":8081" -e NUTS_URL="http://nuts" \
     nutsfoundation/nuts-node:latest
 
 


### PR DESCRIPTION
closes #3045 
dev container user is still `root`