### PR TITLE
Add sqlserver support to storage engine

### DIFF
--- a/storage/engine.go
+++ b/storage/engine.go
@@ -38,6 +38,7 @@ import (
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
+	"gorm.io/driver/sqlserver"
 	"gorm.io/gorm"
 
 	"github.com/amacneil/dbmate/v2/pkg/dbmate"
@@ -197,6 +198,11 @@ func (e *engine) initSQLDatabase() error {
 		"mysql": {
 			connector: func(sqlDB *sql.DB) gorm.Dialector {
 				return mysql.New(mysql.Config{Conn: sqlDB})
+			},
+		},
+		"mssql": {
+			connector: func(sqlDB *sql.DB) gorm.Dialector {
+				return sqlserver.New(sqlserver.Config{Conn: sqlDB})
 			},
 		},
 	}


### PR DESCRIPTION
This commit introduces support for the SQL Server database in the storage engine. A sqlserver driver has been added and appropriate configuration has been set up. This will allow users to use Microsoft SQL Server as one of the database options.