### PR TITLE
VCR: Remove @context default value from OAS

### DIFF
--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -555,7 +555,7 @@ type ServerInterface interface {
 	// Start the authorization code flow to get an access token from a remote authorization server when user context is required.
 	// (POST /internal/auth/v2/{did}/request-user-access-token)
 	RequestUserAccessToken(ctx echo.Context, did string) error
-	// Used by resource owners to initiate the authorization code flow.
+	// Used by resource owners (the browser) to initiate the authorization code flow.
 	// (GET /oauth2/{did}/authorize)
 	HandleAuthorizeRequest(ctx echo.Context, did string, params HandleAuthorizeRequestParams) error
 	// The OAuth2 callback endpoint of the client.
@@ -576,7 +576,7 @@ type ServerInterface interface {
 	// Used by wallets to post the authorization response or error to.
 	// (POST /oauth2/{did}/response)
 	HandleAuthorizeResponse(ctx echo.Context, did string) error
-	// Used by to request access- or refresh tokens.
+	// Used by the OAuth2 client (backend, not the browser) to request access- or refresh tokens.
 	// (POST /oauth2/{did}/token)
 	HandleTokenRequest(ctx echo.Context, did string) error
 	// Get the StatusList2021Credential for the given DID and page
@@ -1764,7 +1764,7 @@ type StrictServerInterface interface {
 	// Start the authorization code flow to get an access token from a remote authorization server when user context is required.
 	// (POST /internal/auth/v2/{did}/request-user-access-token)
 	RequestUserAccessToken(ctx context.Context, request RequestUserAccessTokenRequestObject) (RequestUserAccessTokenResponseObject, error)
-	// Used by resource owners to initiate the authorization code flow.
+	// Used by resource owners (the browser) to initiate the authorization code flow.
 	// (GET /oauth2/{did}/authorize)
 	HandleAuthorizeRequest(ctx context.Context, request HandleAuthorizeRequestRequestObject) (HandleAuthorizeRequestResponseObject, error)
 	// The OAuth2 callback endpoint of the client.
@@ -1785,7 +1785,7 @@ type StrictServerInterface interface {
 	// Used by wallets to post the authorization response or error to.
 	// (POST /oauth2/{did}/response)
 	HandleAuthorizeResponse(ctx context.Context, request HandleAuthorizeResponseRequestObject) (HandleAuthorizeResponseResponseObject, error)
-	// Used by to request access- or refresh tokens.
+	// Used by the OAuth2 client (backend, not the browser) to request access- or refresh tokens.
 	// (POST /oauth2/{did}/token)
 	HandleTokenRequest(ctx context.Context, request HandleTokenRequestRequestObject) (HandleTokenRequestResponseObject, error)
 	// Get the StatusList2021Credential for the given DID and page

--- a/docs/_static/vcr/vcr_v2.yaml
+++ b/docs/_static/vcr/vcr_v2.yaml
@@ -595,7 +595,6 @@ components:
               items:
                 type: string
               example: ["https://www.w3.org/2018/credentials/v1", "https://nuts.nl/credentials/v1"]
-          default: ["https://www.w3.org/2018/credentials/v1", "https://nuts.nl/credentials/v1"]
         type:
           description: Type definition for the credential.
           oneOf:

--- a/docs/_static/vcr/vcr_v2.yaml
+++ b/docs/_static/vcr/vcr_v2.yaml
@@ -588,6 +588,7 @@ components:
         "@context":
           description: |
             The resolvable context of the credentialSubject as URI. If omitted, the "https://nuts.nl/credentials/v1" context is used.
+            It always adds the "https://www.w3.org/2018/credentials/v1" context if not present.
           oneOf:
             - type: string
               example: "https://nuts.nl/credentials/v1"


### PR DESCRIPTION
It breaks code generation in Java. Can be safely deleted, we don't necerassily need it.