### PR TITLE
Code cleanup

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+run:
+  tests: false
+issues:
+  exclude-files:
+    - ".*/generated.go"
+    - ".*/.*_test.go"
+    - ".*/test.go"
+    - "docs/.*"

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -63,7 +63,7 @@ var oauthRequestObjectKey = []string{"oauth", "requestobject"}
 const apiPath = "iam"
 const apiModuleName = auth.ModuleName + "/" + apiPath
 
-var httpRequestContextKey = struct{}{}
+type httpRequestContextKey struct{}
 
 // accessTokenValidity defines how long access tokens are valid.
 // TODO: Might want to make this configurable at some point
@@ -143,7 +143,7 @@ func middleware(ctx echo.Context, operationID string) {
 	ctx.Set(core.ModuleNameContextKey, apiModuleName)
 
 	// Add http.Request to context, to allow reading URL query parameters
-	requestCtx := context.WithValue(ctx.Request().Context(), httpRequestContextKey, ctx.Request())
+	requestCtx := context.WithValue(ctx.Request().Context(), httpRequestContextKey{}, ctx.Request())
 	ctx.SetRequest(ctx.Request().WithContext(requestCtx))
 	if strings.HasPrefix(ctx.Request().URL.Path, "/oauth2/") {
 		ctx.Set(core.ErrorWriterContextKey, &oauth.Oauth2ErrorWriter{
@@ -298,7 +298,7 @@ func (r Wrapper) HandleAuthorizeRequest(ctx context.Context, request HandleAutho
 
 	// Workaround: deepmap codegen doesn't support dynamic query parameters.
 	//             See https://github.com/deepmap/oapi-codegen/issues/1129
-	httpRequest := ctx.Value(httpRequestContextKey).(*http.Request)
+	httpRequest := ctx.Value(httpRequestContextKey{}).(*http.Request)
 	queryParams := httpRequest.URL.Query()
 
 	// parse and validate as JAR (RFC9101, JWT Authorization Request)

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -62,7 +62,8 @@ var oauthRequestObjectKey = []string{"oauth", "requestobject"}
 
 const apiPath = "iam"
 const apiModuleName = auth.ModuleName + "/" + apiPath
-const httpRequestContextKey = "http-request"
+
+var httpRequestContextKey = struct{}{}
 
 // accessTokenValidity defines how long access tokens are valid.
 // TODO: Might want to make this configurable at some point
@@ -89,7 +90,6 @@ type Wrapper struct {
 	auth          auth.AuthenticationServices
 	policyBackend policy.PDPBackend
 	storageEngine storage.Engine
-	keyStore      cryptoNuts.KeyStore
 	vcr           vcr.VCR
 	vdr           vdr.VDR
 	jwtSigner     cryptoNuts.JWTSigner
@@ -280,7 +280,7 @@ func (r Wrapper) IntrospectAccessToken(_ context.Context, request IntrospectAcce
 	if token.InputDescriptorConstraintIdMap != nil {
 		for _, reserved := range []string{"iss", "sub", "exp", "iat", "active", "client_id", "scope"} {
 			if _, exists := token.InputDescriptorConstraintIdMap[reserved]; exists {
-				return nil, errors.New(fmt.Sprintf("IntrospectAccessToken: InputDescriptorConstraintIdMap contains reserved claim name '%s'", reserved))
+				return nil, fmt.Errorf("IntrospectAccessToken: InputDescriptorConstraintIdMap contains reserved claim name '%s'", reserved)
 			}
 		}
 		response.AdditionalProperties = token.InputDescriptorConstraintIdMap
@@ -783,38 +783,31 @@ func (r Wrapper) CallbackOid4vciCredentialIssuance(ctx context.Context, request 
 	tokenEndpoint := oid4vciSession.IssuerTokenEndpoint
 	credentialEndpoint := oid4vciSession.IssuerCredentialEndpoint
 	if err != nil {
-		log.Logger().WithError(err).Error("cannot fetch the right endpoints")
 		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("cannot fetch the right endpoints: %s", err.Error())), oid4vciSession.remoteRedirectUri())
 	}
 	response, err := r.auth.IAMClient().AccessToken(ctx, code, *issuerDid, oid4vciSession.RedirectUri, *holderDid, pkceParams.Verifier)
 	if err != nil {
-		log.Logger().WithError(err).Errorf("error while fetching the access_token from endpoint: %s", tokenEndpoint)
 		return nil, withCallbackURI(oauthError(oauth.AccessDenied, fmt.Sprintf("error while fetching the access_token from endpoint: %s, error: %s", tokenEndpoint, err.Error())), oid4vciSession.remoteRedirectUri())
 	}
 	cNonce := response.Get(oauth.CNonceParam)
 	proofJWT, err := r.proofJwt(ctx, *holderDid, *issuerDid, &cNonce)
 	if err != nil {
-		log.Logger().WithError(err).Error("error while building proof")
-		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("error while fetching the credential from endpoint %s, error: %s", credentialEndpoint, err.Error())), oid4vciSession.remoteRedirectUri())
+		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("error building proof to fetch the credential from endpoint %s, error: %s", credentialEndpoint, err.Error())), oid4vciSession.remoteRedirectUri())
 	}
 	credentials, err := r.auth.IAMClient().VerifiableCredentials(ctx, credentialEndpoint, response.AccessToken, proofJWT)
 	if err != nil {
-		log.Logger().WithError(err).Errorf("error while fetching the credential from endpoint: %s", credentialEndpoint)
 		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("error while fetching the credential from endpoint %s, error: %s", credentialEndpoint, err.Error())), oid4vciSession.remoteRedirectUri())
 	}
 	credential, err := vc.ParseVerifiableCredential(credentials.Credential)
 	if err != nil {
-		log.Logger().WithError(err).Errorf("error while parsing the credential: %s", credentials.Credential)
 		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("error while parsing the credential: %s, error: %s", credentials.Credential, err.Error())), oid4vciSession.remoteRedirectUri())
 	}
 	err = r.vcr.Verifier().Verify(*credential, true, true, nil)
 	if err != nil {
-		log.Logger().WithError(err).Errorf("error while verifying the credential from issuer: %s", credential.Issuer.String())
 		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("error while verifying the credential from issuer: %s, error: %s", credential.Issuer.String(), err.Error())), oid4vciSession.remoteRedirectUri())
 	}
 	err = r.vcr.Wallet().Put(ctx, *credential)
 	if err != nil {
-		log.Logger().WithError(err).Errorf("error while storing credential with id: %s", credential.ID)
 		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("error while storing credential with id: %s, error: %s", credential.ID, err.Error())), oid4vciSession.remoteRedirectUri())
 	}
 
@@ -830,19 +823,18 @@ func (r Wrapper) openidIssuerEndpoints(ctx context.Context, issuerDid did.DID) (
 	if err != nil {
 		return "", "", "", err
 	}
-	for i := range metadata.AuthorizationServers {
-		serverURL := metadata.AuthorizationServers[i]
-		openIdConfiguration, err := r.auth.IAMClient().OpenIdConfiguration(ctx, serverURL)
-		if err != nil {
-			return "", "", "", err
-		}
-		authorizationEndpoint := openIdConfiguration.AuthorizationEndpoint
-		tokenEndpoint := openIdConfiguration.TokenEndpoint
-		credentialEndpoint := metadata.CredentialEndpoint
-		return authorizationEndpoint, tokenEndpoint, credentialEndpoint, nil
+	if len(metadata.AuthorizationServers) == 0 {
+		return "", "", "", fmt.Errorf("cannot locate any authorization endpoint in %s", issuerDid.String())
 	}
-	err = errors.New(fmt.Sprintf("cannot locate any authorization endpoint in %s", issuerDid.String()))
-	return "", "", "", err
+	serverURL := metadata.AuthorizationServers[0]
+	openIdConfiguration, err := r.auth.IAMClient().OpenIdConfiguration(ctx, serverURL)
+	if err != nil {
+		return "", "", "", err
+	}
+	authorizationEndpoint := openIdConfiguration.AuthorizationEndpoint
+	tokenEndpoint := openIdConfiguration.TokenEndpoint
+	credentialEndpoint := metadata.CredentialEndpoint
+	return authorizationEndpoint, tokenEndpoint, credentialEndpoint, nil
 }
 
 // CreateAuthorizationRequest creates an OAuth2.0 authorizationRequest redirect URL that redirects to the authorization server.

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -1542,7 +1542,7 @@ func requestContext(queryParams map[string]interface{}) context.Context {
 			RawQuery: vals.Encode(),
 		},
 	}
-	return context.WithValue(audit.TestContext(), httpRequestContextKey, httpRequest)
+	return context.WithValue(audit.TestContext(), httpRequestContextKey{}, httpRequest)
 }
 
 // statusCodeFrom returns the statuscode for the given error

--- a/auth/api/iam/params.go
+++ b/auth/api/iam/params.go
@@ -18,22 +18,12 @@
 
 package iam
 
-import "net/url"
-
 // oauthParameters is a helper for oauth params.
 // oauth params can be derived from query params or JWT claims (RFC9101).
 // in theory all params could be string, arrays or numbers. Our handlers only want single string values for all params.
 // since empty values always lead to validation errors, the get method will return an empty value if the param is not present or has a wrong format.
 // array values with len == 1 will be treated as single string values.
 type oauthParameters map[string]interface{}
-
-func parseQueryParams(values url.Values) oauthParameters {
-	underlying := make(map[string]interface{})
-	for key, value := range values {
-		underlying[key] = value
-	}
-	return underlying
-}
 
 func parseJWTClaims(claims map[string]interface{}) oauthParameters { return claims }
 

--- a/auth/api/iam/s2s_vptoken.go
+++ b/auth/api/iam/s2s_vptoken.go
@@ -131,9 +131,7 @@ func (r Wrapper) createAccessToken(issuer did.DID, walletDID did.DID, issueTime 
 		InputDescriptorConstraintIdMap: fieldsMap,
 	}
 	for _, envelope := range pexState.SubmittedEnvelopes {
-		for _, presentation := range envelope.Presentations {
-			accessToken.VPToken = append(accessToken.VPToken, presentation)
-		}
+		accessToken.VPToken = append(accessToken.VPToken, envelope.Presentations...)
 	}
 	err = r.accessTokenServerStore().Put(accessToken.Token, accessToken)
 	if err != nil {

--- a/auth/api/iam/types.go
+++ b/auth/api/iam/types.go
@@ -25,7 +25,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 	"net/http"
-	"time"
 )
 
 // DIDDocument is an alias
@@ -65,10 +64,6 @@ type WalletOwnerType = pe.WalletOwnerType
 
 // RequiredPresentationDefinitions is an alias
 type RequiredPresentationDefinitions = pe.WalletOwnerMapping
-
-const (
-	sessionExpiry = 5 * time.Minute
-)
 
 // CookieReader is an interface for reading cookies from an HTTP request.
 // It is implemented by echo.Context and http.Request.
@@ -134,10 +129,6 @@ var grantTypesSupported = []string{grantTypeAuthorizationCode, grantTypeVPToken,
 // https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-verifier-metadata-managemen
 var clientIdSchemesSupported = []string{didScheme}
 
-// clientMetadataParam is the name of the OpenID4VP client_metadata parameter.
-// Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-authorization-request
-const clientMetadataParam = "client_metadata"
-
 // clientMetadataParam is the name of the OpenID4VP client_metadata_uri parameter.
 // Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-authorization-request
 const clientMetadataURIParam = "client_metadata_uri"
@@ -152,18 +143,6 @@ const didScheme = "did"
 // responseURIParam is the name of the OpenID4VP response_uri parameter.
 const responseURIParam = "response_uri"
 
-// presentationDefParam is the name of the OpenID4VP presentation_definition parameter.
-// Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-presentation_definition-par
-const presentationDefParam = "presentation_definition"
-
 // presentationDefUriParam is the name of the OpenID4VP presentation_definition_uri parameter.
 // Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-presentation_definition_uri
 const presentationDefUriParam = "presentation_definition_uri"
-
-// presentationSubmissionParam is the name of the OpenID4VP presentation_submission parameter.
-// Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-response-parameters
-const presentationSubmissionParam = "presentation_submission"
-
-// vpTokenParam is the name of the OpenID4VP vp_token parameter.
-// Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-response-type-vp_token
-const vpTokenParam = "vp_token"

--- a/auth/api/iam/types.go
+++ b/auth/api/iam/types.go
@@ -129,6 +129,10 @@ var grantTypesSupported = []string{grantTypeAuthorizationCode, grantTypeVPToken,
 // https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-verifier-metadata-managemen
 var clientIdSchemesSupported = []string{didScheme}
 
+// clientMetadataParam is the name of the OpenID4VP client_metadata parameter.
+// Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-authorization-request
+const clientMetadataParam = "client_metadata"
+
 // clientMetadataParam is the name of the OpenID4VP client_metadata_uri parameter.
 // Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-authorization-request
 const clientMetadataURIParam = "client_metadata_uri"
@@ -142,6 +146,10 @@ const didScheme = "did"
 
 // responseURIParam is the name of the OpenID4VP response_uri parameter.
 const responseURIParam = "response_uri"
+
+// presentationDefParam is the name of the OpenID4VP presentation_definition parameter.
+// Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-presentation_definition-par
+const presentationDefParam = "presentation_definition"
 
 // presentationDefUriParam is the name of the OpenID4VP presentation_definition_uri parameter.
 // Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-presentation_definition_uri

--- a/auth/client/iam/client.go
+++ b/auth/client/iam/client.go
@@ -154,7 +154,7 @@ func (hb HTTPClient) AccessToken(ctx context.Context, tokenEndpoint string, data
 		if len(responseBodyString) > core.HttpResponseBodyLogClipAt {
 			responseBodyString = responseBodyString[:core.HttpResponseBodyLogClipAt] + "...(clipped)"
 		}
-		return token, fmt.Errorf("unable to unmarshal response: %w, %s", err, string(responseData))
+		return token, fmt.Errorf("unable to unmarshal response: %w, %s", err, responseBodyString)
 	}
 	return token, nil
 }
@@ -231,7 +231,6 @@ type CredentialResponse struct {
 }
 
 func (hb HTTPClient) VerifiableCredentials(ctx context.Context, credentialEndpoint string, accessToken string, proofJwt string) (*CredentialResponse, error) {
-
 	credentialEndpointURL, err := url.Parse(credentialEndpoint)
 	if err != nil {
 		return nil, err
@@ -243,7 +242,7 @@ func (hb HTTPClient) VerifiableCredentials(ctx context.Context, credentialEndpoi
 			Jwt:       proofJwt,
 		},
 	}
-	jsonBody, err := json.Marshal(credentialRequest)
+	jsonBody, _ := json.Marshal(credentialRequest)
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, credentialEndpointURL.String(), bytes.NewBuffer(jsonBody))
 	if err != nil {
 		return nil, err

--- a/auth/services/dummy/dummy.go
+++ b/auth/services/dummy/dummy.go
@@ -182,8 +182,7 @@ func (d signingSessionResult) VerifiablePresentation() (*vc.VerifiablePresentati
 	}, nil
 }
 
-func (d Dummy) Start(ctx context.Context) {
-	return
+func (d Dummy) Start(_ context.Context) {
 }
 
 // VerifyVP check a Dummy VerifiablePresentation. It Returns a verificationResult if all was fine, an error otherwise.
@@ -264,7 +263,7 @@ func (d Dummy) StartSigningSession(contract contract.Contract, params map[string
 		return nil, errNotEnabled
 	}
 	sessionBytes := make([]byte, 16)
-	rand.Reader.Read(sessionBytes)
+	_, _ = rand.Reader.Read(sessionBytes)
 
 	sessionID := hex.EncodeToString(sessionBytes)
 	d.Status[sessionID] = SessionCreated

--- a/auth/services/irma/signer.go
+++ b/auth/services/irma/signer.go
@@ -77,7 +77,6 @@ func (s SessionPtr) MarshalJSON() ([]byte, error) {
 const NutsIrmaSignedContract = "NutsIrmaSignedContract"
 
 func (v Signer) Start(ctx context.Context) {
-	return
 }
 
 // StartSigningSession accepts a rawContractText and creates an IRMA signing session.

--- a/auth/services/selfsigned/signer.go
+++ b/auth/services/selfsigned/signer.go
@@ -146,7 +146,6 @@ func (v *signer) createVP(ctx context.Context, s types.Session, issuanceDate tim
 
 func (v *signer) Start(ctx context.Context) {
 	v.store.Start(ctx)
-	return
 }
 
 func (v *signer) StartSigningSession(userContract contract.Contract, params map[string]interface{}) (contract.SessionPointer, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -136,7 +136,9 @@ func startServer(ctx context.Context, system *core.System) error {
 			if err != nil {
 				return err
 			}
-			pprof.StartCPUProfile(f)
+			if err := pprof.StartCPUProfile(f); err != nil {
+				return err
+			}
 			defer pprof.StopCPUProfile()
 		} else {
 			logrus.Warn("Ignoring CPU profile option, strictmode is enabled")

--- a/core/engine.go
+++ b/core/engine.go
@@ -179,7 +179,7 @@ func (system *System) VisitEnginesE(visitor func(engine Engine) error) error {
 // FindEngineByName looks up given target engine by name, or nil if not found.
 func (system *System) FindEngineByName(target string) Engine {
 	for _, curr := range system.engines {
-		if strings.ToLower(engineName(curr)) == strings.ToLower(target) {
+		if strings.EqualFold(engineName(curr), strings.ToLower(target)) {
 			return curr
 		}
 	}

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -45,7 +45,8 @@ func TestCrypto_Exists(t *testing.T) {
 	client := createCrypto(t)
 
 	kid := "kid"
-	client.New(audit.TestContext(), StringNamingFunc(kid))
+	_, err := client.New(audit.TestContext(), StringNamingFunc(kid))
+	require.NoError(t, err)
 
 	t.Run("returns true for existing key", func(t *testing.T) {
 		assert.True(t, client.Exists(ctx, kid))

--- a/crypto/jwx.go
+++ b/crypto/jwx.go
@@ -138,11 +138,13 @@ func jwkKey(signer crypto.Signer) (key jwk.Key, err error) {
 
 	switch k := signer.(type) {
 	case *rsa.PrivateKey:
-		key.Set(jwk.AlgorithmKey, jwa.PS256)
+		_ = key.Set(jwk.AlgorithmKey, jwa.PS256)
 	case *ecdsa.PrivateKey:
 		var alg jwa.SignatureAlgorithm
 		alg, err = ecAlg(k)
-		key.Set(jwk.AlgorithmKey, alg)
+		if err == nil {
+			_ = key.Set(jwk.AlgorithmKey, alg)
+		}
 	default:
 		err = errors.New("unsupported signing private key")
 	}

--- a/crypto/jwx.go
+++ b/crypto/jwx.go
@@ -432,27 +432,13 @@ func SignatureAlgorithm(key crypto.PublicKey) (jwa.SignatureAlgorithm, error) {
 }
 
 func encryptionAlgorithm(key crypto.PublicKey) (jwa.KeyEncryptionAlgorithm, error) {
-	var ptr interface{}
-	switch v := key.(type) {
-	case crypto.PublicKey:
-		ptr = &v
-	case rsa.PublicKey:
-		ptr = &v
-	case ecdsa.PublicKey:
-		ptr = &v
-	default:
-		ptr = v
-	}
-
-	switch ptr.(type) {
-	case *crypto.PublicKey:
-		return defaultEcEncryptionAlgorithm, nil
+	switch key.(type) {
 	case *rsa.PublicKey:
 		return defaultRsaEncryptionAlgorithm, nil
 	case *ecdsa.PublicKey:
 		return defaultEcEncryptionAlgorithm, nil
 	default:
-		return "", fmt.Errorf("could not determine signature algorithm for key type '%T'", key)
+		return "", fmt.Errorf("could not determine encryption algorithm for key type '%T'", key)
 	}
 }
 

--- a/crypto/jwx_test.go
+++ b/crypto/jwx_test.go
@@ -319,7 +319,7 @@ func TestCrypto_EncryptJWE(t *testing.T) {
 		_, err := client.EncryptJWE(audit.TestContext(), []byte{1, 2, 3}, headers, public)
 
 		require.NoError(t, err)
-		auditLogs.AssertContains(t, ModuleName, "EncryptJWE", audit.TestActor, fmt.Sprintf("Encrypting a JWE"))
+		auditLogs.AssertContains(t, ModuleName, "EncryptJWE", audit.TestActor, "Encrypting a JWE")
 	})
 }
 

--- a/crypto/jwx_test.go
+++ b/crypto/jwx_test.go
@@ -248,7 +248,7 @@ func TestCrypto_EncryptJWE(t *testing.T) {
 	public := key.Public()
 
 	headers := map[string]interface{}{"typ": "JWT", "kid": key.KID()}
-	t.Run("creates valid JWE", func(t *testing.T) {
+	t.Run("creates valid JWE (EC)", func(t *testing.T) {
 		payload, _ := json.Marshal(map[string]interface{}{"iss": "nuts"})
 		tokenString, err := client.EncryptJWE(audit.TestContext(), payload, headers, public)
 
@@ -258,6 +258,23 @@ func TestCrypto_EncryptJWE(t *testing.T) {
 		require.NoError(t, err)
 
 		token, err := jwe.Decrypt([]byte(tokenString), jwe.WithKey(defaultEcEncryptionAlgorithm, privateKey))
+		require.NoError(t, err)
+
+		var body = make(map[string]interface{})
+		err = json.Unmarshal(token, &body)
+
+		require.NoError(t, err)
+
+		assert.Equal(t, "nuts", body["iss"])
+	})
+	t.Run("creates valid JWE (RSA)", func(t *testing.T) {
+		keyPair, _ := rsa.GenerateKey(rand.Reader, 1024)
+		payload, _ := json.Marshal(map[string]interface{}{"iss": "nuts"})
+		tokenString, err := client.EncryptJWE(audit.TestContext(), payload, headers, keyPair.Public())
+
+		require.NoError(t, err)
+
+		token, err := jwe.Decrypt([]byte(tokenString), jwe.WithKey(defaultRsaEncryptionAlgorithm, keyPair))
 		require.NoError(t, err)
 
 		var body = make(map[string]interface{})

--- a/discovery/api/v1/api.go
+++ b/discovery/api/v1/api.go
@@ -32,7 +32,7 @@ import (
 
 var _ StrictServerInterface = (*Wrapper)(nil)
 
-const requestQueryContextKey = "request.url.query"
+var requestQueryContextKey = struct{}{}
 
 type Wrapper struct {
 	Client discovery.Client

--- a/discovery/api/v1/api.go
+++ b/discovery/api/v1/api.go
@@ -32,7 +32,7 @@ import (
 
 var _ StrictServerInterface = (*Wrapper)(nil)
 
-var requestQueryContextKey = struct{}{}
+type requestQueryContextKey struct{}
 
 type Wrapper struct {
 	Client discovery.Client
@@ -48,7 +48,7 @@ func (w *Wrapper) Routes(router core.EchoRouter) {
 				// deepmap/openapi codegen does not support dynamic query parameters ("exploded form parameters"),
 				// so we expose the request URL query parameters to the request context,
 				// so the API handler can use them directly.
-				newContext := context.WithValue(ctx.Request().Context(), requestQueryContextKey, ctx.Request().URL.Query())
+				newContext := context.WithValue(ctx.Request().Context(), requestQueryContextKey{}, ctx.Request().URL.Query())
 				newRequest := ctx.Request().WithContext(newContext)
 				ctx.SetRequest(newRequest)
 				return f(ctx, request)
@@ -62,7 +62,7 @@ func (w *Wrapper) Routes(router core.EchoRouter) {
 
 func (w *Wrapper) SearchPresentations(ctx context.Context, request SearchPresentationsRequestObject) (SearchPresentationsResponseObject, error) {
 	// Use query parameters provided in request context (see Routes())
-	queryValues := ctx.Value(requestQueryContextKey).(url.Values)
+	queryValues := ctx.Value(requestQueryContextKey{}).(url.Values)
 	query := make(map[string]string)
 	for path, values := range queryValues {
 		query[path] = values[0]

--- a/discovery/api/v1/api_test.go
+++ b/discovery/api/v1/api_test.go
@@ -108,7 +108,7 @@ func TestWrapper_DeactivateServiceForDID(t *testing.T) {
 }
 
 func TestWrapper_SearchPresentations(t *testing.T) {
-	ctx := context.WithValue(audit.TestContext(), requestQueryContextKey, url.Values{
+	ctx := context.WithValue(audit.TestContext(), requestQueryContextKey{}, url.Values{
 		"foo": []string{"bar"},
 	})
 	expectedQuery := map[string]string{

--- a/discovery/interface.go
+++ b/discovery/interface.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
-	"math"
 	"strconv"
 	"strings"
 )
@@ -48,10 +47,6 @@ func (t Tag) Timestamp(tagPrefix string) *Timestamp {
 	result, err := strconv.ParseUint(trimmed, 10, 64)
 	if err != nil {
 		// Not a number
-		return nil
-	}
-	if result < 0 || result > math.MaxUint64 {
-		// Invalid uint64
 		return nil
 	}
 	lamport := Timestamp(result)

--- a/discovery/module.go
+++ b/discovery/module.go
@@ -194,7 +194,7 @@ func (m *Module) verifyRegistration(definition ServiceDefinition, presentation v
 		return errors.Join(ErrInvalidPresentation, errPresentationWithoutExpiration)
 	}
 	// VPs should not be valid for too long, as that would prevent the server from pruning them.
-	if int(expiration.Sub(time.Now()).Seconds()) > definition.PresentationMaxValidity {
+	if time.Until(expiration) > time.Duration(definition.PresentationMaxValidity)*time.Second {
 		return errors.Join(ErrInvalidPresentation, fmt.Errorf("presentation is valid for too long (max %s)", time.Duration(definition.PresentationMaxValidity)*time.Second))
 	}
 	// Check if the presentation already exists

--- a/makefile
+++ b/makefile
@@ -7,6 +7,7 @@ install-tools:
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.33.0
 	go install go.uber.org/mock/mockgen@v0.4.0
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2
 
 gen-mocks:
 	mockgen -destination=auth/mock.go -package=auth -source=auth/interface.go
@@ -100,6 +101,9 @@ all-docs: cli-docs gen-diagrams
 
 fix-copyright:
 	go run ./docs copyright
+
+lint:
+	golangci-lint run -v
 
 test:
 	go test ./...

--- a/network/dag/signing.go
+++ b/network/dag/signing.go
@@ -71,7 +71,7 @@ func (d transactionSigner) Sign(ctx context.Context, input UnsignedTransaction, 
 		if err != nil {
 			return nil, fmt.Errorf(errSigningTransactionFmt, err)
 		}
-		key.Set(jwk.KeyIDKey, d.key.KID())
+		_ = key.Set(jwk.KeyIDKey, d.key.KID())
 	}
 
 	prevsAsString := make([]string, len(input.Previous()))

--- a/pki/cmd.go
+++ b/pki/cmd.go
@@ -36,7 +36,11 @@ func FlagSet() *pflag.FlagSet {
 
 	// Changing these config values is not recommended, and they are expected to almost always be the same value, so
 	// do not show them in the config dump
-	flagSet.MarkHidden("pki.denylist.trustedsigner")
-	flagSet.MarkHidden("pki.denylist.url")
+	if err := flagSet.MarkHidden("pki.denylist.trustedsigner"); err != nil {
+		panic(err)
+	}
+	if err := flagSet.MarkHidden("pki.denylist.url"); err != nil {
+		panic(err)
+	}
 	return flagSet
 }

--- a/pki/denylist.go
+++ b/pki/denylist.go
@@ -248,7 +248,7 @@ func certKeyJWKThumbprint(cert *x509.Certificate) string {
 
 	if key, _ := jwk.PublicKeyOf(cert.PublicKey); key != nil {
 		// Compute the fingerprint of the key
-		jwk.AssignKeyID(key)
+		_ = jwk.AssignKeyID(key)
 
 		// Retrieve the fingerprint, which annoyingly is an "any" return type
 		fingerprint, _ := key.Get(jwk.KeyIDKey)

--- a/pki/validator.go
+++ b/pki/validator.go
@@ -405,8 +405,8 @@ func (v *validator) updateCRL(endpoint string, current *revocationList) error {
 	}
 
 	// parse revocations
-	revoked := make(map[string]bool, len(crl.RevokedCertificates))
-	for _, rev := range crl.RevokedCertificates {
+	revoked := make(map[string]bool, len(crl.RevokedCertificateEntries))
+	for _, rev := range crl.RevokedCertificateEntries {
 		revoked[rev.SerialNumber.String()] = true
 	}
 	// set the new CRL

--- a/test/http/handler.go
+++ b/test/http/handler.go
@@ -57,5 +57,5 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 		writer.Header().Add(k, v[0])
 	}
 	writer.WriteHeader(h.StatusCode)
-	writer.Write(bytes)
+	_, _ = writer.Write(bytes)
 }

--- a/vcr/holder/openid.go
+++ b/vcr/holder/openid.go
@@ -193,6 +193,9 @@ func getPreAuthorizedCodeFromOffer(offer openid4vci.CredentialOffer) string {
 
 func (h *openidHandler) retrieveCredential(ctx context.Context, issuerClient openid4vci.IssuerAPIClient, offer *openid4vci.CredentialDefinition, tokenResponse *oauth.TokenResponse) (*vc.VerifiableCredential, error) {
 	keyID, _, err := h.resolver.ResolveKey(h.did, nil, resolver.NutsSigningKeyType)
+	if err != nil {
+		return nil, err
+	}
 	headers := map[string]interface{}{
 		"typ": openid4vci.JWTTypeOpenID4VCIProof, // MUST be openid4vci-proof+jwt, which explicitly types the proof JWT as recommended in Section 3.11 of [RFC8725].
 		"kid": keyID.String(),                    // JOSE Header containing the key ID. If the Credential shall be bound to a DID, the kid refers to a DID URL which identifies a particular key in the DID Document that the Credential shall be bound to.

--- a/vcr/pe/presentation_definition.go
+++ b/vcr/pe/presentation_definition.go
@@ -460,7 +460,7 @@ func matchFilter(filter Filter, value interface{}) (bool, error) {
 		return false, nil
 	}
 
-	switch value.(type) {
+	switch typedValue := value.(type) {
 	case string:
 		if filter.Type != "string" {
 			return false, nil
@@ -478,8 +478,7 @@ func matchFilter(filter Filter, value interface{}) (bool, error) {
 			return false, nil
 		}
 	case []interface{}:
-		values := value.([]interface{})
-		for _, v := range values {
+		for _, v := range typedValue {
 			match, err := matchFilter(filter, v)
 			if err != nil {
 				return false, err

--- a/vcr/pe/util.go
+++ b/vcr/pe/util.go
@@ -101,10 +101,10 @@ func parseJSONArrayEnvelope(arr []interface{}) (interface{}, []vc.VerifiablePres
 	for _, entry := range arr {
 		// Each entry can be a VP as JWT (string) or JSON (object)
 		var entryBytes []byte
-		switch entry.(type) {
+		switch typedEntry := entry.(type) {
 		case string:
 			// JWT
-			entryBytes = []byte(entry.(string))
+			entryBytes = []byte(typedEntry)
 		default:
 			var err error
 			entryBytes, err = json.Marshal(entry)

--- a/vcr/revocation/statuslist2021_issuer.go
+++ b/vcr/revocation/statuslist2021_issuer.go
@@ -437,8 +437,7 @@ func (cs *StatusList2021) Revoke(ctx context.Context, credentialID ssi.URI, entr
 		}
 
 		// append new revocation and re-issue the StatusList2021Credential.
-		credRecord := new(credentialRecord)
-		_, credRecord, err = cs.updateCredential(ctx, issuerRecord, key)
+		_, credRecord, err := cs.updateCredential(ctx, issuerRecord, key)
 		if err != nil {
 			return err
 		}

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -240,10 +240,6 @@ func (c *vcr) Configure(config core.ServerConfig) error {
 	return c.trustConfig.Load()
 }
 
-func (c *vcr) credentialsDBPath() string {
-	return path.Join(c.datadir, "vcr", "credentials.db")
-}
-
 func (c *vcr) createCredentialsStore() error {
 	credentialsStorePath := path.Join(c.datadir, "vcr", "credentials.db")
 	credentialsBackupStore, err := c.storageClient.GetProvider(ModuleName).GetKVStore("backup-credentials", storage.PersistentStorageClass)

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -116,7 +116,7 @@ func TestVCR_Start(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		instance := NewTestVCRInstance(t)
 
-		_, err := os.Stat(instance.credentialsDBPath())
+		_, err := os.Stat(credentialsDBPath(instance.datadir))
 		assert.NoError(t, err)
 	})
 
@@ -150,7 +150,7 @@ func TestVCR_Start(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		dbPath := instance.credentialsDBPath()
+		dbPath := credentialsDBPath(instance.datadir)
 		db, err := bbolt.Open(dbPath, os.ModePerm, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -453,4 +453,8 @@ func TestWhitespaceOrExactTokenizer(t *testing.T) {
 	input := "a b c"
 
 	assert.Equal(t, []string{"a", "b", "c", "a b c"}, whitespaceOrExactTokenizer(input))
+}
+
+func credentialsDBPath(datadir string) string {
+	return path.Join(datadir, "vcr", "credentials.db")
 }

--- a/vdr/didnuts/ambassador.go
+++ b/vdr/didnuts/ambassador.go
@@ -26,21 +26,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/nats-io/nats.go"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/nuts-node/core"
-	"github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
-	"github.com/nuts-foundation/nuts-node/vdr/resolver"
-	"sort"
-
-	"github.com/lestrrat-go/jwx/v2/jwk"
-	"github.com/nuts-foundation/go-did/did"
 	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
-	"github.com/nuts-foundation/nuts-node/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/events"
 	"github.com/nuts-foundation/nuts-node/network"
 	"github.com/nuts-foundation/nuts-node/network/dag"
+	"github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
 	"github.com/nuts-foundation/nuts-node/vdr/log"
+	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 )
 
 // DIDDocumentType contains network transaction mime-type to identify a DID Document in the network.
@@ -347,48 +344,6 @@ func (n *ambassador) resolveControllers(document did.Document, transaction dag.T
 	}
 
 	return controllers, nil
-}
-
-func sortHashes(input []hash.SHA256Hash) {
-	sort.Slice(input, func(i, j int) bool {
-		return bytes.Compare(input[i].Slice(), input[j].Slice()) < 0
-	})
-}
-
-// missingTransactions does: current - incoming. Non conflicted updates will have an empty slice
-func missingTransactions(current []hash.SHA256Hash, incoming []hash.SHA256Hash) []hash.SHA256Hash {
-	j := 0
-	for _, h := range current {
-		found := false
-		for _, h2 := range incoming {
-			if h.Equals(h2) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			current[j] = h
-			j++
-		}
-	}
-
-	return current[:j]
-}
-
-// uniqueTransactions does: Set(current + incoming).
-func uniqueTransactions(current []hash.SHA256Hash, incoming hash.SHA256Hash) []hash.SHA256Hash {
-	set := map[hash.SHA256Hash]bool{}
-	for _, h := range current {
-		set[h] = true
-	}
-	set[incoming] = true
-
-	list := make([]hash.SHA256Hash, 0)
-	for k := range set {
-		list = append(list, k)
-	}
-
-	return list
 }
 
 // checkTransactionIntegrity performs basic integrity checks on the Transaction fields

--- a/vdr/didnuts/ambassador_test.go
+++ b/vdr/didnuts/ambassador_test.go
@@ -608,15 +608,6 @@ func TestAmbassador_handleUpdateDIDDocument(t *testing.T) {
 	})
 }
 
-func Test_sortHashes(t *testing.T) {
-	h0 := hash.SHA256Hash{}
-	h1 := hash.SHA256Hash{1}
-	h2 := hash.SHA256Hash{2}
-	input := []hash.SHA256Hash{h2, h0, h1}
-	sortHashes(input)
-	assert.Equal(t, []hash.SHA256Hash{h0, h1, h2}, input)
-}
-
 func Test_handleUpdateDIDDocument(t *testing.T) {
 	t.Run("error - unable to resolve controllers", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -729,69 +720,6 @@ func Test_checkTransactionIntegrity(t *testing.T) {
 			}
 		})
 	}
-}
-
-func Test_missingTransactions(t *testing.T) {
-	h1 := hash.SHA256Sum([]byte("hash1"))
-	h2 := hash.SHA256Sum([]byte("hash2"))
-	h3 := hash.SHA256Sum([]byte("hash3"))
-
-	t.Run("non-conflicted updated as expected", func(t *testing.T) {
-		current := []hash.SHA256Hash{h1}
-		incoming := []hash.SHA256Hash{h1, h2}
-
-		diff := missingTransactions(current, incoming)
-
-		assert.Empty(t, diff)
-	})
-
-	t.Run("non-conflicted updated without ref", func(t *testing.T) {
-		current := []hash.SHA256Hash{h1}
-		incoming := []hash.SHA256Hash{h2}
-
-		diff := missingTransactions(current, incoming)
-
-		assert.Len(t, diff, 1)
-		assert.Equal(t, current, diff)
-	})
-
-	t.Run("conflicted resolved", func(t *testing.T) {
-		current := []hash.SHA256Hash{h1, h2}
-		incoming := []hash.SHA256Hash{h1, h2, h3}
-
-		diff := missingTransactions(current, incoming)
-
-		assert.Empty(t, diff)
-	})
-}
-
-func Test_uniqueTransactions(t *testing.T) {
-	h1 := hash.SHA256Sum([]byte("hash1"))
-	h2 := hash.SHA256Sum([]byte("hash2"))
-
-	t.Run("ok - empty list", func(t *testing.T) {
-		current := []hash.SHA256Hash{}
-
-		unique := uniqueTransactions(current, h1)
-
-		assert.Len(t, unique, 1)
-	})
-
-	t.Run("ok - no overlap", func(t *testing.T) {
-		current := []hash.SHA256Hash{h2}
-
-		unique := uniqueTransactions(current, h1)
-
-		assert.Len(t, unique, 2)
-	})
-
-	t.Run("ok - duplicates", func(t *testing.T) {
-		current := []hash.SHA256Hash{h1, h2}
-
-		unique := uniqueTransactions(current, h1)
-
-		assert.Len(t, unique, 2)
-	})
 }
 
 func newDidDocWithOptions(selfControl bool, controllers ...did.DID) (did.Document, jwk.Key, error) {

--- a/vdr/didweb/manager.go
+++ b/vdr/didweb/manager.go
@@ -240,11 +240,6 @@ func (m Manager) DeleteService(_ context.Context, subjectDID did.DID, serviceID 
 }
 
 func buildDocument(subject did.DID, verificationMethods []did.VerificationMethod, services []did.Service) did.Document {
-	var vms []*did.VerificationMethod
-	for _, verificationMethod := range verificationMethods {
-		vms = append(vms, &verificationMethod)
-	}
-
 	document := did.Document{
 		Context: []interface{}{
 			ssi.MustParseURI(jsonld.Jws2020Context),

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -150,8 +150,7 @@ func (r *Module) Configure(config core.ServerConfig) error {
 	r.didResolver.Register(didkey.MethodName, didkey.NewResolver())
 
 	// Initiate the routines for auto-updating the data.
-	r.networkAmbassador.Configure()
-	return nil
+	return r.networkAmbassador.Configure()
 }
 
 func (r *Module) Start() error {


### PR DESCRIPTION
Fixes https://github.com/nuts-foundation/nuts-node/issues/2966

Only thing left is to upgrade the JWT middleware:

```
http/engine.go:224:18: SA1019: middleware.JWTWithConfig is deprecated: Please use https://github.com/labstack/echo-jwt instead (staticcheck)
                echoServer.Use(middleware.JWTWithConfig(middleware.JWTConfig{
```