### PR TITLE
VCR: StatusList2021 forward compatibility for other DID methods

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -26,6 +26,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/labstack/echo/v4"
 	"github.com/nuts-foundation/nuts-node/http/cache"
 	"github.com/nuts-foundation/nuts-node/http/user"
 	"html/template"
@@ -34,7 +35,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/labstack/echo/v4"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/audit"

--- a/vcr/revocation/types.go
+++ b/vcr/revocation/types.go
@@ -105,14 +105,16 @@ var _ StatusList2021Verifier = (*StatusList2021)(nil)
 type StatusList2021 struct {
 	client          core.HTTPRequestDoer
 	db              *gorm.DB
+	baseURL         string
 	VerifySignature VerifySignFn // injected by verifier
 	Sign            SignFn       // injected by issuer, context must contain an audit log
 	ResolveKey      ResolveKeyFn // injected by issuer
 }
 
 // NewStatusList2021 returns a StatusList2021 without a Sign or VerifySignature method.
-func NewStatusList2021(db *gorm.DB, client core.HTTPRequestDoer) *StatusList2021 {
-	return &StatusList2021{client: client, db: db}
+// The URL in the credential will be constructed as follows using the given base URL: <baseURL>/statuslist/<did>/<page>
+func NewStatusList2021(db *gorm.DB, client core.HTTPRequestDoer, baseURL string) *StatusList2021 {
+	return &StatusList2021{client: client, db: db, baseURL: baseURL}
 }
 
 // StatusList2021Entry is the "credentialStatus" property used by issuers to enable VerifiableCredential status information.

--- a/vcr/revocation/types_test.go
+++ b/vcr/revocation/types_test.go
@@ -33,7 +33,7 @@ import (
 
 // newTestStatusList2021 returns a StatusList2021 that does not Sign or VerifySignature, with a SQLite db containing the dids, and no http-client.
 func newTestStatusList2021(t testing.TB, dids ...did.DID) *StatusList2021 {
-	cs := NewStatusList2021(storage.NewTestStorageEngine(t).GetSQLDatabase(), nil)
+	cs := NewStatusList2021(storage.NewTestStorageEngine(t).GetSQLDatabase(), nil, "https://example.com")
 	cs.Sign = noopSign
 	cs.ResolveKey = noopResolveKey
 	cs.VerifySignature = noopSignVerify

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -225,7 +225,7 @@ func (c *vcr) Configure(config core.ServerConfig) error {
 		c.openidSessionStore = c.storageClient.GetSessionDatabase()
 	}
 
-	status := revocation.NewStatusList2021(c.storageClient.GetSQLDatabase(), client.NewWithCache(config.HTTPClient.Timeout))
+	status := revocation.NewStatusList2021(c.storageClient.GetSQLDatabase(), client.NewWithCache(config.HTTPClient.Timeout), config.URL)
 	c.issuer = issuer.NewIssuer(c.issuerStore, c, networkPublisher, openidHandlerFn, didResolver, c.keyStore, c.jsonldManager, c.trustConfig, status)
 	c.verifier = verifier.NewVerifier(c.verifierStore, didResolver, c.keyResolver, c.jsonldManager, c.trustConfig, status)
 

--- a/vcr/verifier/verifier_test.go
+++ b/vcr/verifier/verifier_test.go
@@ -152,7 +152,7 @@ func TestVerifier_Verify(t *testing.T) {
 		ctx := newMockContext(t)
 		ctx.store.EXPECT().GetRevocations(gomock.Any()).Return([]*credential.Revocation{{}}, ErrNotFound).AnyTimes()
 		db := storage.NewTestStorageEngine(t).GetSQLDatabase()
-		ctx.verifier.credentialStatus = revocation.NewStatusList2021(db, ts.Client())
+		ctx.verifier.credentialStatus = revocation.NewStatusList2021(db, ts.Client(), "https://example.com")
 		ctx.verifier.credentialStatus.(*revocation.StatusList2021).VerifySignature = func(_ vc.VerifiableCredential, _ *time.Time) error { return nil } // don't check signatures on 'downloaded' StatusList2021Credentials
 		ctx.verifier.credentialStatus.(*revocation.StatusList2021).Sign = func(_ context.Context, unsignedCredential vc.VerifiableCredential, _ crypto.Key) (*vc.VerifiableCredential, error) {
 			bs, err := json.Marshal(unsignedCredential)


### PR DESCRIPTION
To support other DID methods in future (`did:tdw`), the StatusList2021 issuer can't use `didweb.DIDtoURL` to determine the URL the StatusCredential lives on. This PR changes it to more explicit configuration.

Note: should we lookup the statuslist through `(DID, page)` combination instead? Since that also supports migration scenarios?