### PR TITLE
cleanup oauth constants

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -337,7 +337,7 @@ func (r Wrapper) handleAuthorizeRequest(ctx context.Context, ownDID did.DID, req
 	}
 
 	switch requestObject.get(oauth.ResponseTypeParam) {
-	case responseTypeCode:
+	case oauth.CodeResponseType:
 		// Options:
 		// - Regular authorization code flow for EHR data access through access token, authentication of end-user using OpenID4VP.
 		// - OpenID4VCI; authorization code flow for credential issuance to (end-user) wallet
@@ -359,7 +359,7 @@ func (r Wrapper) handleAuthorizeRequest(ctx context.Context, ownDID did.DID, req
 				Description: "client_id must be a did:web",
 			}
 		}
-	case responseTypeVPToken:
+	case oauth.VPTokenResponseType:
 		// Options:
 		// - OpenID4VP flow, vp_token is sent in Authorization Response
 		// non-spec: if the scheme is openid4vp (URL starts with openid4vp:), the OpenID4VP request should be handled by a user wallet, rather than an organization wallet.
@@ -773,13 +773,13 @@ func (r Wrapper) RequestOid4vciCredentialIssuance(ctx context.Context, request R
 	}
 	// Build the redirect URL, the client browser should be redirected to.
 	redirectUrl := nutsHttp.AddQueryParams(*endpoint, map[string]string{
-		"response_type":         "code",
-		"state":                 state,
-		"client_id":             requestHolder.String(),
-		"authorization_details": string(authorizationDetails),
-		"redirect_uri":          redirectUri.String(),
-		"code_challenge":        pkceParams.Challenge,
-		"code_challenge_method": pkceParams.ChallengeMethod,
+		oauth.ResponseTypeParam:         oauth.CodeResponseType,
+		oauth.StateParam:                state,
+		oauth.ClientIDParam:             requestHolder.String(),
+		oauth.AuthorizationDetailsParam: string(authorizationDetails),
+		oauth.RedirectURIParam:          redirectUri.String(),
+		oauth.CodeChallengeParam:        pkceParams.Challenge,
+		oauth.CodeChallengeMethodParam:  pkceParams.ChallengeMethod,
 	})
 
 	log.Logger().Debugf("generated the following redirect_uri for did %s, to issuer %s: %s", requestHolder.String(), issuerDid.String(), redirectUri.String())

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -315,7 +315,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 			oauth.ClientIDParam:            holderDID.String(),
 			oauth.NonceParam:               "nonce",
 			oauth.RedirectURIParam:         "https://example.com",
-			oauth.ResponseTypeParam:        responseTypeCode,
+			oauth.ResponseTypeParam:        oauth.CodeResponseType,
 			oauth.ScopeParam:               "test",
 			oauth.StateParam:               "state",
 			oauth.CodeChallengeParam:       "code_challenge",
@@ -328,7 +328,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 		expectedURL := "https://example.com/authorize?client_id=did%3Aweb%3Aexample.com%3Aiam%3Averifier&request_uri=https://example.com/oauth2/" + verifierDID.String() + "/request.jwt/&request_uri_method=get"
 		serverMetadata := oauth.AuthorizationServerMetadata{
 			AuthorizationEndpoint:      "https://example.com/authorize",
-			ClientIdSchemesSupported:   []string{didScheme},
+			ClientIdSchemesSupported:   []string{didClientIDScheme},
 			VPFormats:                  oauth.DefaultOpenIDSupportedFormats(),
 			RequireSignedRequestObject: true,
 		}
@@ -339,11 +339,11 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 			params := req.Claims
 			// check the parameters
 			assert.NotEmpty(t, params[oauth.NonceParam])
-			assert.Equal(t, didScheme, params[clientIDSchemeParam])
-			assert.Equal(t, responseTypeVPToken, params[oauth.ResponseTypeParam])
-			assert.Equal(t, "https://example.com/oauth2/did:web:example.com:iam:verifier/response", params[responseURIParam])
-			assert.Equal(t, "https://example.com/oauth2/did:web:example.com:iam:verifier/oauth-client", params[clientMetadataURIParam])
-			assert.Equal(t, responseModeDirectPost, params[responseModeParam])
+			assert.Equal(t, didClientIDScheme, params[oauth.ClientIDSchemeParam])
+			assert.Equal(t, oauth.VPTokenResponseType, params[oauth.ResponseTypeParam])
+			assert.Equal(t, "https://example.com/oauth2/did:web:example.com:iam:verifier/response", params[oauth.ResponseURIParam])
+			assert.Equal(t, "https://example.com/oauth2/did:web:example.com:iam:verifier/oauth-client", params[oauth.ClientMetadataURIParam])
+			assert.Equal(t, responseModeDirectPost, params[oauth.ResponseModeParam])
 			assert.NotEmpty(t, params[oauth.StateParam])
 			return req
 		})
@@ -370,16 +370,16 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 
 		// HandleAuthorizeRequest
 		requestParams := oauthParameters{
-			oauth.ClientIDParam:     verifierDID.String(),
-			clientIDSchemeParam:     didScheme,
-			clientMetadataURIParam:  "https://example.com/.well-known/authorization-server/iam/verifier",
-			oauth.NonceParam:        "nonce",
-			presentationDefUriParam: "https://example.com/oauth2/did:web:example.com:iam:verifier/presentation_definition?scope=test",
-			responseURIParam:        "https://example.com/oauth2/did:web:example.com:iam:verifier/response",
-			responseModeParam:       responseModeDirectPost,
-			oauth.ResponseTypeParam: responseTypeVPToken,
-			oauth.ScopeParam:        "test",
-			oauth.StateParam:        "state",
+			oauth.ClientIDParam:           verifierDID.String(),
+			oauth.ClientIDSchemeParam:     didClientIDScheme,
+			oauth.ClientMetadataURIParam:  "https://example.com/.well-known/authorization-server/iam/verifier",
+			oauth.NonceParam:              "nonce",
+			oauth.PresentationDefUriParam: "https://example.com/oauth2/did:web:example.com:iam:verifier/presentation_definition?scope=test",
+			oauth.ResponseURIParam:        "https://example.com/oauth2/did:web:example.com:iam:verifier/response",
+			oauth.ResponseModeParam:       responseModeDirectPost,
+			oauth.ResponseTypeParam:       oauth.VPTokenResponseType,
+			oauth.ScopeParam:              "test",
+			oauth.StateParam:              "state",
 		}
 		ctx.vdr.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
 		ctx.jar.EXPECT().Parse(gomock.Any(), holderDID, gomock.Any()).Return(requestParams, nil)

--- a/auth/api/iam/metadata.go
+++ b/auth/api/iam/metadata.go
@@ -72,7 +72,7 @@ func staticAuthorizationServerMetadata() oauth.AuthorizationServerMetadata {
 	return oauth.AuthorizationServerMetadata{
 		Issuer:                 "https://self-issued.me/v2",
 		AuthorizationEndpoint:  "openid4vp:",
-		ResponseTypesSupported: []string{responseTypeVPToken},
+		ResponseTypesSupported: []string{oauth.VPTokenResponseType},
 		VPFormatsSupported: map[string]map[string][]string{
 			"jwt_vp_json": {"alg_values_supported": []string{string(jwa.ES256)}},
 			"jwt_vc_json": {"alg_values_supported": []string{string(jwa.ES256)}},
@@ -91,6 +91,6 @@ func clientMetadata(identity url.URL) oauth.OAuthClientMetadata {
 		SoftwareID:              softwareID,      // nuts-node-refimpl
 		SoftwareVersion:         softwareVersion, // version tag or "unknown"
 		VPFormats:               oauth.DefaultOpenIDSupportedFormats(),
-		ClientIdScheme:          didScheme,
+		ClientIdScheme:          didClientIDScheme,
 	}
 }

--- a/auth/api/iam/metadata_test.go
+++ b/auth/api/iam/metadata_test.go
@@ -37,7 +37,7 @@ func Test_authorizationServerMetadata(t *testing.T) {
 		AuthorizationEndpoint:                      "openid4vp:",
 		ClientIdSchemesSupported:                   []string{"did"},
 		DPoPSigningAlgValuesSupported:              jwx.SupportedAlgorithmsAsStrings(),
-		GrantTypesSupported:                        []string{"authorization_code", "vp_token", "urn:ietf:params:oauth:grant-type:pre-authorized_code"},
+		GrantTypesSupported:                        []string{"authorization_code", "vp_token-bearer"},
 		Issuer:                                     didExample.String(),
 		PreAuthorizedGrantAnonymousAccessSupported: true,
 		PresentationDefinitionUriSupported:         &presentationDefinitionURISupported,
@@ -75,7 +75,7 @@ func Test_clientMetadata(t *testing.T) {
 	expected := OAuthClientMetadata{
 		RedirectURIs:            nil,
 		TokenEndpointAuthMethod: "none",
-		GrantTypes:              []string{"authorization_code", "vp_token", "urn:ietf:params:oauth:grant-type:pre-authorized_code"},
+		GrantTypes:              []string{"authorization_code", "vp_token-bearer"},
 		ResponseTypes:           []string{"code", "vp_token"},
 		Scope:                   "",
 		Contacts:                nil,

--- a/auth/api/iam/session.go
+++ b/auth/api/iam/session.go
@@ -21,12 +21,13 @@ package iam
 import (
 	"errors"
 	"fmt"
+	"net/url"
+
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/http"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
-	"net/url"
 )
 
 // OAuthSession is the session object that is used to store information about the OAuth request.

--- a/auth/api/iam/types.go
+++ b/auth/api/iam/types.go
@@ -74,84 +74,22 @@ type CookieReader interface {
 }
 
 const (
-	// oauth.ResponseTypeParam is the name of the response_type parameter.
-	// Specified by https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.1
-	//
-	// TODO: reconsider the following
-	//	Extension response types MAY contain a space-delimited (%x20) list of
-	//	values, where the order of values does not matter (e.g., response
-	//	type "a b" is the same as "b a").  The meaning of such composite
-	//	response types is defined by their respective specifications.
-	//
-	//	If an authorization request is missing the "response_type" parameter,
-	//	or if the response type is not understood, the authorization server
-	//	MUST return an error response as described in Section 4.1.2.1.
-
-	// responseTypeCode is the default response_type in the OAuth2 authorized code flow
-	responseTypeCode = "code"
-	// responseTypeVPToken is defined in the OpenID4VP vp_token flow
-	// https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#appendix-B
-	responseTypeVPToken = "vp_token"
-)
-
-var responseTypesSupported = []string{responseTypeCode, responseTypeVPToken}
-
-const (
-	// responseModeParam is the name of the OAuth2 response_mode parameter.
-	// Specified by https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html
-	responseModeParam = "response_mode"
 	// responseModeQuery returns the answer to the authorization request append as query parameters to the provided redirect_uri
 	responseModeQuery = "query" // default if no response_mode is specified
 	// responseModeDirectPost signals the Authorization Server to POST the requested presentation definition to the provided response_uri
-	// https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-response-mode-direct_post
 	responseModeDirectPost = "direct_post"
 )
 
 var responseModesSupported = []string{responseModeQuery, responseModeDirectPost}
 
-const (
-	// grantTypeAuthorizationCode is the default OAuth2 grant type
-	grantTypeAuthorizationCode = "authorization_code"
-	// grantTypeVPToken is used to present a vp_token in exchange for an access_token in service-to-service flows
-	// TODO: EBSI inspired flow that is not standardized
-	// 		 https://api-conformance.ebsi.eu/docs/ct/verifiable-presentation-exchange-guidelines-v3#service-to-service-token-flow
-	grantTypeVPToken = "vp_token"
-	// grantTypePreAuthorizedCode is defined in the pre-authorized_code flow of OpenID4VCI
-	// https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-sub-namespace-registration
-	grantTypePreAuthorizedCode = "urn:ietf:params:oauth:grant-type:pre-authorized_code"
-)
+var responseTypesSupported = []string{oauth.CodeResponseType, oauth.VPTokenResponseType}
 
-var grantTypesSupported = []string{grantTypeAuthorizationCode, grantTypeVPToken, grantTypePreAuthorizedCode}
+var grantTypesSupported = []string{oauth.AuthorizationCodeGrantType, oauth.VpTokenGrantType}
 
-// clientIdSchemesSupported lists the supported client_id_scheme
-// https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-verifier-metadata-managemen
-var clientIdSchemesSupported = []string{didScheme}
+var clientIdSchemesSupported = []string{didClientIDScheme}
 
-// clientMetadataParam is the name of the OpenID4VP client_metadata parameter.
-// Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-authorization-request
-const clientMetadataParam = "client_metadata"
-
-// clientMetadataParam is the name of the OpenID4VP client_metadata_uri parameter.
-// Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-authorization-request
-const clientMetadataURIParam = "client_metadata_uri"
-
-// clientIDSchemeParam is the name of the OpenID4VP client_id_scheme parameter.
-// Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-authorization-request
-const clientIDSchemeParam = "client_id_scheme"
-
-// didScheme is the client_id_scheme value for DIDs
-const didScheme = "did"
-
-// responseURIParam is the name of the OpenID4VP response_uri parameter.
-const responseURIParam = "response_uri"
-
-// presentationDefParam is the name of the OpenID4VP presentation_definition parameter.
-// Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-presentation_definition-par
-const presentationDefParam = "presentation_definition"
-
-// presentationDefUriParam is the name of the OpenID4VP presentation_definition_uri parameter.
-// Specified by https://openid.bitbucket.io/connect/openid-4-verifiable-presentations-1_0.html#name-presentation_definition_uri
-const presentationDefUriParam = "presentation_definition_uri"
+// didClientIDScheme is the client_id_scheme value for DIDs
+const didClientIDScheme = "did"
 
 const (
 	AccessTokenTypeBearer = "Bearer"

--- a/auth/api/iam/user.go
+++ b/auth/api/iam/user.go
@@ -28,18 +28,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/labstack/echo/v4"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
+	"github.com/nuts-foundation/nuts-node/auth/log"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
+	"github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
-	issuer "github.com/nuts-foundation/nuts-node/vcr/issuer"
-
-	"github.com/labstack/echo/v4"
-	"github.com/nuts-foundation/go-did/did"
-	"github.com/nuts-foundation/nuts-node/auth/log"
-	"github.com/nuts-foundation/nuts-node/crypto"
+	"github.com/nuts-foundation/nuts-node/vcr/issuer"
 )
 
 const (
@@ -148,7 +147,7 @@ func (r Wrapper) handleUserLanding(echoCtx echo.Context) error {
 		values[oauth.CodeChallengeParam] = oauthSession.PKCEParams.Challenge
 		values[oauth.CodeChallengeMethodParam] = oauthSession.PKCEParams.ChallengeMethod
 		values[oauth.RedirectURIParam] = callbackURL.String()
-		values[oauth.ResponseTypeParam] = responseTypeCode
+		values[oauth.ResponseTypeParam] = oauth.CodeResponseType
 		values[oauth.StateParam] = oauthSession.ClientState
 		values[oauth.ScopeParam] = accessTokenRequest.Body.Scope
 	}

--- a/auth/api/iam/user_test.go
+++ b/auth/api/iam/user_test.go
@@ -25,13 +25,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nuts-foundation/nuts-node/auth/oauth"
-
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
+	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	cryptoNuts "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/mock"
 	"github.com/nuts-foundation/nuts-node/vcr/issuer"
@@ -83,7 +82,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 
 	serverMetadata := oauth.AuthorizationServerMetadata{
 		AuthorizationEndpoint:      "https://example.com/authorize",
-		ClientIdSchemesSupported:   []string{didScheme},
+		ClientIdSchemesSupported:   []string{didClientIDScheme},
 		VPFormats:                  oauth.DefaultOpenIDSupportedFormats(),
 		RequireSignedRequestObject: true,
 	}

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -176,7 +176,7 @@ func (c *OpenID4VPClient) AccessToken(ctx context.Context, code string, verifier
 	data := url.Values{}
 	data.Set(oauth.ClientIDParam, clientID.String())
 	data.Set(oauth.GrantTypeParam, oauth.AuthorizationCodeGrantType)
-	data.Set(oauth.CodeParam, code)
+	data.Set(oauth.CodeResponseType, code)
 	data.Set(oauth.RedirectURIParam, callbackURI)
 	data.Set(oauth.CodeVerifierParam, codeVerifier)
 

--- a/auth/oauth/types.go
+++ b/auth/oauth/types.go
@@ -109,6 +109,7 @@ const (
 	AccessTokenRequestStatusActive = "active"
 )
 
+// metadata endpoints
 const (
 	// AuthzServerWellKnown is the well-known base path for the oauth authorization server metadata as defined in RFC8414
 	AuthzServerWellKnown = "/.well-known/oauth-authorization-server"
@@ -118,50 +119,80 @@ const (
 	// OpenID4VCI specification
 	OpenIdCredIssuerWellKnown    = "/.well-known/openid-credential-issuer"
 	OpenIdConfigurationWellKnown = "/.well-known/openid-configuration"
-	// AssertionParam is the parameter name for the assertion parameter
+)
+
+// oauth parameter keys
+const (
+	// AssertionParam is the parameter name for the assertion parameter. (RFC021)
 	AssertionParam = "assertion"
-	// AuthorizationCodeGrantType is the grant_type for the authorization_code grant type
-	AuthorizationCodeGrantType = "authorization_code"
-	// ClientIDParam is the parameter name for the client_id parameter
+	// AuthorizationDetailsParam is the parameter name for the authorization_details parameter. (RFC9396)
+	AuthorizationDetailsParam = "authorization_details"
+	// ClientIDParam is the parameter name for the client_id parameter. (RFC6749)
 	ClientIDParam = "client_id"
-	// CodeChallengeParam is the parameter name for the code_challenge parameter
+	// ClientIDSchemeParam is the parameter name for the client_id_scheme parameter. (OpenID4VP)
+	ClientIDSchemeParam = "client_id_scheme"
+	// ClientMetadataParam is the parameter name for the client_metadata parameter. (OpenID4VP)
+	ClientMetadataParam = "client_metadata"
+	// ClientMetadataURIParam is the parameter name for the client_metadata_uri parameter. (OpenID4VP)
+	ClientMetadataURIParam = "client_metadata_uri"
+	// CNonceParam is the parameter name for the c_nonce parameter. (OpenID4VCI)
+	CNonceParam = "c_nonce"
+	// CodeChallengeParam is the parameter name for the code_challenge parameter. (RFC7636)
 	CodeChallengeParam = "code_challenge"
-	// CodeChallengeMethodParam is the parameter name for the code_challenge_method parameter
+	// CodeChallengeMethodParam is the parameter name for the code_challenge_method parameter. (RFC7636)
 	CodeChallengeMethodParam = "code_challenge_method"
-	// CodeVerifierParam is the parameter name for the code_verifier parameter
+	// CodeVerifierParam is the parameter name for the code_verifier parameter. (RFC7636)
 	CodeVerifierParam = "code_verifier"
-	// CodeParam is the parameter name for the code parameter
-	CodeParam = "code"
-	// GrantTypeParam is the parameter name for the grant_type parameter
+	// GrantTypeParam is the parameter name for the grant_type parameter. (RFC6749)
 	GrantTypeParam = "grant_type"
 	// NonceParam is the parameter name for the nonce parameter
 	NonceParam = "nonce"
-	// RedirectURIParam is the parameter name for the redirect_uri parameter
-	RedirectURIParam = "redirect_uri"
-	// RequestParam is the parameter name for the request parameter.	Defined in RFC9101
-	RequestParam = "request"
-	// RequestURIParam is the parameter name for the request parameter. Defined in RFC9101
-	RequestURIParam = "request_uri"
-	// RequestURIMethodParam states what http method (get/post) should be used for RequestURIParam. Defined in OpenID4VP
-	RequestURIMethodParam = "request_uri_method"
-	// ResponseTypeParam is the parameter name for the response_type parameter
-	ResponseTypeParam = "response_type"
-	// ScopeParam is the parameter name for the scope parameter
-	ScopeParam = "scope"
-	// StateParam is the parameter name for the state parameter
-	StateParam = "state"
-	// PresentationSubmissionParam is the parameter name for the presentation_submission parameter
+	// PresentationDefParam is the parameter name for the OpenID4VP presentation_definition parameter. (OpenID4VP)
+	PresentationDefParam = "presentation_definition"
+	// PresentationDefUriParam is the parameter name for the OpenID4VP presentation_definition_uri parameter. (OpenID4VP)
+	PresentationDefUriParam = "presentation_definition_uri"
+	// PresentationSubmissionParam is the parameter name for the presentation_submission parameter. (OpenID4VP)
 	PresentationSubmissionParam = "presentation_submission"
-	// VpTokenParam is the parameter name for the vp_token parameter
+	// RedirectURIParam is the parameter name for the redirect_uri parameter. (RFC6749)
+	RedirectURIParam = "redirect_uri"
+	// RequestParam is the parameter name for the request parameter.	(RFC9101)
+	RequestParam = "request"
+	// RequestURIParam is the parameter name for the request parameter. (RFC9101)
+	RequestURIParam = "request_uri"
+	// RequestURIMethodParam states what http method (get/post) should be used for RequestURIParam. (OpenID4VP)
+	RequestURIMethodParam = "request_uri_method"
+	// ResponseModeParam is the parameter name for the OAuth2 response_mode parameter.
+	ResponseModeParam = "response_mode"
+	// ResponseTypeParam is the parameter name for the response_type parameter. (RFC6749)
+	ResponseTypeParam = "response_type"
+	// ResponseURIParam is the parameter name for the OpenID4VP response_uri parameter.
+	ResponseURIParam = "response_uri"
+	// ScopeParam is the parameter name for the scope parameter. (RFC6749)
+	ScopeParam = "scope"
+	// StateParam is the parameter name for the state parameter. (RFC6749)
+	StateParam = "state"
+	// VpTokenParam is the parameter name for the vp_token parameter. (OpenID4VP)
 	VpTokenParam = "vp_token"
 	// WalletMetadataParam is used by the wallet to provide its metadata in an authorization request when RequestURIMethodParam is 'post'
 	WalletMetadataParam = "wallet_metadata"
 	// WalletNonceParam is a wallet generated nonce to prevent authorization request replay when RequestURIMethodParam is 'post'
 	WalletNonceParam = "wallet_nonce"
-	// VpTokenGrantType is the grant_type for the vp_token-bearer grant type
+)
+
+// grant types
+const (
+	// AuthorizationCodeGrantType is the grant_type for the authorization_code grant type. (RFC6749)
+	AuthorizationCodeGrantType = "authorization_code"
+	// VpTokenGrantType is the grant_type for the vp_token-bearer grant type. (RFC021)
 	VpTokenGrantType = "vp_token-bearer"
-	// CNonceParam is the parameter name for the c_nonce parameter. Defined in OpenID4VCI.
-	CNonceParam = "c_nonce"
+)
+
+// response types
+const (
+	// CodeResponseType is the parameter name for the code parameter. (RFC6749)
+	CodeResponseType = "code"
+	// VPTokenResponseType is paramter name for the vp_token repsponse type. (OpenID4VP)
+	VPTokenResponseType = "vp_token"
 )
 
 const (


### PR DESCRIPTION
moved a bunch of constants from `auth/api/iam/types.go` to `auth/oauth/types.go`
removed duplicate and unused constants