### PR TITLE
Burn nonce type SessionStore entries after first use

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -239,12 +239,10 @@ func (r Wrapper) RetrieveAccessToken(_ context.Context, request RetrieveAccessTo
 	}
 	// access token is active, return to caller and delete access token from store
 	// change this when tokens can be cached
-	defer func() {
-		err = r.accessTokenClientStore().Delete(request.SessionID)
-		if err != nil {
-			log.Logger().WithError(err).Warn("Failed to delete access token")
-		}
-	}()
+	err = r.accessTokenClientStore().Delete(request.SessionID)
+	if err != nil {
+		log.Logger().WithError(err).Warn("Failed to delete access token")
+	}
 	// return access token
 	return RetrieveAccessToken200JSONResponse(token), nil
 }

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -237,12 +237,14 @@ func (r Wrapper) RetrieveAccessToken(_ context.Context, request RetrieveAccessTo
 		// return pending status
 		return RetrieveAccessToken200JSONResponse(token), nil
 	}
-	// delete access token from store
+	// access token is active, return to caller and delete access token from store
 	// change this when tokens can be cached
-	err = r.accessTokenClientStore().Delete(request.SessionID)
-	if err != nil {
-		return nil, err
-	}
+	defer func() {
+		err = r.accessTokenClientStore().Delete(request.SessionID)
+		if err != nil {
+			log.Logger().WithError(err).Warn("Failed to delete access token")
+		}
+	}()
 	// return access token
 	return RetrieveAccessToken200JSONResponse(token), nil
 }
@@ -385,8 +387,7 @@ func (r Wrapper) handleAuthorizeRequest(ctx context.Context, ownDID did.DID, req
 // RFC9101: The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR).
 func (r Wrapper) RequestJWTByGet(ctx context.Context, request RequestJWTByGetRequestObject) (RequestJWTByGetResponseObject, error) {
 	ro := new(jarRequest)
-	// TODO: burn request object to prevent DoS through signing requests https://github.com/nuts-foundation/nuts-node/issues/3063
-	err := r.authzRequestObjectStore().Get(request.Id, ro)
+	err := r.authzRequestObjectStore().GetAndDelete(request.Id, ro)
 	if err != nil {
 		return nil, oauth.OAuth2Error{
 			Code:        oauth.InvalidRequest,
@@ -401,7 +402,7 @@ func (r Wrapper) RequestJWTByGet(ctx context.Context, request RequestJWTByGetReq
 		}
 	}
 	if ro.RequestURIMethod != "get" { // case sensitive
-		// TODO: wallet does not support `request_uri_method=post`. Unclear if this should fail, or fallback to using staticAuthorizationServerMetadata().
+		// TODO: wallet does not support `request_uri_method=post`. Spec is unclear if this should fail, or fallback to using staticAuthorizationServerMetadata().
 		return nil, oauth.OAuth2Error{
 			Code:          oauth.InvalidRequest,
 			Description:   "used request_uri_method 'get' on a 'post' request_uri",
@@ -429,8 +430,7 @@ func (r Wrapper) RequestJWTByGet(ctx context.Context, request RequestJWTByGetReq
 // RFC9101: The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR).
 func (r Wrapper) RequestJWTByPost(ctx context.Context, request RequestJWTByPostRequestObject) (RequestJWTByPostResponseObject, error) {
 	ro := new(jarRequest)
-	// TODO: burn request object to prevent DoS through signing requests https://github.com/nuts-foundation/nuts-node/issues/3063
-	err := r.authzRequestObjectStore().Get(request.Id, ro)
+	err := r.authzRequestObjectStore().GetAndDelete(request.Id, ro)
 	if err != nil {
 		return nil, oauth.OAuth2Error{
 			Code:        oauth.InvalidRequest,
@@ -759,7 +759,7 @@ func (r Wrapper) RequestOid4vciCredentialIssuance(ctx context.Context, request R
 		return nil, err
 	}
 	// Store the session
-	err = r.oid4vciSssionStore().Put(state, &Oid4vciSession{
+	err = r.openid4vciSessionStore().Put(state, &Oid4vciSession{
 		HolderDid:                requestHolder,
 		IssuerDid:                issuerDid,
 		RemoteRedirectUri:        request.Body.RedirectUri,
@@ -793,7 +793,7 @@ func (r Wrapper) RequestOid4vciCredentialIssuance(ctx context.Context, request R
 func (r Wrapper) CallbackOid4vciCredentialIssuance(ctx context.Context, request CallbackOid4vciCredentialIssuanceRequestObject) (CallbackOid4vciCredentialIssuanceResponseObject, error) {
 	state := request.Params.State
 	oid4vciSession := Oid4vciSession{}
-	err := r.oid4vciSssionStore().Get(state, &oid4vciSession)
+	err := r.openid4vciSessionStore().Get(state, &oid4vciSession)
 	if err != nil {
 		return nil, core.NotFoundError("Cannot locate active session for state: %s", state)
 	}
@@ -1002,6 +1002,11 @@ func (r Wrapper) authzRequestObjectStore() storage.SessionStore {
 	return r.storageEngine.GetSessionDatabase().GetStore(accessTokenValidity, oauthRequestObjectKey...)
 }
 
+// openid4vciSessionStore is used by the Client to keep track of OpenID4VCI requests
+func (r Wrapper) openid4vciSessionStore() storage.SessionStore {
+	return r.storageEngine.GetSessionDatabase().GetStore(oid4vciSessionValidity, "openid4vci")
+}
+
 // createOAuth2BaseURL creates an OAuth2 base URL for an owned did:web DID
 // It creates a URL in the following format: https://<did:web host>/oauth2/<did>
 func createOAuth2BaseURL(webDID did.DID) (*url.URL, error) {
@@ -1010,8 +1015,4 @@ func createOAuth2BaseURL(webDID did.DID) (*url.URL, error) {
 		return nil, fmt.Errorf("failed to convert DID to URL: %w", err)
 	}
 	return didURL.Parse("/oauth2/" + webDID.String())
-}
-
-func (r Wrapper) oid4vciSssionStore() storage.SessionStore {
-	return r.storageEngine.GetSessionDatabase().GetStore(oid4vciSessionValidity, "oid4vci")
 }

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -179,20 +179,21 @@ func (r Wrapper) HandleTokenRequest(ctx context.Context, request HandleTokenRequ
 		return nil, err
 	}
 	switch request.Body.GrantType {
-	case "authorization_code":
+	case oauth.AuthorizationCodeGrantType:
 		// Options:
 		// - OpenID4VCI
 		// - OpenID4VP
 		// verifier DID is taken from code->oauthSession storage
 		return r.handleAccessTokenRequest(ctx, *request.Body)
-	case "urn:ietf:params:oauth:grant-type:pre-authorized_code":
+	case oauth.PreAuthorizedCodeGrantType:
 		// Options:
 		// - OpenID4VCI
+		// todo: add to grantTypesSupported in AS metadata once supported
 		return nil, oauth.OAuth2Error{
 			Code:        oauth.UnsupportedGrantType,
 			Description: "not implemented yet",
 		}
-	case "vp_token-bearer":
+	case oauth.VpTokenGrantType:
 		// Nuts RFC021 vp_token bearer flow
 		if request.Body.PresentationSubmission == nil || request.Body.Scope == nil || request.Body.Assertion == nil {
 			return nil, oauth.OAuth2Error{

--- a/auth/api/iam/user.go
+++ b/auth/api/iam/user.go
@@ -75,9 +75,8 @@ func (r Wrapper) handleUserLanding(echoCtx echo.Context) error {
 	}
 
 	// extract request from store
-	store := r.userRedirectStore()
 	redirectSession := RedirectSession{}
-	err := store.Get(token, &redirectSession)
+	err := r.userRedirectStore().GetAndDelete(token, &redirectSession)
 	if err != nil {
 		log.Logger().Debug("token not found in store")
 		return echoCtx.NoContent(http.StatusForbidden)
@@ -109,12 +108,6 @@ func (r Wrapper) handleUserLanding(echoCtx echo.Context) error {
 		}
 	}
 
-	// burn token
-	err = store.Delete(token)
-	if err != nil {
-		//rare, log just in case
-		log.Logger().WithError(err).Warn("delete token failed")
-	}
 	// use DPoP or not
 	useDPoP := true
 	if redirectSession.AccessTokenRequest.Body.TokenType != nil && strings.ToLower(string(*redirectSession.AccessTokenRequest.Body.TokenType)) == strings.ToLower(AccessTokenTypeBearer) {
@@ -151,7 +144,6 @@ func (r Wrapper) handleUserLanding(echoCtx echo.Context) error {
 		values[oauth.StateParam] = oauthSession.ClientState
 		values[oauth.ScopeParam] = accessTokenRequest.Body.Scope
 	}
-	// TODO: First create user session, or AuthorizationRequest first? (which one is more expensive? both sign stuff)
 	redirectURL, err := r.CreateAuthorizationRequest(echoCtx.Request().Context(), redirectSession.OwnDID, verifier, modifier)
 	if err != nil {
 		return err
@@ -159,18 +151,23 @@ func (r Wrapper) handleUserLanding(echoCtx echo.Context) error {
 	return echoCtx.Redirect(http.StatusFound, redirectURL.String())
 }
 
+// userRedirectStore is used to store a short-lived RedirectSession that persist state between the RequestUserAccessToken
+// call and the redirect back to this node to initiate the actual authorization request. Burn on use.
 func (r Wrapper) userRedirectStore() storage.SessionStore {
 	return r.storageEngine.GetSessionDatabase().GetStore(userRedirectTimeout, userRedirectSessionKey...)
 }
 
+// userSessionStore is used to keep track of active UserSession
 func (r Wrapper) userSessionStore() storage.SessionStore {
 	return r.storageEngine.GetSessionDatabase().GetStore(userSessionTimeout, userSessionKey...)
 }
 
+// oauthClientStateStore is used tot store the client's OAuthSession
 func (r Wrapper) oauthClientStateStore() storage.SessionStore {
 	return r.storageEngine.GetSessionDatabase().GetStore(oAuthFlowTimeout, oauthClientStateKey...)
 }
 
+// oauthCodeStore is used to store the authorization server's OAuthSession in the authorization_code flow. Burn on use.
 func (r Wrapper) oauthCodeStore() storage.SessionStore {
 	return r.storageEngine.GetSessionDatabase().GetStore(oAuthFlowTimeout, oauthCodeKey...)
 }

--- a/auth/api/iam/user_test.go
+++ b/auth/api/iam/user_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	cryptoNuts "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/mock"
+	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/nuts-foundation/nuts-node/vcr/issuer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -190,7 +191,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 
 		err := ctx.client.handleUserLanding(echoCtx)
 
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 	t.Run("error - no token", func(t *testing.T) {
 		ctx := newTestClient(t)
@@ -200,7 +201,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 
 		err := ctx.client.handleUserLanding(echoCtx)
 
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 	t.Run("error - token not found", func(t *testing.T) {
 		ctx := newTestClient(t)
@@ -210,7 +211,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 
 		err := ctx.client.handleUserLanding(echoCtx)
 
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 	t.Run("error - verifier did parse error", func(t *testing.T) {
 		ctx := newTestClient(t)
@@ -232,7 +233,9 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 
 		err = ctx.client.handleUserLanding(echoCtx)
 
-		require.Error(t, err)
+		assert.EqualError(t, err, "invalid DID")
+		// token has been burned
+		assert.ErrorIs(t, store.Get("token", new(RedirectSession)), storage.ErrNotFound)
 	})
 	t.Run("error - authorization request error", func(t *testing.T) {
 		ctx := newTestClient(t)
@@ -252,7 +255,9 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 
 		err = ctx.client.handleUserLanding(echoCtx)
 
-		assert.Error(t, err)
+		assert.ErrorIs(t, err, assert.AnError)
+		// token has been burned
+		assert.ErrorIs(t, store.Get("token", new(RedirectSession)), storage.ErrNotFound)
 	})
 }
 

--- a/auth/oauth/types.go
+++ b/auth/oauth/types.go
@@ -183,6 +183,8 @@ const (
 const (
 	// AuthorizationCodeGrantType is the grant_type for the authorization_code grant type. (RFC6749)
 	AuthorizationCodeGrantType = "authorization_code"
+	// PreAuthorizedCodeGrantType is the grant_type for the pre-authorized_code grant type. (OpenID4VCI)
+	PreAuthorizedCodeGrantType = "urn:ietf:params:oauth:grant-type:pre-authorized_code"
 	// VpTokenGrantType is the grant_type for the vp_token-bearer grant type. (RFC021)
 	VpTokenGrantType = "vp_token-bearer"
 )


### PR DESCRIPTION
closes #3063 

rewrote nonce validation in `handleAuthorizeResponseSubmission` since it assumed the first VP contained the "correct" nonce and later on did a second validation over all VPs