### PR TITLE
SQL: Fix SQL Server e2e test connection strings

### DIFF
--- a/docs/pages/deployment/storage.rst
+++ b/docs/pages/deployment/storage.rst
@@ -35,7 +35,7 @@ Refer to the documentation of the driver for the database you are using for the 
 
 - Postgres `github.com/jackc/pgx <https://github.com/jackc/pgx?tab=readme-ov-file#example-usage>`_ (e.g. ``postgres://user:password@localhost:5432/dbname?sslmode=disable``)
 - MySql: `github.com/go-sql-driver/mysql <https://github.com/go-sql-driver/mysql?tab=readme-ov-file#dsn-data-source-name>`_ (e.g. ``mysql://user:password@tcp(localhost:3306)/dbname?charset=utf8mb4&parseTime=True&loc=Local``)
-- MS SQL Server: `github.com/microsoft/go-mssqldb <https://github.com/microsoft/go-mssqldb>`_
+- MS SQL Server: `github.com/microsoft/go-mssqldb <https://github.com/microsoft/go-mssqldb>`_ (e.g. ``sqlserver://user:password@localhost:1433?database=dbname``)
 - SQLite (e.g. ``sqlite:file:/some/path/sqlite.db?_pragma=foreign_keys(1)&journal_mode(WAL)``)
 
 Private Keys

--- a/e2e-tests/oauth-flow/rfc021/do-test.sh
+++ b/e2e-tests/oauth-flow/rfc021/do-test.sh
@@ -109,5 +109,5 @@ fi
 echo "------------------------------------"
 echo "Stopping Docker containers..."
 echo "------------------------------------"
-#$db_dc down
+$db_dc down
 rm node-*/*.txt

--- a/e2e-tests/oauth-flow/rfc021/do-test.sh
+++ b/e2e-tests/oauth-flow/rfc021/do-test.sh
@@ -109,5 +109,5 @@ fi
 echo "------------------------------------"
 echo "Stopping Docker containers..."
 echo "------------------------------------"
-$db_dc down
+#$db_dc down
 rm node-*/*.txt

--- a/e2e-tests/oauth-flow/rfc021/sqlserver.yml
+++ b/e2e-tests/oauth-flow/rfc021/sqlserver.yml
@@ -4,13 +4,13 @@ services:
       db:
         condition: service_healthy
     environment:
-      NUTS_STORAGE_SQL_CONNECTION: sqlserver://sa:MyStrong(!)Password@db:1433/node_a?sslmode=disable
+      NUTS_STORAGE_SQL_CONNECTION: sqlserver://sa:MyStrong(!)Password@db:1433?database=node_a
   nodeB-backend:
     depends_on:
       db:
         condition: service_healthy
     environment:
-      NUTS_STORAGE_SQL_CONNECTION: sqlserver://sa:MyStrong(!)Password@db:1433/node_b?sslmode=disable
+      NUTS_STORAGE_SQL_CONNECTION: sqlserver://sa:MyStrong(!)Password@db:1433?database=node_b
   db:
     # image: mcr.microsoft.com/azure-sql-edge:latest <-- "The sqlcmd utility is not included in the ARM64 version of the SQL Edge container" - https://github.com/microsoft/mssql-docker/issues/734
     image: mcr.microsoft.com/mssql/server:2022-latest


### PR DESCRIPTION
Both were using the same database (`master`) since the database was passed incorrectly.

Fixes https://github.com/nuts-foundation/nuts-node/issues/3111