### PR TITLE
RFC9101 request_uri

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -881,6 +881,7 @@ func (r Wrapper) CreateAuthorizationRequest(ctx context.Context, client did.DID,
 			return nil, fmt.Errorf("failed to resolve key for signing authorization request: %w", err)
 		}
 		requestObjectParams := createRequestObject(client, server, modifier)
+		// TODO: signature type produced here must be in metadata.RequestObjectSigningAlgValuesSupported
 		token, err := r.jwtSigner.SignJWT(ctx, requestObjectParams, nil, keyId.String())
 		if err != nil {
 			return nil, fmt.Errorf("failed to sign authorization request: %w", err)

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -289,23 +289,6 @@ func (r Wrapper) IntrospectAccessToken(_ context.Context, request IntrospectAcce
 	return response, nil
 }
 
-// toAnyMap marshals and unmarshals input into *map[string]any. Useful to generate OAPI response objects.
-func toAnyMap(input any) (*map[string]any, error) {
-	if input == nil {
-		return nil, nil
-	}
-	bs, err := json.Marshal(input)
-	if err != nil {
-		return nil, err
-	}
-	result := make(map[string]any)
-	err = json.Unmarshal(bs, &result)
-	if err != nil {
-		return nil, err
-	}
-	return &result, nil
-}
-
 // HandleAuthorizeRequest handles calls to the authorization endpoint for starting an authorization code flow.
 func (r Wrapper) HandleAuthorizeRequest(ctx context.Context, request HandleAuthorizeRequestRequestObject) (HandleAuthorizeRequestResponseObject, error) {
 	ownDID, err := r.toOwnedDIDForOAuth2(ctx, request.Did)
@@ -371,6 +354,21 @@ func (r Wrapper) HandleAuthorizeRequest(ctx context.Context, request HandleAutho
 			RedirectURI: redirectURI,
 		}
 	}
+}
+
+// GetRequestJWT returns the Request Object referenced as 'request_uri' in an authorization request.
+// RFC9101: The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR).
+func (r Wrapper) GetRequestJWT(ctx context.Context, request GetRequestJWTRequestObject) (GetRequestJWTResponseObject, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+// PostRequestJWT returns the Request Object referenced as 'request_uri' in an authorization request.
+// Extension of OpenID 4 Verifiable Presentations (OpenID4VP) on
+// RFC9101: The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR).
+func (r Wrapper) PostRequestJWT(ctx context.Context, request PostRequestJWTRequestObject) (PostRequestJWTResponseObject, error) {
+	//TODO implement me
+	panic("implement me")
 }
 
 // validateJARRequest validates a JAR (JWT Authorization Request) and returns the JWT claims.

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -343,7 +344,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 		bytes, err := createSignedRequestObject(t, key, requestParams)
 		require.NoError(t, err)
 
-		expectedURL := "https://example.com/authorize?client_id=did%3Aweb%3Aexample.com%3Aiam%3Averifier&request=valid-token"
+		expectedURL := "https://example.com/authorize?client_id=did%3Aweb%3Aexample.com%3Aiam%3Averifier&request_uri=https://example.com/oauth2/request.jwt/"
 		ctx.vdr.EXPECT().IsOwner(gomock.Any(), verifierDID).Return(true, nil)
 		ctx.vdr.EXPECT().Resolve(holderDID, gomock.Any()).Return(&didDocument, &resolver.DocumentMetadata{}, nil)
 		ctx.policy.EXPECT().PresentationDefinitions(gomock.Any(), verifierDID, "test").Return(pe.WalletOwnerMapping{pe.WalletOwnerOrganization: pe.PresentationDefinition{Id: "test"}}, nil)
@@ -370,8 +371,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 
 		require.NoError(t, err)
 		require.IsType(t, HandleAuthorizeRequest302Response{}, res)
-		location := res.(HandleAuthorizeRequest302Response).Headers.Location
-		assert.Equal(t, expectedURL, location)
+		testAuthzReqRedirectURI(t, expectedURL, res.(HandleAuthorizeRequest302Response).Headers.Location)
 	})
 	t.Run("error - invalid request parameter", func(t *testing.T) {
 		ctx := newTestClient(t)
@@ -1004,12 +1004,17 @@ func TestWrapper_CreateAuthorizationRequest(t *testing.T) {
 				assert.NotEmpty(t, claims[oauth.NonceParam])
 				return "signed JWT", nil
 			})
+			expectedURL := "https://server.test/authorize?client_id=did%3Aweb%3Aclient.test%3Aiam%3A123&request_uri=https://client.test/oauth2/request.jwt/"
+
 			redirectURL, err := ctx.client.CreateAuthorizationRequest(context.Background(), clientDID, serverDID, modifier)
 
 			assert.NoError(t, err)
 			require.NotNil(t, redirectURL)
-			assert.Equal(t, "signed JWT", redirectURL.Query().Get(oauth.RequestParam))
-			assert.Equal(t, clientDID.String(), redirectURL.Query().Get(oauth.ClientIDParam))
+			testAuthzReqRedirectURI(t, expectedURL, redirectURL.String())
+			parts := strings.Split(redirectURL.Query().Get(oauth.RequestURIParam), "/")
+			token := new([]byte)
+			require.NoError(t, ctx.client.authzRequestObjectStore().Get(parts[len(parts)-1], token))
+			assert.Equal(t, []byte("signed JWT"), *token)
 		})
 		t.Run("error - failed to sign JWT", func(t *testing.T) {
 			ctx := newTestClient(t)
@@ -1398,6 +1403,26 @@ func TestWrapper_CallbackOid4vciCredentialIssuance(t *testing.T) {
 		assert.Nil(t, callback)
 		assert.ErrorContains(t, err, "failed to sign the JWT with kid (kid): signature failed")
 	})
+}
+
+// testAuthzReqRedirectURI compares to expectedRedirectURI and actualRedirectURI
+// 'request_uri' is checked for presence,
+// and if expectedRedirectURI contains a 'request_uri' it will do a partial match on URL decoded actual value
+func testAuthzReqRedirectURI(t testing.TB, expectedRedirectURI, actualRedirectURI string) {
+	stripRequestURI := func(uri string) (string, string) {
+		u, err := url.Parse(uri)
+		require.NoError(t, err)
+		q := u.Query()
+		requestURI := q.Get(oauth.RequestURIParam)
+		q.Set(oauth.RequestURIParam, "<IGNORED>")
+		u.RawQuery = q.Encode()
+		return u.String(), requestURI
+	}
+	expected, expectedReqURIPartial := stripRequestURI(expectedRedirectURI)
+	actual, actualReqURI := stripRequestURI(actualRedirectURI)
+	assert.Equal(t, expected, actual)
+	assert.NotEmpty(t, actualReqURI)
+	assert.Contains(t, actualReqURI, expectedReqURIPartial) // both are URL decoded
 }
 
 func createIssuerCredential(issuerDID did.DID, holderDID did.DID) *vc.VerifiableCredential {

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -1047,9 +1047,9 @@ func TestWrapper_CreateAuthorizationRequest(t *testing.T) {
 			require.NotNil(t, redirectURL)
 			testAuthzReqRedirectURI(t, expectedURL, redirectURL.String())
 			parts := strings.Split(redirectURL.Query().Get(oauth.RequestURIParam), "/")
-			token := new([]byte)
+			token := new(string)
 			require.NoError(t, ctx.client.authzRequestObjectStore().Get(parts[len(parts)-1], token))
-			assert.Equal(t, []byte("signed JWT"), *token)
+			assert.Equal(t, "signed JWT", *token)
 		})
 		t.Run("error - failed to sign JWT", func(t *testing.T) {
 			ctx := newTestClient(t)

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -141,8 +141,9 @@ type RequestUserAccessTokenJSONBody struct {
 
 // PostRequestJWTFormdataBody defines parameters for PostRequestJWT.
 type PostRequestJWTFormdataBody struct {
-	// WalletMetadata Token Responses are made as defined in (RFC6749)[https://datatracker.ietf.org/doc/html/rfc6749#section-5.1]
-	WalletMetadata *TokenResponse `form:"wallet_metadata,omitempty" json:"wallet_metadata,omitempty"`
+	// WalletMetadata OAuth2 Authorization Server Metadata
+	// Contain properties from several specifications and may grow over time
+	WalletMetadata *OAuthAuthorizationServerMetadata `form:"wallet_metadata,omitempty" json:"wallet_metadata,omitempty"`
 
 	// WalletNonce A String value used to mitigate replay attacks of the Authorization Request.
 	// When received, the Verifier MUST use it as the wallet_nonce value in the signed authorization request object.

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -28,6 +28,9 @@ type RedirectResponseWithID struct {
 	SessionId string `json:"session_id"`
 }
 
+// RequestObjectResponse A JSON Web Token (JWT) whose JWT Claims Set holds the JSON-encoded OAuth 2.0 authorization request parameters.
+type RequestObjectResponse = string
+
 // TokenIntrospectionRequest Token introspection request as described in RFC7662 section 2.1
 // Alongside the defined properties, it can return values (additionalProperties) from the Verifiable Credentials that resulted from the Presentation Exchange.
 type TokenIntrospectionRequest struct {
@@ -136,6 +139,16 @@ type RequestUserAccessTokenJSONBody struct {
 	Verifier string `json:"verifier"`
 }
 
+// PostRequestJWTFormdataBody defines parameters for PostRequestJWT.
+type PostRequestJWTFormdataBody struct {
+	// WalletMetadata Token Responses are made as defined in (RFC6749)[https://datatracker.ietf.org/doc/html/rfc6749#section-5.1]
+	WalletMetadata *TokenResponse `form:"wallet_metadata,omitempty" json:"wallet_metadata,omitempty"`
+
+	// WalletNonce A String value used to mitigate replay attacks of the Authorization Request.
+	// When received, the Verifier MUST use it as the wallet_nonce value in the signed authorization request object.
+	WalletNonce *string `form:"wallet_nonce,omitempty" json:"wallet_nonce,omitempty"`
+}
+
 // HandleAuthorizeRequestParams defines parameters for HandleAuthorizeRequest.
 type HandleAuthorizeRequestParams struct {
 	Params *map[string]string `form:"params,omitempty" json:"params,omitempty"`
@@ -200,6 +213,9 @@ type RequestServiceAccessTokenJSONRequestBody RequestServiceAccessTokenJSONBody
 
 // RequestUserAccessTokenJSONRequestBody defines body for RequestUserAccessToken for application/json ContentType.
 type RequestUserAccessTokenJSONRequestBody RequestUserAccessTokenJSONBody
+
+// PostRequestJWTFormdataRequestBody defines body for PostRequestJWT for application/x-www-form-urlencoded ContentType.
+type PostRequestJWTFormdataRequestBody PostRequestJWTFormdataBody
 
 // HandleAuthorizeResponseFormdataRequestBody defines body for HandleAuthorizeResponse for application/x-www-form-urlencoded ContentType.
 type HandleAuthorizeResponseFormdataRequestBody HandleAuthorizeResponseFormdataBody
@@ -455,6 +471,12 @@ type ServerInterface interface {
 	// Start the authorization code flow to get an access token from a remote authorization server when user context is required.
 	// (POST /internal/auth/v2/{did}/request-user-access-token)
 	RequestUserAccessToken(ctx echo.Context, did string) error
+	// Get Request Object referenced in an authorization request to the Authorization Server.
+	// (GET /oauth2/request.jwt/{id})
+	GetRequestJWT(ctx echo.Context, id string) error
+	// Provide missing information to Client to finish Authorization request's Request Object, which is then returned.
+	// (POST /oauth2/request.jwt/{id})
+	PostRequestJWT(ctx echo.Context, id string) error
 	// Used by resource owners to initiate the authorization code flow.
 	// (GET /oauth2/{did}/authorize)
 	HandleAuthorizeRequest(ctx echo.Context, did string, params HandleAuthorizeRequestParams) error
@@ -653,6 +675,42 @@ func (w *ServerInterfaceWrapper) RequestUserAccessToken(ctx echo.Context) error 
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.RequestUserAccessToken(ctx, did)
+	return err
+}
+
+// GetRequestJWT converts echo context to params.
+func (w *ServerInterfaceWrapper) GetRequestJWT(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	ctx.Set(JwtBearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetRequestJWT(ctx, id)
+	return err
+}
+
+// PostRequestJWT converts echo context to params.
+func (w *ServerInterfaceWrapper) PostRequestJWT(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	ctx.Set(JwtBearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.PostRequestJWT(ctx, id)
 	return err
 }
 
@@ -862,6 +920,8 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.POST(baseURL+"/internal/auth/v2/:did/request-credential", wrapper.RequestOid4vciCredentialIssuance)
 	router.POST(baseURL+"/internal/auth/v2/:did/request-service-access-token", wrapper.RequestServiceAccessToken)
 	router.POST(baseURL+"/internal/auth/v2/:did/request-user-access-token", wrapper.RequestUserAccessToken)
+	router.GET(baseURL+"/oauth2/request.jwt/:id", wrapper.GetRequestJWT)
+	router.POST(baseURL+"/oauth2/request.jwt/:id", wrapper.PostRequestJWT)
 	router.GET(baseURL+"/oauth2/:did/authorize", wrapper.HandleAuthorizeRequest)
 	router.GET(baseURL+"/oauth2/:did/callback", wrapper.Callback)
 	router.GET(baseURL+"/oauth2/:did/oauth-client", wrapper.OAuthClientMetadata)
@@ -1219,6 +1279,103 @@ func (response RequestUserAccessTokendefaultApplicationProblemPlusJSONResponse) 
 	return json.NewEncoder(w).Encode(response.Body)
 }
 
+type GetRequestJWTRequestObject struct {
+	Id string `json:"id"`
+}
+
+type GetRequestJWTResponseObject interface {
+	VisitGetRequestJWTResponse(w http.ResponseWriter) error
+}
+
+type GetRequestJWT200ApplicationoauthAuthzReqJwtResponse struct {
+	Body          io.Reader
+	ContentLength int64
+}
+
+func (response GetRequestJWT200ApplicationoauthAuthzReqJwtResponse) VisitGetRequestJWTResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/oauth-authz-req+jwt")
+	if response.ContentLength != 0 {
+		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+	}
+	w.WriteHeader(200)
+
+	if closer, ok := response.Body.(io.ReadCloser); ok {
+		defer closer.Close()
+	}
+	_, err := io.Copy(w, response.Body)
+	return err
+}
+
+type GetRequestJWTdefaultApplicationProblemPlusJSONResponse struct {
+	Body struct {
+		// Detail A human-readable explanation specific to this occurrence of the problem.
+		Detail string `json:"detail"`
+
+		// Status HTTP statuscode
+		Status float32 `json:"status"`
+
+		// Title A short, human-readable summary of the problem type.
+		Title string `json:"title"`
+	}
+	StatusCode int
+}
+
+func (response GetRequestJWTdefaultApplicationProblemPlusJSONResponse) VisitGetRequestJWTResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(response.StatusCode)
+
+	return json.NewEncoder(w).Encode(response.Body)
+}
+
+type PostRequestJWTRequestObject struct {
+	Id   string `json:"id"`
+	Body *PostRequestJWTFormdataRequestBody
+}
+
+type PostRequestJWTResponseObject interface {
+	VisitPostRequestJWTResponse(w http.ResponseWriter) error
+}
+
+type PostRequestJWT200ApplicationoauthAuthzReqJwtResponse struct {
+	Body          io.Reader
+	ContentLength int64
+}
+
+func (response PostRequestJWT200ApplicationoauthAuthzReqJwtResponse) VisitPostRequestJWTResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/oauth-authz-req+jwt")
+	if response.ContentLength != 0 {
+		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+	}
+	w.WriteHeader(200)
+
+	if closer, ok := response.Body.(io.ReadCloser); ok {
+		defer closer.Close()
+	}
+	_, err := io.Copy(w, response.Body)
+	return err
+}
+
+type PostRequestJWTdefaultApplicationProblemPlusJSONResponse struct {
+	Body struct {
+		// Detail A human-readable explanation specific to this occurrence of the problem.
+		Detail string `json:"detail"`
+
+		// Status HTTP statuscode
+		Status float32 `json:"status"`
+
+		// Title A short, human-readable summary of the problem type.
+		Title string `json:"title"`
+	}
+	StatusCode int
+}
+
+func (response PostRequestJWTdefaultApplicationProblemPlusJSONResponse) VisitPostRequestJWTResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(response.StatusCode)
+
+	return json.NewEncoder(w).Encode(response.Body)
+}
+
 type HandleAuthorizeRequestRequestObject struct {
 	Did    string `json:"did"`
 	Params HandleAuthorizeRequestParams
@@ -1501,6 +1658,12 @@ type StrictServerInterface interface {
 	// Start the authorization code flow to get an access token from a remote authorization server when user context is required.
 	// (POST /internal/auth/v2/{did}/request-user-access-token)
 	RequestUserAccessToken(ctx context.Context, request RequestUserAccessTokenRequestObject) (RequestUserAccessTokenResponseObject, error)
+	// Get Request Object referenced in an authorization request to the Authorization Server.
+	// (GET /oauth2/request.jwt/{id})
+	GetRequestJWT(ctx context.Context, request GetRequestJWTRequestObject) (GetRequestJWTResponseObject, error)
+	// Provide missing information to Client to finish Authorization request's Request Object, which is then returned.
+	// (POST /oauth2/request.jwt/{id})
+	PostRequestJWT(ctx context.Context, request PostRequestJWTRequestObject) (PostRequestJWTResponseObject, error)
 	// Used by resource owners to initiate the authorization code flow.
 	// (GET /oauth2/{did}/authorize)
 	HandleAuthorizeRequest(ctx context.Context, request HandleAuthorizeRequestRequestObject) (HandleAuthorizeRequestResponseObject, error)
@@ -1802,6 +1965,66 @@ func (sh *strictHandler) RequestUserAccessToken(ctx echo.Context, did string) er
 		return err
 	} else if validResponse, ok := response.(RequestUserAccessTokenResponseObject); ok {
 		return validResponse.VisitRequestUserAccessTokenResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// GetRequestJWT operation middleware
+func (sh *strictHandler) GetRequestJWT(ctx echo.Context, id string) error {
+	var request GetRequestJWTRequestObject
+
+	request.Id = id
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetRequestJWT(ctx.Request().Context(), request.(GetRequestJWTRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetRequestJWT")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(GetRequestJWTResponseObject); ok {
+		return validResponse.VisitGetRequestJWTResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// PostRequestJWT operation middleware
+func (sh *strictHandler) PostRequestJWT(ctx echo.Context, id string) error {
+	var request PostRequestJWTRequestObject
+
+	request.Id = id
+
+	if form, err := ctx.FormParams(); err == nil {
+		var body PostRequestJWTFormdataRequestBody
+		if err := runtime.BindForm(&body, form, nil, nil); err != nil {
+			return err
+		}
+		request.Body = &body
+	} else {
+		return err
+	}
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.PostRequestJWT(ctx.Request().Context(), request.(PostRequestJWTRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PostRequestJWT")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(PostRequestJWTResponseObject); ok {
+		return validResponse.VisitPostRequestJWTResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}

--- a/auth/api/iam/user_test.go
+++ b/auth/api/iam/user_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	"net/http"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -91,11 +90,14 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 
 	t.Run("new session", func(t *testing.T) {
 		ctx := newTestClient(t)
-		expectedURL, _ := url.Parse("https://example.com/authorize?client_id=did%3Aweb%3Aexample.com%3Aiam%3A123&request=token")
+		expectedURL := "https://example.com/authorize?client_id=did%3Aweb%3Aexample.com%3Aiam%3A123&request_uri=https://example.com/oauth2/request.jwt/"
 		echoCtx := mock.NewMockContext(ctx.ctrl)
 		echoCtx.EXPECT().QueryParam("token").Return("token")
 		echoCtx.EXPECT().Request().MinTimes(1).Return(&http.Request{Host: "example.com"})
-		echoCtx.EXPECT().Redirect(http.StatusFound, expectedURL.String())
+		echoCtx.EXPECT().Redirect(http.StatusFound, gomock.Any()).DoAndReturn(func(_ int, arg1 string) error {
+			testAuthzReqRedirectURI(t, expectedURL, arg1)
+			return nil
+		})
 		var capturedCookie *http.Cookie
 		echoCtx.EXPECT().Cookie(gomock.Any()).Return(nil, http.ErrNoCookie)
 		echoCtx.EXPECT().SetCookie(gomock.Any()).DoAndReturn(func(cookie *http.Cookie) {
@@ -161,11 +163,14 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 	})
 	t.Run("existing session", func(t *testing.T) {
 		ctx := newTestClient(t)
-		expectedURL := "https://example.com/authorize?client_id=did%3Aweb%3Aexample.com%3Aiam%3A123&request=token"
+		expectedURL := "https://example.com/authorize?client_id=did%3Aweb%3Aexample.com%3Aiam%3A123&request_uri=https://example.com/oauth2/request.jwt/"
 		echoCtx := mock.NewMockContext(ctx.ctrl)
 		echoCtx.EXPECT().QueryParam("token").Return("token")
 		echoCtx.EXPECT().Request().MinTimes(1).Return(&http.Request{Host: "example.com"})
-		echoCtx.EXPECT().Redirect(http.StatusFound, expectedURL)
+		echoCtx.EXPECT().Redirect(http.StatusFound, gomock.Any()).DoAndReturn(func(_ int, arg1 string) error {
+			testAuthzReqRedirectURI(t, expectedURL, arg1)
+			return nil
+		})
 		echoCtx.EXPECT().Cookie(gomock.Any()).Return(&sessionCookie, nil)
 		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierDID).Return(&serverMetadata, nil)
 		ctx.keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.AssertionMethod).Return(vmId.URI(), key.Public(), nil)

--- a/auth/client/iam/client.go
+++ b/auth/client/iam/client.go
@@ -108,6 +108,28 @@ func (hb HTTPClient) PresentationDefinition(ctx context.Context, presentationDef
 	return &presentationDefinition, hb.doRequest(ctx, request, &presentationDefinition)
 }
 
+func (hb HTTPClient) RequestObject(ctx context.Context, requestURI string) (string, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURI, nil)
+	if err != nil {
+		return "", err
+	}
+	request.Header.Add("Accept", "application/oauth-authz-req+jwt")
+
+	response, err := hb.httpClient.Do(request.WithContext(ctx))
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	if httpErr := core.TestResponseCode(http.StatusOK, response); httpErr != nil {
+		return "", httpErr
+	}
+
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return "", fmt.Errorf("unable to read response: %w", err)
+	}
+	return string(data), err
+}
+
 func (hb HTTPClient) AccessToken(ctx context.Context, tokenEndpoint string, data url.Values) (oauth.TokenResponse, error) {
 	var token oauth.TokenResponse
 	tokenURL, err := url.Parse(tokenEndpoint)

--- a/auth/client/iam/client_test.go
+++ b/auth/client/iam/client_test.go
@@ -318,6 +318,41 @@ func TestHTTPClient_postFormExpectRedirect(t *testing.T) {
 	})
 }
 
+func TestHTTPClient_RequestObject(t *testing.T) {
+	ctx := context.Background()
+	// params are checked server side, so we don't need to provide valid values here
+	t.Run("ok", func(t *testing.T) {
+		responseData := "signed request object"
+		handler := http2.Handler{StatusCode: http.StatusOK, ResponseData: responseData}
+		tlsServer, client := testServerAndClient(t, &handler)
+
+		response, err := client.RequestObject(ctx, tlsServer.URL)
+
+		require.NoError(t, err)
+		assert.Equal(t, responseData, response)
+	})
+	t.Run("error - invalid request_uri", func(t *testing.T) {
+		_, client := testServerAndClient(t, &http2.Handler{})
+
+		response, err := client.RequestObject(ctx, ":")
+
+		assert.EqualError(t, err, "parse \":\": missing protocol scheme")
+		assert.Empty(t, response)
+	})
+	t.Run("error - not found", func(t *testing.T) {
+		handler := http2.Handler{StatusCode: http.StatusNotFound, ResponseData: "throw this away"}
+		tlsServer, client := testServerAndClient(t, &handler)
+
+		response, err := client.RequestObject(ctx, tlsServer.URL)
+
+		var httpErr core.HttpError
+		require.ErrorAs(t, err, &httpErr)
+		assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+		assert.Empty(t, response)
+
+	})
+}
+
 func testServerAndClient(t *testing.T, handler http.Handler) (*httptest.Server, *HTTPClient) {
 	tlsServer := http2.TestTLSServer(t, handler)
 	return tlsServer, &HTTPClient{

--- a/auth/client/iam/interface.go
+++ b/auth/client/iam/interface.go
@@ -50,4 +50,6 @@ type Client interface {
 	AccessTokenOid4vci(ctx context.Context, clientId string, tokenEndpoint string, redirectUri string, code string, pkceCodeVerifier *string) (*oauth.Oid4vciTokenResponse, error)
 
 	VerifiableCredentials(ctx context.Context, credentialEndpoint string, accessToken string, proofJWT string) (*CredentialResponse, error)
+	// RequestObject is returned from the authorization request's 'request_uri' defined in RFC9101.
+	RequestObject(ctx context.Context, requestURI string) (string, error)
 }

--- a/auth/client/iam/mock.go
+++ b/auth/client/iam/mock.go
@@ -178,6 +178,21 @@ func (mr *MockClientMockRecorder) PresentationDefinition(ctx, endpoint any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PresentationDefinition", reflect.TypeOf((*MockClient)(nil).PresentationDefinition), ctx, endpoint)
 }
 
+// RequestObject mocks base method.
+func (m *MockClient) RequestObject(ctx context.Context, requestURI string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RequestObject", ctx, requestURI)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RequestObject indicates an expected call of RequestObject.
+func (mr *MockClientMockRecorder) RequestObject(ctx, requestURI any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestObject", reflect.TypeOf((*MockClient)(nil).RequestObject), ctx, requestURI)
+}
+
 // RequestRFC021AccessToken mocks base method.
 func (m *MockClient) RequestRFC021AccessToken(ctx context.Context, requestHolder, verifier did.DID, scopes string) (*oauth.TokenResponse, error) {
 	m.ctrl.T.Helper()

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -126,6 +126,20 @@ func (c *OpenID4VPClient) AuthorizationServerMetadata(ctx context.Context, webdi
 	return metadata, nil
 }
 
+func (c *OpenID4VPClient) RequestObject(ctx context.Context, requestURI string) (string, error) {
+	iamClient := c.httpClient
+	parsedURL, err := core.ParsePublicURL(requestURI, c.strictMode)
+	if err != nil {
+		return "", fmt.Errorf("invalid request_uri: %w", err)
+	}
+	// the wallet/client acts as authorization server
+	requestObject, err := iamClient.RequestObject(ctx, parsedURL.String())
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve JAR Request Object: %w", err)
+	}
+	return requestObject, nil
+}
+
 func (c *OpenID4VPClient) AccessToken(ctx context.Context, code string, verifier did.DID, callbackURI string, clientID did.DID, codeVerifier string) (*oauth.TokenResponse, error) {
 	iamClient := c.httpClient
 	metadata, err := iamClient.OAuthAuthorizationServerMetadata(ctx, verifier)

--- a/auth/client/iam/openid4vp_test.go
+++ b/auth/client/iam/openid4vp_test.go
@@ -281,6 +281,28 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 	})
 }
 
+func TestIAMClient_RequestObject(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		ctx := createClientServerTestContext(t)
+		requestURI := ctx.tlsServer.URL + "/request.jwt"
+
+		response, err := ctx.client.RequestObject(context.Background(), requestURI)
+
+		require.NoError(t, err)
+		assert.Equal(t, "Request Object", response)
+	})
+	t.Run("error - failed to get access token", func(t *testing.T) {
+		ctx := createClientServerTestContext(t)
+		ctx.requestObjectJWT = nil
+		requestURI := ctx.tlsServer.URL + "/request.jwt"
+
+		response, err := ctx.client.RequestObject(context.Background(), requestURI)
+
+		assert.EqualError(t, err, "failed to retrieve JAR Request Object: server returned HTTP 404 (expected: 200)")
+		assert.Empty(t, response)
+	})
+}
+
 func createClientTestContext(t *testing.T, tlsConfig *tls.Config) *clientTestContext {
 	ctrl := gomock.NewController(t)
 	jwtSigner := crypto.NewMockJWTSigner(ctrl)
@@ -332,6 +354,7 @@ type clientServerTestContext struct {
 	response                       func(writer http.ResponseWriter)
 	token                          func(writer http.ResponseWriter)
 	credentials                    func(writer http.ResponseWriter)
+	requestObjectJWT               func(writer http.ResponseWriter)
 }
 
 func createClientServerTestContext(t *testing.T) *clientServerTestContext {
@@ -390,6 +413,12 @@ func createClientServerTestContext(t *testing.T) *clientServerTestContext {
 			_, _ = writer.Write([]byte(`{"format": "format", "credential": "credential"}`))
 			return
 		},
+		requestObjectJWT: func(writer http.ResponseWriter) {
+			writer.Header().Add("Content-Type", "application/oauth-authz-req+jwt")
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write([]byte(`Request Object`))
+			return
+		},
 	}
 
 	ctx.handler = func(writer http.ResponseWriter, request *http.Request) {
@@ -436,6 +465,11 @@ func createClientServerTestContext(t *testing.T) *clientServerTestContext {
 		case "/credentials":
 			if ctx.credentials != nil {
 				ctx.credentials(writer)
+				return
+			}
+		case "/request.jwt":
+			if ctx.requestObjectJWT != nil {
+				ctx.requestObjectJWT(writer)
 				return
 			}
 		}

--- a/docs/_static/auth/iam.yaml
+++ b/docs/_static/auth/iam.yaml
@@ -50,7 +50,7 @@ paths:
                 $ref: '#/components/schemas/DIDDocument'
         "404":
           description: DID does not exist.
-  "/oauth2/{did}/token":
+  /oauth2/{did}/token:
     post:
       summary: Used by to request access- or refresh tokens.
       description: Specified by https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-token-endpoint
@@ -103,7 +103,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  "/oauth2/{did}/authorize":
+  /oauth2/{did}/authorize:
     get:
       summary: Used by resource owners to initiate the authorization code flow.
       description: Specified by https://datatracker.ietf.org/doc/html/rfc6749#section-3.1
@@ -145,7 +145,60 @@ paths:
               schema:
                 type: string
                 format: uri
-  "/oauth2/{did}/callback":
+  /oauth2/request.jwt/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Identifier of the Request Object
+        schema:
+          type: string
+    get:
+      summary: Get Request Object referenced in an authorization request to the Authorization Server.
+      description: |
+        Get the Request Object containing the OAuth 2.0 authorization request parameters, including extension parameters.
+        The Request Object is a JWT with signature (JWS) and may be encrypted (JWE).
+        See [RFC9101] The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR) for details.
+      operationId: getRequestJWT
+      tags:
+        - oauth2
+      responses:
+        200:
+          description: Authorization Request Object is found
+          content:
+            application/oauth-authz-req+jwt:
+              schema:
+                "$ref": "#/components/schemas/RequestObjectResponse"
+        default:
+          $ref: '../common/error_response.yaml'
+    post:
+      summary: Provide missing information to Client to finish Authorization request's Request Object, which is then returned.
+      operationId: postRequestJWT
+      tags:
+        - oauth2
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                wallet_metadata:
+                  $ref: '#/components/schemas/TokenResponse'
+                wallet_nonce:
+                  description: |
+                    A String value used to mitigate replay attacks of the Authorization Request. 
+                    When received, the Verifier MUST use it as the wallet_nonce value in the signed authorization request object.
+                  type: string
+      responses:
+        200:
+          description: Authorization Request Object is found
+          content:
+            application/oauth-authz-req+jwt:
+              schema:
+                "$ref": "#/components/schemas/RequestObjectResponse"
+        default:
+          $ref: '../common/error_response.yaml'
+  /oauth2/{did}/callback:
     get:
       summary: The OAuth2 callback endpoint of the client.
       description: |
@@ -195,7 +248,7 @@ paths:
                 format: uri
         "default":
           $ref: '../common/error_response.yaml'
-  "/oauth2/{did}/presentation_definition":
+  /oauth2/{did}/presentation_definition:
     get:
       summary: Used by relying parties to obtain a presentation definition for desired scopes as specified by Nuts RFC021.
       description: |
@@ -237,7 +290,7 @@ paths:
                 "$ref": "#/components/schemas/PresentationDefinition"
         "default":
           $ref: '../common/error_response.yaml'
-  "/oauth2/{did}/response":
+  /oauth2/{did}/response:
     post:
       summary: Used by wallets to post the authorization response or error to.
       description: | 
@@ -781,6 +834,9 @@ components:
           type: string
           description: The session ID that can be used to retrieve the access token by the calling application.
           example: "eyJhbGciOiJSUzI1NiIsI"
+    RequestObjectResponse:
+      description: "A JSON Web Token (JWT) whose JWT Claims Set holds the JSON-encoded OAuth 2.0 authorization request parameters."
+      type: string
     UserDetails:
       type: object
       description: |

--- a/docs/_static/auth/iam.yaml
+++ b/docs/_static/auth/iam.yaml
@@ -183,7 +183,7 @@ paths:
               type: object
               properties:
                 wallet_metadata:
-                  $ref: '#/components/schemas/TokenResponse'
+                  $ref: '#/components/schemas/OAuthAuthorizationServerMetadata'
                 wallet_nonce:
                   description: |
                     A String value used to mitigate replay attacks of the Authorization Request. 

--- a/docs/_static/auth/iam.yaml
+++ b/docs/_static/auth/iam.yaml
@@ -157,7 +157,7 @@ paths:
       summary: Get Request Object referenced in an authorization request to the Authorization Server.
       description: |
         Get the Request Object containing the OAuth 2.0 authorization request parameters, including extension parameters.
-        The Request Object is a JWT with signature (JWS) and may be encrypted (JWE).
+        The Request Object is a JWT with signature (JWS).
         See [RFC9101] The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR) for details.
       operationId: getRequestJWT
       tags:


### PR DESCRIPTION
part of #2712

this adds the `request_uri` param as specced in [RFC9101](https://www.rfc-editor.org/rfc/rfc9101.html)

implemented separate from the OpenID4VP extension using `request_uri_method` to keep the PRs small