### PR TITLE
Extend VCR an VDRv2 API clients

### DIFF
--- a/vcr/api/vcr/v2/client.go
+++ b/vcr/api/vcr/v2/client.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/core"
 	"io"
 	"net/http"
@@ -88,6 +90,19 @@ func (hb HTTPClient) Untrusted(credentialType string) ([]string, error) {
 	ctx := context.Background()
 
 	return handleTrustedResponse(hb.client().ListUntrusted(ctx, credentialType))
+}
+
+// LoadVC loads the given Verifiable Credential into the holder's wallet.
+func (hb HTTPClient) LoadVC(holder did.DID, credential vc.VerifiableCredential) error {
+	ctx := context.Background()
+
+	httpResponse, err := hb.client().LoadVC(ctx, holder.String(), credential)
+	if err != nil {
+		return err
+	} else if err := core.TestResponseCode(http.StatusNoContent, httpResponse); err != nil {
+		return err
+	}
+	return nil
 }
 
 // IssueVC issues a new Verifiable Credential and returns it

--- a/vcr/api/vcr/v2/client_test.go
+++ b/vcr/api/vcr/v2/client_test.go
@@ -20,6 +20,8 @@
 package v2
 
 import (
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/stretchr/testify/require"
 	"net/http"
@@ -204,5 +206,47 @@ func TestHttpClient_IssueVC(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, credential)
+	})
+}
+
+func TestHttpClient_LoadVC(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		s := httptest.NewServer(&http2.Handler{StatusCode: http.StatusNoContent})
+		c := &HTTPClient{
+			ClientConfig: core.ClientConfig{
+				Address: s.URL,
+				Timeout: time.Second,
+			},
+		}
+
+		err := c.LoadVC(did.DID{}, vc.VerifiableCredential{})
+
+		assert.NoError(t, err)
+	})
+	t.Run("error - not status 204", func(t *testing.T) {
+		s := httptest.NewServer(&http2.Handler{StatusCode: http.StatusInternalServerError})
+		c := &HTTPClient{
+			ClientConfig: core.ClientConfig{
+				Address: s.URL,
+				Timeout: time.Second,
+			},
+		}
+
+		err := c.LoadVC(did.DID{}, vc.VerifiableCredential{})
+
+		assert.Error(t, err)
+	})
+	t.Run("error - not status 200", func(t *testing.T) {
+		s := httptest.NewServer(&http2.Handler{StatusCode: http.StatusOK})
+		c := &HTTPClient{
+			ClientConfig: core.ClientConfig{
+				Address: s.URL,
+				Timeout: time.Second,
+			},
+		}
+
+		err := c.LoadVC(did.DID{}, vc.VerifiableCredential{})
+
+		assert.Error(t, err)
 	})
 }

--- a/vdr/api/v2/client.go
+++ b/vdr/api/v2/client.go
@@ -46,10 +46,10 @@ func (hb HTTPClient) client() ClientInterface {
 
 // Create calls the server and creates a new DID Document
 // It does not parse a custom id but depends on the server to generate one
-func (hb HTTPClient) Create() (*did.Document, error) {
+func (hb HTTPClient) Create(options CreateDIDOptions) (*did.Document, error) {
 	ctx := context.Background()
 
-	if response, err := hb.client().CreateDID(ctx, CreateDIDJSONRequestBody{}); err != nil {
+	if response, err := hb.client().CreateDID(ctx, options); err != nil {
 		return nil, err
 	} else if err := core.TestResponseCode(http.StatusOK, response); err != nil {
 		return nil, err

--- a/vdr/api/v2/client_test.go
+++ b/vdr/api/v2/client_test.go
@@ -41,7 +41,7 @@ func TestHTTPClient_Create(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		s := httptest.NewServer(&http2.Handler{StatusCode: http.StatusOK, ResponseData: didDoc})
 		c := getClient(s.URL)
-		doc, err := c.Create()
+		doc, err := c.Create(CreateDIDOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, doc)
 	})
@@ -49,13 +49,13 @@ func TestHTTPClient_Create(t *testing.T) {
 	t.Run("error - server error", func(t *testing.T) {
 		s := httptest.NewServer(&http2.Handler{StatusCode: http.StatusInternalServerError, ResponseData: ""})
 		c := getClient(s.URL)
-		_, err := c.Create()
+		_, err := c.Create(CreateDIDOptions{})
 		assert.Error(t, err)
 	})
 
 	t.Run("error - wrong address", func(t *testing.T) {
 		c := getClient("not_an_address")
-		_, err := c.Create()
+		_, err := c.Create(CreateDIDOptions{})
 		assert.Error(t, err)
 	})
 }

--- a/vdr/cmd/cmd.go
+++ b/vdr/cmd/cmd.go
@@ -91,7 +91,7 @@ func createCmd() *cobra.Command {
 				err error
 			)
 			if useV2 {
-				doc, err = httpClientV2(clientConfig).Create()
+				doc, err = httpClientV2(clientConfig).Create(apiv2.CreateDIDOptions{})
 			} else {
 				doc, err = httpClient(clientConfig).Create(createRequest)
 			}


### PR DESCRIPTION
Required by coming e2e browser test for EmployeeCredential.

Seperate PR to keep other PR smaller.