### PR TITLE
Crypto: work on crypto.Signer instead of concrete private keys for signing

### DIFF
--- a/auth/api/iam/dpop_test.go
+++ b/auth/api/iam/dpop_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
-	"github.com/lestrrat-go/jwx/v2/jwk"
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
@@ -242,11 +241,9 @@ func newSignedTestDPoP() (*dpop.DPoP, *dpop.DPoP, string) {
 	dpopToken := newTestDPoP()
 	withProof := newTestDPoP()
 	keyPair, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	jwkKey, _ := jwk.FromRaw(keyPair)
-	jwkKey.Set(jwk.AlgorithmKey, jwa.ES256)
 	_ = withProof.GenerateProof("token")
-	_, _ = withProof.Sign(jwkKey)
-	_, _ = dpopToken.Sign(jwkKey)
+	_, _ = withProof.Sign(keyPair, jwa.ES256)
+	_, _ = dpopToken.Sign(keyPair, jwa.ES256)
 	thumbprintBytes, _ := dpopToken.Headers.JWK().Thumbprint(crypto2.SHA256)
 	thumbprint := base64.RawURLEncoding.EncodeToString(thumbprintBytes)
 	return dpopToken, withProof, thumbprint

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -26,6 +26,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"path"
 	"time"
@@ -204,11 +205,11 @@ func GenerateJWK() (jwk.Key, error) {
 	if err != nil {
 		return nil, nil
 	}
-	result, err := jwkKey(keyPair)
+	result, err := jwk.FromRaw(keyPair)
 	if err != nil {
 		return nil, err
 	}
-	return result, nil
+	return result, result.Set(jwk.AlgorithmKey, jwa.ES256)
 }
 
 // Exists checks storage for an entry for the given legal entity and returns true if it exists

--- a/crypto/dpop.go
+++ b/crypto/dpop.go
@@ -24,15 +24,15 @@ import (
 )
 
 func (client *Crypto) SignDPoP(ctx context.Context, token dpop.DPoP, kid string) (string, error) {
-	privateKey, kid, err := client.getPrivateKey(ctx, kid)
+	privateKey, _, err := client.getPrivateKey(ctx, kid)
 	if err != nil {
 		return "", err
 	}
 
-	keyAsJWK, err := jwkKey(privateKey)
+	alg, err := signingAlg(privateKey.Public())
 	if err != nil {
 		return "", err
 	}
 
-	return token.Sign(keyAsJWK)
+	return token.Sign(privateKey, alg)
 }

--- a/crypto/jwx.go
+++ b/crypto/jwx.go
@@ -48,16 +48,16 @@ func (client *Crypto) SignJWT(ctx context.Context, claims map[string]interface{}
 
 	audit.Log(ctx, log.Logger(), audit.CryptoSignJWTEvent).Infof("Signing a JWT with key: %s (issuer: %s, subject: %s)", kid, claims["iss"], claims["sub"])
 
-	keyAsJWK, err := jwkKey(privateKey)
+	if headers == nil {
+		headers = make(map[string]interface{})
+	}
+	headers["kid"] = kid
+	alg, err := signingAlg(privateKey.Public())
 	if err != nil {
 		return "", err
 	}
 
-	if err = keyAsJWK.Set(jwk.KeyIDKey, kid); err != nil {
-		return "", err
-	}
-
-	return signJWT(keyAsJWK, claims, headers)
+	return signJWT(privateKey, alg, claims, headers)
 }
 
 // SignJWS creates a signed JWS using the indicated key and map of headers and payload as bytes.
@@ -66,10 +66,14 @@ func (client *Crypto) SignJWS(ctx context.Context, payload []byte, headers map[s
 	if err != nil {
 		return "", err
 	}
+	alg, err := SignatureAlgorithm(privateKey.Public())
+	if err != nil {
+		return "", err
+	}
 
 	audit.Log(ctx, log.Logger(), audit.CryptoSignJWSEvent).Infof("Signing a JWS with key: %s", kid)
 
-	return signJWS(payload, headers, privateKey, detached)
+	return signJWS(payload, headers, privateKey, alg, detached)
 }
 
 // EncryptJWE encrypts a payload using the provided public key and key identifier.
@@ -130,7 +134,7 @@ func jwkKey(signer crypto.Signer) (key jwk.Key, err error) {
 }
 
 // signJWT signs claims with the signer and returns the compacted token. The headers param can be used to add additional headers
-func signJWT(key jwk.Key, claims map[string]interface{}, headers map[string]interface{}) (token string, err error) {
+func signJWT(key crypto.Signer, alg jwa.SignatureAlgorithm, claims map[string]interface{}, headers map[string]interface{}) (token string, err error) {
 	var sig []byte
 	t := jwt.New()
 
@@ -144,7 +148,7 @@ func signJWT(key jwk.Key, claims map[string]interface{}, headers map[string]inte
 		return "", fmt.Errorf("invalid JWT headers: %w", err)
 	}
 
-	sig, err = jwt.Sign(t, jwt.WithKey(jwa.SignatureAlgorithm(key.Algorithm().String()), key, jws.WithProtectedHeaders(hdr)))
+	sig, err = jwt.Sign(t, jwt.WithKey(jwa.SignatureAlgorithm(alg.String()), key, jws.WithProtectedHeaders(hdr)))
 	token = string(sig)
 
 	return
@@ -238,16 +242,12 @@ func ParseJWS(token []byte, f PublicKeyFunc) (payload []byte, err error) {
 	return body, nil
 }
 
-func signJWS(payload []byte, protectedHeaders map[string]interface{}, privateKey crypto.Signer, detachedPayload bool) (string, error) {
+func signJWS(payload []byte, protectedHeaders map[string]interface{}, privateKey crypto.Signer, alg jwa.SignatureAlgorithm, detachedPayload bool) (string, error) {
 	headers := jws.NewHeaders()
 	for key, value := range protectedHeaders {
 		if err := headers.Set(key, value); err != nil {
 			return "", fmt.Errorf("unable to set header %s: %w", key, err)
 		}
-	}
-	privateKeyAsJWK, err := jwkKey(privateKey)
-	if err != nil {
-		return "", err
 	}
 	// The JWX library is fine with creating a JWK for a private key (including the private exponents), so
 	// we want to make sure the `jwk` header (if present) does not (accidentally) contain a private key.
@@ -260,17 +260,17 @@ func signJWS(payload []byte, protectedHeaders map[string]interface{}, privateKey
 			return "", errors.New("refusing to sign JWS with private key in JWK header")
 		}
 	}
-	algo := jwa.SignatureAlgorithm(privateKeyAsJWK.Algorithm().String())
 
 	var (
 		data []byte
+		err  error
 	)
 	if detachedPayload {
 		// Sign JWS with detached payload
-		data, err = jws.Sign(nil, jws.WithKey(algo, privateKey, jws.WithProtectedHeaders(headers)), jws.WithDetachedPayload(payload))
+		data, err = jws.Sign(nil, jws.WithKey(alg, privateKey, jws.WithProtectedHeaders(headers)), jws.WithDetachedPayload(payload))
 	} else {
 		// Sign normal JWS
-		data, err = jws.Sign(payload, jws.WithKey(algo, privateKey, jws.WithProtectedHeaders(headers)))
+		data, err = jws.Sign(payload, jws.WithKey(alg, privateKey, jws.WithProtectedHeaders(headers)))
 	}
 	if err != nil {
 		return "", fmt.Errorf("unable to sign JWS %w", err)
@@ -350,6 +350,19 @@ func convertHeaders(headers map[string]interface{}) (jws.Headers, error) {
 		}
 	}
 	return hdr, nil
+}
+
+func signingAlg(key crypto.PublicKey) (jwa.SignatureAlgorithm, error) {
+	switch k := key.(type) {
+	case *rsa.PublicKey:
+		return jwa.PS256, nil
+	case *ecdsa.PublicKey:
+		return ecAlgUsingPublicKey(*k)
+	case ed25519.PublicKey:
+		return jwa.EdDSA, nil
+	default:
+		return "", fmt.Errorf(`could not determine signature algorithm for key type '%T'`, key)
+	}
 }
 
 func ecAlg(key *ecdsa.PrivateKey) (alg jwa.SignatureAlgorithm, err error) {

--- a/crypto/jwx.go
+++ b/crypto/jwx.go
@@ -121,27 +121,6 @@ func headerWithKID(headers map[string]interface{}, kid string) map[string]interf
 	return headersCopy
 }
 
-func jwkKey(signer crypto.Signer) (key jwk.Key, err error) {
-	key, err = jwk.FromRaw(signer)
-	if err != nil {
-		return nil, err
-	}
-
-	switch k := signer.(type) {
-	case *rsa.PrivateKey:
-		_ = key.Set(jwk.AlgorithmKey, jwa.PS256)
-	case *ecdsa.PrivateKey:
-		var alg jwa.SignatureAlgorithm
-		alg, err = ecAlg(k)
-		if err == nil {
-			_ = key.Set(jwk.AlgorithmKey, alg)
-		}
-	default:
-		err = errors.New("unsupported signing private key")
-	}
-	return
-}
-
 // signJWT signs claims with the signer and returns the compacted token. The headers param can be used to add additional headers
 func signJWT(key crypto.Signer, alg jwa.SignatureAlgorithm, claims map[string]interface{}, headers map[string]interface{}) (token string, err error) {
 	var sig []byte

--- a/crypto/jwx.go
+++ b/crypto/jwx.go
@@ -48,16 +48,22 @@ func (client *Crypto) SignJWT(ctx context.Context, claims map[string]interface{}
 
 	audit.Log(ctx, log.Logger(), audit.CryptoSignJWTEvent).Infof("Signing a JWT with key: %s (issuer: %s, subject: %s)", kid, claims["iss"], claims["sub"])
 
-	if headers == nil {
-		headers = make(map[string]interface{})
+	// We want to set the kid claim as headers, but we don't want to modify the original headers map.
+	// So we copy the headers map and add the kid claim to it.
+	headersCopy := make(map[string]interface{})
+	if headers != nil {
+		for k, v := range headers {
+			headersCopy[k] = v
+		}
 	}
-	headers["kid"] = kid
+	headersCopy["kid"] = kid
+
 	alg, err := signingAlg(privateKey.Public())
 	if err != nil {
 		return "", err
 	}
 
-	return signJWT(privateKey, alg, claims, headers)
+	return signJWT(privateKey, alg, claims, headersCopy)
 }
 
 // SignJWS creates a signed JWS using the indicated key and map of headers and payload as bytes.

--- a/crypto/memory.go
+++ b/crypto/memory.go
@@ -20,6 +20,7 @@ package crypto
 
 import (
 	"context"
+	"crypto"
 	"errors"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/nuts-foundation/nuts-node/crypto/dpop"
@@ -42,7 +43,15 @@ func (m MemoryJWTSigner) SignJWT(_ context.Context, claims map[string]interface{
 	if keyID != m.Key.KeyID() {
 		return "", ErrPrivateKeyNotFound
 	}
-	return signJWT(m.Key, claims, headers)
+	var signer crypto.Signer
+	if err := m.Key.Raw(&signer); err != nil {
+		return "", err
+	}
+	alg, err := signingAlg(signer.Public())
+	if err != nil {
+		return "", err
+	}
+	return signJWT(signer, alg, claims, headers)
 }
 
 func (m MemoryJWTSigner) SignJWS(_ context.Context, _ []byte, _ map[string]interface{}, _ interface{}, _ bool) (string, error) {

--- a/crypto/memory.go
+++ b/crypto/memory.go
@@ -51,7 +51,7 @@ func (m MemoryJWTSigner) SignJWT(_ context.Context, claims map[string]interface{
 	if err != nil {
 		return "", err
 	}
-	return signJWT(signer, alg, claims, headers)
+	return signJWT(signer, alg, claims, headerWithKID(headers, keyID))
 }
 
 func (m MemoryJWTSigner) SignJWS(_ context.Context, _ []byte, _ map[string]interface{}, _ interface{}, _ bool) (string, error) {


### PR DESCRIPTION
Initially Crypto was set up to just act on `crypto.Signer`, to support unexportable keys in a separate key vault at some point (meaning the private keys itself are never in the application memory, cryptographic operations are performed in the key vault). I tried implementing Azure Key Vault using this approach, but found that several functions act on the private key assuming it's always in-memory. This PR fixes that.

Note that this only applies to signing, not to encryption: our encryption algorithm of choice (ECIES) isn't supported by Hashicorp Vault/Azure Key Vault. If encryption is a feature we want to retain in combination with secure key storage, RSA keys could be used instead.