### PR TITLE
E2E: employee credential: use 2 nodes to simplify debugging

### DIFF
--- a/e2e-tests/browser/openid4vp_employeecredential/docker-compose.yml
+++ b/e2e-tests/browser/openid4vp_employeecredential/docker-compose.yml
@@ -4,8 +4,7 @@ services:
     environment:
       NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
     ports:
-      - 8080:8080
-      - 8081:8081
+      - 18081:8081
     volumes:
       - "./config/nuts.yaml:/opt/nuts/nuts.yaml"
       - "./config/policy/:/opt/nuts/policy:ro"
@@ -15,11 +14,33 @@ services:
   nodeA:
     image: nginx:1.25.1
     ports:
-      - "443:443"
+      - "443"
     volumes:
       - "../../shared_config/nodeA-http-nginx.conf:/etc/nginx/conf.d/nuts-http.conf:ro"
       - "../../tls-certs/nodeA-certificate.pem:/etc/nginx/ssl/server.pem:ro"
       - "../../tls-certs/nodeA-certificate.pem:/etc/nginx/ssl/key.pem:ro"
+      - "../../tls-certs/truststore.pem:/etc/nginx/ssl/truststore.pem:ro"
+  nodeB-backend:
+    image: "${IMAGE_NODE_B:-nutsfoundation/nuts-node:master}"
+    environment:
+      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
+      NUTS_URL: "https://nodeB"
+    ports:
+      - 28081:8081
+    volumes:
+      - "./config/nuts.yaml:/opt/nuts/nuts.yaml"
+      - "./config/policy/:/opt/nuts/policy:ro"
+      # did:web resolver uses the OS CA bundle, but e2e tests use a self-signed CA which can be found in truststore.pem
+      # So we need to mount that file to the OS CA bundle location, otherwise did:web resolving will fail due to untrusted certs.
+      - "../../tls-certs/truststore.pem:/etc/ssl/certs/Nuts_RootCA.pem:ro"
+  nodeB:
+    image: nginx:1.25.1
+    ports:
+      - "443"
+    volumes:
+      - "../../shared_config/nodeB-http-nginx.conf:/etc/nginx/conf.d/nuts-http.conf:ro"
+      - "../../tls-certs/nodeB-certificate.pem:/etc/nginx/ssl/server.pem:ro"
+      - "../../tls-certs/nodeB-certificate.pem:/etc/nginx/ssl/key.pem:ro"
       - "../../tls-certs/truststore.pem:/etc/nginx/ssl/truststore.pem:ro"
   chrome-headless-shell:
     image: chromedp/headless-shell:latest
@@ -29,4 +50,4 @@ services:
     # and added "--ignore-certificate-errors" to ignore self-signed certs in the e2e tests.
     # Otherwise, it fails with:
     #   page load error net::ERR_CERT_AUTHORITY_INVALID
-    entrypoint: ["/headless-shell/headless-shell", "--no-sandbox", "--use-gl=angle", "--use-angle=swiftshader", "--remote-debugging-address=0.0.0.0", "--remote-debugging-port=9222", "--ignore-certificate-errors"]
+    entrypoint: [ "/headless-shell/headless-shell", "--no-sandbox", "--use-gl=angle", "--use-angle=swiftshader", "--remote-debugging-address=0.0.0.0", "--remote-debugging-port=9222", "--ignore-certificate-errors" ]

--- a/e2e-tests/browser/openid4vp_employeecredential/openid4vp.go
+++ b/e2e-tests/browser/openid4vp_employeecredential/openid4vp.go
@@ -23,6 +23,7 @@ package openid4vp_employeecredential
 import (
 	"context"
 	"fmt"
+
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/e2e-tests/browser/client/iam"
 )

--- a/e2e-tests/browser/rfc019_selfsigned/main_test.go
+++ b/e2e-tests/browser/rfc019_selfsigned/main_test.go
@@ -21,6 +21,10 @@
 package rfc019_selfsigned
 
 import (
+	"os"
+	"testing"
+	"time"
+
 	"github.com/nuts-foundation/go-did/did"
 	didmanAPI "github.com/nuts-foundation/nuts-node/didman/api/v1"
 	"github.com/nuts-foundation/nuts-node/e2e-tests/browser"
@@ -28,9 +32,6 @@ import (
 	didAPI "github.com/nuts-foundation/nuts-node/vdr/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"testing"
-	"time"
 )
 
 func Test_LoginWithSelfSignedMeans(t *testing.T) {
@@ -51,14 +52,14 @@ func Test_LoginWithSelfSignedMeans(t *testing.T) {
 	require.NoError(t, err)
 	err = registerCompoundService(verifyingOrganization.ID, purposeOfUse)
 	require.NoError(t, err)
-	err = browser.IssueOrganizationCredential(verifyingOrganization, "Verifying Organization", "Testland")
+	err = browser.IssueOrganizationCredential(verifyingOrganization, "Verifying Organization", "Testland", apps.NodeClientConfig)
 	require.NoError(t, err)
 
 	issuingOrganization, err := createDID()
 	require.NoError(t, err)
 	err = registerCompoundService(issuingOrganization.ID, purposeOfUse)
 	require.NoError(t, err)
-	err = browser.IssueOrganizationCredential(issuingOrganization, "Issuing Organization", "Testland")
+	err = browser.IssueOrganizationCredential(issuingOrganization, "Issuing Organization", "Testland", apps.NodeClientConfig)
 	require.NoError(t, err)
 
 	selfSigned := apps.SelfSigned{

--- a/e2e-tests/browser/util.go
+++ b/e2e-tests/browser/util.go
@@ -1,3 +1,5 @@
+//go:build e2e_tests
+
 /*
  * Copyright (C) 2024 Nuts community
  *
@@ -16,18 +18,16 @@
  *
  */
 
-//go:build e2e_tests
-
 package browser
 
 import (
 	"github.com/nuts-foundation/go-did/did"
-	"github.com/nuts-foundation/nuts-node/e2e-tests/browser/rfc019_selfsigned/apps"
+	"github.com/nuts-foundation/nuts-node/core"
 	vcrAPI "github.com/nuts-foundation/nuts-node/vcr/api/vcr/v2"
 )
 
-func IssueOrganizationCredential(organization *did.Document, name, city string) error {
-	vcrClient := vcrAPI.HTTPClient{ClientConfig: apps.NodeClientConfig}
+func IssueOrganizationCredential(organization *did.Document, name, city string, clientConfig core.ClientConfig) error {
+	vcrClient := vcrAPI.HTTPClient{ClientConfig: clientConfig}
 	request := vcrAPI.IssueVCRequest{
 		Issuer: organization.ID.String(),
 		CredentialSubject: map[string]interface{}{


### PR DESCRIPTION
By letting the verifier and requester use their own node it is a lot easier to figure out what requests are being made

also removes dependencies between tests