### PR TITLE
Add SessionStore.GetAndDelete

### DIFF
--- a/storage/interface.go
+++ b/storage/interface.go
@@ -20,10 +20,11 @@ package storage
 
 import (
 	"errors"
+	"time"
+
 	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/nuts-node/core"
 	"gorm.io/gorm"
-	"time"
 )
 
 const lockAcquireTimeout = time.Second
@@ -94,4 +95,6 @@ type SessionStore interface {
 	Get(key string, target interface{}) error
 	// Put stores the given value for the given key.
 	Put(key string, value interface{}) error
+	// GetAndDelete combines Get and Delete as a convenience for burning nonce entries.
+	GetAndDelete(key string, target interface{}) error
 }

--- a/storage/mock.go
+++ b/storage/mock.go
@@ -347,6 +347,20 @@ func (mr *MockSessionStoreMockRecorder) Get(key, target any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSessionStore)(nil).Get), key, target)
 }
 
+// GetAndDelete mocks base method.
+func (m *MockSessionStore) GetAndDelete(key string, target any) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAndDelete", key, target)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetAndDelete indicates an expected call of GetAndDelete.
+func (mr *MockSessionStoreMockRecorder) GetAndDelete(key, target any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAndDelete", reflect.TypeOf((*MockSessionStore)(nil).GetAndDelete), key, target)
+}
+
 // Put mocks base method.
 func (m *MockSessionStore) Put(key string, value any) error {
 	m.ctrl.T.Helper()

--- a/storage/session_inmemory.go
+++ b/storage/session_inmemory.go
@@ -20,10 +20,11 @@ package storage
 
 import (
 	"encoding/json"
-	"github.com/nuts-foundation/nuts-node/storage/log"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/nuts-foundation/nuts-node/storage/log"
 )
 
 var _ SessionDatabase = (*InMemorySessionDatabase)(nil)
@@ -133,7 +134,10 @@ func (i InMemorySessionStore) Exists(key string) bool {
 func (i InMemorySessionStore) Get(key string, target interface{}) error {
 	i.db.mux.Lock()
 	defer i.db.mux.Unlock()
+	return i.get(key, target)
+}
 
+func (i InMemorySessionStore) get(key string, target interface{}) error {
 	fullKey := i.getFullKey(key)
 	entry, ok := i.db.entries[fullKey]
 	if !ok {
@@ -161,6 +165,15 @@ func (i InMemorySessionStore) Put(key string, value interface{}) error {
 	}
 
 	i.db.entries[i.getFullKey(key)] = entry
+	return nil
+}
+func (i InMemorySessionStore) GetAndDelete(key string, target interface{}) error {
+	i.db.mux.Lock()
+	defer i.db.mux.Unlock()
+	if err := i.get(key, target); err != nil {
+		return err
+	}
+	delete(i.db.entries, i.getFullKey(key))
 	return nil
 }
 


### PR DESCRIPTION
part of #3063 

I chose this solution over changing `Delete(key string) (interface{}, error)` since the returned interface is always going to be an `[]byte` that still needs to be marshaled to the target object.