### PR TITLE
Use token endpoint from session

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -814,7 +814,7 @@ func (r Wrapper) CallbackOid4vciCredentialIssuance(ctx context.Context, request 
 	if err != nil {
 		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("cannot fetch the right endpoints: %s", err.Error())), oid4vciSession.remoteRedirectUri())
 	}
-	response, err := r.auth.IAMClient().AccessToken(ctx, code, *issuerDid, oid4vciSession.RedirectUri, *holderDid, pkceParams.Verifier, false)
+	response, err := r.auth.IAMClient().AccessToken(ctx, code, tokenEndpoint, oid4vciSession.RedirectUri, *holderDid, pkceParams.Verifier, false)
 	if err != nil {
 		return nil, withCallbackURI(oauthError(oauth.AccessDenied, fmt.Sprintf("error while fetching the access_token from endpoint: %s, error: %s", tokenEndpoint, err.Error())), oid4vciSession.remoteRedirectUri())
 	}

--- a/auth/api/iam/dpop.go
+++ b/auth/api/iam/dpop.go
@@ -133,3 +133,9 @@ func dpopFromRequest(httpRequest http.Request) (*dpop.DPoP, error) {
 	}
 	return dpopProof, nil
 }
+
+// useNonceOnceStore is used to store nonces that are used once, e.g. DPoP jti
+// it uses the access token validity as the expiration time
+func (r Wrapper) useNonceOnceStore() storage.SessionStore {
+	return r.storageEngine.GetSessionDatabase().GetStore(accessTokenValidity, "nonceonce")
+}

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -206,12 +206,8 @@ type CallbackOid4vciCredentialIssuanceParams struct {
 
 // RequestOid4vciCredentialIssuanceJSONBody defines parameters for RequestOid4vciCredentialIssuance.
 type RequestOid4vciCredentialIssuanceJSONBody struct {
-	AuthorizationDetails []struct {
-		CredentialDefinition *map[string]interface{} `json:"credential_definition,omitempty"`
-		Format               *string                 `json:"format,omitempty"`
-		Type                 *string                 `json:"type,omitempty"`
-	} `json:"authorization_details"`
-	Issuer string `json:"issuer"`
+	AuthorizationDetails []map[string]interface{} `json:"authorization_details"`
+	Issuer               string                   `json:"issuer"`
 
 	// RedirectUri The URL to which the user-agent will be redirected after the authorization request.
 	RedirectUri string `json:"redirect_uri"`

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -817,6 +817,8 @@ func (r Wrapper) handleCallback(ctx context.Context, request CallbackRequestObje
 	}, nil
 }
 
+// oauthNonceStore is used to map nonce to state. Burn on use.
+// This mapping is needed because we have one OAuthSession (state), but use a new nonce for every OpenID4VP flow.
 func (r Wrapper) oauthNonceStore() storage.SessionStore {
 	return r.storageEngine.GetSessionDatabase().GetStore(oAuthFlowTimeout, oauthNonceKey...)
 }

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -42,6 +42,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
 	"github.com/nuts-foundation/nuts-node/vdr/didjwk"
+	"github.com/nuts-foundation/nuts-node/vdr/didweb"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 )
 
@@ -108,7 +109,12 @@ func (r Wrapper) handleAuthorizeRequestFromHolder(ctx context.Context, verifier 
 	if err != nil || walletDID.Method != "web" {
 		return nil, withCallbackURI(oauthError(oauth.InvalidRequest, "invalid client_id parameter (only did:web is supported)"), redirectURL)
 	}
-	metadata, err := r.auth.IAMClient().AuthorizationServerMetadata(ctx, *walletDID)
+	oauthIssuer, err := didweb.DIDToURL(*walletDID)
+	if err != nil {
+		// can't fail since it's a valid did:web
+		return nil, err
+	}
+	metadata, err := r.auth.IAMClient().AuthorizationServerMetadata(ctx, oauthIssuer.String())
 	if err != nil {
 		return nil, withCallbackURI(oauthError(oauth.ServerError, "failed to get metadata from wallet", err), redirectURL)
 	}

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -797,7 +797,7 @@ func (r Wrapper) handleCallback(ctx context.Context, request CallbackRequestObje
 	checkURL = checkURL.JoinPath(oauth.CallbackPath)
 
 	// use code to request access token from remote token endpoint
-	tokenResponse, err := r.auth.IAMClient().AccessToken(ctx, *request.Params.Code, *oauthSession.VerifierDID, checkURL.String(), *oauthSession.OwnDID, oauthSession.PKCEParams.Verifier, oauthSession.UseDPoP)
+	tokenResponse, err := r.auth.IAMClient().AccessToken(ctx, *request.Params.Code, oauthSession.TokenEndpoint, checkURL.String(), *oauthSession.OwnDID, oauthSession.PKCEParams.Verifier, oauthSession.UseDPoP)
 	if err != nil {
 		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("failed to retrieve access token: %s", err.Error())), appCallbackURI)
 	}

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -112,7 +112,7 @@ func (r Wrapper) handleAuthorizeRequestFromHolder(ctx context.Context, verifier 
 	oauthIssuer, err := didweb.DIDToURL(*walletDID)
 	if err != nil {
 		// can't fail since it's a valid did:web
-		return nil, err
+		return nil, withCallbackURI(oauthError(oauth.InvalidRequest, "invalid client_id parameter (only did:web is supported)"), redirectURL)
 	}
 	metadata, err := r.auth.IAMClient().AuthorizationServerMetadata(ctx, oauthIssuer.String())
 	if err != nil {
@@ -819,6 +819,11 @@ func (r Wrapper) handleCallback(ctx context.Context, request CallbackRequestObje
 
 func (r Wrapper) oauthNonceStore() storage.SessionStore {
 	return r.storageEngine.GetSessionDatabase().GetStore(oAuthFlowTimeout, oauthNonceKey...)
+}
+
+// oauthCodeStore is used to store the authorization server's OAuthSession in the authorization_code flow. Burn on use.
+func (r Wrapper) oauthCodeStore() storage.SessionStore {
+	return r.storageEngine.GetSessionDatabase().GetStore(oAuthFlowTimeout, oauthCodeKey...)
 }
 
 func oauthError(code oauth.ErrorCode, description string, internalError ...error) oauth.OAuth2Error {

--- a/auth/api/iam/openid4vp_test.go
+++ b/auth/api/iam/openid4vp_test.go
@@ -754,11 +754,12 @@ func Test_handleCallback(t *testing.T) {
 	state := "state"
 
 	session := OAuthSession{
-		SessionID:   "token",
-		OwnDID:      &holderDID,
-		RedirectURI: "https://example.com/iam/holder/cb",
-		VerifierDID: &verifierDID,
-		PKCEParams:  generatePKCEParams(),
+		SessionID:     "token",
+		OwnDID:        &holderDID,
+		RedirectURI:   "https://example.com/iam/holder/cb",
+		VerifierDID:   &verifierDID,
+		PKCEParams:    generatePKCEParams(),
+		TokenEndpoint: "https://example.com/token",
 	}
 
 	t.Run("err - missing state", func(t *testing.T) {
@@ -804,7 +805,7 @@ func Test_handleCallback(t *testing.T) {
 		putState(ctx, "state", session)
 		codeVerifier := getState(ctx, state).PKCEParams.Verifier
 		ctx.vdr.EXPECT().IsOwner(gomock.Any(), webDID).Return(true, nil)
-		ctx.iamClient.EXPECT().AccessToken(gomock.Any(), code, verifierDID, "https://example.com/oauth2/"+webDID.String()+"/callback", holderDID, codeVerifier, false).Return(nil, assert.AnError)
+		ctx.iamClient.EXPECT().AccessToken(gomock.Any(), code, session.TokenEndpoint, "https://example.com/oauth2/"+webDID.String()+"/callback", holderDID, codeVerifier, false).Return(nil, assert.AnError)
 
 		_, err := ctx.client.handleCallback(nil, CallbackRequestObject{
 			Did: webDID.String(),

--- a/auth/api/iam/openid4vp_test.go
+++ b/auth/api/iam/openid4vp_test.go
@@ -42,6 +42,8 @@ import (
 
 var holderDID = did.MustParseDID("did:web:example.com:iam:holder")
 var issuerDID = did.MustParseDID("did:web:example.com:iam:issuer")
+var holderURL = "https://example.com/iam/holder"
+var issuerURL = "https://example.com/iam/issuer"
 
 func TestWrapper_handleAuthorizeRequestFromHolder(t *testing.T) {
 	defaultParams := func() oauthParameters {
@@ -98,7 +100,7 @@ func TestWrapper_handleAuthorizeRequestFromHolder(t *testing.T) {
 	t.Run("missing did in supported_client_id_schemes", func(t *testing.T) {
 		ctx := newTestClient(t)
 		params := defaultParams()
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), holderDID).Return(&oauth.AuthorizationServerMetadata{
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), holderURL).Return(&oauth.AuthorizationServerMetadata{
 			AuthorizationEndpoint:    "http://example.com",
 			ClientIdSchemesSupported: []string{"not_did"},
 		}, nil)
@@ -119,7 +121,7 @@ func TestWrapper_handleAuthorizeRequestFromHolder(t *testing.T) {
 	})
 	t.Run("unknown scope", func(t *testing.T) {
 		ctx := newTestClient(t)
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), holderDID).Return(&oauth.AuthorizationServerMetadata{
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), holderURL).Return(&oauth.AuthorizationServerMetadata{
 			AuthorizationEndpoint:    "http://example.com",
 			ClientIdSchemesSupported: []string{"did"},
 		}, nil)
@@ -142,7 +144,7 @@ func TestWrapper_handleAuthorizeRequestFromHolder(t *testing.T) {
 	})
 	t.Run("error on authorization server metadata", func(t *testing.T) {
 		ctx := newTestClient(t)
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), holderDID).Return(nil, assert.AnError)
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), holderURL).Return(nil, assert.AnError)
 
 		_, err := ctx.client.handleAuthorizeRequestFromHolder(context.Background(), verifierDID, defaultParams())
 
@@ -152,7 +154,7 @@ func TestWrapper_handleAuthorizeRequestFromHolder(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.policy.EXPECT().PresentationDefinitions(gomock.Any(), verifierDID, "test").Return(pe.WalletOwnerMapping{pe.WalletOwnerOrganization: PresentationDefinition{}}, nil)
 		params := defaultParams()
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(context.Background(), holderDID).Return(&oauth.AuthorizationServerMetadata{
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(context.Background(), holderURL).Return(&oauth.AuthorizationServerMetadata{
 			ClientIdSchemesSupported: []string{didClientIDScheme},
 		}, nil).Times(2)
 

--- a/auth/api/iam/session.go
+++ b/auth/api/iam/session.go
@@ -43,6 +43,7 @@ type OAuthSession struct {
 	ResponseType      string       `json:"response_type,omitempty"`
 	Scope             string       `json:"scope,omitempty"`
 	SessionID         string       `json:"session_id,omitempty"`
+	TokenEndpoint     string       `json:"token_endpoint,omitempty"`
 	UseDPoP           bool         `json:"use_dpop,omitempty"`
 	VerifierDID       *did.DID     `json:"verifier_did,omitempty"`
 }

--- a/auth/api/iam/user.go
+++ b/auth/api/iam/user.go
@@ -115,7 +115,7 @@ func (r Wrapper) handleUserLanding(echoCtx echo.Context) error {
 		useDPoP = false
 	}
 
-	//
+	// get AS metadata
 	oauthIssuer, err := didweb.DIDToURL(*verifier)
 	if err != nil {
 		return err
@@ -125,10 +125,10 @@ func (r Wrapper) handleUserLanding(echoCtx echo.Context) error {
 		return fmt.Errorf("failed to retrieve remote OAuth Authorization Server metadata: %w", err)
 	}
 	if len(metadata.AuthorizationEndpoint) == 0 {
-		return fmt.Errorf("no authorization endpoint found in metadata for %s", verifier.String())
+		return fmt.Errorf("no authorization_endpoint found for %s", verifier.String())
 	}
 	if len(metadata.TokenEndpoint) == 0 {
-		return fmt.Errorf("no token endpoint found in metadata for %s", verifier.String())
+		return fmt.Errorf("no token_endpoint found for %s", verifier.String())
 	}
 	// create oauthSession with userID from request
 	// generate new sessionID and clientState with crypto.GenerateNonce()
@@ -183,11 +183,6 @@ func (r Wrapper) userSessionStore() storage.SessionStore {
 // oauthClientStateStore is used tot store the client's OAuthSession
 func (r Wrapper) oauthClientStateStore() storage.SessionStore {
 	return r.storageEngine.GetSessionDatabase().GetStore(oAuthFlowTimeout, oauthClientStateKey...)
-}
-
-// oauthCodeStore is used to store the authorization server's OAuthSession in the authorization_code flow. Burn on use.
-func (r Wrapper) oauthCodeStore() storage.SessionStore {
-	return r.storageEngine.GetSessionDatabase().GetStore(oAuthFlowTimeout, oauthCodeKey...)
 }
 
 // loadUserSession loads the user session given the session ID in the cookie.

--- a/auth/api/iam/user.go
+++ b/auth/api/iam/user.go
@@ -39,6 +39,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/issuer"
+	"github.com/nuts-foundation/nuts-node/vdr/didweb"
 )
 
 const (
@@ -115,7 +116,11 @@ func (r Wrapper) handleUserLanding(echoCtx echo.Context) error {
 	}
 
 	//
-	metadata, err := r.auth.IAMClient().AuthorizationServerMetadata(echoCtx.Request().Context(), *verifier)
+	oauthIssuer, err := didweb.DIDToURL(*verifier)
+	if err != nil {
+		return err
+	}
+	metadata, err := r.auth.IAMClient().AuthorizationServerMetadata(echoCtx.Request().Context(), oauthIssuer.String())
 	if err != nil {
 		return fmt.Errorf("failed to retrieve remote OAuth Authorization Server metadata: %w", err)
 	}

--- a/auth/api/iam/user_test.go
+++ b/auth/api/iam/user_test.go
@@ -111,7 +111,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 			employeeCredentialOptions = o
 			return &t, nil
 		})
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierDID).Return(&serverMetadata, nil).Times(2)
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierURL).Return(&serverMetadata, nil).Times(2)
 		ctx.jar.EXPECT().Create(webDID, &verifierDID, gomock.Any()).DoAndReturn(func(client did.DID, server *did.DID, modifier requestObjectModifier) jarRequest {
 			req := createJarRequest(client, server, modifier)
 			params := req.Claims
@@ -178,7 +178,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 			return nil
 		})
 		echoCtx.EXPECT().Cookie(gomock.Any()).Return(&sessionCookie, nil)
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierDID).Return(&serverMetadata, nil).Times(2)
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierURL).Return(&serverMetadata, nil).Times(2)
 		ctx.jar.EXPECT().Create(webDID, &verifierDID, gomock.Any())
 		require.NoError(t, ctx.client.userRedirectStore().Put("token", redirectSession))
 		session := UserSession{
@@ -252,7 +252,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 		store := ctx.client.storageEngine.GetSessionDatabase().GetStore(time.Second*5, "user", "redirect")
 		err := store.Put("token", redirectSession)
 		require.NoError(t, err)
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierDID).Return(nil, assert.AnError)
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierURL).Return(nil, assert.AnError)
 
 		err = ctx.client.handleUserLanding(echoCtx)
 

--- a/auth/api/iam/user_test.go
+++ b/auth/api/iam/user_test.go
@@ -83,6 +83,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 
 	serverMetadata := oauth.AuthorizationServerMetadata{
 		AuthorizationEndpoint:      "https://example.com/authorize",
+		TokenEndpoint:              "https://example.com/token",
 		ClientIdSchemesSupported:   []string{didClientIDScheme},
 		VPFormats:                  oauth.DefaultOpenIDSupportedFormats(),
 		RequireSignedRequestObject: true,
@@ -110,7 +111,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 			employeeCredentialOptions = o
 			return &t, nil
 		})
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierDID).Return(&serverMetadata, nil)
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierDID).Return(&serverMetadata, nil).Times(2)
 		ctx.jar.EXPECT().Create(webDID, &verifierDID, gomock.Any()).DoAndReturn(func(client did.DID, server *did.DID, modifier requestObjectModifier) jarRequest {
 			req := createJarRequest(client, server, modifier)
 			params := req.Claims
@@ -177,7 +178,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 			return nil
 		})
 		echoCtx.EXPECT().Cookie(gomock.Any()).Return(&sessionCookie, nil)
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierDID).Return(&serverMetadata, nil)
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierDID).Return(&serverMetadata, nil).Times(2)
 		ctx.jar.EXPECT().Create(webDID, &verifierDID, gomock.Any())
 		require.NoError(t, ctx.client.userRedirectStore().Put("token", redirectSession))
 		session := UserSession{

--- a/auth/client/iam/client.go
+++ b/auth/client/iam/client.go
@@ -41,7 +41,8 @@ type HTTPClient struct {
 	httpClient core.HTTPRequestDoer
 }
 
-// OAuthAuthorizationServerMetadata retrieves the OAuth authorization server metadata for the given web DID.
+// OAuthAuthorizationServerMetadata retrieves the OAuth authorization server metadata for the given oauth issuer.
+// oauthIssuer is the oauth.AuthorizationServerMetadata.Issuer from which the metadata endpoint is derived.
 func (hb HTTPClient) OAuthAuthorizationServerMetadata(ctx context.Context, oauthIssuer string) (*oauth.AuthorizationServerMetadata, error) {
 	metadataURL, err := oauth.IssuerIdToWellKnown(oauthIssuer, oauth.AuthzServerWellKnown, hb.strictMode)
 	if err != nil {

--- a/auth/client/iam/client.go
+++ b/auth/client/iam/client.go
@@ -28,13 +28,11 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/auth/log"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
-	"github.com/nuts-foundation/nuts-node/vdr/didweb"
 )
 
 // HTTPClient holds the server address and other basic settings for the http client
@@ -44,13 +42,8 @@ type HTTPClient struct {
 }
 
 // OAuthAuthorizationServerMetadata retrieves the OAuth authorization server metadata for the given web DID.
-func (hb HTTPClient) OAuthAuthorizationServerMetadata(ctx context.Context, webDID did.DID) (*oauth.AuthorizationServerMetadata, error) {
-	serverURL, err := didweb.DIDToURL(webDID)
-	if err != nil {
-		return nil, err
-	}
-
-	metadataURL, err := oauth.IssuerIdToWellKnown(serverURL.String(), oauth.AuthzServerWellKnown, hb.strictMode)
+func (hb HTTPClient) OAuthAuthorizationServerMetadata(ctx context.Context, oauthIssuer string) (*oauth.AuthorizationServerMetadata, error) {
+	metadataURL, err := oauth.IssuerIdToWellKnown(oauthIssuer, oauth.AuthzServerWellKnown, hb.strictMode)
 	if err != nil {
 		return nil, err
 	}
@@ -211,25 +204,8 @@ func (hb HTTPClient) PostAuthorizationResponse(ctx context.Context, vp vc.Verifi
 	return hb.postFormExpectRedirect(ctx, data, verifierResponseURI)
 }
 
-func (hb HTTPClient) OpenIdConfiguration(ctx context.Context, serverURL string) (*oauth.OpenIDConfigurationMetadata, error) {
-	metadataURL, err := oauth.IssuerIdToWellKnown(serverURL, oauth.OpenIdConfigurationWellKnown, hb.strictMode)
-	if err != nil {
-		return nil, err
-	}
-	var metadata oauth.OpenIDConfigurationMetadata
-	err = hb.doGet(ctx, metadataURL.String(), &metadata)
-	if err != nil {
-		return nil, err
-	}
-	return &metadata, err
-}
-
-func (hb HTTPClient) OpenIdCredentialIssuerMetadata(ctx context.Context, webDID did.DID) (*oauth.OpenIDCredentialIssuerMetadata, error) {
-	serverURL, err := didweb.DIDToURL(webDID)
-	if err != nil {
-		return nil, err
-	}
-	metadataURL, err := oauth.IssuerIdToWellKnown(serverURL.String(), oauth.OpenIdCredIssuerWellKnown, hb.strictMode)
+func (hb HTTPClient) OpenIdCredentialIssuerMetadata(ctx context.Context, oauthIssuerURI string) (*oauth.OpenIDCredentialIssuerMetadata, error) {
+	metadataURL, err := oauth.IssuerIdToWellKnown(oauthIssuerURI, oauth.OpenIdCredIssuerWellKnown, hb.strictMode)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/client/iam/client_test.go
+++ b/auth/client/iam/client_test.go
@@ -26,14 +26,12 @@ import (
 	"testing"
 
 	ssi "github.com/nuts-foundation/go-did"
-	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/test"
 	http2 "github.com/nuts-foundation/nuts-node/test/http"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
-	"github.com/nuts-foundation/nuts-node/vdr/didweb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,9 +43,8 @@ func TestHTTPClient_OAuthAuthorizationServerMetadata(t *testing.T) {
 		result := oauth.AuthorizationServerMetadata{TokenEndpoint: "/token"}
 		handler := http2.Handler{StatusCode: http.StatusOK, ResponseData: result}
 		tlsServer, client := testServerAndClient(t, &handler)
-		testDID := didweb.ServerURLToDIDWeb(t, tlsServer.URL)
 
-		metadata, err := client.OAuthAuthorizationServerMetadata(ctx, testDID)
+		metadata, err := client.OAuthAuthorizationServerMetadata(ctx, tlsServer.URL)
 
 		require.NoError(t, err)
 		require.NotNil(t, metadata)
@@ -60,10 +57,8 @@ func TestHTTPClient_OAuthAuthorizationServerMetadata(t *testing.T) {
 		result := oauth.AuthorizationServerMetadata{TokenEndpoint: "/token"}
 		handler := http2.Handler{StatusCode: http.StatusOK, ResponseData: result}
 		tlsServer, client := testServerAndClient(t, &handler)
-		testDID := didweb.ServerURLToDIDWeb(t, tlsServer.URL)
-		testDID = did.MustParseDID(testDID.String() + ":iam:123")
 
-		metadata, err := client.OAuthAuthorizationServerMetadata(ctx, testDID)
+		metadata, err := client.OAuthAuthorizationServerMetadata(ctx, tlsServer.URL+"/iam/123")
 
 		require.NoError(t, err)
 		require.NotNil(t, metadata)

--- a/auth/client/iam/interface.go
+++ b/auth/client/iam/interface.go
@@ -34,7 +34,7 @@ type Client interface {
 	// The response will be unmarshalled into the given tokenResponseOut parameter.
 	AccessToken(ctx context.Context, code string, tokenURI, callbackURI string, clientID did.DID, codeVerifier string, useDPoP bool) (*oauth.TokenResponse, error)
 	// AuthorizationServerMetadata returns the metadata of the remote wallet.
-	AuthorizationServerMetadata(ctx context.Context, webdid did.DID) (*oauth.AuthorizationServerMetadata, error)
+	AuthorizationServerMetadata(ctx context.Context, oauthIssuerURI string) (*oauth.AuthorizationServerMetadata, error)
 	// ClientMetadata returns the metadata of the remote verifier.
 	ClientMetadata(ctx context.Context, endpoint string) (*oauth.OAuthClientMetadata, error)
 	// PostError posts an error to the verifier. If it fails, an error is returned.
@@ -46,9 +46,7 @@ type Client interface {
 	// RequestRFC021AccessToken is called by the local EHR node to request an access token from a remote Nuts node using Nuts RFC021.
 	RequestRFC021AccessToken(ctx context.Context, requestHolder did.DID, verifier did.DID, scopes string, useDPoP bool) (*oauth.TokenResponse, error)
 
-	OpenIdConfiguration(ctx context.Context, serverURL string) (*oauth.OpenIDConfigurationMetadata, error)
-
-	OpenIdCredentialIssuerMetadata(ctx context.Context, webDID did.DID) (*oauth.OpenIDCredentialIssuerMetadata, error)
+	OpenIdCredentialIssuerMetadata(ctx context.Context, oauthIssuerURI string) (*oauth.OpenIDCredentialIssuerMetadata, error)
 
 	VerifiableCredentials(ctx context.Context, credentialEndpoint string, accessToken string, proofJWT string) (*CredentialResponse, error)
 	// RequestObjectByGet retrieves the RequestObjectByGet from the authorization request's 'request_uri' endpoint using a GET method as defined in RFC9101/OpenID4VP.

--- a/auth/client/iam/interface.go
+++ b/auth/client/iam/interface.go
@@ -34,7 +34,8 @@ type Client interface {
 	// The response will be unmarshalled into the given tokenResponseOut parameter.
 	AccessToken(ctx context.Context, code string, tokenURI, callbackURI string, clientID did.DID, codeVerifier string, useDPoP bool) (*oauth.TokenResponse, error)
 	// AuthorizationServerMetadata returns the metadata of the remote wallet.
-	AuthorizationServerMetadata(ctx context.Context, oauthIssuerURI string) (*oauth.AuthorizationServerMetadata, error)
+	// oauthIssuer is the address that identifies the Authorization Server. For a did:web it is its URL. (same as oauth.AuthorizationServerMetadata.Issuer)
+	AuthorizationServerMetadata(ctx context.Context, oauthIssuer string) (*oauth.AuthorizationServerMetadata, error)
 	// ClientMetadata returns the metadata of the remote verifier.
 	ClientMetadata(ctx context.Context, endpoint string) (*oauth.OAuthClientMetadata, error)
 	// PostError posts an error to the verifier. If it fails, an error is returned.

--- a/auth/client/iam/interface.go
+++ b/auth/client/iam/interface.go
@@ -32,7 +32,7 @@ type Client interface {
 	// AccessToken requests an access token at the oauth2 token endpoint.
 	// The token endpoint can be a regular OAuth2 token endpoint or OpenID4VCI-related endpoint.
 	// The response will be unmarshalled into the given tokenResponseOut parameter.
-	AccessToken(ctx context.Context, code string, verifier did.DID, callbackURI string, clientID did.DID, codeVerifier string, useDPoP bool) (*oauth.TokenResponse, error)
+	AccessToken(ctx context.Context, code string, tokenURI, callbackURI string, clientID did.DID, codeVerifier string, useDPoP bool) (*oauth.TokenResponse, error)
 	// AuthorizationServerMetadata returns the metadata of the remote wallet.
 	AuthorizationServerMetadata(ctx context.Context, webdid did.DID) (*oauth.AuthorizationServerMetadata, error)
 	// ClientMetadata returns the metadata of the remote verifier.

--- a/auth/client/iam/mock.go
+++ b/auth/client/iam/mock.go
@@ -59,18 +59,18 @@ func (mr *MockClientMockRecorder) AccessToken(ctx, code, tokenURI, callbackURI, 
 }
 
 // AuthorizationServerMetadata mocks base method.
-func (m *MockClient) AuthorizationServerMetadata(ctx context.Context, webdid did.DID) (*oauth.AuthorizationServerMetadata, error) {
+func (m *MockClient) AuthorizationServerMetadata(ctx context.Context, oauthIssuerURI string) (*oauth.AuthorizationServerMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AuthorizationServerMetadata", ctx, webdid)
+	ret := m.ctrl.Call(m, "AuthorizationServerMetadata", ctx, oauthIssuerURI)
 	ret0, _ := ret[0].(*oauth.AuthorizationServerMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AuthorizationServerMetadata indicates an expected call of AuthorizationServerMetadata.
-func (mr *MockClientMockRecorder) AuthorizationServerMetadata(ctx, webdid any) *gomock.Call {
+func (mr *MockClientMockRecorder) AuthorizationServerMetadata(ctx, oauthIssuerURI any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizationServerMetadata", reflect.TypeOf((*MockClient)(nil).AuthorizationServerMetadata), ctx, webdid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizationServerMetadata", reflect.TypeOf((*MockClient)(nil).AuthorizationServerMetadata), ctx, oauthIssuerURI)
 }
 
 // ClientMetadata mocks base method.
@@ -88,34 +88,19 @@ func (mr *MockClientMockRecorder) ClientMetadata(ctx, endpoint any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientMetadata", reflect.TypeOf((*MockClient)(nil).ClientMetadata), ctx, endpoint)
 }
 
-// OpenIdConfiguration mocks base method.
-func (m *MockClient) OpenIdConfiguration(ctx context.Context, serverURL string) (*oauth.OpenIDConfigurationMetadata, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenIdConfiguration", ctx, serverURL)
-	ret0, _ := ret[0].(*oauth.OpenIDConfigurationMetadata)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// OpenIdConfiguration indicates an expected call of OpenIdConfiguration.
-func (mr *MockClientMockRecorder) OpenIdConfiguration(ctx, serverURL any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenIdConfiguration", reflect.TypeOf((*MockClient)(nil).OpenIdConfiguration), ctx, serverURL)
-}
-
 // OpenIdCredentialIssuerMetadata mocks base method.
-func (m *MockClient) OpenIdCredentialIssuerMetadata(ctx context.Context, webDID did.DID) (*oauth.OpenIDCredentialIssuerMetadata, error) {
+func (m *MockClient) OpenIdCredentialIssuerMetadata(ctx context.Context, oauthIssuerURI string) (*oauth.OpenIDCredentialIssuerMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenIdCredentialIssuerMetadata", ctx, webDID)
+	ret := m.ctrl.Call(m, "OpenIdCredentialIssuerMetadata", ctx, oauthIssuerURI)
 	ret0, _ := ret[0].(*oauth.OpenIDCredentialIssuerMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // OpenIdCredentialIssuerMetadata indicates an expected call of OpenIdCredentialIssuerMetadata.
-func (mr *MockClientMockRecorder) OpenIdCredentialIssuerMetadata(ctx, webDID any) *gomock.Call {
+func (mr *MockClientMockRecorder) OpenIdCredentialIssuerMetadata(ctx, oauthIssuerURI any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenIdCredentialIssuerMetadata", reflect.TypeOf((*MockClient)(nil).OpenIdCredentialIssuerMetadata), ctx, webDID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenIdCredentialIssuerMetadata", reflect.TypeOf((*MockClient)(nil).OpenIdCredentialIssuerMetadata), ctx, oauthIssuerURI)
 }
 
 // PostAuthorizationResponse mocks base method.

--- a/auth/client/iam/mock.go
+++ b/auth/client/iam/mock.go
@@ -44,18 +44,18 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // AccessToken mocks base method.
-func (m *MockClient) AccessToken(ctx context.Context, code string, verifier did.DID, callbackURI string, clientID did.DID, codeVerifier string, useDPoP bool) (*oauth.TokenResponse, error) {
+func (m *MockClient) AccessToken(ctx context.Context, code, tokenURI, callbackURI string, clientID did.DID, codeVerifier string, useDPoP bool) (*oauth.TokenResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AccessToken", ctx, code, verifier, callbackURI, clientID, codeVerifier, useDPoP)
+	ret := m.ctrl.Call(m, "AccessToken", ctx, code, tokenURI, callbackURI, clientID, codeVerifier, useDPoP)
 	ret0, _ := ret[0].(*oauth.TokenResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AccessToken indicates an expected call of AccessToken.
-func (mr *MockClientMockRecorder) AccessToken(ctx, code, verifier, callbackURI, clientID, codeVerifier, useDPoP any) *gomock.Call {
+func (mr *MockClientMockRecorder) AccessToken(ctx, code, tokenURI, callbackURI, clientID, codeVerifier, useDPoP any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccessToken", reflect.TypeOf((*MockClient)(nil).AccessToken), ctx, code, verifier, callbackURI, clientID, codeVerifier, useDPoP)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccessToken", reflect.TypeOf((*MockClient)(nil).AccessToken), ctx, code, tokenURI, callbackURI, clientID, codeVerifier, useDPoP)
 }
 
 // AuthorizationServerMetadata mocks base method.

--- a/auth/client/iam/mock.go
+++ b/auth/client/iam/mock.go
@@ -59,18 +59,18 @@ func (mr *MockClientMockRecorder) AccessToken(ctx, code, tokenURI, callbackURI, 
 }
 
 // AuthorizationServerMetadata mocks base method.
-func (m *MockClient) AuthorizationServerMetadata(ctx context.Context, oauthIssuerURI string) (*oauth.AuthorizationServerMetadata, error) {
+func (m *MockClient) AuthorizationServerMetadata(ctx context.Context, oauthIssuer string) (*oauth.AuthorizationServerMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AuthorizationServerMetadata", ctx, oauthIssuerURI)
+	ret := m.ctrl.Call(m, "AuthorizationServerMetadata", ctx, oauthIssuer)
 	ret0, _ := ret[0].(*oauth.AuthorizationServerMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AuthorizationServerMetadata indicates an expected call of AuthorizationServerMetadata.
-func (mr *MockClientMockRecorder) AuthorizationServerMetadata(ctx, oauthIssuerURI any) *gomock.Call {
+func (mr *MockClientMockRecorder) AuthorizationServerMetadata(ctx, oauthIssuer any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizationServerMetadata", reflect.TypeOf((*MockClient)(nil).AuthorizationServerMetadata), ctx, oauthIssuerURI)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizationServerMetadata", reflect.TypeOf((*MockClient)(nil).AuthorizationServerMetadata), ctx, oauthIssuer)
 }
 
 // ClientMetadata mocks base method.

--- a/auth/client/iam/openid4vp_test.go
+++ b/auth/client/iam/openid4vp_test.go
@@ -211,7 +211,7 @@ func TestIAMClient_AuthorizationServerMetadata(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		ctx := createClientServerTestContext(t)
 
-		metadata, err := ctx.client.AuthorizationServerMetadata(context.Background(), ctx.verifierDID)
+		metadata, err := ctx.client.AuthorizationServerMetadata(context.Background(), ctx.tlsServer.URL)
 
 		require.NoError(t, err)
 		require.NotNil(t, metadata)
@@ -221,7 +221,7 @@ func TestIAMClient_AuthorizationServerMetadata(t *testing.T) {
 		ctx := createClientServerTestContext(t)
 		ctx.metadata = nil
 
-		_, err := ctx.client.AuthorizationServerMetadata(context.Background(), ctx.verifierDID)
+		_, err := ctx.client.AuthorizationServerMetadata(context.Background(), ctx.tlsServer.URL)
 
 		require.Error(t, err)
 		assert.EqualError(t, err, "failed to retrieve remote OAuth Authorization Server metadata: server returned HTTP 404 (expected: 200)")
@@ -422,7 +422,6 @@ type clientTestContext struct {
 type clientServerTestContext struct {
 	*clientTestContext
 	authzServerMetadata            *oauth.AuthorizationServerMetadata
-	openIDConfigurationMetadata    *oauth.OpenIDConfigurationMetadata
 	openIDCredentialIssuerMetadata *oauth.OpenIDCredentialIssuerMetadata
 	handler                        http.HandlerFunc
 	tlsServer                      *httptest.Server
@@ -509,11 +508,6 @@ func createClientServerTestContext(t *testing.T) *clientServerTestContext {
 				ctx.metadata(writer)
 				return
 			}
-		case "/.well-known/openid-configuration":
-			if ctx.metadata != nil {
-				ctx.metadata(writer)
-				return
-			}
 		case "/.well-known/openid-credential-issuer/issuer":
 			if ctx.credentialIssuerMetadata != nil {
 				ctx.credentialIssuerMetadata(writer)
@@ -565,7 +559,6 @@ func createClientServerTestContext(t *testing.T) *clientServerTestContext {
 	ctx.authzServerMetadata.AuthorizationEndpoint = ctx.tlsServer.URL + "/authorize"
 	ctx.authzServerMetadata.RequireSignedRequestObject = true
 
-	ctx.openIDConfigurationMetadata = metadata
 	ctx.openIDCredentialIssuerMetadata = credentialIssuerMetadata
 	ctx.openIDCredentialIssuerMetadata.AuthorizationServers = []string{ctx.authzServerMetadata.AuthorizationEndpoint}
 	ctx.openIDCredentialIssuerMetadata.CredentialIssuer = "issuer"
@@ -574,35 +567,11 @@ func createClientServerTestContext(t *testing.T) *clientServerTestContext {
 	return ctx
 }
 
-func TestIAMClient_OpenIdConfiguration(t *testing.T) {
-
-	t.Run("ok", func(t *testing.T) {
-		ctx := createClientServerTestContext(t)
-
-		serverURL := ctx.tlsServer.URL
-		metadata, err := ctx.client.OpenIdConfiguration(context.Background(), serverURL)
-
-		require.NoError(t, err)
-		require.NotNil(t, metadata)
-		assert.Equal(t, *ctx.openIDConfigurationMetadata, *metadata)
-	})
-	t.Run("error - failed to get access token", func(t *testing.T) {
-		ctx := createClientServerTestContext(t)
-		ctx.metadata = nil
-
-		serverURL := ctx.tlsServer.URL
-		response, err := ctx.client.OpenIdConfiguration(context.Background(), serverURL)
-
-		assert.Error(t, err)
-		assert.Nil(t, response)
-		assert.EqualError(t, err, "failed to retrieve Openid configuration: server returned HTTP 404 (expected: 200)")
-	})
-}
 func TestIAMClient_OpenIdCredentialIssuerMetadata(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		ctx := createClientServerTestContext(t)
 
-		metadata, err := ctx.client.OpenIdCredentialIssuerMetadata(context.Background(), ctx.issuerDID)
+		metadata, err := ctx.client.OpenIdCredentialIssuerMetadata(context.Background(), ctx.tlsServer.URL+"/issuer")
 
 		require.NoError(t, err)
 		require.NotNil(t, metadata)
@@ -612,20 +581,16 @@ func TestIAMClient_OpenIdCredentialIssuerMetadata(t *testing.T) {
 		ctx := createClientServerTestContext(t)
 		ctx.credentialIssuerMetadata = nil
 
-		response, err := ctx.client.OpenIdCredentialIssuerMetadata(context.Background(), ctx.issuerDID)
+		response, err := ctx.client.OpenIdCredentialIssuerMetadata(context.Background(), ctx.tlsServer.URL+"/issuer")
 
 		require.Error(t, err)
 		assert.Nil(t, response)
 		assert.EqualError(t, err, "failed to retrieve Openid credential issuer metadata: server returned HTTP 404 (expected: 200)")
 	})
-
 }
 
 func TestIAMClient_VerifiableCredentials(t *testing.T) {
-	//walletDID := did.MustParseDID("did:web:test.test:iam:123")
 	accessToken := "code"
-	//cNonce := crypto.GenerateNonce()
-
 	proowJWT := "top secret"
 
 	t.Run("ok", func(t *testing.T) {

--- a/auth/client/iam/openid4vp_test.go
+++ b/auth/client/iam/openid4vp_test.go
@@ -57,7 +57,7 @@ func TestIAMClient_AccessToken(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		ctx := createClientServerTestContext(t)
 
-		response, err := ctx.client.AccessToken(context.Background(), code, ctx.verifierDID, callbackURI, clientID, codeVerifier, false)
+		response, err := ctx.client.AccessToken(context.Background(), code, ctx.authzServerMetadata.TokenEndpoint, callbackURI, clientID, codeVerifier, false)
 
 		require.NoError(t, err)
 		require.NotNil(t, response)
@@ -69,7 +69,7 @@ func TestIAMClient_AccessToken(t *testing.T) {
 		ctx.keyResolver.EXPECT().ResolveKey(clientID, nil, resolver.NutsSigningKeyType).Return(kid, nil, nil)
 		ctx.jwtSigner.EXPECT().SignDPoP(context.Background(), gomock.Any(), kid.String()).Return("dpop", nil)
 
-		response, err := ctx.client.AccessToken(context.Background(), code, ctx.verifierDID, callbackURI, clientID, codeVerifier, true)
+		response, err := ctx.client.AccessToken(context.Background(), code, ctx.authzServerMetadata.TokenEndpoint, callbackURI, clientID, codeVerifier, true)
 
 		require.NoError(t, err)
 		require.NotNil(t, response)
@@ -80,7 +80,7 @@ func TestIAMClient_AccessToken(t *testing.T) {
 		ctx := createClientServerTestContext(t)
 		ctx.token = nil
 
-		response, err := ctx.client.AccessToken(context.Background(), code, ctx.verifierDID, callbackURI, clientID, codeVerifier, false)
+		response, err := ctx.client.AccessToken(context.Background(), code, ctx.authzServerMetadata.TokenEndpoint, callbackURI, clientID, codeVerifier, false)
 
 		assert.EqualError(t, err, "remote server: error creating access token: server returned HTTP 404 (expected: 200)")
 		assert.Nil(t, response)
@@ -90,7 +90,7 @@ func TestIAMClient_AccessToken(t *testing.T) {
 		ctx.keyResolver.EXPECT().ResolveKey(clientID, nil, resolver.NutsSigningKeyType).Return(kid, nil, nil)
 		ctx.jwtSigner.EXPECT().SignDPoP(context.Background(), gomock.Any(), kid.String()).Return("", assert.AnError)
 
-		response, err := ctx.client.AccessToken(context.Background(), code, ctx.verifierDID, callbackURI, clientID, codeVerifier, true)
+		response, err := ctx.client.AccessToken(context.Background(), code, ctx.authzServerMetadata.TokenEndpoint, callbackURI, clientID, codeVerifier, true)
 
 		assert.Error(t, err)
 		assert.Nil(t, response)

--- a/auth/oauth/types.go
+++ b/auth/oauth/types.go
@@ -117,8 +117,7 @@ const (
 	ClientMetadataPath = "/oauth-client"
 	// OpenIdCredIssuerWellKnown is the well-known base path for the openID credential issuer metadata as defined in
 	// OpenID4VCI specification
-	OpenIdCredIssuerWellKnown    = "/.well-known/openid-credential-issuer"
-	OpenIdConfigurationWellKnown = "/.well-known/openid-configuration"
+	OpenIdCredIssuerWellKnown = "/.well-known/openid-credential-issuer"
 )
 
 // oauth parameter keys
@@ -384,8 +383,3 @@ type OpenIDCredentialIssuerMetadata struct {
 	// - Display: a slice of maps where each map represents the display information (optional)
 	Display []map[string]string `json:"display,omitempty"`
 }
-
-// OpenIDConfigurationMetadata is the metadata of an OpenID Connect configuration.
-// It includes the issuer, authorization endpoint, token endpoint, JWKS URI,
-// and supported grant types for authentication and authorization.
-type OpenIDConfigurationMetadata = AuthorizationServerMetadata

--- a/auth/oauth/types.go
+++ b/auth/oauth/types.go
@@ -137,6 +137,8 @@ const (
 	ClientMetadataURIParam = "client_metadata_uri"
 	// CNonceParam is the parameter name for the c_nonce parameter. (OpenID4VCI)
 	CNonceParam = "c_nonce"
+	// CodeParam is the parameter name for the code parameter. (RFC6749)
+	CodeParam = CodeResponseType
 	// CodeChallengeParam is the parameter name for the code_challenge parameter. (RFC7636)
 	CodeChallengeParam = "code_challenge"
 	// CodeChallengeMethodParam is the parameter name for the code_challenge_method parameter. (RFC7636)

--- a/docs/_static/auth/v2.yaml
+++ b/docs/_static/auth/v2.yaml
@@ -80,7 +80,7 @@ paths:
               $ref: '#/components/schemas/UserAccessTokenRequest'
       responses:
         '200':
-          description: | 
+          description: |
             Successful request. Responds with a redirect_uri for the user and a token for the calling application.
             The token can be used by the calling application to get the status of the session.
           content:
@@ -110,7 +110,7 @@ paths:
             example: eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp
       responses:
         '200':
-          description: | 
+          description: |
             Successful request. Responds with an access token as described in rfc6749 section 5.1 when available.
             If the OAuth2 flow hasn't completed yet, the response will only contain the 'pending' status value.
           content:
@@ -241,27 +241,29 @@ paths:
               properties:
                 issuer:
                   type: string
-                  example: did:web:example.com
+                  example: did:web:issuer.example.com
                 authorization_details:
                   type: array
                   items:
                     type: object
-                    description: | 
-                      The request parameter authorization_details defined in Section 2 of [RFC9396] MUST be used to convey the details about the Credentials the Wallet wants to obtain..
-                    properties:
-                      type:
-                        type: string
-                      format:
-                        type: string
-                      credential_definition:
-                        type: object
+                    description: |
+                      The request parameter authorization_details defined in Section 2 of [RFC9396] MUST be used to convey the details about the Credentials the Wallet wants to obtain.
+                      See the RFC9396/OpenID4VCI for the format of an authorization_details object, and consult the Credential Issuer for requestable credentials.
+                  example: |
+                    [
+                      {
+                        "type": "openid_credential",
+                        "credential_configuration_id": "UniversityDegreeCredential"
+                      }
+                    ]
                 redirect_uri:
                   type: string
                   description: |
                     The URL to which the user-agent will be redirected after the authorization request.
+                  example: https://my-xis.example.com/callback
       responses:
         '200':
-          description: | 
+          description: |
             Successful request. Responds with a redirect_uri for the user and a session_id for correlation.
           content:
             application/json:
@@ -569,5 +571,5 @@ components:
       scheme: Bearer
 
 security:
-  - {}
-  - jwtBearerAuth: []
+  - { }
+  - jwtBearerAuth: [ ]

--- a/e2e-tests/browser/client/iam/generated.go
+++ b/e2e-tests/browser/client/iam/generated.go
@@ -189,12 +189,8 @@ type Cnf struct {
 
 // RequestOid4vciCredentialIssuanceJSONBody defines parameters for RequestOid4vciCredentialIssuance.
 type RequestOid4vciCredentialIssuanceJSONBody struct {
-	AuthorizationDetails []struct {
-		CredentialDefinition *map[string]interface{} `json:"credential_definition,omitempty"`
-		Format               *string                 `json:"format,omitempty"`
-		Type                 *string                 `json:"type,omitempty"`
-	} `json:"authorization_details"`
-	Issuer string `json:"issuer"`
+	AuthorizationDetails []map[string]interface{} `json:"authorization_details"`
+	Issuer               string                   `json:"issuer"`
 
 	// RedirectUri The URL to which the user-agent will be redirected after the authorization request.
 	RedirectUri string `json:"redirect_uri"`


### PR DESCRIPTION
- store `token_endpoint` in session and use this to exchange `authorization_code`. closes #3134 
- replace `/.well-known/openid-configuration` with `/.well-known/oauth-authorization-server`. closes #3135 
- made `authorization_details` in the credential issuance request an object since the full contents are undefined
- increase test coverage

