### PR TITLE
Docs: fix incorrect PEX example

### DIFF
--- a/docs/pages/deployment/pex.rst
+++ b/docs/pages/deployment/pex.rst
@@ -43,19 +43,18 @@ JSON documents used for policies must have the following structure:
 
 .. code-block:: json
 
-  {
-    "example_scope": {
-      "organization": {
-        "id": "example",
-        "format": {
-          "ldp_vc": {
-            "proof_type": ["JsonWebSignature2020"]
+    {
+      "example_scope": {
+        "organization": {
+          "id": "example",
+          "format": {
+            "ldp_vc": {
+              "proof_type": ["JsonWebSignature2020"]
+            },
+            "ldp_vp": {
+              "proof_type": ["JsonWebSignature2020"]
+            }
           },
-          "ldp_vp": {
-            "proof_type": ["JsonWebSignature2020"]
-          }
-        },
-        "definition": {
           "input_descriptors": [
             {
               "id": "1",
@@ -69,11 +68,11 @@ JSON documents used for policies must have the following structure:
                     }
                   },
                   {
-                      "id": "fullName",
-                      "path": ["$.credentialSubject.fullName"],
-                      "filter": {
-                        "type": "string",
-                      }
+                    "id": "fullName",
+                    "path": ["$.credentialSubject.fullName"],
+                    "filter": {
+                      "type": "string"
+                    }
                   }
                 ]
               }
@@ -82,7 +81,6 @@ JSON documents used for policies must have the following structure:
         }
       }
     }
-  }
 
 Where ``example_scope`` is the scope that the presentation definition is associated with.
 The ``presentation_definition`` object contains the presentation definition that should be used for the given scope.


### PR DESCRIPTION
Had an incorrect `definitions` field.