### PR TITLE
prevent panic on sql timestamp update statement

### DIFF
--- a/discovery/store.go
+++ b/discovery/store.go
@@ -122,12 +122,15 @@ func (s *sqlStore) add(serviceID string, presentation vc.VerifiablePresentation,
 		if timestamp == 0 {
 			var newTs *int
 			newTs, err = s.incrementTimestamp(tx, serviceID)
+			if err != nil {
+				return err
+			}
 			timestamp = *newTs
 		} else {
 			err = s.setTimestamp(tx, serviceID, timestamp)
-		}
-		if err != nil {
-			return err
+			if err != nil {
+				return err
+			}
 		}
 		// Delete any previous presentations of the subject
 		if err := tx.Delete(&presentationRecord{}, "service_id = ? AND credential_subject_id = ?", serviceID, credentialSubjectID.String()).


### PR DESCRIPTION
during testing, I had an invalid schema which caused a sql statement failure. This resulted in a panic due to the error check being after the pointer dereference.