### PR TITLE
refactor: move CreateAuthorizationRequest from OpenID4VPClient to Wrapper

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -20,11 +20,18 @@ package iam
 
 import (
 	"context"
-	crypto2 "crypto"
+	"crypto"
 	"embed"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
+	"html/template"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
 	"github.com/labstack/echo/v4"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/nuts-foundation/go-did/did"
@@ -35,8 +42,8 @@ import (
 	"github.com/nuts-foundation/nuts-node/auth/log"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	"github.com/nuts-foundation/nuts-node/core"
-	"github.com/nuts-foundation/nuts-node/crypto"
-	http2 "github.com/nuts-foundation/nuts-node/http"
+	cryptoNuts "github.com/nuts-foundation/nuts-node/crypto"
+	httpNuts "github.com/nuts-foundation/nuts-node/http"
 	"github.com/nuts-foundation/nuts-node/policy"
 	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/nuts-foundation/nuts-node/vcr"
@@ -45,11 +52,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/vdr"
 	"github.com/nuts-foundation/nuts-node/vdr/didweb"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
-	"html/template"
-	"net/http"
-	"net/url"
-	"strings"
-	"time"
 )
 
 var _ core.Routable = &Wrapper{}
@@ -79,17 +81,22 @@ const userSessionCookieName = "__Host-SID"
 //go:embed assets
 var assetsFS embed.FS
 
+// requestModifier is a function that modifies the claims/params of an unsigned or signed (JWT) OAuth2 request
+type requestModifier func(claims map[string]string)
+
 // Wrapper handles OAuth2 flows.
 type Wrapper struct {
 	auth          auth.AuthenticationServices
 	policyBackend policy.PDPBackend
 	storageEngine storage.Engine
-	keyStore      crypto.KeyStore
+	keyStore      cryptoNuts.KeyStore
 	vcr           vcr.VCR
 	vdr           vdr.VDR
+	jwtSigner     cryptoNuts.JWTSigner
+	keyResolver   resolver.KeyResolver
 }
 
-func New(authInstance auth.AuthenticationServices, vcrInstance vcr.VCR, vdrInstance vdr.VDR, storageEngine storage.Engine, policyBackend policy.PDPBackend) *Wrapper {
+func New(authInstance auth.AuthenticationServices, vcrInstance vcr.VCR, vdrInstance vdr.VDR, storageEngine storage.Engine, policyBackend policy.PDPBackend, jwtSigner cryptoNuts.JWTSigner) *Wrapper {
 	templates := template.New("oauth2 templates")
 	_, err := templates.ParseFS(assetsFS, "assets/*.html")
 	if err != nil {
@@ -101,6 +108,8 @@ func New(authInstance auth.AuthenticationServices, vcrInstance vcr.VCR, vdrInsta
 		storageEngine: storageEngine,
 		vcr:           vcrInstance,
 		vdr:           vdrInstance,
+		jwtSigner:     jwtSigner,
+		keyResolver:   resolver.DIDKeyResolver{Resolver: vdrInstance.Resolver()},
 	}
 }
 
@@ -330,7 +339,13 @@ func (r Wrapper) HandleAuthorizeRequest(ctx context.Context, request HandleAutho
 		if err != nil {
 			return nil, err
 		}
-	} // else, we'll allow for now, since other flows will break if we require JAR at this point.
+	} else if requestURI := params.get(oauth.RequestURIParam); requestURI != "" {
+		// TODO: implemented in next PR
+		return nil, oauth.OAuth2Error{Code: "request_uri_not_supported", Description: "not supported yet"}
+	} else {
+		// require_signed_request_object is true, so we reject anything that isn't
+		return nil, oauth.OAuth2Error{Code: oauth.InvalidRequest, Description: "authorization request are required to use signed request objects (RFC9101)"}
+	}
 
 	session := createSession(params, *ownDID)
 
@@ -376,31 +391,31 @@ func (r Wrapper) HandleAuthorizeRequest(ctx context.Context, request HandleAutho
 func (r *Wrapper) validateJARRequest(ctx context.Context, rawToken string, clientId string) (oauthParameters, error) {
 	var signerKid string
 	// Parse and validate the JWT
-	token, err := crypto.ParseJWT(rawToken, func(kid string) (crypto2.PublicKey, error) {
+	token, err := cryptoNuts.ParseJWT(rawToken, func(kid string) (crypto.PublicKey, error) {
 		signerKid = kid
 		return resolver.DIDKeyResolver{Resolver: r.vdr}.ResolveKeyByID(kid, nil, resolver.AssertionMethod)
 	}, jwt.WithValidate(true))
 	if err != nil {
-		return nil, oauth.OAuth2Error{Code: oauth.InvalidRequest, Description: "unable to validate request signature", InternalError: err}
+		return nil, oauth.OAuth2Error{Code: oauth.InvalidRequestObject, Description: "request signature validation failed", InternalError: err}
 	}
 	claimsAsMap, err := token.AsMap(ctx)
 	if err != nil {
 		// very unlikely
-		return nil, oauth.OAuth2Error{Code: oauth.InvalidRequest, Description: "invalid request parameter", InternalError: err}
+		return nil, oauth.OAuth2Error{Code: oauth.InvalidRequestObject, Description: "invalid request parameter", InternalError: err}
 	}
 	params := parseJWTClaims(claimsAsMap)
 	// check client_id claim, it must be the same as the client_id in the request
 	if clientId != params.get(oauth.ClientIDParam) {
-		return nil, oauth.OAuth2Error{Code: oauth.InvalidRequest, Description: "invalid client_id claim in signed authorization request"}
+		return nil, oauth.OAuth2Error{Code: oauth.InvalidRequestObject, Description: "invalid client_id claim in signed authorization request"}
 	}
 	// check if the signer of the JWT is the client
 	signer, err := did.ParseDIDURL(signerKid)
 	if err != nil {
 		// very unlikely since the key has already been resolved
-		return nil, oauth.OAuth2Error{Code: oauth.InvalidRequest, Description: "invalid signer", InternalError: err}
+		return nil, oauth.OAuth2Error{Code: oauth.InvalidRequestObject, Description: "invalid signer", InternalError: err}
 	}
 	if signer.DID.String() != clientId {
-		return nil, oauth.OAuth2Error{Code: oauth.InvalidRequest, Description: "client_id does not match signer of authorization request"}
+		return nil, oauth.OAuth2Error{Code: oauth.InvalidRequestObject, Description: "client_id does not match signer of authorization request"}
 	}
 	return params, nil
 }
@@ -594,10 +609,10 @@ func (r Wrapper) RequestUserAccessToken(ctx context.Context, request RequestUser
 	}
 
 	// session ID for calling app (supports polling for token)
-	sessionID := crypto.GenerateNonce()
+	sessionID := cryptoNuts.GenerateNonce()
 
 	// generate a redirect token valid for 5 seconds
-	token := crypto.GenerateNonce()
+	token := cryptoNuts.GenerateNonce()
 	err = r.userRedirectStore().Put(token, RedirectSession{
 		AccessTokenRequest: request,
 		SessionID:          sessionID,
@@ -618,7 +633,7 @@ func (r Wrapper) RequestUserAccessToken(ctx context.Context, request RequestUser
 	}
 	webURL = webURL.JoinPath("user")
 	// redirect to generic user page, context of token will render correct page
-	redirectURL := http2.AddQueryParams(*webURL, map[string]string{
+	redirectURL := httpNuts.AddQueryParams(*webURL, map[string]string{
 		"token": token,
 	})
 	return RequestUserAccessToken200JSONResponse{
@@ -692,7 +707,7 @@ func (r Wrapper) RequestOid4vciCredentialIssuance(ctx context.Context, request R
 		authorizationDetails, _ = json.Marshal(request.Body.AuthorizationDetails)
 	}
 	// Generate the state and PKCE
-	state := crypto.GenerateNonce()
+	state := cryptoNuts.GenerateNonce()
 	pkceParams := generatePKCEParams()
 	if err != nil {
 		log.Logger().WithError(err).Errorf("failed to create the PKCE parameters")
@@ -724,7 +739,7 @@ func (r Wrapper) RequestOid4vciCredentialIssuance(ctx context.Context, request R
 		return nil, err
 	}
 	// Build the redirect URL, the client browser should be redirected to.
-	redirectUrl := http2.AddQueryParams(*endpoint, map[string]string{
+	redirectUrl := httpNuts.AddQueryParams(*endpoint, map[string]string{
 		"response_type":         "code",
 		"state":                 state,
 		"client_id":             requestHolder.String(),
@@ -765,33 +780,38 @@ func (r Wrapper) CallbackOid4vciCredentialIssuance(ctx context.Context, request 
 	tokenEndpoint := oid4vciSession.IssuerTokenEndpoint
 	credentialEndpoint := oid4vciSession.IssuerCredentialEndpoint
 	if err != nil {
-		log.Logger().WithError(err).Errorf("cannot fetch the right endpoints")
+		log.Logger().WithError(err).Error("cannot fetch the right endpoints")
 		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("cannot fetch the right endpoints: %s", err.Error())), oid4vciSession.remoteRedirectUri())
 	}
 	response, err := r.auth.IAMClient().AccessTokenOid4vci(ctx, holderDid.String(), tokenEndpoint, oid4vciSession.RedirectUri, code, &pkceParams.Verifier)
 	if err != nil {
 		log.Logger().WithError(err).Errorf("error while fetching the access_token from endpoint: %s", tokenEndpoint)
-		return nil, withCallbackURI(oauthError(oauth.AccessDenied, fmt.Sprintf("error while fetching the access_token from endpoint: %s, error : %s", tokenEndpoint, err.Error())), oid4vciSession.remoteRedirectUri())
+		return nil, withCallbackURI(oauthError(oauth.AccessDenied, fmt.Sprintf("error while fetching the access_token from endpoint: %s, error: %s", tokenEndpoint, err.Error())), oid4vciSession.remoteRedirectUri())
 	}
-	credentials, err := r.auth.IAMClient().VerifiableCredentials(ctx, credentialEndpoint, response.AccessToken, response.CNonce, *holderDid, *issuerDid)
+	proofJWT, err := r.proofJwt(ctx, *holderDid, *issuerDid, response.CNonce)
+	if err != nil {
+		log.Logger().WithError(err).Error("error while building proof")
+		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("error while fetching the credential from endpoint %s, error: %s", credentialEndpoint, err.Error())), oid4vciSession.remoteRedirectUri())
+	}
+	credentials, err := r.auth.IAMClient().VerifiableCredentials(ctx, credentialEndpoint, response.AccessToken, proofJWT)
 	if err != nil {
 		log.Logger().WithError(err).Errorf("error while fetching the credential from endpoint: %s", credentialEndpoint)
-		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("error while fetching the credential from endpoint %s, error : %s", credentialEndpoint, err.Error())), oid4vciSession.remoteRedirectUri())
+		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("error while fetching the credential from endpoint %s, error: %s", credentialEndpoint, err.Error())), oid4vciSession.remoteRedirectUri())
 	}
 	credential, err := vc.ParseVerifiableCredential(credentials.Credential)
 	if err != nil {
 		log.Logger().WithError(err).Errorf("error while parsing the credential: %s", credentials.Credential)
-		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("error while parsing the credential: %s, error : %s", credentials.Credential, err.Error())), oid4vciSession.remoteRedirectUri())
+		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("error while parsing the credential: %s, error: %s", credentials.Credential, err.Error())), oid4vciSession.remoteRedirectUri())
 	}
 	err = r.vcr.Verifier().Verify(*credential, true, true, nil)
 	if err != nil {
 		log.Logger().WithError(err).Errorf("error while verifying the credential from issuer: %s", credential.Issuer.String())
-		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("error while verifying the credential from issuer: %s, error : %s", credential.Issuer.String(), err.Error())), oid4vciSession.remoteRedirectUri())
+		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("error while verifying the credential from issuer: %s, error: %s", credential.Issuer.String(), err.Error())), oid4vciSession.remoteRedirectUri())
 	}
 	err = r.vcr.Wallet().Put(ctx, *credential)
 	if err != nil {
 		log.Logger().WithError(err).Errorf("error while storing credential with id: %s", credential.ID)
-		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("error while storing credential with id: %s, error : %s", credential.ID, err.Error())), oid4vciSession.remoteRedirectUri())
+		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("error while storing credential with id: %s, error: %s", credential.ID, err.Error())), oid4vciSession.remoteRedirectUri())
 	}
 
 	log.Logger().Debugf("stored the credential with id: %s, now redirecting to %s", credential.ID, oid4vciSession.RemoteRedirectUri)
@@ -819,6 +839,102 @@ func (r Wrapper) openidIssuerEndpoints(ctx context.Context, issuerDid did.DID) (
 	}
 	err = errors.New(fmt.Sprintf("cannot locate any authorization endpoint in %s", issuerDid.String()))
 	return "", "", "", err
+}
+
+// CreateAuthorizationRequest creates an OAuth2.0 authorizationRequest redirect URL that redirects to the authorization server.
+// It can create both regular OAuth2 requests and OpenID4VP requests due to the RequestModifier.
+// It's able to create an unsigned request and a signed request (JAR) based on the OAuth Server Metadata.
+// By default, it adds the following parameters to a regular request:
+// - client_id
+// and to a signed request:
+// - client_id
+// - jwt.Issuer
+// - jwt.Audience
+// - nonce
+// any of these params can be overridden by the requestModifier.
+func (r Wrapper) CreateAuthorizationRequest(ctx context.Context, client did.DID, server did.DID, modifier requestModifier) (*url.URL, error) {
+	// we want to make a call according to §4.1.1 of RFC6749, https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.1
+	// The URL should be listed in the verifier metadata under the "authorization_endpoint" key
+	metadata, err := r.auth.IAMClient().AuthorizationServerMetadata(ctx, server)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve remote OAuth Authorization Server metadata: %w", err)
+	}
+	if len(metadata.AuthorizationEndpoint) == 0 {
+		return nil, fmt.Errorf("no authorization endpoint found in metadata for %s", server)
+	}
+	endpoint, err := url.Parse(metadata.AuthorizationEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse authorization endpoint URL: %w", err)
+	}
+	// one default param for both signed and unsigned
+	params := map[string]string{
+		oauth.ClientIDParam: client.String(),
+	}
+	// use JAR (JWT Authorization Request, RFC9101) if the verifier supports/requires it
+	if metadata.RequireSignedRequestObject {
+		// construct JWT
+		// first get a valid keyID from the vdr.KeyResolver
+		keyId, _, err := r.keyResolver.ResolveKey(client, nil, resolver.AssertionMethod)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve key for signing authorization request: %w", err)
+		}
+		// default claims for JAR
+		params[jwt.IssuerKey] = client.String()
+		params[jwt.AudienceKey] = server.String()
+		params[oauth.ClientIDParam] = client.String()
+		// added by default, can be overriden by the caller
+		params[oauth.NonceParam] = cryptoNuts.GenerateNonce()
+
+		// additional claims can be added by the caller
+		modifier(params)
+
+		paramsAny := make(map[string]any, len(params))
+		for k, v := range params {
+			paramsAny[k] = v
+		}
+
+		token, err := r.jwtSigner.SignJWT(ctx, paramsAny, nil, keyId.String())
+		if err != nil {
+			return nil, fmt.Errorf("failed to sign authorization request: %w", err)
+		}
+		redirectURL := httpNuts.AddQueryParams(*endpoint, map[string]string{
+			oauth.ClientIDParam: client.String(),
+			oauth.RequestParam:  token,
+		})
+		return &redirectURL, nil
+	}
+	// else return an unsigned regular authorization request
+	// left here for completeness, node 2 node interaction always uses JAR since the AS metadata has it hardcoded
+
+	// additional claims can be added by the caller
+	modifier(params)
+	redirectURL := httpNuts.AddQueryParams(*endpoint, params)
+	return &redirectURL, nil
+}
+
+func (r *Wrapper) proofJwt(ctx context.Context, holderDid did.DID, audienceDid did.DID, nonce *string) (string, error) {
+	// TODO: is this the right key type?
+	kid, _, err := r.keyResolver.ResolveKey(holderDid, nil, resolver.NutsSigningKeyType)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve key for did (%s): %w", holderDid.String(), err)
+	}
+	jti, err := uuid.NewUUID()
+	if err != nil {
+		return "", err
+	}
+	claims := map[string]interface{}{
+		"iss": holderDid.String(),
+		"aud": audienceDid.String(),
+		"jti": jti.String(),
+	}
+	if nonce != nil {
+		claims["nonce"] = nonce
+	}
+	proofJwt, err := r.jwtSigner.SignJWT(ctx, claims, nil, kid.String())
+	if err != nil {
+		return "", fmt.Errorf("failed to sign the JWT with kid (%s): %w", kid.String(), err)
+	}
+	return proofJwt, nil
 }
 
 // requestedDID constructs a did:web DID as it was requested by the API caller. It can be a DID with or without user path, e.g.:

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -43,11 +43,10 @@ import (
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	oauthServices "github.com/nuts-foundation/nuts-node/auth/services/oauth"
 	"github.com/nuts-foundation/nuts-node/core"
-	"github.com/nuts-foundation/nuts-node/crypto"
+	cryptoNuts "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/jsonld"
 	"github.com/nuts-foundation/nuts-node/policy"
 	"github.com/nuts-foundation/nuts-node/storage"
-	"github.com/nuts-foundation/nuts-node/test"
 	"github.com/nuts-foundation/nuts-node/vcr"
 	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"github.com/nuts-foundation/nuts-node/vcr/issuer"
@@ -308,8 +307,10 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 		VPFormats: oauth.DefaultOpenIDSupportedFormats(),
 	}
 	serverMetadata := oauth.AuthorizationServerMetadata{
-		ClientIdSchemesSupported: []string{didScheme},
-		VPFormats:                oauth.DefaultOpenIDSupportedFormats(),
+		AuthorizationEndpoint:      "https://example.com/authorize",
+		ClientIdSchemesSupported:   []string{didScheme},
+		VPFormats:                  oauth.DefaultOpenIDSupportedFormats(),
+		RequireSignedRequestObject: true,
 	}
 	pdEndpoint := "https://example.com/oauth2/did:web:example.com:iam:verifier/presentation_definition?scope=test"
 	// setup did document and keys
@@ -318,8 +319,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 		Fragment:        "key",
 		DecodedFragment: "key",
 	}
-	kid := vmId.String()
-	key := crypto.NewTestKey(kid)
+	key := cryptoNuts.NewTestKey(vmId.String())
 	didDocument := did.Document{ID: holderDID}
 	vm, _ := did.NewVerificationMethod(vmId, ssi.JsonWebKey2020, did.DID{}, key.Public())
 	didDocument.AddAssertionMethod(vm)
@@ -328,30 +328,28 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 		ctx := newTestClient(t)
 
 		// create signed request
-		request := jwt.New()
-		_ = request.Set(jwt.AudienceKey, []string{verifierDID.String()})
-		_ = request.Set(jwt.IssuerKey, holderDID.String())
-		_ = request.Set(oauth.ClientIDParam, holderDID.String())
-		_ = request.Set(oauth.NonceParam, "nonce")
-		_ = request.Set(oauth.RedirectURIParam, "https://example.com")
-		_ = request.Set(oauth.ResponseTypeParam, responseTypeCode)
-		_ = request.Set(oauth.ScopeParam, "test")
-		_ = request.Set(oauth.StateParam, "state")
-		_ = request.Set(oauth.CodeChallengeParam, "code_challenge")
-		_ = request.Set(oauth.CodeChallengeMethodParam, "S256")
-		headers := jws.NewHeaders()
-		headers.Set(jws.KeyIDKey, kid)
-		bytes, err := jwt.Sign(request, jwt.WithKey(jwa.ES256, key.Private(), jws.WithProtectedHeaders(headers)))
+		requestParams := oauthParameters{
+			jwt.AudienceKey:                []string{verifierDID.String()},
+			jwt.IssuerKey:                  holderDID.String(),
+			oauth.ClientIDParam:            holderDID.String(),
+			oauth.NonceParam:               "nonce",
+			oauth.RedirectURIParam:         "https://example.com",
+			oauth.ResponseTypeParam:        responseTypeCode,
+			oauth.ScopeParam:               "test",
+			oauth.StateParam:               "state",
+			oauth.CodeChallengeParam:       "code_challenge",
+			oauth.CodeChallengeMethodParam: "S256",
+		}
+		bytes, err := createSignedRequestObject(t, key, requestParams)
 		require.NoError(t, err)
 
-		expectedURL := test.MustParseURL("https://example.com/oauth2/did:web:example.com:iam:holder/authorize")
+		expectedURL := "https://example.com/authorize?client_id=did%3Aweb%3Aexample.com%3Aiam%3Averifier&request=valid-token"
 		ctx.vdr.EXPECT().IsOwner(gomock.Any(), verifierDID).Return(true, nil)
 		ctx.vdr.EXPECT().Resolve(holderDID, gomock.Any()).Return(&didDocument, &resolver.DocumentMetadata{}, nil)
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), holderDID).Return(&serverMetadata, nil)
-		ctx.iamClient.EXPECT().CreateAuthorizationRequest(gomock.Any(), verifierDID, holderDID, gomock.Any()).DoAndReturn(func(ctx context.Context, verifierDID, holderDID did.DID, modifier iam.RequestModifier) (*url.URL, error) {
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), holderDID).Return(&serverMetadata, nil).Times(2)
+		ctx.keyResolver.EXPECT().ResolveKey(verifierDID, nil, resolver.AssertionMethod).Return(vmId.URI(), key.Public(), nil)
+		ctx.jwtSigner.EXPECT().SignJWT(gomock.Any(), gomock.Any(), nil, key.KID()).DoAndReturn(func(ctx context.Context, params map[string]any, headers map[string]any, key any) (string, error) {
 			// check the parameters
-			params := map[string]interface{}{}
-			modifier(params)
 			assert.NotEmpty(t, params[oauth.NonceParam])
 			assert.Equal(t, didScheme, params[clientIDSchemeParam])
 			assert.Equal(t, responseTypeVPToken, params[oauth.ResponseTypeParam])
@@ -359,7 +357,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 			assert.Equal(t, "https://example.com/oauth2/did:web:example.com:iam:verifier/oauth-client", params[clientMetadataURIParam])
 			assert.Equal(t, responseModeDirectPost, params[responseModeParam])
 			assert.NotEmpty(t, params[oauth.StateParam])
-			return expectedURL, nil
+			return "valid-token", nil
 		})
 
 		res, err := ctx.client.HandleAuthorizeRequest(requestContext(map[string]interface{}{
@@ -370,9 +368,9 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		assert.IsType(t, HandleAuthorizeRequest302Response{}, res)
+		require.IsType(t, HandleAuthorizeRequest302Response{}, res)
 		location := res.(HandleAuthorizeRequest302Response).Headers.Location
-		assert.Equal(t, location, expectedURL.String())
+		assert.Equal(t, expectedURL, location)
 	})
 	t.Run("error - invalid request parameter", func(t *testing.T) {
 		ctx := newTestClient(t)
@@ -385,7 +383,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 			Did: verifierDID.String(),
 		})
 
-		requireOAuthError(t, err, oauth.InvalidRequest, "unable to validate request signature")
+		requireOAuthError(t, err, oauth.InvalidRequestObject, "request signature validation failed")
 		assert.Nil(t, res)
 	})
 	t.Run("error - client_id does not match", func(t *testing.T) {
@@ -397,7 +395,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 		_ = request.Set(jwt.IssuerKey, holderDID.String())
 		_ = request.Set(oauth.ClientIDParam, holderDID.String())
 		headers := jws.NewHeaders()
-		headers.Set(jws.KeyIDKey, kid)
+		headers.Set(jws.KeyIDKey, key.KID())
 		bytes, err := jwt.Sign(request, jwt.WithKey(jwa.ES256, key.Private(), jws.WithProtectedHeaders(headers)))
 		require.NoError(t, err)
 
@@ -408,7 +406,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 			Did: verifierDID.String(),
 		})
 
-		requireOAuthError(t, err, oauth.InvalidRequest, "invalid client_id claim in signed authorization request")
+		requireOAuthError(t, err, oauth.InvalidRequestObject, "invalid client_id claim in signed authorization request")
 		assert.Nil(t, res)
 	})
 	t.Run("error - client_id does not match signer", func(t *testing.T) {
@@ -420,7 +418,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 		_ = request.Set(jwt.IssuerKey, verifierDID.String())
 		_ = request.Set(oauth.ClientIDParam, verifierDID.String())
 		headers := jws.NewHeaders()
-		headers.Set(jws.KeyIDKey, kid)
+		headers.Set(jws.KeyIDKey, key.KID())
 		bytes, err := jwt.Sign(request, jwt.WithKey(jwa.ES256, key.Private(), jws.WithProtectedHeaders(headers)))
 		require.NoError(t, err)
 
@@ -431,67 +429,25 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 			Did: verifierDID.String(),
 		})
 
-		requireOAuthError(t, err, oauth.InvalidRequest, "client_id does not match signer of authorization request")
+		requireOAuthError(t, err, oauth.InvalidRequestObject, "client_id does not match signer of authorization request")
 		assert.Nil(t, res)
-	})
-	t.Run("ok - code response type - from holder", func(t *testing.T) {
-		ctx := newTestClient(t)
-		expectedURL := test.MustParseURL("https://example.com/iam/holder/authorize")
-		ctx.vdr.EXPECT().IsOwner(gomock.Any(), verifierDID).Return(true, nil)
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), holderDID).Return(&serverMetadata, nil)
-		ctx.iamClient.EXPECT().CreateAuthorizationRequest(gomock.Any(), verifierDID, holderDID, gomock.Any()).DoAndReturn(func(ctx context.Context, verifierDID, holderDID did.DID, modifier iam.RequestModifier) (*url.URL, error) {
-			// check the parameters
-			params := map[string]interface{}{}
-			modifier(params)
-			assert.NotEmpty(t, params[oauth.NonceParam])
-			assert.Equal(t, didScheme, params[clientIDSchemeParam])
-			assert.Equal(t, responseTypeVPToken, params[oauth.ResponseTypeParam])
-			assert.Equal(t, "https://example.com/oauth2/did:web:example.com:iam:verifier/response", params[responseURIParam])
-			assert.Equal(t, "https://example.com/oauth2/did:web:example.com:iam:verifier/oauth-client", params[clientMetadataURIParam])
-			assert.Equal(t, responseModeDirectPost, params[responseModeParam])
-			assert.NotEmpty(t, params[oauth.StateParam])
-			return expectedURL, nil
-		})
-
-		res, err := ctx.client.HandleAuthorizeRequest(requestContext(map[string]interface{}{
-			jwt.AudienceKey:                verifierDID.String(),
-			jwt.IssuerKey:                  holderDID.String(),
-			oauth.ClientIDParam:            holderDID.String(),
-			oauth.NonceParam:               "nonce",
-			oauth.RedirectURIParam:         "https://example.com",
-			oauth.ResponseTypeParam:        responseTypeCode,
-			oauth.ScopeParam:               "test",
-			oauth.StateParam:               "state",
-			oauth.CodeChallengeParam:       "code_challenge",
-			oauth.CodeChallengeMethodParam: "S256",
-		}), HandleAuthorizeRequestRequestObject{
-			Did: verifierDID.String(),
-		})
-
-		require.NoError(t, err)
-		assert.IsType(t, HandleAuthorizeRequest302Response{}, res)
-		location := res.(HandleAuthorizeRequest302Response).Headers.Location
-		assert.Equal(t, location, expectedURL.String())
-
 	})
 	t.Run("ok - vp_token response type - from verifier", func(t *testing.T) {
 		ctx := newTestClient(t)
-		_ = ctx.client.storageEngine.GetSessionDatabase().GetStore(oAuthFlowTimeout, oauthClientStateKey...).Put("state", OAuthSession{
-			// this is the state from the holder that was stored at the creation of the first authorization request to the verifier
-			ClientID:     holderDID.String(),
-			Scope:        "test",
-			OwnDID:       &holderDID,
-			ClientState:  "state",
-			RedirectURI:  "https://example.com/iam/holder/cb",
-			ResponseType: "code",
-		})
-		ctx.vdr.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
-		ctx.iamClient.EXPECT().ClientMetadata(gomock.Any(), "https://example.com/.well-known/authorization-server/iam/verifier").Return(&clientMetadata, nil)
-		ctx.iamClient.EXPECT().PresentationDefinition(gomock.Any(), pdEndpoint).Return(&pe.PresentationDefinition{}, nil)
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), holderDID, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
-		ctx.iamClient.EXPECT().PostAuthorizationResponse(gomock.Any(), vc.VerifiablePresentation{}, pe.PresentationSubmission{}, "https://example.com/oauth2/did:web:example.com:iam:verifier/response", "state").Return("https://example.com/iam/holder/redirect", nil)
 
-		res, err := ctx.client.HandleAuthorizeRequest(requestContext(map[string]interface{}{
+		vmId := did.DIDURL{
+			DID:             verifierDID,
+			Fragment:        "key",
+			DecodedFragment: "key",
+		}
+		kid := vmId.String()
+		key := cryptoNuts.NewTestKey(kid)
+		didDocument := did.Document{ID: verifierDID}
+		vm, _ := did.NewVerificationMethod(vmId, ssi.JsonWebKey2020, did.DID{}, key.Public())
+		didDocument.AddAssertionMethod(vm)
+
+		// create signed request
+		requestParams := oauthParameters{
 			oauth.ClientIDParam:     verifierDID.String(),
 			clientIDSchemeParam:     didScheme,
 			clientMetadataURIParam:  "https://example.com/.well-known/authorization-server/iam/verifier",
@@ -502,8 +458,31 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 			oauth.ResponseTypeParam: responseTypeVPToken,
 			oauth.ScopeParam:        "test",
 			oauth.StateParam:        "state",
+		}
+		bytes, err := createSignedRequestObject(t, key, requestParams)
+		require.NoError(t, err)
+
+		_ = ctx.client.storageEngine.GetSessionDatabase().GetStore(oAuthFlowTimeout, oauthClientStateKey...).Put("state", OAuthSession{
+			// this is the state from the holder that was stored at the creation of the first authorization request to the verifier
+			ClientID:     holderDID.String(),
+			Scope:        "test",
+			OwnDID:       &holderDID,
+			ClientState:  "state",
+			RedirectURI:  "https://example.com/iam/holder/cb",
+			ResponseType: "code",
+		})
+		ctx.vdr.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
+		ctx.vdr.EXPECT().Resolve(verifierDID, gomock.Any()).Return(&didDocument, &resolver.DocumentMetadata{}, nil)
+		ctx.iamClient.EXPECT().ClientMetadata(gomock.Any(), "https://example.com/.well-known/authorization-server/iam/verifier").Return(&clientMetadata, nil)
+		ctx.iamClient.EXPECT().PresentationDefinition(gomock.Any(), pdEndpoint).Return(&pe.PresentationDefinition{}, nil)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), holderDID, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
+		ctx.iamClient.EXPECT().PostAuthorizationResponse(gomock.Any(), vc.VerifiablePresentation{}, pe.PresentationSubmission{}, "https://example.com/oauth2/did:web:example.com:iam:verifier/response", "state").Return("https://example.com/iam/holder/redirect", nil)
+
+		res, err := ctx.client.HandleAuthorizeRequest(requestContext(map[string]interface{}{
+			oauth.ClientIDParam: verifierDID.String(),
+			oauth.RequestParam:  string(bytes),
 		}), HandleAuthorizeRequestRequestObject{
-			Did: "did:web:example.com:iam:holder",
+			Did: holderDID.String(),
 		})
 
 		require.NoError(t, err)
@@ -513,13 +492,22 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 	})
 	t.Run("unsupported response type", func(t *testing.T) {
 		ctx := newTestClient(t)
-		ctx.vdr.EXPECT().IsOwner(gomock.Any(), webDID).Return(true, nil)
+		// create signed request
+		requestParams := oauthParameters{
+			oauth.ClientIDParam:     holderDID.String(),
+			oauth.ResponseTypeParam: "unsupported",
+		}
+		bytes, err := createSignedRequestObject(t, key, requestParams)
+		require.NoError(t, err)
+
+		ctx.vdr.EXPECT().IsOwner(gomock.Any(), verifierDID).Return(true, nil)
+		ctx.vdr.EXPECT().Resolve(holderDID, gomock.Any()).Return(&didDocument, &resolver.DocumentMetadata{}, nil)
 
 		res, err := ctx.client.HandleAuthorizeRequest(requestContext(map[string]interface{}{
-			"redirect_uri":  "https://example.com",
-			"response_type": "unsupported",
+			oauth.ClientIDParam: holderDID.String(),
+			oauth.RequestParam:  string(bytes),
 		}), HandleAuthorizeRequestRequestObject{
-			Did: webDID.String(),
+			Did: verifierDID.String(),
 		})
 
 		requireOAuthError(t, err, oauth.UnsupportedResponseType, "")
@@ -975,6 +963,105 @@ func TestWrapper_StatusList(t *testing.T) {
 	})
 }
 
+func TestWrapper_CreateAuthorizationRequest(t *testing.T) {
+	clientDID := did.MustParseDID("did:web:client.test:iam:123")
+	serverDID := did.MustParseDID("did:web:server.test:iam:123")
+	modifier := func(values map[string]string) {
+		values["custom"] = "value"
+	}
+	serverMetadata := oauth.AuthorizationServerMetadata{
+		AuthorizationEndpoint:      "https://server.test/authorize",
+		RequireSignedRequestObject: true,
+	}
+
+	t.Run("JAR", func(t *testing.T) {
+		keyId := clientDID.URI()
+		keyId.Fragment = "1"
+		privKey := cryptoNuts.NewTestKey(keyId.String())
+
+		t.Run("ok", func(t *testing.T) {
+			ctx := newTestClient(t)
+			ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), serverDID).Return(&serverMetadata, nil)
+			ctx.keyResolver.EXPECT().ResolveKey(clientDID, nil, resolver.NutsSigningKeyType).Return(keyId, privKey.Public(), nil)
+			ctx.jwtSigner.EXPECT().SignJWT(gomock.Any(), gomock.Any(), nil, gomock.Any()).DoAndReturn(func(_ context.Context, claims map[string]interface{}, _ interface{}, key string) (string, error) {
+				assert.Equal(t, keyId.String(), key)
+				assert.Equal(t, clientDID.String(), claims[jwt.IssuerKey])
+				assert.Equal(t, serverDID.String(), claims[jwt.AudienceKey])
+				assert.Equal(t, clientDID.String(), claims[oauth.ClientIDParam])
+				assert.Equal(t, "value", claims["custom"])
+				assert.NotEmpty(t, claims[oauth.NonceParam])
+				return "signed JWT", nil
+			})
+			redirectURL, err := ctx.client.CreateAuthorizationRequest(context.Background(), clientDID, serverDID, modifier)
+
+			assert.NoError(t, err)
+			require.NotNil(t, redirectURL)
+			assert.Equal(t, "signed JWT", redirectURL.Query().Get(oauth.RequestParam))
+			assert.Equal(t, clientDID.String(), redirectURL.Query().Get(oauth.ClientIDParam))
+		})
+		t.Run("error - failed to sign JWT", func(t *testing.T) {
+			ctx := newTestClient(t)
+			ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), serverDID).Return(&serverMetadata, nil)
+			ctx.keyResolver.EXPECT().ResolveKey(clientDID, nil, resolver.NutsSigningKeyType).Return(keyId, privKey.Public(), nil)
+			ctx.jwtSigner.EXPECT().SignJWT(gomock.Any(), gomock.Any(), nil, gomock.Any()).Return("", assert.AnError)
+
+			redirectURL, err := ctx.client.CreateAuthorizationRequest(context.Background(), clientDID, serverDID, modifier)
+
+			assert.Error(t, err)
+			assert.Empty(t, redirectURL)
+		})
+		t.Run("error - failed to resolve key", func(t *testing.T) {
+			ctx := newTestClient(t)
+			ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), serverDID).Return(&serverMetadata, nil)
+			ctx.keyResolver.EXPECT().ResolveKey(clientDID, nil, resolver.NutsSigningKeyType).Return(keyId, nil, resolver.ErrKeyNotFound)
+
+			redirectURL, err := ctx.client.CreateAuthorizationRequest(context.Background(), clientDID, serverDID, modifier)
+
+			assert.Error(t, err)
+			assert.Empty(t, redirectURL)
+		})
+	})
+	t.Run("non-JAR", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			ctx := newTestClient(t)
+			ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), serverDID).Return(&oauth.AuthorizationServerMetadata{AuthorizationEndpoint: serverMetadata.AuthorizationEndpoint}, nil)
+
+			redirectURL, err := ctx.client.CreateAuthorizationRequest(context.Background(), clientDID, serverDID, modifier)
+
+			assert.NoError(t, err)
+			require.NotNil(t, redirectURL)
+			assert.Equal(t, clientDID.String(), redirectURL.Query().Get("client_id"))
+			assert.Equal(t, "value", redirectURL.Query().Get("custom"))
+		})
+		t.Run("error - missing authorization endpoint", func(t *testing.T) {
+			ctx := newTestClient(t)
+			ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), serverDID).Return(&oauth.AuthorizationServerMetadata{}, nil)
+
+			_, err := ctx.client.CreateAuthorizationRequest(context.Background(), clientDID, serverDID, modifier)
+
+			assert.Error(t, err)
+			assert.ErrorContains(t, err, "no authorization endpoint found in metadata for")
+		})
+		t.Run("error - failed to get authorization server metadata", func(t *testing.T) {
+			ctx := newTestClient(t)
+			ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), serverDID).Return(nil, assert.AnError)
+
+			_, err := ctx.client.CreateAuthorizationRequest(context.Background(), clientDID, serverDID, modifier)
+
+			assert.Error(t, err)
+		})
+		t.Run("error - failed to get metadata", func(t *testing.T) {
+			ctx := newTestClient(t)
+			ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), serverDID).Return(&oauth.AuthorizationServerMetadata{}, nil)
+
+			_, err := ctx.client.CreateAuthorizationRequest(context.Background(), clientDID, serverDID, modifier)
+
+			assert.Error(t, err)
+			assert.ErrorContains(t, err, "no authorization endpoint found in metadata for")
+		})
+	})
+}
+
 func Test_createOAuth2BaseURL(t *testing.T) {
 	t.Run("no endpoint", func(t *testing.T) {
 		webDID := did.MustParseDID("did:web:example.com:iam:holder")
@@ -1131,7 +1218,7 @@ func TestWrapper_CallbackOid4vciCredentialIssuance(t *testing.T) {
 	redirectURI := "https://test.test/iam/123/cb"
 	authServer := "https://auth.server"
 	tokenEndpoint := authServer + "/token"
-	cNonce := crypto.GenerateNonce()
+	cNonce := cryptoNuts.GenerateNonce()
 	credEndpoint := authServer + "/credz"
 	pkceParams := generatePKCEParams()
 	code := "code"
@@ -1162,7 +1249,9 @@ func TestWrapper_CallbackOid4vciCredentialIssuance(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.client.storageEngine.GetSessionDatabase().GetStore(15*time.Minute, "oid4vci").Put(state, &session)
 		ctx.iamClient.EXPECT().AccessTokenOid4vci(nil, holderDID.String(), tokenEndpoint, redirectURI, code, &pkceParams.Verifier).Return(&tokenResponse, nil)
-		ctx.iamClient.EXPECT().VerifiableCredentials(nil, credEndpoint, accessToken, &cNonce, holderDID, issuerDID).Return(&credentialResponse, nil)
+		ctx.keyResolver.EXPECT().ResolveKey(holderDID, nil, resolver.NutsSigningKeyType).Return(ssi.MustParseURI("kid"), nil, nil)
+		ctx.jwtSigner.EXPECT().SignJWT(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("signed-proof", nil)
+		ctx.iamClient.EXPECT().VerifiableCredentials(nil, credEndpoint, accessToken, "signed-proof").Return(&credentialResponse, nil)
 		ctx.vcVerifier.EXPECT().Verify(*verifiableCredential, true, true, nil)
 		ctx.wallet.EXPECT().Put(nil, *verifiableCredential)
 
@@ -1172,6 +1261,7 @@ func TestWrapper_CallbackOid4vciCredentialIssuance(t *testing.T) {
 				State: state,
 			},
 		})
+
 		require.NoError(t, err)
 		assert.NotNil(t, callback)
 		actual := callback.(CallbackOid4vciCredentialIssuance302Response)
@@ -1179,10 +1269,10 @@ func TestWrapper_CallbackOid4vciCredentialIssuance(t *testing.T) {
 	})
 	t.Run("error_on_redirect", func(t *testing.T) {
 		ctx := newTestClient(t)
-
-		ctx.client.storageEngine.GetSessionDatabase().GetStore(15*time.Minute, "oid4vci").Put(state, &session)
+		require.NoError(t, ctx.client.storageEngine.GetSessionDatabase().GetStore(15*time.Minute, "oid4vci").Put(state, &session))
 		errorCode := "failed"
 		errorDesc := "errorDesc"
+
 		callback, err := ctx.client.CallbackOid4vciCredentialIssuance(nil, CallbackOid4vciCredentialIssuanceRequestObject{
 			Params: CallbackOid4vciCredentialIssuanceParams{
 				Code:             "",
@@ -1191,6 +1281,7 @@ func TestWrapper_CallbackOid4vciCredentialIssuance(t *testing.T) {
 				ErrorDescription: &errorDesc,
 			},
 		})
+
 		require.Error(t, err)
 		assert.Nil(t, callback)
 		assert.Equal(t, fmt.Sprintf("%s - %s", errorCode, errorDesc), err.Error())
@@ -1210,9 +1301,6 @@ func TestWrapper_CallbackOid4vciCredentialIssuance(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.client.storageEngine.GetSessionDatabase().GetStore(15*time.Minute, "oid4vci").Put(state, &session)
 		ctx.iamClient.EXPECT().AccessTokenOid4vci(nil, holderDID.String(), tokenEndpoint, redirectURI, code, &pkceParams.Verifier).Return(nil, errors.New("FAIL"))
-		//ctx.iamClient.EXPECT().VerifiableCredentials(nil, credEndpoint, accessToken, holderDID, issuerDID).Return(&credentialResponse, nil)
-		//ctx.vcVerifier.EXPECT().Verify(*verifiableCredential, true, true, nil)
-		//ctx.wallet.EXPECT().Put(nil, *verifiableCredential)
 
 		callback, err := ctx.client.CallbackOid4vciCredentialIssuance(nil, CallbackOid4vciCredentialIssuanceRequestObject{
 			Params: CallbackOid4vciCredentialIssuanceParams{
@@ -1220,15 +1308,18 @@ func TestWrapper_CallbackOid4vciCredentialIssuance(t *testing.T) {
 				State: state,
 			},
 		})
+
 		assert.Error(t, err)
 		assert.Nil(t, callback)
-		assert.Equal(t, "access_denied - error while fetching the access_token from endpoint: https://auth.server/token, error : FAIL", err.Error())
+		assert.Equal(t, "access_denied - error while fetching the access_token from endpoint: https://auth.server/token, error: FAIL", err.Error())
 	})
 	t.Run("fail_credential_response", func(t *testing.T) {
 		ctx := newTestClient(t)
-		ctx.client.storageEngine.GetSessionDatabase().GetStore(15*time.Minute, "oid4vci").Put(state, &session)
+		require.NoError(t, ctx.client.storageEngine.GetSessionDatabase().GetStore(15*time.Minute, "oid4vci").Put(state, &session))
 		ctx.iamClient.EXPECT().AccessTokenOid4vci(nil, holderDID.String(), tokenEndpoint, redirectURI, code, &pkceParams.Verifier).Return(&tokenResponse, nil)
-		ctx.iamClient.EXPECT().VerifiableCredentials(nil, credEndpoint, accessToken, &cNonce, holderDID, issuerDID).Return(nil, errors.New("FAIL"))
+		ctx.keyResolver.EXPECT().ResolveKey(holderDID, nil, resolver.NutsSigningKeyType).Return(ssi.MustParseURI("kid"), nil, nil)
+		ctx.jwtSigner.EXPECT().SignJWT(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("signed-proof", nil)
+		ctx.iamClient.EXPECT().VerifiableCredentials(nil, credEndpoint, accessToken, "signed-proof").Return(nil, errors.New("FAIL"))
 
 		callback, err := ctx.client.CallbackOid4vciCredentialIssuance(nil, CallbackOid4vciCredentialIssuanceRequestObject{
 			Params: CallbackOid4vciCredentialIssuanceParams{
@@ -1236,16 +1327,18 @@ func TestWrapper_CallbackOid4vciCredentialIssuance(t *testing.T) {
 				State: state,
 			},
 		})
+
 		assert.Error(t, err)
 		assert.Nil(t, callback)
-		assert.Equal(t, "server_error - error while fetching the credential from endpoint https://auth.server/credz, error : FAIL", err.Error())
-
+		assert.Equal(t, "server_error - error while fetching the credential from endpoint https://auth.server/credz, error: FAIL", err.Error())
 	})
 	t.Run("fail_verify", func(t *testing.T) {
 		ctx := newTestClient(t)
-		ctx.client.storageEngine.GetSessionDatabase().GetStore(15*time.Minute, "oid4vci").Put(state, &session)
+		require.NoError(t, ctx.client.storageEngine.GetSessionDatabase().GetStore(15*time.Minute, "oid4vci").Put(state, &session))
 		ctx.iamClient.EXPECT().AccessTokenOid4vci(nil, holderDID.String(), tokenEndpoint, redirectURI, code, &pkceParams.Verifier).Return(&tokenResponse, nil)
-		ctx.iamClient.EXPECT().VerifiableCredentials(nil, credEndpoint, accessToken, &cNonce, holderDID, issuerDID).Return(&credentialResponse, nil)
+		ctx.keyResolver.EXPECT().ResolveKey(holderDID, nil, resolver.NutsSigningKeyType).Return(ssi.MustParseURI("kid"), nil, nil)
+		ctx.jwtSigner.EXPECT().SignJWT(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("signed-proof", nil)
+		ctx.iamClient.EXPECT().VerifiableCredentials(nil, credEndpoint, accessToken, "signed-proof").Return(&credentialResponse, nil)
 		ctx.vcVerifier.EXPECT().Verify(*verifiableCredential, true, true, nil).Return(errors.New("FAIL"))
 
 		callback, err := ctx.client.CallbackOid4vciCredentialIssuance(nil, CallbackOid4vciCredentialIssuanceRequestObject{
@@ -1256,21 +1349,43 @@ func TestWrapper_CallbackOid4vciCredentialIssuance(t *testing.T) {
 		})
 		assert.Error(t, err)
 		assert.Nil(t, callback)
-		assert.Equal(t, "server_error - error while verifying the credential from issuer: did:web:issuer.test:iam:456, error : FAIL", err.Error())
-
+		assert.Equal(t, "server_error - error while verifying the credential from issuer: did:web:issuer.test:iam:456, error: FAIL", err.Error())
 	})
-}
+	t.Run("error - key not found", func(t *testing.T) {
+		ctx := newTestClient(t)
+		require.NoError(t, ctx.client.storageEngine.GetSessionDatabase().GetStore(15*time.Minute, "oid4vci").Put(state, &session))
+		ctx.iamClient.EXPECT().AccessTokenOid4vci(nil, holderDID.String(), tokenEndpoint, redirectURI, code, &pkceParams.Verifier).Return(&tokenResponse, nil)
+		ctx.keyResolver.EXPECT().ResolveKey(holderDID, nil, resolver.NutsSigningKeyType).Return(ssi.URI{}, nil, resolver.ErrKeyNotFound)
 
-func errorFromUrl(location string) string {
-	parsedUrl, err := url.Parse(location)
-	if err != nil {
-		return ""
-	}
-	query := parsedUrl.Query()
-	if query.Has("error") {
-		return query.Get("error")
-	}
-	return ""
+		callback, err := ctx.client.CallbackOid4vciCredentialIssuance(nil, CallbackOid4vciCredentialIssuanceRequestObject{
+			Params: CallbackOid4vciCredentialIssuanceParams{
+				Code:  code,
+				State: state,
+			},
+		})
+
+		assert.Error(t, err)
+		assert.Nil(t, callback)
+		assert.ErrorContains(t, err, "failed to resolve key for did (did:web:holder.test:iam:123): "+resolver.ErrKeyNotFound.Error())
+	})
+	t.Run("error - signature failure", func(t *testing.T) {
+		ctx := newTestClient(t)
+		require.NoError(t, ctx.client.storageEngine.GetSessionDatabase().GetStore(15*time.Minute, "oid4vci").Put(state, &session))
+		ctx.iamClient.EXPECT().AccessTokenOid4vci(nil, holderDID.String(), tokenEndpoint, redirectURI, code, &pkceParams.Verifier).Return(&tokenResponse, nil)
+		ctx.keyResolver.EXPECT().ResolveKey(holderDID, nil, resolver.NutsSigningKeyType).Return(ssi.MustParseURI("kid"), nil, nil)
+		ctx.jwtSigner.EXPECT().SignJWT(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("signature failed"))
+
+		callback, err := ctx.client.CallbackOid4vciCredentialIssuance(nil, CallbackOid4vciCredentialIssuanceRequestObject{
+			Params: CallbackOid4vciCredentialIssuanceParams{
+				Code:  code,
+				State: state,
+			},
+		})
+
+		assert.Error(t, err)
+		assert.Nil(t, callback)
+		assert.ErrorContains(t, err, "failed to sign the JWT with kid (kid): signature failed")
+	})
 }
 
 func createIssuerCredential(issuerDID did.DID, holderDID did.DID) *vc.VerifiableCredential {
@@ -1280,7 +1395,7 @@ func createIssuerCredential(issuerDID did.DID, holderDID did.DID) *vc.Verifiable
 		DecodedFragment: "key",
 	}
 	kid := vmId.String()
-	key := crypto.NewTestKey(kid)
+	key := cryptoNuts.NewTestKey(kid)
 	credType := ssi.MustParseURI("ExampleType")
 
 	captureFn := func(ctx context.Context, claims map[string]interface{}, headers map[string]interface{}) (string, error) {
@@ -1305,6 +1420,16 @@ func createIssuerCredential(issuerDID did.DID, holderDID did.DID) *vc.Verifiable
 	}
 	verifiableCredential, _ := vc.CreateJWTVerifiableCredential(nil, template, captureFn)
 	return verifiableCredential
+}
+
+func createSignedRequestObject(t testing.TB, testKey *cryptoNuts.TestKey, params oauthParameters) ([]byte, error) {
+	request := jwt.New()
+	for k, v := range params {
+		require.NoError(t, request.Set(k, v))
+	}
+	headers := jws.NewHeaders()
+	require.NoError(t, headers.Set(jws.KeyIDKey, testKey.KID()))
+	return jwt.Sign(request, jwt.WithKey(jwa.ES256, testKey.Private(), jws.WithProtectedHeaders(headers)))
 }
 
 type strictServerCallCapturer bool
@@ -1366,6 +1491,8 @@ type testCtx struct {
 	ctrl          *gomock.Controller
 	client        *Wrapper
 	iamClient     *iam.MockClient
+	jwtSigner     *cryptoNuts.MockJWTSigner
+	keyResolver   *resolver.MockKeyResolver
 	policy        *policy.MockPDPBackend
 	resolver      *resolver.MockDIDResolver
 	relyingParty  *oauthServices.MockRelyingParty
@@ -1382,7 +1509,6 @@ func newTestClient(t testing.TB) *testCtx {
 	ctrl := gomock.NewController(t)
 	storageEngine := storage.NewTestStorageEngine(t)
 	authnServices := auth.NewMockAuthenticationServices(ctrl)
-	authnServices.EXPECT().PublicURL().Return(publicURL).AnyTimes()
 	policyInstance := policy.NewMockPDPBackend(ctrl)
 	mockResolver := resolver.NewMockDIDResolver(ctrl)
 	relyingPary := oauthServices.NewMockRelyingParty(ctrl)
@@ -1392,6 +1518,8 @@ func newTestClient(t testing.TB) *testCtx {
 	mockVDR := vdr.NewMockVDR(ctrl)
 	mockVCR := vcr.NewMockVCR(ctrl)
 	mockWallet := holder.NewMockWallet(ctrl)
+	jwtSigner := cryptoNuts.NewMockJWTSigner(ctrl)
+	keyResolver := resolver.NewMockKeyResolver(ctrl)
 
 	authnServices.EXPECT().PublicURL().Return(publicURL).AnyTimes()
 	authnServices.EXPECT().RelyingParty().Return(relyingPary).AnyTimes()
@@ -1413,12 +1541,16 @@ func newTestClient(t testing.TB) *testCtx {
 		iamClient:     iamClient,
 		vcr:           mockVCR,
 		wallet:        mockWallet,
+		keyResolver:   keyResolver,
+		jwtSigner:     jwtSigner,
 		client: &Wrapper{
 			auth:          authnServices,
 			vdr:           mockVDR,
 			vcr:           mockVCR,
 			storageEngine: storageEngine,
 			policyBackend: policyInstance,
+			keyResolver:   keyResolver,
+			jwtSigner:     jwtSigner,
 		},
 	}
 }

--- a/auth/api/iam/metadata.go
+++ b/auth/api/iam/metadata.go
@@ -39,6 +39,7 @@ func authorizationServerMetadata(identity url.URL, oauth2BaseURL url.URL) oauth.
 		TokenEndpoint:                              oauth2BaseURL.JoinPath("token").String(),
 		VPFormats:                                  oauth.DefaultOpenIDSupportedFormats(),
 		VPFormatsSupported:                         oauth.DefaultOpenIDSupportedFormats(),
+		RequestObjectSigningAlgValuesSupported:     oauth.AlgValuesSupported,
 	}
 }
 
@@ -58,6 +59,7 @@ func clientMetadata(identity url.URL) OAuthClientMetadata {
 		SoftwareVersion: softwareVersion, // version tag or "unknown"
 		//CredentialOfferEndpoint: "",
 		VPFormats:      oauth.DefaultOpenIDSupportedFormats(),
-		ClientIdScheme: "did",
+		ClientIdScheme: didScheme,
+		//RequestObjectSigningAlg: // all mutually supported alg's are valid if this is not defined
 	}
 }

--- a/auth/api/iam/metadata_test.go
+++ b/auth/api/iam/metadata_test.go
@@ -43,6 +43,7 @@ func Test_authorizationServerMetadata(t *testing.T) {
 		VPFormats:                                  oauth.DefaultOpenIDSupportedFormats(),
 		VPFormatsSupported:                         oauth.DefaultOpenIDSupportedFormats(),
 		ClientIdSchemesSupported:                   []string{"did"},
+		RequestObjectSigningAlgValuesSupported:     oauth.AlgValuesSupported,
 	}
 	assert.Equal(t, expected, authorizationServerMetadata(*identity, *oauth2Base))
 }

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -145,7 +145,7 @@ func (r Wrapper) handleAuthorizeRequestFromHolder(ctx context.Context, verifier 
 
 	// create a client state for the verifier
 	state := crypto.GenerateNonce()
-	modifier := func(values map[string]interface{}) {
+	modifier := func(values map[string]string) {
 		values[oauth.ResponseTypeParam] = responseTypeVPToken
 		values[clientIDSchemeParam] = didScheme
 		values[responseURIParam] = callbackURL.String()
@@ -155,7 +155,11 @@ func (r Wrapper) handleAuthorizeRequestFromHolder(ctx context.Context, verifier 
 		values[oauth.NonceParam] = nonce
 		values[oauth.StateParam] = state
 	}
-	authServerURL, err := r.auth.IAMClient().CreateAuthorizationRequest(ctx, verifier, *walletDID, modifier)
+	authServerURL, err := r.CreateAuthorizationRequest(ctx, verifier, *walletDID, modifier)
+	if err != nil {
+		// TODO: fix error return
+		return nil, err
+	}
 	// TODO WIP: add PEX IDs completed to the storage, use server state for this
 	openid4vpRequest := OAuthSession{
 		ClientID:    walletID,

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -157,9 +157,14 @@ func (r Wrapper) handleAuthorizeRequestFromHolder(ctx context.Context, verifier 
 	}
 	authServerURL, err := r.CreateAuthorizationRequest(ctx, verifier, *walletDID, modifier)
 	if err != nil {
-		// TODO: fix error return
-		return nil, err
+		return nil, oauth.OAuth2Error{
+			Code:          oauth.ServerError,
+			Description:   "failed to authorize client",
+			InternalError: fmt.Errorf("failed to generate authorization request URL: %w", err),
+			RedirectURI:   redirectURL,
+		}
 	}
+
 	// TODO WIP: add PEX IDs completed to the storage, use server state for this
 	openid4vpRequest := OAuthSession{
 		ClientID:    walletID,

--- a/auth/api/iam/openid4vp_test.go
+++ b/auth/api/iam/openid4vp_test.go
@@ -142,6 +142,17 @@ func TestWrapper_handleAuthorizeRequestFromHolder(t *testing.T) {
 
 		requireOAuthError(t, err, oauth.InvalidRequest, "invalid verifier DID")
 	})
+	t.Run("failed to generate authorization request", func(t *testing.T) {
+		ctx := newTestClient(t)
+		params := defaultParams()
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(context.Background(), holderDID).Return(&oauth.AuthorizationServerMetadata{
+			ClientIdSchemesSupported: []string{didScheme},
+		}, nil).Times(2)
+
+		_, err := ctx.client.handleAuthorizeRequestFromHolder(context.Background(), verifierDID, params)
+
+		requireOAuthError(t, err, oauth.ServerError, "failed to authorize client")
+	})
 }
 
 func TestWrapper_handleAuthorizeRequestFromVerifier(t *testing.T) {

--- a/auth/api/iam/openid4vp_test.go
+++ b/auth/api/iam/openid4vp_test.go
@@ -19,11 +19,9 @@
 package iam
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"github.com/lestrrat-go/jwx/v2/jwt"
-	"net/http"
 	"strings"
 	"testing"
 
@@ -793,31 +791,6 @@ func assertOAuthError(t *testing.T, err error, expectedDescription string) oauth
 	assert.Equal(t, oauth.InvalidRequest, oauthErr.Code)
 	assert.Equal(t, expectedDescription, oauthErr.Description)
 	return oauthErr
-}
-
-type stubResponseWriter struct {
-	headers    http.Header
-	body       *bytes.Buffer
-	statusCode int
-}
-
-func (s *stubResponseWriter) Header() http.Header {
-	if s.headers == nil {
-		s.headers = make(http.Header)
-	}
-	return s.headers
-
-}
-
-func (s *stubResponseWriter) Write(i []byte) (int, error) {
-	if s.body == nil {
-		s.body = new(bytes.Buffer)
-	}
-	return s.body.Write(i)
-}
-
-func (s *stubResponseWriter) WriteHeader(statusCode int) {
-	s.statusCode = statusCode
 }
 
 func putState(ctx *testCtx, state string) {

--- a/auth/api/iam/params.go
+++ b/auth/api/iam/params.go
@@ -35,13 +35,7 @@ func parseQueryParams(values url.Values) oauthParameters {
 	return underlying
 }
 
-func parseJWTClaims(claims map[string]interface{}) oauthParameters {
-	underlying := make(map[string]interface{})
-	for key, value := range claims {
-		underlying[key] = value
-	}
-	return underlying
-}
+func parseJWTClaims(claims map[string]interface{}) oauthParameters { return claims }
 
 // get returns the string value if present and if an actual string
 // for arrays it'll return the first value if len == 1

--- a/auth/api/iam/types.go
+++ b/auth/api/iam/types.go
@@ -101,8 +101,6 @@ const (
 var responseTypesSupported = []string{responseTypeCode, responseTypeVPToken, responseTypeVPIDToken}
 
 const (
-	// didScheme is the client_id_scheme value for DIDs
-	didScheme = "did"
 	// responseModeParam is the name of the OAuth2 response_mode parameter.
 	// Specified by https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html
 	responseModeParam = "response_mode"
@@ -131,7 +129,7 @@ var grantTypesSupported = []string{grantTypeAuthorizationCode, grantTypeVPToken,
 
 // clientIdSchemesSupported lists the supported client_id_scheme
 // https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-verifier-metadata-managemen
-var clientIdSchemesSupported = []string{"did"}
+var clientIdSchemesSupported = []string{didScheme}
 
 // clientMetadataParam is the name of the OpenID4VP client_metadata parameter.
 // Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-authorization-request
@@ -144,6 +142,9 @@ const clientMetadataURIParam = "client_metadata_uri"
 // clientIDSchemeParam is the name of the OpenID4VP client_id_scheme parameter.
 // Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-authorization-request
 const clientIDSchemeParam = "client_id_scheme"
+
+// didScheme is the client_id_scheme value for DIDs
+const didScheme = "did"
 
 // responseURIParam is the name of the OpenID4VP response_uri parameter.
 const responseURIParam = "response_uri"

--- a/auth/api/iam/user.go
+++ b/auth/api/iam/user.go
@@ -54,7 +54,6 @@ const (
 
 var oauthClientStateKey = []string{"oauth", "client_state"}
 var oauthCodeKey = []string{"oauth", "code"}
-var oauthServerStateKey = []string{"oauth", "server_state"}
 var userRedirectSessionKey = []string{"user", "redirect"}
 var userSessionKey = []string{"user", "session"}
 
@@ -136,7 +135,7 @@ func (r Wrapper) handleUserLanding(echoCtx echo.Context) error {
 		return fmt.Errorf("failed to create callback URL: %w", err)
 	}
 	callbackURL = callbackURL.JoinPath(oauth.CallbackPath)
-	modifier := func(values map[string]interface{}) {
+	modifier := func(values map[string]string) {
 		values[oauth.CodeChallengeParam] = oauthSession.PKCEParams.Challenge
 		values[oauth.CodeChallengeMethodParam] = oauthSession.PKCEParams.ChallengeMethod
 		values[oauth.RedirectURIParam] = callbackURL.String()
@@ -145,7 +144,7 @@ func (r Wrapper) handleUserLanding(echoCtx echo.Context) error {
 		values[oauth.ScopeParam] = accessTokenRequest.Body.Scope
 	}
 	// TODO: First create user session, or AuthorizationRequest first? (which one is more expensive? both sign stuff)
-	redirectURL, err := r.auth.IAMClient().CreateAuthorizationRequest(echoCtx.Request().Context(), redirectSession.OwnDID, *verifier, modifier)
+	redirectURL, err := r.CreateAuthorizationRequest(echoCtx.Request().Context(), redirectSession.OwnDID, *verifier, modifier)
 	if err != nil {
 		return err
 	}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -107,8 +107,7 @@ func (auth *Auth) RelyingParty() oauth.RelyingParty {
 }
 
 func (auth *Auth) IAMClient() iam.Client {
-	keyResolver := resolver.DIDKeyResolver{Resolver: auth.vdrInstance.Resolver()}
-	return iam.NewClient(auth.vcr.Wallet(), keyResolver, auth.keyStore, auth.strictMode, auth.httpClientTimeout)
+	return iam.NewClient(auth.vcr.Wallet(), auth.strictMode, auth.httpClientTimeout)
 }
 
 // Configure the Auth struct by creating a validator and create an Irma server

--- a/auth/client/iam/interface.go
+++ b/auth/client/iam/interface.go
@@ -24,7 +24,6 @@ import (
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
-	"net/url"
 )
 
 // Client defines OpenID4VP client methods using the IAM OpenAPI Spec.
@@ -35,18 +34,6 @@ type Client interface {
 	AuthorizationServerMetadata(ctx context.Context, webdid did.DID) (*oauth.AuthorizationServerMetadata, error)
 	// ClientMetadata returns the metadata of the remote verifier.
 	ClientMetadata(ctx context.Context, endpoint string) (*oauth.OAuthClientMetadata, error)
-	// CreateAuthorizationRequest creates an OAuth2.0 authorizationRequest redirect URL that redirects to the authorization server.
-	// It can create both regular OAuth2 requests and OpenID4VP requests due to the RequestModifier.
-	// It's able to create an unsigned request and a signed request (JAR) based on the OAuth Server Metadata.
-	// By default, it adds the following parameters to a regular request:
-	// - client_id
-	// and to a signed request:
-	// - client_id
-	// - jwt.Issuer
-	// - jwt.Audience
-	// - nonce
-	// any of these params can be overridden by the RequestModifier.
-	CreateAuthorizationRequest(ctx context.Context, client did.DID, server did.DID, modifier RequestModifier) (*url.URL, error)
 	// PostError posts an error to the verifier. If it fails, an error is returned.
 	PostError(ctx context.Context, auth2Error oauth.OAuth2Error, verifierResponseURI string, verifierClientState string) (string, error)
 	// PostAuthorizationResponse posts the authorization response to the verifier. If it fails, an error is returned.
@@ -62,8 +49,5 @@ type Client interface {
 
 	AccessTokenOid4vci(ctx context.Context, clientId string, tokenEndpoint string, redirectUri string, code string, pkceCodeVerifier *string) (*oauth.Oid4vciTokenResponse, error)
 
-	VerifiableCredentials(ctx context.Context, credentialEndpoint string, accessToken string, cNonce *string, holderDid did.DID, audienceDid did.DID) (*CredentialResponse, error)
+	VerifiableCredentials(ctx context.Context, credentialEndpoint string, accessToken string, proofJWT string) (*CredentialResponse, error)
 }
-
-// RequestModifier is a function that modifies the claims/params of a unsigned or signed request (JWT)
-type RequestModifier func(claims map[string]interface{})

--- a/auth/client/iam/mock.go
+++ b/auth/client/iam/mock.go
@@ -11,7 +11,6 @@ package iam
 
 import (
 	context "context"
-	url "net/url"
 	reflect "reflect"
 
 	did "github.com/nuts-foundation/go-did/did"
@@ -102,21 +101,6 @@ func (m *MockClient) ClientMetadata(ctx context.Context, endpoint string) (*oaut
 func (mr *MockClientMockRecorder) ClientMetadata(ctx, endpoint any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientMetadata", reflect.TypeOf((*MockClient)(nil).ClientMetadata), ctx, endpoint)
-}
-
-// CreateAuthorizationRequest mocks base method.
-func (m *MockClient) CreateAuthorizationRequest(ctx context.Context, client, server did.DID, modifier RequestModifier) (*url.URL, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAuthorizationRequest", ctx, client, server, modifier)
-	ret0, _ := ret[0].(*url.URL)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateAuthorizationRequest indicates an expected call of CreateAuthorizationRequest.
-func (mr *MockClientMockRecorder) CreateAuthorizationRequest(ctx, client, server, modifier any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAuthorizationRequest", reflect.TypeOf((*MockClient)(nil).CreateAuthorizationRequest), ctx, client, server, modifier)
 }
 
 // OpenIdConfiguration mocks base method.
@@ -210,16 +194,16 @@ func (mr *MockClientMockRecorder) RequestRFC021AccessToken(ctx, requestHolder, v
 }
 
 // VerifiableCredentials mocks base method.
-func (m *MockClient) VerifiableCredentials(ctx context.Context, credentialEndpoint, accessToken string, cNonce *string, holderDid, audienceDid did.DID) (*CredentialResponse, error) {
+func (m *MockClient) VerifiableCredentials(ctx context.Context, credentialEndpoint, accessToken, proofJWT string) (*CredentialResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifiableCredentials", ctx, credentialEndpoint, accessToken, cNonce, holderDid, audienceDid)
+	ret := m.ctrl.Call(m, "VerifiableCredentials", ctx, credentialEndpoint, accessToken, proofJWT)
 	ret0, _ := ret[0].(*CredentialResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // VerifiableCredentials indicates an expected call of VerifiableCredentials.
-func (mr *MockClientMockRecorder) VerifiableCredentials(ctx, credentialEndpoint, accessToken, cNonce, holderDid, audienceDid any) *gomock.Call {
+func (mr *MockClientMockRecorder) VerifiableCredentials(ctx, credentialEndpoint, accessToken, proofJWT any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifiableCredentials", reflect.TypeOf((*MockClient)(nil).VerifiableCredentials), ctx, credentialEndpoint, accessToken, cNonce, holderDid, audienceDid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifiableCredentials", reflect.TypeOf((*MockClient)(nil).VerifiableCredentials), ctx, credentialEndpoint, accessToken, proofJWT)
 }

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -23,8 +23,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/lestrrat-go/jwx/v2/jwt"
+	"net/url"
+	"time"
+
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/auth/log"
@@ -34,32 +35,25 @@ import (
 	"github.com/nuts-foundation/nuts-node/http"
 	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
-	"github.com/nuts-foundation/nuts-node/vdr/resolver"
-	"net/url"
-	"time"
 )
 
 var _ Client = (*OpenID4VPClient)(nil)
 
 type OpenID4VPClient struct {
-	httpClient  HTTPClient
-	jwtSigner   nutsCrypto.JWTSigner
-	keyResolver resolver.KeyResolver
-	strictMode  bool
-	wallet      holder.Wallet
+	httpClient HTTPClient
+	strictMode bool
+	wallet     holder.Wallet
 }
 
 // NewClient returns an implementation of Holder
-func NewClient(wallet holder.Wallet, keyResolver resolver.KeyResolver, jwtSigner nutsCrypto.JWTSigner, strictMode bool, httpClientTimeout time.Duration) *OpenID4VPClient {
+func NewClient(wallet holder.Wallet, strictMode bool, httpClientTimeout time.Duration) *OpenID4VPClient {
 	return &OpenID4VPClient{
 		httpClient: HTTPClient{
 			strictMode: strictMode,
 			httpClient: core.NewStrictHTTPClient(strictMode, httpClientTimeout, nil),
 		},
-		keyResolver: keyResolver,
-		jwtSigner:   jwtSigner,
-		strictMode:  strictMode,
-		wallet:      wallet,
+		strictMode: strictMode,
+		wallet:     wallet,
 	}
 }
 
@@ -155,66 +149,6 @@ func (c *OpenID4VPClient) AccessToken(ctx context.Context, code string, verifier
 	return &token, nil
 }
 
-func (c *OpenID4VPClient) CreateAuthorizationRequest(ctx context.Context, client did.DID, server did.DID, modifier RequestModifier) (*url.URL, error) {
-	// we want to make a call according to §4.1.1 of RFC6749, https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.1
-	// The URL should be listed in the verifier metadata under the "authorization_endpoint" key
-	iamClient := c.httpClient
-	metadata, err := iamClient.OAuthAuthorizationServerMetadata(ctx, server)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve remote OAuth Authorization Server metadata: %w", err)
-	}
-	if len(metadata.AuthorizationEndpoint) == 0 {
-		return nil, fmt.Errorf("no authorization endpoint found in metadata for %s", server)
-	}
-	endpoint, err := url.Parse(metadata.AuthorizationEndpoint)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse authorization endpoint URL: %w", err)
-	}
-	// one default param for both signed and unsigned
-	params := map[string]interface{}{
-		oauth.ClientIDParam: client.String(),
-	}
-	// use JAR (JWT Authorization Request, RFC9101) if the verifier supports/requires it
-	if metadata.RequireSignedRequestObject {
-		// construct JWT
-		// first get a valid keyID from the vdr.KeyResolver
-		keyId, _, err := c.keyResolver.ResolveKey(client, nil, resolver.AssertionMethod)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve key for signing authorization request: %w", err)
-		}
-		// default claims for JAR
-		params[jwt.IssuerKey] = client.String()
-		params[jwt.AudienceKey] = server.String()
-		params[oauth.ClientIDParam] = client.String()
-		// added by default, can be overriden by the caller
-		params[oauth.NonceParam] = nutsCrypto.GenerateNonce()
-
-		// additional claims can be added by the caller
-		modifier(params)
-
-		token, err := c.jwtSigner.SignJWT(ctx, params, nil, keyId.String())
-		if err != nil {
-			return nil, fmt.Errorf("failed to sign authorization request: %w", err)
-		}
-		redirectURL := http.AddQueryParams(*endpoint, map[string]string{
-			oauth.ClientIDParam: client.String(),
-			oauth.RequestParam:  token,
-		})
-		return &redirectURL, nil
-	}
-	// else return an unsigned regular authorization request
-	// left here for completeness, node 2 node interaction always uses JAR since the AS metadata has it hardcoded
-
-	// additional claims can be added by the caller
-	modifier(params)
-	stringParams := make(map[string]string)
-	for k, v := range params {
-		stringParams[k] = fmt.Sprintf("%v", v)
-	}
-	redirectURL := http.AddQueryParams(*endpoint, stringParams)
-	return &redirectURL, nil
-}
-
 func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, requester did.DID, verifier did.DID, scopes string) (*oauth.TokenResponse, error) {
 	iamClient := c.httpClient
 	metadata, err := iamClient.OAuthAuthorizationServerMetadata(ctx, verifier)
@@ -240,7 +174,7 @@ func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, requeste
 		Expires:  time.Now().Add(time.Second * 5),
 		Nonce:    nutsCrypto.GenerateNonce(),
 	}
-	vp, submission, err := c.wallet.BuildSubmission(ctx, requester, *presentationDefinition, metadata.VPFormats, params)
+	vp, submission, err := c.wallet.BuildSubmission(ctx, requester, *presentationDefinition, metadata.VPFormatsSupported, params)
 	if err != nil {
 		return nil, err
 	}
@@ -305,37 +239,9 @@ func (c *OpenID4VPClient) AccessTokenOid4vci(ctx context.Context, clientId strin
 	return rsp, nil
 }
 
-func (c *OpenID4VPClient) proofJwt(ctx context.Context, holderDid did.DID, audienceDid did.DID, nonce *string) (string, error) {
-	kid, _, err := c.keyResolver.ResolveKey(holderDid, nil, resolver.NutsSigningKeyType)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve key for did (%s): %w", holderDid.String(), err)
-	}
-	jti, err := uuid.NewUUID()
-	if err != nil {
-		return "", err
-	}
-	claims := map[string]interface{}{
-		"iss": holderDid.String(),
-		"aud": audienceDid.String(),
-		"jti": jti.String(),
-	}
-	if nonce != nil {
-		claims["nonce"] = nonce
-	}
-	proofJwt, err := c.jwtSigner.SignJWT(ctx, claims, nil, kid.String())
-	if err != nil {
-		return "", fmt.Errorf("failed to sign the JWT with kid (%s): %w", kid.String(), err)
-	}
-	return proofJwt, nil
-}
-func (c *OpenID4VPClient) VerifiableCredentials(ctx context.Context, credentialEndpoint string, accessToken string, cNonce *string, holderDid did.DID, audienceDid did.DID) (*CredentialResponse, error) {
-	// The cNonce becomes the nonce in the JWT proof of possession.
-	proofJwt, err := c.proofJwt(ctx, holderDid, audienceDid, cNonce)
-	if err != nil {
-		return nil, err
-	}
+func (c *OpenID4VPClient) VerifiableCredentials(ctx context.Context, credentialEndpoint string, accessToken string, proofJWT string) (*CredentialResponse, error) {
 	iamClient := c.httpClient
-	rsp, err := iamClient.VerifiableCredentials(ctx, credentialEndpoint, accessToken, proofJwt)
+	rsp, err := iamClient.VerifiableCredentials(ctx, credentialEndpoint, accessToken, proofJWT)
 	if err != nil {
 		return nil, fmt.Errorf("remote server: failed to retrieve credentials: %w", err)
 	}

--- a/auth/client/iam/openid4vp_test.go
+++ b/auth/client/iam/openid4vp_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/core"
 	"net/http"
@@ -30,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lestrrat-go/jwx/v2/jwt"
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
@@ -205,104 +203,6 @@ func TestIAMClient_AuthorizationServerMetadata(t *testing.T) {
 	})
 }
 
-func TestIAMClient_AuthorizationRequest(t *testing.T) {
-	walletDID := did.MustParseDID("did:web:test.test:iam:123")
-	modifier := func(values map[string]interface{}) {
-		values["custom"] = "value"
-	}
-
-	t.Run("JAR", func(t *testing.T) {
-		keyId := walletDID.URI()
-		keyId.Fragment = "1"
-		privKey := crypto.NewTestKey(keyId.String())
-
-		t.Run("ok", func(t *testing.T) {
-			ctx := createClientServerTestContext(t)
-			ctx.keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.NutsSigningKeyType).Return(keyId, privKey.Public(), nil)
-			ctx.jwtSigner.EXPECT().SignJWT(gomock.Any(), gomock.Any(), nil, gomock.Any()).DoAndReturn(func(_ context.Context, claims map[string]interface{}, _ interface{}, key string) (string, error) {
-				assert.Equal(t, keyId.String(), key)
-				assert.Equal(t, walletDID.String(), claims[jwt.IssuerKey])
-				assert.Equal(t, ctx.verifierDID.String(), claims[jwt.AudienceKey])
-				assert.Equal(t, walletDID.String(), claims[oauth.ClientIDParam])
-				assert.Equal(t, "value", claims["custom"])
-				assert.NotEmpty(t, claims[oauth.NonceParam])
-				return "signed JWT", nil
-			})
-			redirectURL, err := ctx.client.CreateAuthorizationRequest(context.Background(), walletDID, ctx.verifierDID, modifier)
-
-			assert.NoError(t, err)
-			require.NotNil(t, redirectURL)
-			assert.Equal(t, "signed JWT", redirectURL.Query().Get(oauth.RequestParam))
-			assert.Equal(t, walletDID.String(), redirectURL.Query().Get(oauth.ClientIDParam))
-		})
-		t.Run("error - failed to sign JWT", func(t *testing.T) {
-			ctx := createClientServerTestContext(t)
-			ctx.authzServerMetadata.RequireSignedRequestObject = true
-			ctx.keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.NutsSigningKeyType).Return(keyId, privKey.Public(), nil)
-			ctx.jwtSigner.EXPECT().SignJWT(gomock.Any(), gomock.Any(), nil, gomock.Any()).Return("", assert.AnError)
-
-			redirectURL, err := ctx.client.CreateAuthorizationRequest(context.Background(), walletDID, ctx.verifierDID, modifier)
-
-			assert.Error(t, err)
-			assert.Empty(t, redirectURL)
-		})
-		t.Run("error - failed to resolve key", func(t *testing.T) {
-			ctx := createClientServerTestContext(t)
-			ctx.authzServerMetadata.RequireSignedRequestObject = true
-			ctx.keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.NutsSigningKeyType).Return(keyId, nil, resolver.ErrKeyNotFound)
-
-			redirectURL, err := ctx.client.CreateAuthorizationRequest(context.Background(), walletDID, ctx.verifierDID, modifier)
-
-			assert.Error(t, err)
-			assert.Empty(t, redirectURL)
-		})
-	})
-	t.Run("non-JAR", func(t *testing.T) {
-		t.Run("ok", func(t *testing.T) {
-			ctx := createClientServerTestContext(t)
-			ctx.authzServerMetadata.RequireSignedRequestObject = false
-
-			redirectURL, err := ctx.client.CreateAuthorizationRequest(context.Background(), walletDID, ctx.verifierDID, modifier)
-
-			assert.NoError(t, err)
-			require.NotNil(t, redirectURL)
-			assert.Equal(t, walletDID.String(), redirectURL.Query().Get("client_id"))
-			assert.Equal(t, "value", redirectURL.Query().Get("custom"))
-		})
-		t.Run("error - failed to get authorization server metadata", func(t *testing.T) {
-			ctx := createClientServerTestContext(t)
-			ctx.metadata = nil
-
-			_, err := ctx.client.CreateAuthorizationRequest(context.Background(), walletDID, ctx.verifierDID, modifier)
-
-			assert.Error(t, err)
-			assert.EqualError(t, err, "failed to retrieve remote OAuth Authorization Server metadata: server returned HTTP 404 (expected: 200)")
-		})
-		t.Run("error - faulty authorization server metadata", func(t *testing.T) {
-			ctx := createClientServerTestContext(t)
-			ctx.metadata = func(writer http.ResponseWriter) {
-				writer.Header().Add("Content-Type", "application/json")
-				writer.WriteHeader(http.StatusOK)
-				_, _ = writer.Write([]byte("{"))
-			}
-
-			_, err := ctx.client.CreateAuthorizationRequest(context.Background(), walletDID, ctx.verifierDID, modifier)
-
-			assert.Error(t, err)
-			assert.EqualError(t, err, "failed to retrieve remote OAuth Authorization Server metadata: unable to unmarshal response: unexpected end of JSON input, {")
-		})
-		t.Run("error - missing authorization endpoint", func(t *testing.T) {
-			ctx := createClientServerTestContext(t)
-			ctx.authzServerMetadata.AuthorizationEndpoint = ""
-
-			_, err := ctx.client.CreateAuthorizationRequest(context.Background(), walletDID, ctx.verifierDID, modifier)
-
-			assert.Error(t, err)
-			assert.ErrorContains(t, err, "no authorization endpoint found in metadata for")
-		})
-	})
-}
-
 func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 	walletDID := did.MustParseDID("did:test:123")
 	scopes := "first second"
@@ -395,9 +295,7 @@ func createClientTestContext(t *testing.T, tlsConfig *tls.Config) *clientTestCon
 		audit: audit.TestContext(),
 		ctrl:  ctrl,
 		client: &OpenID4VPClient{
-			jwtSigner:   jwtSigner,
-			keyResolver: keyResolver,
-			wallet:      wallet,
+			wallet: wallet,
 			httpClient: HTTPClient{
 				strictMode: false,
 				httpClient: core.NewStrictHTTPClient(false, 10*time.Second, tlsConfig),
@@ -437,8 +335,8 @@ type clientServerTestContext struct {
 }
 
 func createClientServerTestContext(t *testing.T) *clientServerTestContext {
-	metadata := &oauth.AuthorizationServerMetadata{VPFormats: oauth.DefaultOpenIDSupportedFormats()}
 	credentialIssuerMetadata := &oauth.OpenIDCredentialIssuerMetadata{}
+	metadata := &oauth.AuthorizationServerMetadata{VPFormatsSupported: oauth.DefaultOpenIDSupportedFormats()}
 	ctx := &clientServerTestContext{
 		clientTestContext: createClientTestContext(t, nil),
 		metadata: func(writer http.ResponseWriter) {
@@ -633,27 +531,16 @@ func TestIAMClient_AccessTokenOid4vci(t *testing.T) {
 	})
 }
 func TestIAMClient_VerifiableCredentials(t *testing.T) {
-	walletDID := did.MustParseDID("did:web:test.test:iam:123")
+	//walletDID := did.MustParseDID("did:web:test.test:iam:123")
 	accessToken := "code"
-	cNonce := crypto.GenerateNonce()
+	//cNonce := crypto.GenerateNonce()
+
+	proowJWT := "top secret"
 
 	t.Run("ok", func(t *testing.T) {
-		keyId := walletDID.URI()
-		keyId.Fragment = "1"
-		privKey := crypto.NewTestKey(keyId.String())
-
 		ctx := createClientServerTestContext(t)
 
-		ctx.keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.NutsSigningKeyType).Return(keyId, privKey.Public(), nil)
-		ctx.jwtSigner.EXPECT().SignJWT(gomock.Any(), gomock.Any(), nil, gomock.Any()).DoAndReturn(func(_ context.Context, claims map[string]interface{}, _ interface{}, key string) (string, error) {
-			assert.Equal(t, keyId.String(), key)
-			assert.Equal(t, walletDID.String(), claims[jwt.IssuerKey])
-			assert.Equal(t, ctx.issuerDID.String(), claims[jwt.AudienceKey])
-			assert.NotEmpty(t, claims[jwt.JwtIDKey])
-			return "signed JWT", nil
-		})
-
-		response, err := ctx.client.VerifiableCredentials(context.Background(), ctx.openIDCredentialIssuerMetadata.CredentialEndpoint, accessToken, &cNonce, walletDID, ctx.issuerDID)
+		response, err := ctx.client.VerifiableCredentials(context.Background(), ctx.openIDCredentialIssuerMetadata.CredentialEndpoint, accessToken, proowJWT)
 
 		require.NoError(t, err)
 		require.NotNil(t, response)
@@ -661,43 +548,17 @@ func TestIAMClient_VerifiableCredentials(t *testing.T) {
 		assert.Equal(t, "format", response.Format)
 	})
 	t.Run("error - failed to get access token", func(t *testing.T) {
-		keyId := walletDID.URI()
-		keyId.Fragment = "1"
-		privKey := crypto.NewTestKey(keyId.String())
-
 		ctx := createClientServerTestContext(t)
-
-		ctx.keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.NutsSigningKeyType).Return(keyId, privKey.Public(), nil)
-		ctx.jwtSigner.EXPECT().SignJWT(gomock.Any(), gomock.Any(), nil, gomock.Any()).DoAndReturn(func(_ context.Context, claims map[string]interface{}, _ interface{}, key string) (string, error) {
-			assert.Equal(t, keyId.String(), key)
-			assert.Equal(t, walletDID.String(), claims[jwt.IssuerKey])
-			assert.Equal(t, ctx.issuerDID.String(), claims[jwt.AudienceKey])
-			assert.NotEmpty(t, claims[jwt.JwtIDKey])
-			return "signed JWT", nil
-		})
 
 		ctx.credentials = nil
 
-		response, err := ctx.client.VerifiableCredentials(context.Background(), ctx.openIDCredentialIssuerMetadata.CredentialEndpoint, accessToken, &cNonce, walletDID, ctx.issuerDID)
+		response, err := ctx.client.VerifiableCredentials(context.Background(), ctx.openIDCredentialIssuerMetadata.CredentialEndpoint, accessToken, proowJWT)
 
 		assert.EqualError(t, err, "remote server: failed to retrieve credentials: server returned HTTP 404 (expected: 200)")
 		assert.Nil(t, response)
 	})
 	t.Run("error - invalid access token", func(t *testing.T) {
-		keyId := walletDID.URI()
-		keyId.Fragment = "1"
-		privKey := crypto.NewTestKey(keyId.String())
-
 		ctx := createClientServerTestContext(t)
-
-		ctx.keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.NutsSigningKeyType).Return(keyId, privKey.Public(), nil)
-		ctx.jwtSigner.EXPECT().SignJWT(gomock.Any(), gomock.Any(), nil, gomock.Any()).DoAndReturn(func(_ context.Context, claims map[string]interface{}, _ interface{}, key string) (string, error) {
-			assert.Equal(t, keyId.String(), key)
-			assert.Equal(t, walletDID.String(), claims[jwt.IssuerKey])
-			assert.Equal(t, ctx.issuerDID.String(), claims[jwt.AudienceKey])
-			assert.NotEmpty(t, claims[jwt.JwtIDKey])
-			return "signed JWT", nil
-		})
 
 		ctx.credentials = func(writer http.ResponseWriter) {
 			writer.Header().Add("Content-Type", "application/json")
@@ -706,41 +567,9 @@ func TestIAMClient_VerifiableCredentials(t *testing.T) {
 			return
 		}
 
-		response, err := ctx.client.VerifiableCredentials(context.Background(), ctx.openIDCredentialIssuerMetadata.CredentialEndpoint, accessToken, &cNonce, walletDID, ctx.issuerDID)
+		response, err := ctx.client.VerifiableCredentials(context.Background(), ctx.openIDCredentialIssuerMetadata.CredentialEndpoint, accessToken, proowJWT)
 
 		assert.Error(t, err)
-		assert.Nil(t, response)
-	})
-	t.Run("error - key not found", func(t *testing.T) {
-		keyId := walletDID.URI()
-		keyId.Fragment = "1"
-
-		ctx := createClientServerTestContext(t)
-
-		ctx.keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.NutsSigningKeyType).Return(ssi.URI{}, nil, resolver.ErrKeyNotFound)
-
-		ctx.credentials = nil
-
-		response, err := ctx.client.VerifiableCredentials(context.Background(), ctx.openIDCredentialIssuerMetadata.CredentialEndpoint, accessToken, &cNonce, walletDID, ctx.issuerDID)
-
-		assert.EqualError(t, err, "failed to resolve key for did (did:web:test.test:iam:123): "+resolver.ErrKeyNotFound.Error())
-		assert.Nil(t, response)
-	})
-	t.Run("error - signature failure", func(t *testing.T) {
-		keyId := walletDID.URI()
-		keyId.Fragment = "1"
-		privKey := crypto.NewTestKey(keyId.String())
-
-		ctx := createClientServerTestContext(t)
-
-		ctx.keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.NutsSigningKeyType).Return(keyId, privKey.Public(), nil)
-		ctx.jwtSigner.EXPECT().SignJWT(gomock.Any(), gomock.Any(), nil, gomock.Any()).DoAndReturn(func(_ context.Context, claims map[string]interface{}, _ interface{}, key string) (string, error) {
-			return "", errors.New("signature failed")
-		})
-
-		response, err := ctx.client.VerifiableCredentials(context.Background(), ctx.openIDCredentialIssuerMetadata.CredentialEndpoint, accessToken, &cNonce, walletDID, ctx.issuerDID)
-
-		assert.EqualError(t, err, "failed to sign the JWT with kid (did:web:test.test:iam:123#1): signature failed")
 		assert.Nil(t, response)
 	})
 }

--- a/auth/oauth/error.go
+++ b/auth/oauth/error.go
@@ -51,9 +51,13 @@ const (
 	// ServerError is returned when the Authorization Server encounters an unexpected condition that prevents it from fulfilling the request.
 	ServerError ErrorCode = "server_error"
 	// InvalidScope is returned when the requested scope is invalid, unknown or malformed.
-	InvalidScope = ErrorCode("invalid_scope")
+	InvalidScope ErrorCode = "invalid_scope"
 	// InvalidPresentationDefinitionURI is returned when the requested presentation definition URI is invalid or can't be reached.
-	InvalidPresentationDefinitionURI = ErrorCode("invalid_presentation_definition_uri")
+	InvalidPresentationDefinitionURI ErrorCode = "invalid_presentation_definition_uri"
+	// InvalidRequestObject is returned when the JAR Request Object signature validation or decryption fails. RFC9101
+	InvalidRequestObject ErrorCode = "invalid_request_object"
+	// InvalidRequestURI is returned whn the request_uri in the authorization request returns an error or contains invalid data. RFC9101
+	InvalidRequestURI ErrorCode = "invalid_request_uri"
 )
 
 // Make sure the error implements core.HTTPStatusCodeError, so the HTTP request logger can log the correct status code.

--- a/auth/oauth/jwx_es256k.go
+++ b/auth/oauth/jwx_es256k.go
@@ -23,5 +23,5 @@ package oauth
 import "github.com/lestrrat-go/jwx/v2/jwa"
 
 func init() {
-	algValuesSupported = append(algValuesSupported, jwa.ES256K.String())
+	AlgValuesSupported = append(AlgValuesSupported, jwa.ES256K.String())
 }

--- a/auth/oauth/openid.go
+++ b/auth/oauth/openid.go
@@ -18,10 +18,10 @@
 
 package oauth
 
-// algValuesSupported contains a list of supported cipher suites for jwt_vc_json & jwt_vp_json presentation formats
+// AlgValuesSupported contains a list of supported cipher suites for jwt_vc_json & jwt_vp_json presentation formats
 // Recommended list of options https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms
 // TODO: validate list, should reflect current recommendations from https://www.ncsc.nl
-var algValuesSupported = []string{"PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}
+var AlgValuesSupported = []string{"PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}
 
 // proofTypeValuesSupported contains a list of supported cipher suites for ldp_vc & ldp_vp presentation formats
 // Recommended list of options https://w3c-ccg.github.io/ld-cryptosuite-registry/
@@ -35,8 +35,8 @@ var proofTypeValuesSupported = []string{"JsonWebSignature2020"}
 // See https://github.com/nuts-foundation/nuts-node/issues/2447
 func DefaultOpenIDSupportedFormats() map[string]map[string][]string {
 	return map[string]map[string][]string{
-		"jwt_vp_json": {"alg_values_supported": algValuesSupported},
-		"jwt_vc_json": {"alg_values_supported": algValuesSupported},
+		"jwt_vp_json": {"alg_values_supported": AlgValuesSupported},
+		"jwt_vc_json": {"alg_values_supported": AlgValuesSupported},
 		"ldp_vc":      {"proof_type_values_supported": proofTypeValuesSupported},
 		"ldp_vp":      {"proof_type_values_supported": proofTypeValuesSupported},
 	}

--- a/auth/oauth/types.go
+++ b/auth/oauth/types.go
@@ -76,8 +76,10 @@ const (
 	MaxAgeParam = "max_age"
 	// RedirectURIParam is the parameter name for the redirect_uri parameter
 	RedirectURIParam = "redirect_uri"
-	// RequestParam is the parameter name for the request parameter
+	// RequestParam is the parameter name for the request parameter.	Defined in RFC9101
 	RequestParam = "request"
+	// RequestURIParam is the parameter name for the request parameter. Defined in RFC9101
+	RequestURIParam = "request_uri"
 	// ResponseTypeParam is the parameter name for the response_type parameter
 	ResponseTypeParam = "response_type"
 	// ScopeParam is the parameter name for the scope parameter
@@ -165,18 +167,25 @@ type AuthorizationServerMetadata struct {
 	// If omitted, the default value is true. (hence pointer, or add custom unmarshalling)
 	PresentationDefinitionUriSupported *bool `json:"presentation_definition_uri_supported,omitempty"`
 
-	// RequireSignedRequestObject specifies if the authorization server requires the use of signed request objects.
-	RequireSignedRequestObject bool `json:"require_signed_request_object,omitempty"`
-
 	// VPFormatsSupported is an object containing a list of key value pairs, where the key is a string identifying a Credential format supported by the Wallet.
 	VPFormatsSupported map[string]map[string][]string `json:"vp_formats_supported,omitempty"`
 
 	// VPFormats is an object containing a list of key value pairs, where the key is a string identifying a Credential format supported by the Verifier.
+	// TODO: Remove. VPFormatsSupported is the correct param, but the OpenID4VP spec is ambiguous so support both for now.
 	VPFormats map[string]map[string][]string `json:"vp_formats,omitempty"`
 
 	// ClientIdSchemesSupported defines the `client_id_schemes` currently supported.
 	// If omitted, the default value is `pre-registered` (referring to the client), which is currently not supported.
 	ClientIdSchemesSupported []string `json:"client_id_schemes_supported,omitempty"`
+
+	/* ******** JWT-Secured Authorization Request RFC9101 & OpenID Connect Core v1.0: §6. Passing Request Parameters as JWTs ******** */
+
+	// RequireSignedRequestObject specifies if the authorization server requires the use of signed request objects.
+	RequireSignedRequestObject bool `json:"require_signed_request_object,omitempty"`
+
+	// RequestObjectSigningAlgValuesSupported is a JSON array containing a list of the JWS signing algorithms (alg values) supported by the OP for Request Objects, which are described in Section 6.1 of OpenID Connect Core 1.0 [OpenID.Core].
+	// These algorithms are used both when the Request Object is passed by value (using the request parameter) and when it is passed by reference (using the request_uri parameter).
+	RequestObjectSigningAlgValuesSupported []string `json:"request_object_signing_alg_values_supported,omitempty"`
 }
 
 // OAuthClientMetadata defines the OAuth Client metadata.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -222,7 +222,7 @@ func CreateSystem(shutdownCallback context.CancelFunc) *core.System {
 	system.RegisterRoutes(statusEngine.(core.Routable))
 	system.RegisterRoutes(metricsEngine.(core.Routable))
 	system.RegisterRoutes(&authAPIv1.Wrapper{Auth: authInstance, CredentialResolver: credentialInstance})
-	system.RegisterRoutes(authIAMAPI.New(authInstance, credentialInstance, vdrInstance, storageInstance, policyInstance))
+	system.RegisterRoutes(authIAMAPI.New(authInstance, credentialInstance, vdrInstance, storageInstance, policyInstance, cryptoInstance))
 	system.RegisterRoutes(&authMeansAPI.Wrapper{Auth: authInstance})
 	system.RegisterRoutes(&didmanAPI.Wrapper{Didman: didmanInstance})
 	system.RegisterRoutes(&discoveryAPI.Wrapper{Client: discoveryInstance})


### PR DESCRIPTION
cleanup in preparation of #2712 
This change is needed since JAR with a `request_uri` will require storing some state. This belongs in the server and not he client.

also contains some bug fixes and cleanup that got squashed into 1 commit by accident after a rebase