### PR TITLE
Auth v2: change OAuth2 issuer URL from /iam to /oauth2

### DIFF
--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/nuts-foundation/nuts-node/core/to"
 	"github.com/nuts-foundation/nuts-node/http/user"
 	"github.com/nuts-foundation/nuts-node/test"
 	"net/http"
@@ -806,16 +807,16 @@ func TestWrapper_IntrospectAccessToken(t *testing.T) {
 		require.NoError(t, ctx.client.accessTokenServerStore().Put(token.Token, token))
 		expectedResponse, err := json.Marshal(IntrospectAccessTokenExtended200JSONResponse{
 			Active:                  true,
-			ClientId:                ptrTo("client"),
+			ClientId:                to.Ptr("client"),
 			Cnf:                     &Cnf{Jkt: thumbprint},
-			Exp:                     ptrTo(int(tNow.Add(time.Minute).Unix())),
-			Iat:                     ptrTo(int(tNow.Unix())),
-			Iss:                     ptrTo("resource-owner"),
-			Scope:                   ptrTo("test"),
-			Sub:                     ptrTo("resource-owner"),
+			Exp:                     to.Ptr(int(tNow.Add(time.Minute).Unix())),
+			Iat:                     to.Ptr(int(tNow.Unix())),
+			Iss:                     to.Ptr("resource-owner"),
+			Scope:                   to.Ptr("test"),
+			Sub:                     to.Ptr("resource-owner"),
 			Vps:                     &[]VerifiablePresentation{presentation},
-			PresentationSubmissions: ptrTo(presentationSubmissions),
-			PresentationDefinitions: ptrTo(presentationDefinitions),
+			PresentationSubmissions: to.Ptr(presentationSubmissions),
+			PresentationDefinitions: to.Ptr(presentationDefinitions),
 			AdditionalProperties:    map[string]interface{}{"key": "value"},
 		})
 		require.NoError(t, err)
@@ -1459,11 +1460,6 @@ func (s *strictServerCallCapturer) handle(_ echo.Context, _ interface{}) (respon
 
 func putToken(ctx *testCtx, token string) {
 	_ = ctx.client.accessTokenClientStore().Put(token, TokenResponse{AccessToken: "token"})
-}
-
-// OG pointer function. Returns a pointer to any input.
-func ptrTo[T any](v T) *T {
-	return &v
 }
 
 func requireOAuthError(t *testing.T, err error, errorCode oauth.ErrorCode, errorDescription string) {

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -932,12 +932,13 @@ func TestWrapper_toOwnedDID(t *testing.T) {
 func TestWrapper_RequestServiceAccessToken(t *testing.T) {
 	walletDID := did.MustParseDID("did:web:test.test:iam:123")
 	verifierDID := did.MustParseDID("did:web:test.test:iam:456")
+	verifierURL := test.MustParseURL("https://test.test/oauth2/did:web:test.test:iam:456")
 	body := &RequestServiceAccessTokenJSONRequestBody{Verifier: verifierDID.String(), Scope: "first second"}
 
 	t.Run("ok", func(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.vdr.EXPECT().IsOwner(nil, walletDID).Return(true, nil)
-		ctx.iamClient.EXPECT().RequestRFC021AccessToken(nil, walletDID, verifierDID, "first second", true, nil).Return(&oauth.TokenResponse{}, nil)
+		ctx.iamClient.EXPECT().RequestRFC021AccessToken(nil, walletDID, verifierDID, verifierURL, "first second", true, nil).Return(&oauth.TokenResponse{}, nil)
 
 		_, err := ctx.client.RequestServiceAccessToken(nil, RequestServiceAccessTokenRequestObject{Did: walletDID.String(), Body: body})
 
@@ -948,7 +949,7 @@ func TestWrapper_RequestServiceAccessToken(t *testing.T) {
 		tokenTypeBearer := ServiceAccessTokenRequestTokenType("bearer")
 		body := &RequestServiceAccessTokenJSONRequestBody{Verifier: verifierDID.String(), Scope: "first second", TokenType: &tokenTypeBearer}
 		ctx.vdr.EXPECT().IsOwner(nil, walletDID).Return(true, nil)
-		ctx.iamClient.EXPECT().RequestRFC021AccessToken(nil, walletDID, verifierDID, "first second", false, nil).Return(&oauth.TokenResponse{}, nil)
+		ctx.iamClient.EXPECT().RequestRFC021AccessToken(nil, walletDID, verifierDID, verifierURL, "first second", false, nil).Return(&oauth.TokenResponse{}, nil)
 
 		_, err := ctx.client.RequestServiceAccessToken(nil, RequestServiceAccessTokenRequestObject{Did: walletDID.String(), Body: body})
 
@@ -983,7 +984,7 @@ func TestWrapper_RequestServiceAccessToken(t *testing.T) {
 	t.Run("error - verifier error", func(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.vdr.EXPECT().IsOwner(nil, walletDID).Return(true, nil)
-		ctx.iamClient.EXPECT().RequestRFC021AccessToken(nil, walletDID, verifierDID, "first second", true, nil).Return(nil, core.Error(http.StatusPreconditionFailed, "no matching credentials"))
+		ctx.iamClient.EXPECT().RequestRFC021AccessToken(nil, walletDID, verifierDID, verifierURL, "first second", true, nil).Return(nil, core.Error(http.StatusPreconditionFailed, "no matching credentials"))
 
 		_, err := ctx.client.RequestServiceAccessToken(nil, RequestServiceAccessTokenRequestObject{Did: walletDID.String(), Body: body})
 

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -133,6 +133,11 @@ type ServiceAccessTokenRequest struct {
 	// They must be in the form of a Verifiable Credential in JSON form.
 	// The serialized form (JWT or JSON-LD) in the resulting Verifiable Presentation depends on the capability of the authorizing party.
 	// A typical use case is to provide a self-attested credential to convey information about the user that initiated the request.
+	//
+	// The following credential fields are automatically filled (when not present), and may be omitted:
+	// - issuer, credentialSubject.id (filled with the DID of the requester)
+	// - issuanceDate (filled with the current date/time)
+	// - id (filled with a UUID)
 	Credentials *[]VerifiableCredential `json:"credentials,omitempty"`
 
 	// Scope The scope that will be the service for which this access token can be used.
@@ -536,7 +541,7 @@ type ServerInterface interface {
 	// (GET /.well-known/oauth-authorization-server)
 	RootOAuthAuthorizationServerMetadata(ctx echo.Context) error
 	// Get the OAuth2 Authorization Server metadata for the specified DID.
-	// (GET /.well-known/oauth-authorization-server/iam/{did})
+	// (GET /.well-known/oauth-authorization-server/oauth2/{did})
 	OAuthAuthorizationServerMetadata(ctx echo.Context, did string) error
 	// Returns the did:web DID for the specified tenant.
 	// (GET /iam/{id}/did.json)
@@ -1015,7 +1020,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 
 	router.GET(baseURL+"/.well-known/did.json", wrapper.GetRootWebDID)
 	router.GET(baseURL+"/.well-known/oauth-authorization-server", wrapper.RootOAuthAuthorizationServerMetadata)
-	router.GET(baseURL+"/.well-known/oauth-authorization-server/iam/:did", wrapper.OAuthAuthorizationServerMetadata)
+	router.GET(baseURL+"/.well-known/oauth-authorization-server/oauth2/:did", wrapper.OAuthAuthorizationServerMetadata)
 	router.GET(baseURL+"/iam/:id/did.json", wrapper.GetTenantWebDID)
 	router.POST(baseURL+"/internal/auth/v2/accesstoken/introspect", wrapper.IntrospectAccessToken)
 	router.POST(baseURL+"/internal/auth/v2/accesstoken/introspect_extended", wrapper.IntrospectAccessTokenExtended)
@@ -1788,7 +1793,7 @@ type StrictServerInterface interface {
 	// (GET /.well-known/oauth-authorization-server)
 	RootOAuthAuthorizationServerMetadata(ctx context.Context, request RootOAuthAuthorizationServerMetadataRequestObject) (RootOAuthAuthorizationServerMetadataResponseObject, error)
 	// Get the OAuth2 Authorization Server metadata for the specified DID.
-	// (GET /.well-known/oauth-authorization-server/iam/{did})
+	// (GET /.well-known/oauth-authorization-server/oauth2/{did})
 	OAuthAuthorizationServerMetadata(ctx context.Context, request OAuthAuthorizationServerMetadataRequestObject) (OAuthAuthorizationServerMetadataResponseObject, error)
 	// Returns the did:web DID for the specified tenant.
 	// (GET /iam/{id}/did.json)

--- a/auth/api/iam/jar.go
+++ b/auth/api/iam/jar.go
@@ -123,11 +123,8 @@ func (j jar) Parse(ctx context.Context, ownDID did.DID, q url.Values) (oauthPara
 				return nil, oauth.OAuth2Error{Code: oauth.InvalidRequestURI, Description: "failed to get Request Object", InternalError: err}
 			}
 		case "post":
-			issuerURL, err := createOAuth2BaseURL(ownDID)
-			if err != nil {
-				return nil, err
-			}
-			md, err := authorizationServerMetadata(ownDID, issuerURL)
+			issuerURL := ownDID.URI().URL
+			md, err := authorizationServerMetadata(ownDID, &issuerURL)
 			if err != nil {
 				// DB error
 				return nil, err

--- a/auth/api/iam/jar.go
+++ b/auth/api/iam/jar.go
@@ -123,7 +123,11 @@ func (j jar) Parse(ctx context.Context, ownDID did.DID, q url.Values) (oauthPara
 				return nil, oauth.OAuth2Error{Code: oauth.InvalidRequestURI, Description: "failed to get Request Object", InternalError: err}
 			}
 		case "post":
-			md, err := authorizationServerMetadata(ownDID)
+			issuerURL, err := createOAuth2BaseURL(ownDID)
+			if err != nil {
+				return nil, err
+			}
+			md, err := authorizationServerMetadata(ownDID, issuerURL)
 			if err != nil {
 				// DB error
 				return nil, err

--- a/auth/api/iam/jar_test.go
+++ b/auth/api/iam/jar_test.go
@@ -141,7 +141,7 @@ func TestJar_Parse(t *testing.T) {
 			require.NotNil(t, res)
 		})
 		t.Run("ok - post", func(t *testing.T) {
-			md, _ := authorizationServerMetadata(verifierDID)
+			md, _ := authorizationServerMetadata(verifierDID, verifierURL)
 			ctx.iamClient.EXPECT().RequestObjectByPost(context.Background(), "request_uri", *md).Return(token, nil)
 			ctx.keyResolver.EXPECT().ResolveKeyByID(key.KID(), nil, resolver.AssertionMethod).Return(key.Public(), nil)
 
@@ -191,7 +191,7 @@ func TestJar_Parse(t *testing.T) {
 			assert.Nil(t, res)
 		})
 		t.Run("post", func(t *testing.T) {
-			md, _ := authorizationServerMetadata(verifierDID)
+			md, _ := authorizationServerMetadata(verifierDID, verifierURL)
 			ctx.iamClient.EXPECT().RequestObjectByPost(context.Background(), "request_uri", *md).Return("", errors.New("server error"))
 			res, err := ctx.jar.Parse(context.Background(), verifierDID,
 				map[string][]string{

--- a/auth/api/iam/metadata_test.go
+++ b/auth/api/iam/metadata_test.go
@@ -38,7 +38,7 @@ func Test_authorizationServerMetadata(t *testing.T) {
 		ClientIdSchemesSupported:                   []string{"did"},
 		DPoPSigningAlgValuesSupported:              jwx.SupportedAlgorithmsAsStrings(),
 		GrantTypesSupported:                        []string{"authorization_code", "vp_token-bearer"},
-		Issuer:                                     didExample.String(),
+		Issuer:                                     "https://example.com/oauth2/" + didExample.String(),
 		PreAuthorizedGrantAnonymousAccessSupported: true,
 		PresentationDefinitionUriSupported:         &presentationDefinitionURISupported,
 		RequireSignedRequestObject:                 true,
@@ -49,22 +49,21 @@ func Test_authorizationServerMetadata(t *testing.T) {
 		RequestObjectSigningAlgValuesSupported:     jwx.SupportedAlgorithmsAsStrings(),
 	}
 	t.Run("base", func(t *testing.T) {
-		md, err := authorizationServerMetadata(didExample)
+		md, err := authorizationServerMetadata(didExample, test.MustParseURL("https://example.com/oauth2/"+didExample.String()))
 		assert.NoError(t, err)
 		assert.Equal(t, baseExpected, *md)
 	})
 	t.Run("did:web", func(t *testing.T) {
 		didWeb := did.MustParseDID("did:web:example.com:iam:123")
-		identity := test.MustParseURL("https://example.com/iam/123")
 		oauth2Base := test.MustParseURL("https://example.com/oauth2/did:web:example.com:iam:123")
 
 		webExpected := baseExpected
-		webExpected.Issuer = identity.String()
+		webExpected.Issuer = oauth2Base.String()
 		webExpected.AuthorizationEndpoint = oauth2Base.String() + "/authorize"
 		webExpected.PresentationDefinitionEndpoint = oauth2Base.String() + "/presentation_definition"
 		webExpected.TokenEndpoint = oauth2Base.String() + "/token"
 
-		md, err := authorizationServerMetadata(didWeb)
+		md, err := authorizationServerMetadata(didWeb, oauth2Base)
 		assert.NoError(t, err)
 		assert.Equal(t, webExpected, *md)
 	})

--- a/auth/api/iam/openid4vci_test.go
+++ b/auth/api/iam/openid4vci_test.go
@@ -21,6 +21,7 @@ package iam
 import (
 	"context"
 	"errors"
+	"github.com/nuts-foundation/nuts-node/core/to"
 	"net/url"
 	"testing"
 	"time"
@@ -260,8 +261,8 @@ func TestWrapper_handleOpenID4VCICallback(t *testing.T) {
 		callback, err := ctx.client.Callback(nil, CallbackRequestObject{
 			Did: holderDID.String(),
 			Params: CallbackParams{
-				Code:  ptrTo(code),
-				State: ptrTo(state),
+				Code:  to.Ptr(code),
+				State: to.Ptr(state),
 			},
 		})
 

--- a/auth/api/iam/openid4vci_test.go
+++ b/auth/api/iam/openid4vci_test.go
@@ -226,6 +226,7 @@ func TestWrapper_handleOpenID4VCICallback(t *testing.T) {
 		RedirectURI:              redirectUrl,
 		PKCEParams:               pkceParams,
 		TokenEndpoint:            tokenEndpoint,
+		IssuerURL:                issuerURL,
 		IssuerCredentialEndpoint: credEndpoint,
 	}
 	tokenResponse := oauth.NewTokenResponse(accessToken, "Bearer", 0, "").With("c_nonce", cNonce)

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -43,7 +43,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
 	"github.com/nuts-foundation/nuts-node/vdr/didjwk"
-	"github.com/nuts-foundation/nuts-node/vdr/didweb"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 )
 
@@ -110,7 +109,7 @@ func (r Wrapper) handleAuthorizeRequestFromHolder(ctx context.Context, verifier 
 	if err != nil || walletDID.Method != "web" {
 		return nil, withCallbackURI(oauthError(oauth.InvalidRequest, "invalid client_id parameter (only did:web is supported)"), redirectURL)
 	}
-	oauthIssuer, err := didweb.DIDToURL(*walletDID)
+	oauthIssuer, err := nutsOAuth2Issuer(*walletDID)
 	if err != nil {
 		// can't fail since it's a valid did:web
 		return nil, withCallbackURI(oauthError(oauth.InvalidRequest, "invalid client_id parameter (only did:web is supported)"), redirectURL)

--- a/auth/api/iam/openid4vp_test.go
+++ b/auth/api/iam/openid4vp_test.go
@@ -43,8 +43,8 @@ import (
 
 var holderDID = did.MustParseDID("did:web:example.com:iam:holder")
 var issuerDID = did.MustParseDID("did:web:example.com:iam:issuer")
-var holderURL = "https://example.com/iam/holder"
-var issuerURL = "https://example.com/iam/issuer"
+var holderURL = "https://example.com/iam/" + holderDID.String()
+var issuerURL = "https://example.com/iam/" + issuerDID.String()
 
 func TestWrapper_handleAuthorizeRequestFromHolder(t *testing.T) {
 	defaultParams := func() oauthParameters {

--- a/auth/api/iam/openid4vp_test.go
+++ b/auth/api/iam/openid4vp_test.go
@@ -43,8 +43,8 @@ import (
 
 var holderDID = did.MustParseDID("did:web:example.com:iam:holder")
 var issuerDID = did.MustParseDID("did:web:example.com:iam:issuer")
-var holderURL = "https://example.com/iam/" + holderDID.String()
-var issuerURL = "https://example.com/iam/" + issuerDID.String()
+var holderURL = "https://example.com/oauth2/" + holderDID.String()
+var issuerURL = "https://example.com/oauth2/" + issuerDID.String()
 
 func TestWrapper_handleAuthorizeRequestFromHolder(t *testing.T) {
 	defaultParams := func() oauthParameters {

--- a/auth/api/iam/session.go
+++ b/auth/api/iam/session.go
@@ -44,7 +44,9 @@ type OAuthSession struct {
 	Scope             string          `json:"scope,omitempty"`
 	SessionID         string          `json:"session_id,omitempty"`
 	TokenEndpoint     string          `json:"token_endpoint,omitempty"`
-	UseDPoP           bool            `json:"use_dpop,omitempty"`
+	// IssuerURL is the URL that identifies the OAuth2 Authorization Server according to RFC 8414 (Authorization Server Metadata).
+	IssuerURL string `json:"issuer_url,omitempty"`
+	UseDPoP   bool   `json:"use_dpop,omitempty"`
 	// IssuerCredentialEndpoint: endpoint to exchange the access_token for a credential in the OpenID4VCI flow
 	IssuerCredentialEndpoint string `json:"issuer_credential_endpoint,omitempty"`
 }

--- a/auth/api/iam/user.go
+++ b/auth/api/iam/user.go
@@ -22,7 +22,9 @@ import (
 	"context"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/http/user"
+	"github.com/nuts-foundation/nuts-node/vdr/didweb"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -202,4 +204,15 @@ func (r Wrapper) issueEmployeeCredential(ctx context.Context, session user.Sessi
 		return nil, fmt.Errorf("issue EmployeeCredential: %w", err)
 	}
 	return employeeCredential, nil
+}
+
+// nutsOAuth2Issuer returns the URL of the OAuth2 issuer for the given DID.
+// It's temporary: soon to be released by the application explicitly specifying the OAuth2 issuer URL.
+func nutsOAuth2Issuer(subject did.DID) (*url.URL, error) {
+	result, err := didweb.DIDToURL(subject)
+	if err != nil {
+		return nil, err
+	}
+	result.Path = "/oauth2/" + url.PathEscape(subject.String())
+	return result, nil
 }

--- a/auth/api/iam/user.go
+++ b/auth/api/iam/user.go
@@ -36,7 +36,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/issuer"
-	"github.com/nuts-foundation/nuts-node/vdr/didweb"
 )
 
 const (
@@ -98,7 +97,7 @@ func (r Wrapper) handleUserLanding(echoCtx echo.Context) error {
 	}
 
 	// get AS metadata
-	oauthIssuer, err := didweb.DIDToURL(*verifier)
+	oauthIssuer, err := nutsOAuth2Issuer(*verifier)
 	if err != nil {
 		return err
 	}

--- a/auth/api/iam/user_test.go
+++ b/auth/api/iam/user_test.go
@@ -114,7 +114,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 			employeeCredentialOptions = o
 			return &t, nil
 		})
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierURL).Return(&serverMetadata, nil).Times(2)
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierURL.String()).Return(&serverMetadata, nil).Times(2)
 		ctx.jar.EXPECT().Create(webDID, &verifierDID, gomock.Any()).DoAndReturn(func(client did.DID, server *did.DID, modifier requestObjectModifier) jarRequest {
 			req := createJarRequest(client, server, modifier)
 			params := req.Claims
@@ -218,7 +218,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 		store := ctx.client.storageEngine.GetSessionDatabase().GetStore(time.Second*5, "user", "redirect")
 		err := store.Put("token", redirectSession)
 		require.NoError(t, err)
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierURL).Return(nil, assert.AnError)
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierURL.String()).Return(nil, assert.AnError)
 
 		err = ctx.client.handleUserLanding(echoCtx)
 
@@ -239,7 +239,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 		echoCtx.EXPECT().QueryParam("token").Return("token")
 		echoCtx.EXPECT().Request().MinTimes(1).Return(httpRequest)
 		require.NoError(t, ctx.client.userRedirectStore().Put("token", redirectSession))
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierURL).Return(&oauth.AuthorizationServerMetadata{
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierURL.String()).Return(&oauth.AuthorizationServerMetadata{
 			AuthorizationEndpoint: "",
 			TokenEndpoint:         "",
 		}, nil)
@@ -256,7 +256,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 		echoCtx.EXPECT().QueryParam("token").Return("token")
 		echoCtx.EXPECT().Request().MinTimes(1).Return(httpRequest)
 		require.NoError(t, ctx.client.userRedirectStore().Put("token", redirectSession))
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierURL).Return(&oauth.AuthorizationServerMetadata{
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), verifierURL.String()).Return(&oauth.AuthorizationServerMetadata{
 			AuthorizationEndpoint: "https://example.com/authorize",
 			TokenEndpoint:         "",
 		}, nil)

--- a/auth/client/iam/client.go
+++ b/auth/client/iam/client.go
@@ -44,6 +44,13 @@ type HTTPClient struct {
 // OAuthAuthorizationServerMetadata retrieves the OAuth authorization server metadata for the given oauth issuer.
 // oauthIssuer is the oauth.AuthorizationServerMetadata.Issuer from which the metadata endpoint is derived.
 func (hb HTTPClient) OAuthAuthorizationServerMetadata(ctx context.Context, oauthIssuer string) (*oauth.AuthorizationServerMetadata, error) {
+	// Wacky: Nuts currently has a convention for how to derive the metadata URL from the did:web DID.
+	// This is to be changed very soon, with explicit registration of the OAuth2 issuer URL as service in the DID document.
+	// (https://github.com/nuts-foundation/nuts-node/issues/3197)
+	// Translate did:web to OAuth2 issuer URL:
+	//  - did:web:example.com becomes https://example.com/.well-known/oauth-authorization-server
+	//  - did:web:example.com:iam:123 becomes https://example.com/.well-known/oauth-authorization-server/did:web:example.com:iam:123
+
 	metadataURL, err := oauth.IssuerIdToWellKnown(oauthIssuer, oauth.AuthzServerWellKnown, hb.strictMode)
 	if err != nil {
 		return nil, err

--- a/auth/client/iam/interface.go
+++ b/auth/client/iam/interface.go
@@ -35,7 +35,7 @@ type Client interface {
 	// The response will be unmarshalled into the given tokenResponseOut parameter.
 	AccessToken(ctx context.Context, code string, tokenURI, callbackURI string, clientID did.DID, codeVerifier string, useDPoP bool) (*oauth.TokenResponse, error)
 	// AuthorizationServerMetadata returns the metadata of the remote wallet.
-	// oauthIssuer is the address that identifies the Authorization Server. For a did:web it is its URL. (same as oauth.AuthorizationServerMetadata.Issuer)
+	// oauthIssuer is the URL of the issuer as specified by RFC 8414 (OAuth 2.0 Authorization Server Metadata).
 	AuthorizationServerMetadata(ctx context.Context, oauthIssuer string) (*oauth.AuthorizationServerMetadata, error)
 	// ClientMetadata returns the metadata of the remote verifier.
 	ClientMetadata(ctx context.Context, endpoint string) (*oauth.OAuthClientMetadata, error)
@@ -49,8 +49,10 @@ type Client interface {
 	RequestRFC021AccessToken(ctx context.Context, requestHolder did.DID, verifier did.DID, oauthIssuer *url.URL, scopes string, useDPoP bool,
 		credentials []vc.VerifiableCredential) (*oauth.TokenResponse, error)
 
+	// OpenIdCredentialIssuerMetadata returns the metadata of the remote credential issuer.
+	// oauthIssuer is the URL of the issuer as specified by RFC 8414 (OAuth 2.0 Authorization Server Metadata).
 	OpenIdCredentialIssuerMetadata(ctx context.Context, oauthIssuerURI string) (*oauth.OpenIDCredentialIssuerMetadata, error)
-
+	// VerifiableCredentials requests Verifiable Credentials from the issuer at the given endpoint.
 	VerifiableCredentials(ctx context.Context, credentialEndpoint string, accessToken string, proofJWT string) (*CredentialResponse, error)
 	// RequestObjectByGet retrieves the RequestObjectByGet from the authorization request's 'request_uri' endpoint using a GET method as defined in RFC9101/OpenID4VP.
 	// This method is used when there is no 'request_uri_method', or its value is 'get'.

--- a/auth/client/iam/interface.go
+++ b/auth/client/iam/interface.go
@@ -20,6 +20,7 @@ package iam
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
@@ -45,7 +46,7 @@ type Client interface {
 	// PresentationDefinition returns the presentation definition from the given endpoint.
 	PresentationDefinition(ctx context.Context, endpoint string) (*pe.PresentationDefinition, error)
 	// RequestRFC021AccessToken is called by the local EHR node to request an access token from a remote Nuts node using Nuts RFC021.
-	RequestRFC021AccessToken(ctx context.Context, requestHolder did.DID, verifier did.DID, scopes string, useDPoP bool,
+	RequestRFC021AccessToken(ctx context.Context, requestHolder did.DID, verifier did.DID, oauthIssuer *url.URL, scopes string, useDPoP bool,
 		credentials []vc.VerifiableCredential) (*oauth.TokenResponse, error)
 
 	OpenIdCredentialIssuerMetadata(ctx context.Context, oauthIssuerURI string) (*oauth.OpenIDCredentialIssuerMetadata, error)

--- a/auth/client/iam/mock.go
+++ b/auth/client/iam/mock.go
@@ -11,6 +11,7 @@ package iam
 
 import (
 	context "context"
+	url "net/url"
 	reflect "reflect"
 
 	did "github.com/nuts-foundation/go-did/did"
@@ -179,18 +180,18 @@ func (mr *MockClientMockRecorder) RequestObjectByPost(ctx, requestURI, walletMet
 }
 
 // RequestRFC021AccessToken mocks base method.
-func (m *MockClient) RequestRFC021AccessToken(ctx context.Context, requestHolder, verifier did.DID, scopes string, useDPoP bool, credentials []vc.VerifiableCredential) (*oauth.TokenResponse, error) {
+func (m *MockClient) RequestRFC021AccessToken(ctx context.Context, requestHolder, verifier did.DID, oauthIssuer *url.URL, scopes string, useDPoP bool, credentials []vc.VerifiableCredential) (*oauth.TokenResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RequestRFC021AccessToken", ctx, requestHolder, verifier, scopes, useDPoP, credentials)
+	ret := m.ctrl.Call(m, "RequestRFC021AccessToken", ctx, requestHolder, verifier, oauthIssuer, scopes, useDPoP, credentials)
 	ret0, _ := ret[0].(*oauth.TokenResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RequestRFC021AccessToken indicates an expected call of RequestRFC021AccessToken.
-func (mr *MockClientMockRecorder) RequestRFC021AccessToken(ctx, requestHolder, verifier, scopes, useDPoP, credentials any) *gomock.Call {
+func (mr *MockClientMockRecorder) RequestRFC021AccessToken(ctx, requestHolder, verifier, oauthIssuer, scopes, useDPoP, credentials any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestRFC021AccessToken", reflect.TypeOf((*MockClient)(nil).RequestRFC021AccessToken), ctx, requestHolder, verifier, scopes, useDPoP, credentials)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestRFC021AccessToken", reflect.TypeOf((*MockClient)(nil).RequestRFC021AccessToken), ctx, requestHolder, verifier, oauthIssuer, scopes, useDPoP, credentials)
 }
 
 // VerifiableCredentials mocks base method.

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -41,7 +41,6 @@ import (
 	nutsHttp "github.com/nuts-foundation/nuts-node/http"
 	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
-	"github.com/nuts-foundation/nuts-node/vdr/didweb"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 )
 
@@ -206,13 +205,9 @@ func (c *OpenID4VPClient) AccessToken(ctx context.Context, code string, tokenEnd
 	return &token, nil
 }
 
-func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, requester did.DID, verifier did.DID, scopes string,
+func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, requester did.DID, verifier did.DID, oauthIssuer *url.URL, scopes string,
 	useDPoP bool, credentials []vc.VerifiableCredential) (*oauth.TokenResponse, error) {
 	iamClient := c.httpClient
-	oauthIssuer, err := didweb.DIDToURL(verifier)
-	if err != nil {
-		return nil, err
-	}
 	metadata, err := c.AuthorizationServerMetadata(ctx, oauthIssuer.String())
 	if err != nil {
 		return nil, err

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -132,12 +132,8 @@ func (c *OpenID4VPClient) PresentationDefinition(ctx context.Context, endpoint s
 
 func (c *OpenID4VPClient) AuthorizationServerMetadata(ctx context.Context, oauthIssuer string) (*oauth.AuthorizationServerMetadata, error) {
 	iamClient := c.httpClient
-	parsedURL, err := core.ParsePublicURL(oauthIssuer, c.strictMode)
-	if err != nil {
-		return nil, fmt.Errorf("invalid oauth issuer url: %w", err)
-	}
 	// the wallet/client acts as authorization server
-	metadata, err := iamClient.OAuthAuthorizationServerMetadata(ctx, parsedURL.String())
+	metadata, err := iamClient.OAuthAuthorizationServerMetadata(ctx, oauthIssuer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve remote OAuth Authorization Server metadata: %w", err)
 	}
@@ -217,9 +213,9 @@ func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, requeste
 	if err != nil {
 		return nil, err
 	}
-	metadata, err := iamClient.OAuthAuthorizationServerMetadata(ctx, oauthIssuer.String())
+	metadata, err := c.AuthorizationServerMetadata(ctx, oauthIssuer.String())
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve remote OAuth Authorization Server metadata: %w", err)
+		return nil, err
 	}
 
 	// get the presentation definition from the verifier
@@ -298,12 +294,7 @@ func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, requeste
 
 func (c *OpenID4VPClient) OpenIdCredentialIssuerMetadata(ctx context.Context, oauthIssuerURI string) (*oauth.OpenIDCredentialIssuerMetadata, error) {
 	iamClient := c.httpClient
-	parsedURL, err := core.ParsePublicURL(oauthIssuerURI, c.strictMode)
-	if err != nil {
-		return nil, fmt.Errorf("invalid oauth issuer url: %w", err)
-	}
-
-	rsp, err := iamClient.OpenIdCredentialIssuerMetadata(ctx, parsedURL.String())
+	rsp, err := iamClient.OpenIdCredentialIssuerMetadata(ctx, oauthIssuerURI)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve Openid credential issuer metadata: %w", err)
 	}

--- a/core/to/util.go
+++ b/core/to/util.go
@@ -1,0 +1,5 @@
+package to
+
+func Ptr[T any](v T) *T {
+	return &v
+}

--- a/core/to/util.go
+++ b/core/to/util.go
@@ -1,5 +1,24 @@
+/*
+ * Copyright (C) 2024 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package to
 
+// Ptr is the OG pointer function. Returns a pointer to any input.
 func Ptr[T any](v T) *T {
 	return &v
 }

--- a/docs/_static/auth/iam.partial.yaml
+++ b/docs/_static/auth/iam.partial.yaml
@@ -346,11 +346,11 @@ paths:
   # TODO: What format to use? (codegenerator breaks on aliases)
   # See issue https://github.com/nuts-foundation/nuts-node/issues/2365
   # create aliases for the specced path
-  #  /iam/{did}/oauth-authorization-server:
-  #    $ref: '#/paths/~1.well-known~1oauth-authorization-server~1iam~1{did}'
-  #  /iam/{did}/.well-known/oauth-authorization-server:
-  #    $ref: '#/paths/~1.well-known~1oauth-authorization-server~1iam~1{did}'
-  /.well-known/oauth-authorization-server/iam/{did}:
+  #  /oauth2/{did}/oauth-authorization-server:
+  #    $ref: '#/paths/~1.well-known~1oauth-authorization-server~1oauth2~1{did}'
+  #  /oauth2/{did}/.well-known/oauth-authorization-server:
+  #    $ref: '#/paths/~1.well-known~1oauth-authorization-server~1oauth2~1{did}'
+  /.well-known/oauth-authorization-server/oauth2/{did}:
     get:
       tags:
         - well-known

--- a/docs/_static/auth/iam.partial.yaml
+++ b/docs/_static/auth/iam.partial.yaml
@@ -350,25 +350,25 @@ paths:
   #    $ref: '#/paths/~1.well-known~1oauth-authorization-server~1iam~1{did}'
   #  /iam/{did}/.well-known/oauth-authorization-server:
   #    $ref: '#/paths/~1.well-known~1oauth-authorization-server~1iam~1{did}'
-  /.well-known/oauth-authorization-server/iam/{id}:
+  /.well-known/oauth-authorization-server/iam/{did}:
     get:
       tags:
         - well-known
-      summary: Get the OAuth2 Authorization Server metadata for a did:web with a :iam:<id> path.
+      summary: Get the OAuth2 Authorization Server metadata for the specified DID.
       description: >
         Specified by https://www.rfc-editor.org/info/rfc8414
         The well-known path is the default specified by https://www.rfc-editor.org/rfc/rfc8414.html#section-3
 
         error returns:
         * 400 - invalid input
-        * 404 - did not found; possibly be non-existing, deactivated, or not managed by this node
+        * 404 - DID not found; possibly be non-existing, deactivated, or not managed by this node
         * 500 - internal server error
       operationId: OAuthAuthorizationServerMetadata
       parameters:
-        - name: id
+        - name: did
           in: path
           required: true
-          description: ID of did:web DID that serves the metadata
+          description: The DID of the metadata subject.
           schema:
             type: string
             example: did:web:example.com
@@ -416,7 +416,7 @@ paths:
         
         error returns:
         * 400 - invalid input
-        * 404 - did not found; possibly be non-existing, deactivated, or not managed by this node
+        * 404 - DID not found; possibly be non-existing, deactivated, or not managed by this node
         * 500 - internal server error
       operationId: OAuthClientMetadata
       parameters:

--- a/e2e-tests/browser/client/iam/generated.go
+++ b/e2e-tests/browser/client/iam/generated.go
@@ -131,6 +131,11 @@ type ServiceAccessTokenRequest struct {
 	// They must be in the form of a Verifiable Credential in JSON form.
 	// The serialized form (JWT or JSON-LD) in the resulting Verifiable Presentation depends on the capability of the authorizing party.
 	// A typical use case is to provide a self-attested credential to convey information about the user that initiated the request.
+	//
+	// The following credential fields are automatically filled (when not present), and may be omitted:
+	// - issuer, credentialSubject.id (filled with the DID of the requester)
+	// - issuanceDate (filled with the current date/time)
+	// - id (filled with a UUID)
 	Credentials *[]VerifiableCredential `json:"credentials,omitempty"`
 
 	// Scope The scope that will be the service for which this access token can be used.

--- a/e2e-tests/browser/openid4vp_employeecredential/run-test.sh
+++ b/e2e-tests/browser/openid4vp_employeecredential/run-test.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 source ../../util.sh
 
-set -e # make script fail if any of the tests returns a non-zero exit code
-
 # Shut down existing containers
 docker compose stop
 docker compose rm -f -v
@@ -11,5 +9,9 @@ docker compose rm -f -v
 docker compose up --wait
 
 go test -v --tags=e2e_tests -count=1 .
+if [ $? -ne 0 ]; then
+	echo "ERROR: test failure"
+	exitWithDockerLogs 1
+fi
 
 docker compose stop

--- a/http/client/caching.go
+++ b/http/client/caching.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2024 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package client
 
 import (

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2024 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package client
 
 import (

--- a/http/client/client_test.go
+++ b/http/client/client_test.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2024 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package client
 
 import (


### PR DESCRIPTION
To support other DID methods. Changes:

- Changed the issuer URL to contain the complete DID instead of just the did:web ID part of the DID
- Changed the path of the issuer URL to `/oauth2` instead of `/iam`, to have it align with the other OAuth endpoints, and to explicitly decouple it from the did:web DID.

This is also preparation work for decoupling did:web from OAuth2; which will require the caller to provide the AS url in (near) future.