### PR TITLE
e2e tests: have Nuts containers wait for DB container healthy

### DIFF
--- a/e2e-tests/oauth-flow/rfc021/do-test.sh
+++ b/e2e-tests/oauth-flow/rfc021/do-test.sh
@@ -11,7 +11,9 @@ db_dc="docker compose -f docker-compose.yml -f ${1}.yml"
 echo "------------------------------------"
 echo "Cleaning up running Docker containers and volumes, and key material..."
 echo "------------------------------------"
-$db_dc down
+# --remove-orphans to ensure that DB containers of previous runs (on e.g. Postgres) are removed when testing with SQLite.
+# Nothing breaks otherwise, but it prevents annoying warnings in the log.
+$db_dc down --remove-orphans
 $db_dc rm -f -v
 
 echo "------------------------------------"

--- a/e2e-tests/oauth-flow/rfc021/mysql.yml
+++ b/e2e-tests/oauth-flow/rfc021/mysql.yml
@@ -4,13 +4,13 @@ services:
       db:
         condition: service_healthy
     environment:
-      NUTS_STORAGE_SQL_CONNECTION: mysql://root:root@db:3306/node_a?charset=utf8mb4&parseTime=True&loc=Local
+      NUTS_STORAGE_SQL_CONNECTION: mysql://root:root@tcp(db:3306)/node_a?charset=utf8mb4&parseTime=True&loc=Local
   nodeB-backend:
     depends_on:
       db:
         condition: service_healthy
     environment:
-      NUTS_STORAGE_SQL_CONNECTION: mysql://root:root@db:3306/node_b?charset=utf8mb4&parseTime=True&loc=Local
+      NUTS_STORAGE_SQL_CONNECTION: mysql://root:root@tcp(db:3306)/node_b?charset=utf8mb4&parseTime=True&loc=Local
   db:
     image: mysql:8.3.0
     restart: always

--- a/e2e-tests/oauth-flow/rfc021/mysql.yml
+++ b/e2e-tests/oauth-flow/rfc021/mysql.yml
@@ -1,12 +1,14 @@
 services:
   nodeA-backend:
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       NUTS_STORAGE_SQL_CONNECTION: mysql://root:root@db:3306/node_a?charset=utf8mb4&parseTime=True&loc=Local
   nodeB-backend:
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       NUTS_STORAGE_SQL_CONNECTION: mysql://root:root@db:3306/node_b?charset=utf8mb4&parseTime=True&loc=Local
   db:

--- a/e2e-tests/oauth-flow/rfc021/postgres.yml
+++ b/e2e-tests/oauth-flow/rfc021/postgres.yml
@@ -1,12 +1,14 @@
 services:
   nodeA-backend:
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       NUTS_STORAGE_SQL_CONNECTION: postgres://postgres:postgres@db:5432/node_a?sslmode=disable
   nodeB-backend:
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       NUTS_STORAGE_SQL_CONNECTION: postgres://postgres:postgres@db:5432/node_b?sslmode=disable
   db:

--- a/e2e-tests/oauth-flow/rfc021/run-test.sh
+++ b/e2e-tests/oauth-flow/rfc021/run-test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e # make script fail if any of the tests returns a non-zero exit code
 ./do-test.sh postgres
 ./do-test.sh mysql
 ./do-test.sh sqlite

--- a/e2e-tests/oauth-flow/rfc021/sqlserver.yml
+++ b/e2e-tests/oauth-flow/rfc021/sqlserver.yml
@@ -1,12 +1,14 @@
 services:
   nodeA-backend:
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       NUTS_STORAGE_SQL_CONNECTION: sqlserver://sa:MyStrong(!)Password@db:1433/node_a?sslmode=disable
   nodeB-backend:
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       NUTS_STORAGE_SQL_CONNECTION: sqlserver://sa:MyStrong(!)Password@db:1433/node_b?sslmode=disable
   db:

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -188,7 +188,11 @@ func (e *engine) initSQLDatabase() error {
 	// Find right SQL adapter for ORM and migrations
 	dbType := strings.Split(connectionString, ":")[0]
 	if dbType == "sqlite" {
-		connectionString = strings.Join(strings.Split(connectionString, ":")[1:], ":")
+		connectionString = connectionString[strings.Index(connectionString, ":")+1:]
+	} else if dbType == "mysql" {
+		// MySQL DSN needs to be without mysql://
+		// See https://github.com/go-sql-driver/mysql#examples
+		connectionString = strings.TrimPrefix(connectionString, "mysql://")
 	}
 	db, err := goose.OpenDBWithDriver(dbType, connectionString)
 	if err != nil {


### PR DESCRIPTION
Hopefully fixes instable tests.

Also, e2e tests didn't ultimately fail if one of the tests failed in some circumstances (couldn't create DID due to DB being unavailable).