### PR TITLE
bugfix: redirect browser instead of returning error

### DIFF
--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -128,7 +128,7 @@ func (r Wrapper) handleAuthorizeRequestFromHolder(ctx context.Context, verifier 
 	// TODO: Support multiple scopes?
 	presentationDefinitions, err := r.presentationDefinitionForScope(ctx, verifier, params.get(oauth.ScopeParam))
 	if err != nil {
-		return nil, err
+		return nil, withCallbackURI(err, redirectURL)
 	}
 
 	session := OAuthSession{


### PR DESCRIPTION
when requested scope is unknown

fixes https://github.com/nuts-foundation/nuts-node/issues/3104