### PR TITLE
VCR: Sign through key ID instead of crypto.Key

### DIFF
--- a/auth/services/selfsigned/test/generate_test.go
+++ b/auth/services/selfsigned/test/generate_test.go
@@ -53,7 +53,7 @@ func Test_GenerateTestData(t *testing.T) {
 	}
 	cryptoStorage := crypto.NewMemoryStorage()
 	cryptoInstance := crypto.NewTestCryptoInstance(cryptoStorage)
-	err = cryptoStorage.SavePrivateKey(context.Background(), keyID, key)
+	err = cryptoStorage.SavePrivateKey(context.Background(), keyID, key.PrivateKey)
 	require.NoError(t, err)
 
 	jws2020 := signature.JSONWebSignature2020{ContextLoader: contextLoader, Signer: cryptoInstance}
@@ -75,7 +75,7 @@ func Test_GenerateTestData(t *testing.T) {
 		}
 		ldProof := proof.NewLDProof(pOptions)
 
-		signedVC, err = ldProof.Sign(audit.TestContext(), document, jws2020, key)
+		signedVC, err = ldProof.Sign(audit.TestContext(), document, jws2020, keyID)
 		require.NoError(t, err)
 		data, err = json.MarshalIndent(signedVC, "", "  ")
 		require.NoError(t, err)
@@ -105,7 +105,7 @@ func Test_GenerateTestData(t *testing.T) {
 		}
 		ldProof := proof.NewLDProof(pOptions)
 
-		result, err := ldProof.Sign(audit.TestContext(), document, jws2020, key)
+		result, err := ldProof.Sign(audit.TestContext(), document, jws2020, keyID)
 		require.NoError(t, err)
 		data, err = json.MarshalIndent(result, "", "  ")
 		require.NoError(t, err)

--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -276,7 +276,7 @@ func (i issuer) buildJSONLDCredential(ctx context.Context, unsignedCredential vc
 	proofOptions := proof.ProofOptions{Created: unsignedCredential.IssuanceDate}
 
 	webSig := signature.JSONWebSignature2020{ContextLoader: i.jsonldManager.DocumentLoader(), Signer: i.keyStore}
-	signingResult, err := proof.NewLDProof(proofOptions).Sign(ctx, credentialAsMap, webSig, key)
+	signingResult, err := proof.NewLDProof(proofOptions).Sign(ctx, credentialAsMap, webSig, key.KID())
 	if err != nil {
 		return nil, err
 	}
@@ -397,7 +397,7 @@ func (i issuer) buildRevocation(ctx context.Context, credentialID ssi.URI) (*cre
 
 	ldProof := proof.NewLDProof(proof.ProofOptions{Created: TimeFunc()})
 	webSig := signature.JSONWebSignature2020{ContextLoader: i.jsonldManager.DocumentLoader(), Signer: i.keyStore}
-	signingResult, err := ldProof.Sign(ctx, revocationAsMap, webSig, assertionKey)
+	signingResult, err := ldProof.Sign(ctx, revocationAsMap, webSig, assertionKey.KID())
 	if err != nil {
 		return nil, err
 	}

--- a/vcr/signature/json_web_signature.go
+++ b/vcr/signature/json_web_signature.go
@@ -37,10 +37,10 @@ type JSONWebSignature2020 struct {
 }
 
 // Sign signs the document as a JWS.
-func (s JSONWebSignature2020) Sign(ctx context.Context, doc []byte, key crypto.Key) ([]byte, error) {
+func (s JSONWebSignature2020) Sign(ctx context.Context, doc []byte, keyID string) ([]byte, error) {
 	headers := detachedJWSHeaders()
-	headers[jws.KeyIDKey] = key.KID()
-	sig, err := s.Signer.SignJWS(ctx, doc, headers, key, true)
+	headers[jws.KeyIDKey] = keyID
+	sig, err := s.Signer.SignJWS(ctx, doc, headers, keyID, true)
 	return []byte(sig), err
 }
 

--- a/vcr/signature/mock.go
+++ b/vcr/signature/mock.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 
 	ssi "github.com/nuts-foundation/go-did"
-	crypto "github.com/nuts-foundation/nuts-node/crypto"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -85,16 +84,16 @@ func (mr *MockSuiteMockRecorder) GetType() *gomock.Call {
 }
 
 // Sign mocks base method.
-func (m *MockSuite) Sign(ctx context.Context, doc []byte, key crypto.Key) ([]byte, error) {
+func (m *MockSuite) Sign(ctx context.Context, doc []byte, keyID string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Sign", ctx, doc, key)
+	ret := m.ctrl.Call(m, "Sign", ctx, doc, keyID)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Sign indicates an expected call of Sign.
-func (mr *MockSuiteMockRecorder) Sign(ctx, doc, key any) *gomock.Call {
+func (mr *MockSuiteMockRecorder) Sign(ctx, doc, keyID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockSuite)(nil).Sign), ctx, doc, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockSuite)(nil).Sign), ctx, doc, keyID)
 }

--- a/vcr/signature/proof/jsonld.go
+++ b/vcr/signature/proof/jsonld.go
@@ -150,7 +150,7 @@ func (p LDProof) Verify(document Document, suite signature.Suite, key crypto.Pub
 
 // Sign signs the provided document with this proof and a signature suite and signer.
 // It returns the complete signed JSON-LD document
-func (p *LDProof) Sign(ctx context.Context, document Document, suite signature.Suite, key nutsCrypto.Key) (interface{}, error) {
+func (p *LDProof) Sign(ctx context.Context, document Document, suite signature.Suite, keyID string) (interface{}, error) {
 	p.Type = suite.GetType()
 	if len(p.ProofPurpose) == 0 {
 		p.ProofPurpose = AssertionMethodProofPurpose
@@ -158,7 +158,7 @@ func (p *LDProof) Sign(ctx context.Context, document Document, suite signature.S
 	if p.Created.IsZero() {
 		p.Created = time.Now()
 	}
-	p.VerificationMethod = ssi.MustParseURI(key.KID())
+	p.VerificationMethod = ssi.MustParseURI(keyID)
 
 	canonicalDocument, err := suite.CanonicalizeDocument(document)
 	if err != nil {
@@ -177,7 +177,7 @@ func (p *LDProof) Sign(ctx context.Context, document Document, suite signature.S
 
 	tbs := append(suite.CalculateDigest(canonicalProof), suite.CalculateDigest(canonicalDocument)...)
 
-	sig, err := suite.Sign(ctx, tbs, key)
+	sig, err := suite.Sign(ctx, tbs, keyID)
 	if err != nil {
 		return nil, fmt.Errorf("error while signing: %w", err)
 	}

--- a/vcr/signature/proof/proof.go
+++ b/vcr/signature/proof/proof.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"crypto"
 	"encoding/json"
-	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/vcr/signature"
 )
 
@@ -71,7 +70,7 @@ func (d SignedDocument) UnmarshalProofValue(target interface{}) error {
 // Proof is the interface that defines a set of methods which a proof should implement.
 type Proof interface {
 	// Sign defines the basic signing operation on the proof.
-	Sign(ctx context.Context, document Document, suite signature.Suite, key nutsCrypto.Key) (interface{}, error)
+	Sign(ctx context.Context, document Document, suite signature.Suite, keyID string) (interface{}, error)
 }
 
 // ProofVerifier defines the generic verifier interface

--- a/vcr/signature/signature.go
+++ b/vcr/signature/signature.go
@@ -21,7 +21,6 @@ package signature
 import (
 	"context"
 	ssi "github.com/nuts-foundation/go-did"
-	"github.com/nuts-foundation/nuts-node/crypto"
 )
 
 // W3idSecurityV1Context defines the v1 of the w3id json-ld context
@@ -35,7 +34,7 @@ var JSONWebSignature2020Context = ssi.MustParseURI("https://w3c-ccg.github.io/ld
 
 // Suite is an interface which defines the methods a signature suite implementation should implement.
 type Suite interface {
-	Sign(ctx context.Context, doc []byte, key crypto.Key) ([]byte, error)
+	Sign(ctx context.Context, doc []byte, keyID string) ([]byte, error)
 	CanonicalizeDocument(doc interface{}) ([]byte, error)
 	CalculateDigest(doc []byte) []byte
 	GetType() ssi.ProofType


### PR DESCRIPTION
Because resolving `crypto.Key` requires another roundtrip to `KeyStore.Resolve`, which is done again when actually signing. So it only adds extra dependencies to functions that want to sign VCs.

Required by https://github.com/nuts-foundation/nuts-node/pull/3009