### PR TITLE
Security: limit data read from external sources

### DIFF
--- a/auth/client/iam/client.go
+++ b/auth/client/iam/client.go
@@ -70,7 +70,7 @@ func (hb HTTPClient) OAuthAuthorizationServerMetadata(ctx context.Context, webDI
 	var metadata oauth.AuthorizationServerMetadata
 	var data []byte
 
-	if data, err = io.ReadAll(response.Body); err != nil {
+	if data, err = core.LimitedReadAll(response.Body); err != nil {
 		return nil, fmt.Errorf("unable to read response: %w", err)
 	}
 	if err = json.Unmarshal(data, &metadata); err != nil {
@@ -143,7 +143,7 @@ func (hb HTTPClient) AccessToken(ctx context.Context, tokenEndpoint string, data
 	}
 
 	var responseData []byte
-	if responseData, err = io.ReadAll(response.Body); err != nil {
+	if responseData, err = core.LimitedReadAll(response.Body); err != nil {
 		return token, fmt.Errorf("unable to read response: %w", err)
 	}
 	if err = json.Unmarshal(responseData, &token); err != nil {
@@ -180,7 +180,6 @@ func (hb HTTPClient) PostAuthorizationResponse(ctx context.Context, vp vc.Verifi
 }
 
 func (hb HTTPClient) OpenIdConfiguration(ctx context.Context, serverURL string) (*oauth.OpenIDConfigurationMetadata, error) {
-
 	metadataURL, err := oauth.IssuerIdToWellKnown(serverURL, oauth.OpenIdConfigurationWellKnown, hb.strictMode)
 	if err != nil {
 		return nil, err
@@ -202,7 +201,7 @@ func (hb HTTPClient) OpenIdConfiguration(ctx context.Context, serverURL string) 
 	var metadata oauth.OpenIDConfigurationMetadata
 	var data []byte
 
-	if data, err = io.ReadAll(response.Body); err != nil {
+	if data, err = core.LimitedReadAll(response.Body); err != nil {
 		return nil, fmt.Errorf("unable to read response: %w", err)
 	}
 	if err = json.Unmarshal(data, &metadata); err != nil {
@@ -239,7 +238,7 @@ func (hb HTTPClient) OpenIdCredentialIssuerMetadata(ctx context.Context, webDID 
 	var metadata oauth.OpenIDCredentialIssuerMetadata
 	var data []byte
 
-	if data, err = io.ReadAll(response.Body); err != nil {
+	if data, err = core.LimitedReadAll(response.Body); err != nil {
 		return nil, fmt.Errorf("unable to read response: %w", err)
 	}
 	if err = json.Unmarshal(data, &metadata); err != nil {
@@ -278,7 +277,7 @@ func (hb HTTPClient) AccessTokenOid4vci(ctx context.Context, presentationDefinit
 	}
 
 	var responseData []byte
-	if responseData, err = io.ReadAll(response.Body); err != nil {
+	if responseData, err = core.LimitedReadAll(response.Body); err != nil {
 		return nil, fmt.Errorf("unable to read response: %w", err)
 	}
 
@@ -384,7 +383,7 @@ func (hb HTTPClient) doRequest(ctx context.Context, request *http.Request, targe
 
 	var data []byte
 
-	if data, err = io.ReadAll(response.Body); err != nil {
+	if data, err = core.LimitedReadAll(response.Body); err != nil {
 		return fmt.Errorf("unable to read response: %w", err)
 	}
 	if err = json.Unmarshal(data, &target); err != nil {

--- a/vcr/openid4vci/issuer_client.go
+++ b/vcr/openid4vci/issuer_client.go
@@ -28,7 +28,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/vcr/log"
-	"io"
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
@@ -168,7 +167,7 @@ func httpDo(httpClient core.HTTPRequestDoer, httpRequest *http.Request, result i
 		return fmt.Errorf("http request error: %w", err)
 	}
 	defer httpResponse.Body.Close()
-	responseBody, err := io.ReadAll(httpResponse.Body)
+	responseBody, err := core.LimitedReadAll(httpResponse.Body)
 	if err != nil {
 		return fmt.Errorf("read error (%s): %w", httpRequest.URL, err)
 	}

--- a/vcr/revocation/statuslist2021_verifier.go
+++ b/vcr/revocation/statuslist2021_verifier.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -199,7 +198,7 @@ func (cs *StatusList2021) download(statusListCredential string) (*vc.VerifiableC
 				Debug("Failed to close response body")
 		}
 	}()
-	body, err := io.ReadAll(io.LimitReader(res.Body, 1024*1024*10)) // 10mb
+	body, err := core.LimitedReadAll(res.Body) // default minimum size is 16kb (PII entropy), so 1mb is already unlikely
 	if res.StatusCode > 299 || err != nil {
 		return nil, errors.Join(fmt.Errorf("fetching StatusList2021Credential from '%s' failed", statusListCredential), err)
 	}

--- a/vcr/revocation/statuslist2021_verifier.go
+++ b/vcr/revocation/statuslist2021_verifier.go
@@ -199,7 +199,7 @@ func (cs *StatusList2021) download(statusListCredential string) (*vc.VerifiableC
 				Debug("Failed to close response body")
 		}
 	}()
-	body, err := io.ReadAll(res.Body)
+	body, err := io.ReadAll(io.LimitReader(res.Body, 1024*1024*10)) // 10mb
 	if res.StatusCode > 299 || err != nil {
 		return nil, errors.Join(fmt.Errorf("fetching StatusList2021Credential from '%s' failed", statusListCredential), err)
 	}

--- a/vdr/didweb/web.go
+++ b/vdr/didweb/web.go
@@ -23,8 +23,8 @@ import (
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
-	"io"
 	"mime"
 	"net/http"
 	"time"
@@ -107,7 +107,7 @@ func (w Resolver) Resolve(id did.DID, _ *resolver.ResolveMetadata) (*did.Documen
 	}
 
 	// Read document
-	data, err := io.ReadAll(httpResponse.Body)
+	data, err := core.LimitedReadAll(httpResponse.Body)
 	if err != nil {
 		return nil, nil, fmt.Errorf("did:web HTTP response read error: %w", err)
 	}


### PR DESCRIPTION
To prevent DoS (attack or accidental). This only applies to untrusted, external sources over which the administrator does not have control (either directly or through endpoint configuration).