### PR TITLE
HTTP: specify Domain attribute in user session cookie

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -171,6 +171,7 @@ func (r Wrapper) Routes(router core.EchoRouter) {
 			// error only happens on invalid did:web DID, which can't happen here
 			return baseURL.Path
 		},
+		CookieDomain: r.auth.PublicURL().Host,
 	}.Handle)
 }
 

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/http/user"
+	"github.com/nuts-foundation/nuts-node/test"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -806,8 +807,11 @@ func TestWrapper_Routes(t *testing.T) {
 		router.EXPECT().GET(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 		router.EXPECT().POST(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
+		authServices := auth.NewMockAuthenticationServices(ctrl)
+		authServices.EXPECT().PublicURL().Return(test.MustParseURL("https://example.com"))
 		(&Wrapper{
 			storageEngine: storage.NewTestStorageEngine(t),
+			auth:          authServices,
 		}).Routes(router)
 	})
 	t.Run("cache middleware URLs match registered paths", func(t *testing.T) {
@@ -824,8 +828,11 @@ func TestWrapper_Routes(t *testing.T) {
 			return nil
 		}).AnyTimes()
 		router.EXPECT().Use(gomock.Any()).AnyTimes()
+		authServices := auth.NewMockAuthenticationServices(ctrl)
+		authServices.EXPECT().PublicURL().Return(test.MustParseURL("https://example.com"))
 		(&Wrapper{
 			storageEngine: storage.NewTestStorageEngine(t),
+			auth:          authServices,
 		}).Routes(router)
 
 		// Check that all cache-control max-age paths are actual paths

--- a/http/user/session_test.go
+++ b/http/user/session_test.go
@@ -261,10 +261,10 @@ func createInstance(t *testing.T) (SessionMiddleware, storage.SessionStore) {
 func TestMiddleware_createUserSessionCookie(t *testing.T) {
 	cookie := SessionMiddleware{
 		TimeOut: 30 * time.Minute,
-	}.createUserSessionCookie("sessionID", "/iam/did:web:example.com:iam:123")
+	}.createUserSessionCookie("sessionID", "example.com", "/iam/did:web:example.com:iam:123")
 	assert.Equal(t, "/iam/did:web:example.com:iam:123", cookie.Path)
 	assert.Equal(t, "__Secure-SID", cookie.Name)
-	assert.Empty(t, cookie.Domain)
+	assert.Equal(t, "example.com", cookie.Domain)
 	assert.Empty(t, cookie.Expires)
 	assert.Equal(t, 30*time.Minute, time.Duration(cookie.MaxAge)*time.Second)
 	assert.Equal(t, http.SameSiteStrictMode, cookie.SameSite)


### PR DESCRIPTION
Cookie is currently rejected by Safari/Firefox

Fixes https://github.com/nuts-foundation/nuts-node/issues/3164