### PR TITLE
Fix nil defer during handlePrivateTxRetry by starting notifiers last in the network stack

### DIFF
--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -74,6 +74,17 @@ The new HTTP configuration reflects this,
 Note that ``8081`` by default maps to ``127.0.0.1`` only, so you might need to configure it to allow it to be accessible from other machines.
 
 ************************
+Hazelnut update (v5.4.7)
+************************
+
+Release date: 2024-05-30
+
+- Fixed an issue where the node would panic during startup when retrying unfinished private transactions.
+- Updated dependencies
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v5.4.6...v5.4.7
+
+************************
 Hazelnut update (v5.4.6)
 ************************
 

--- a/network/dag/state.go
+++ b/network/dag/state.go
@@ -416,11 +416,8 @@ func (s *state) Start() error {
 		return fmt.Errorf("failed to set initial transaction count metric: %w", err)
 	}
 
-	// resume all notifiers
-	s.notifiers.Range(func(_, value any) bool {
-		err = value.(Notifier).Run()
-		return err == nil
-	})
+	// state does not start the notifiers since they may access other network components before they are initialized.
+	// https://github.com/nuts-foundation/nuts-node/issues/3155
 
 	// start xorTreeRepair that waits until the state has triggered it to start via IncorrectStateDetected()
 	s.xorTreeRepair.start()

--- a/network/network.go
+++ b/network/network.go
@@ -25,13 +25,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
-	"github.com/nuts-foundation/nuts-node/vdr/management"
-	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 	"net"
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
+	"github.com/nuts-foundation/nuts-node/vdr/management"
+	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 
 	"github.com/google/uuid"
 	"github.com/nuts-foundation/go-did/did"

--- a/network/network.go
+++ b/network/network.go
@@ -384,6 +384,14 @@ func (n *Network) Start() error {
 	if err != nil {
 		return err
 	}
+
+	// Resume all notifiers. Notifiers may access other components of the network stack.
+	// To prevent nil derefs run the notifiers last. https://github.com/nuts-foundation/nuts-node/issues/3155
+	for _, notifier := range n.state.Notifiers() {
+		if err = notifier.Run(); err != nil {
+			return fmt.Errorf("failed to start notifiers: %w", err)
+		}
+	}
 	return n.connectToKnownNodes(n.nodeDID)
 }
 

--- a/network/network.go
+++ b/network/network.go
@@ -379,9 +379,12 @@ func (n *Network) Start() error {
 			return err
 		}
 	}
-	// Start connection management and protocols
+	// Start connection management, protocols and connections
 	err := n.connectionManager.Start()
 	if err != nil {
+		return err
+	}
+	if err = n.connectToKnownNodes(n.nodeDID); err != nil {
 		return err
 	}
 
@@ -392,7 +395,7 @@ func (n *Network) Start() error {
 			return fmt.Errorf("failed to start notifiers: %w", err)
 		}
 	}
-	return n.connectToKnownNodes(n.nodeDID)
+	return nil
 }
 
 func (n *Network) connectToKnownNodes(nodeDID did.DID) error {

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -80,6 +80,7 @@ func (cxt *networkTestContext) start() error {
 	cxt.connectionManager.EXPECT().Start()
 	cxt.protocol.EXPECT().Start()
 	cxt.state.EXPECT().Start()
+	cxt.state.EXPECT().Notifiers()
 
 	return cxt.network.Start()
 }


### PR DESCRIPTION
closes #3155

similar issued could exist for notifiers registered during configuration for modules, but I did not investigate this considering the scheduled removal of this feature