### PR TITLE
IAM: Provide authorization_server in access token requests 

### DIFF
--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -129,6 +129,10 @@ type RequestObjectResponse = string
 
 // ServiceAccessTokenRequest Request for an access token for a service.
 type ServiceAccessTokenRequest struct {
+	// AuthorizationServer The OAuth Authorization Server's identifier as specified in RFC 8414 (section 2),
+	// used to locate the OAuth2 Authorization Server metadata.
+	AuthorizationServer string `json:"authorization_server"`
+
 	// Credentials Additional credentials to present (if required by the authorizer), in addition to those in the requester's wallet.
 	// They must be in the form of a Verifiable Credential in JSON form.
 	// The serialized form (JWT or JSON-LD) in the resulting Verifiable Presentation depends on the capability of the authorizing party.
@@ -145,7 +149,6 @@ type ServiceAccessTokenRequest struct {
 
 	// TokenType The type of access token that is preferred, default: DPoP
 	TokenType *ServiceAccessTokenRequestTokenType `json:"token_type,omitempty"`
-	Verifier  string                              `json:"verifier"`
 }
 
 // ServiceAccessTokenRequestTokenType The type of access token that is preferred, default: DPoP
@@ -159,6 +162,10 @@ type TokenIntrospectionRequest struct {
 
 // UserAccessTokenRequest Request for an access token for a user.
 type UserAccessTokenRequest struct {
+	// AuthorizationServer The OAuth Authorization Server's identifier as specified in RFC 8414 (section 2),
+	// used to locate the OAuth2 Authorization Server metadata.
+	AuthorizationServer string `json:"authorization_server"`
+
 	// PreauthorizedUser Claims about the authorized user.
 	PreauthorizedUser *UserDetails `json:"preauthorized_user,omitempty"`
 
@@ -172,9 +179,6 @@ type UserAccessTokenRequest struct {
 
 	// TokenType The type of access token that is prefered. Supported values: [Bearer, DPoP], default: DPoP
 	TokenType *UserAccessTokenRequestTokenType `json:"token_type,omitempty"`
-
-	// Verifier The DID of the verifier, the relying party for which this access token is requested.
-	Verifier string `json:"verifier"`
 }
 
 // UserAccessTokenRequestTokenType The type of access token that is prefered. Supported values: [Bearer, DPoP], default: DPoP
@@ -201,7 +205,10 @@ type Cnf struct {
 // RequestOpenid4VCICredentialIssuanceJSONBody defines parameters for RequestOpenid4VCICredentialIssuance.
 type RequestOpenid4VCICredentialIssuanceJSONBody struct {
 	AuthorizationDetails []map[string]interface{} `json:"authorization_details"`
-	Issuer               string                   `json:"issuer"`
+
+	// Issuer The OAuth Authorization Server's identifier, that issues the Verifiable Credentials, as specified in RFC 8414 (section 2),
+	// used to locate the OAuth2 Authorization Server metadata.
+	Issuer string `json:"issuer"`
 
 	// RedirectUri The URL to which the user-agent will be redirected after the authorization request.
 	RedirectUri string `json:"redirect_uri"`

--- a/auth/api/iam/jar.go
+++ b/auth/api/iam/jar.go
@@ -55,7 +55,7 @@ type JAR interface {
 	//  - iss
 	//  - aud (if server is not nil)
 	// the request_uri_method is determined by the presence of a server (get) or not (post)
-	Create(client did.DID, server *did.DID, modifier requestObjectModifier) jarRequest
+	Create(client did.DID, authServerURL string, modifier requestObjectModifier) jarRequest
 	// Sign the jarRequest, which is available on jarRequest.Token.
 	// Returns an error if the jarRequest already contains a signed JWT.
 	// TODO: check if signature type of client is supported by the AS/wallet.
@@ -65,20 +65,20 @@ type JAR interface {
 	Parse(ctx context.Context, ownDID did.DID, q url.Values) (oauthParameters, error)
 }
 
-func (j jar) Create(client did.DID, server *did.DID, modifier requestObjectModifier) jarRequest {
-	return createJarRequest(client, server, modifier)
+func (j jar) Create(client did.DID, authServerURL string, modifier requestObjectModifier) jarRequest {
+	return createJarRequest(client, authServerURL, modifier)
 }
 
-func createJarRequest(client did.DID, server *did.DID, modifier requestObjectModifier) jarRequest {
+func createJarRequest(client did.DID, authServerURL string, modifier requestObjectModifier) jarRequest {
 	requestURIMethod := "post"
 	// default claims for JAR
 	params := map[string]string{
 		jwt.IssuerKey:       client.String(),
 		oauth.ClientIDParam: client.String(),
 	}
-	if server != nil {
+	if authServerURL != "" {
 		requestURIMethod = "get"
-		params[jwt.AudienceKey] = server.String()
+		params[jwt.AudienceKey] = authServerURL
 	}
 
 	// additional claims can be added by the caller

--- a/auth/api/iam/jar_mock.go
+++ b/auth/api/iam/jar_mock.go
@@ -42,17 +42,17 @@ func (m *MockJAR) EXPECT() *MockJARMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockJAR) Create(client did.DID, server *did.DID, modifier requestObjectModifier) jarRequest {
+func (m *MockJAR) Create(client did.DID, authServerURL string, modifier requestObjectModifier) jarRequest {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", client, server, modifier)
+	ret := m.ctrl.Call(m, "Create", client, authServerURL, modifier)
 	ret0, _ := ret[0].(jarRequest)
 	return ret0
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockJARMockRecorder) Create(client, server, modifier any) *gomock.Call {
+func (mr *MockJARMockRecorder) Create(client, authServerURL, modifier any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockJAR)(nil).Create), client, server, modifier)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockJAR)(nil).Create), client, authServerURL, modifier)
 }
 
 // Parse mocks base method.

--- a/auth/api/iam/jar_test.go
+++ b/auth/api/iam/jar_test.go
@@ -44,25 +44,25 @@ func TestJar_Create(t *testing.T) {
 		modifier := func(claims map[string]string) {
 			claims["requestObjectModifier"] = "works"
 		}
-		req := jar{}.Create(verifierDID, &holderDID, modifier)
+		req := jar{}.Create(verifierDID, holderURL, modifier)
 		assert.Equal(t, "get", req.RequestURIMethod)
 		assert.Equal(t, verifierDID, req.Client)
 		assert.Len(t, req.Claims, 4)
-		assert.Equal(t, req.Claims[oauth.ClientIDParam], verifierDID.String())
-		assert.Equal(t, req.Claims[jwt.IssuerKey], verifierDID.String())
-		assert.Equal(t, req.Claims[jwt.AudienceKey], holderDID.String())
-		assert.Equal(t, req.Claims["requestObjectModifier"], "works")
+		assert.Equal(t, verifierDID.String(), req.Claims[oauth.ClientIDParam])
+		assert.Equal(t, verifierDID.String(), req.Claims[jwt.IssuerKey])
+		assert.Equal(t, holderURL, req.Claims[jwt.AudienceKey])
+		assert.Equal(t, "works", req.Claims["requestObjectModifier"])
 	})
 	t.Run("request_uri_method=post", func(t *testing.T) {
 		modifier := func(claims map[string]string) {
 			claims[jwt.IssuerKey] = holderDID.String()
 		}
-		req := jar{}.Create(verifierDID, nil, modifier)
+		req := jar{}.Create(verifierDID, "", modifier)
 		assert.Equal(t, "post", req.RequestURIMethod)
 		assert.Equal(t, verifierDID, req.Client)
 		assert.Len(t, req.Claims, 2)
-		assert.Equal(t, req.Claims[jwt.IssuerKey], holderDID.String())
-		assert.Equal(t, req.Claims[oauth.ClientIDParam], verifierDID.String())
+		assert.Equal(t, holderDID.String(), req.Claims[jwt.IssuerKey])
+		assert.Equal(t, verifierDID.String(), req.Claims[oauth.ClientIDParam])
 		assert.Empty(t, req.Claims[jwt.AudienceKey])
 	})
 }

--- a/auth/api/iam/s2s_vptoken.go
+++ b/auth/api/iam/s2s_vptoken.go
@@ -51,6 +51,7 @@ func (r Wrapper) handleS2SAccessTokenRequest(ctx context.Context, issuer did.DID
 			Description: "assertion parameter is invalid: " + err.Error(),
 		}
 	}
+	issuerURL, _ := createOAuth2BaseURL(issuer)
 
 	submission, err := pe.ParsePresentationSubmission([]byte(submissionJSON))
 	if err != nil {
@@ -70,7 +71,7 @@ func (r Wrapper) handleS2SAccessTokenRequest(ctx context.Context, issuer did.DID
 		} else {
 			credentialSubjectID = *subjectDID
 		}
-		if err := r.validatePresentationAudience(presentation, issuer); err != nil {
+		if err := r.validatePresentationAudience(presentation, issuerURL.String()); err != nil {
 			return nil, err
 		}
 	}

--- a/auth/api/iam/validation.go
+++ b/auth/api/iam/validation.go
@@ -51,7 +51,7 @@ func validatePresentationSigner(presentation vc.VerifiablePresentation, expected
 
 // validatePresentationAudience checks if the presentation audience (aud claim for JWTs, domain property for JSON-LD proofs) contains the issuer DID.
 // it returns an OAuth2 error if the audience is missing or does not match the issuer.
-func (r Wrapper) validatePresentationAudience(presentation vc.VerifiablePresentation, issuer did.DID) error {
+func (r Wrapper) validatePresentationAudience(presentation vc.VerifiablePresentation, expected string) error {
 	var audience []string
 	switch presentation.Format() {
 	case vc.JWTPresentationProofFormat:
@@ -66,14 +66,14 @@ func (r Wrapper) validatePresentationAudience(presentation vc.VerifiablePresenta
 		}
 	}
 	for _, aud := range audience {
-		if aud == issuer.String() {
+		if aud == expected {
 			return nil
 		}
 	}
 	return oauth.OAuth2Error{
 		Code:          oauth.InvalidRequest,
 		Description:   "presentation audience/domain is missing or does not match",
-		InternalError: fmt.Errorf("expected: %s, got: %v", issuer, audience),
+		InternalError: fmt.Errorf("expected: %s, got: %v", expected, audience),
 	}
 }
 

--- a/auth/client/iam/interface.go
+++ b/auth/client/iam/interface.go
@@ -20,8 +20,6 @@ package iam
 
 import (
 	"context"
-	"net/url"
-
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
@@ -45,8 +43,8 @@ type Client interface {
 	PostAuthorizationResponse(ctx context.Context, vp vc.VerifiablePresentation, presentationSubmission pe.PresentationSubmission, verifierResponseURI string, state string) (string, error)
 	// PresentationDefinition returns the presentation definition from the given endpoint.
 	PresentationDefinition(ctx context.Context, endpoint string) (*pe.PresentationDefinition, error)
-	// RequestRFC021AccessToken is called by the local EHR node to request an access token from a remote Nuts node using Nuts RFC021.
-	RequestRFC021AccessToken(ctx context.Context, requestHolder did.DID, verifier did.DID, oauthIssuer *url.URL, scopes string, useDPoP bool,
+	// RequestRFC021AccessToken is called by the local EHR node to request an access token from a remote OAuth2 Authorization Server using Nuts RFC021.
+	RequestRFC021AccessToken(ctx context.Context, requestHolder did.DID, authServerURL string, scopes string, useDPoP bool,
 		credentials []vc.VerifiableCredential) (*oauth.TokenResponse, error)
 
 	// OpenIdCredentialIssuerMetadata returns the metadata of the remote credential issuer.

--- a/auth/client/iam/mock.go
+++ b/auth/client/iam/mock.go
@@ -11,7 +11,6 @@ package iam
 
 import (
 	context "context"
-	url "net/url"
 	reflect "reflect"
 
 	did "github.com/nuts-foundation/go-did/did"
@@ -180,18 +179,18 @@ func (mr *MockClientMockRecorder) RequestObjectByPost(ctx, requestURI, walletMet
 }
 
 // RequestRFC021AccessToken mocks base method.
-func (m *MockClient) RequestRFC021AccessToken(ctx context.Context, requestHolder, verifier did.DID, oauthIssuer *url.URL, scopes string, useDPoP bool, credentials []vc.VerifiableCredential) (*oauth.TokenResponse, error) {
+func (m *MockClient) RequestRFC021AccessToken(ctx context.Context, requestHolder did.DID, authServerURL, scopes string, useDPoP bool, credentials []vc.VerifiableCredential) (*oauth.TokenResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RequestRFC021AccessToken", ctx, requestHolder, verifier, oauthIssuer, scopes, useDPoP, credentials)
+	ret := m.ctrl.Call(m, "RequestRFC021AccessToken", ctx, requestHolder, authServerURL, scopes, useDPoP, credentials)
 	ret0, _ := ret[0].(*oauth.TokenResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RequestRFC021AccessToken indicates an expected call of RequestRFC021AccessToken.
-func (mr *MockClientMockRecorder) RequestRFC021AccessToken(ctx, requestHolder, verifier, oauthIssuer, scopes, useDPoP, credentials any) *gomock.Call {
+func (mr *MockClientMockRecorder) RequestRFC021AccessToken(ctx, requestHolder, authServerURL, scopes, useDPoP, credentials any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestRFC021AccessToken", reflect.TypeOf((*MockClient)(nil).RequestRFC021AccessToken), ctx, requestHolder, verifier, oauthIssuer, scopes, useDPoP, credentials)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestRFC021AccessToken", reflect.TypeOf((*MockClient)(nil).RequestRFC021AccessToken), ctx, requestHolder, authServerURL, scopes, useDPoP, credentials)
 }
 
 // VerifiableCredentials mocks base method.

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -205,10 +205,10 @@ func (c *OpenID4VPClient) AccessToken(ctx context.Context, code string, tokenEnd
 	return &token, nil
 }
 
-func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, requester did.DID, verifier did.DID, oauthIssuer *url.URL, scopes string,
+func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, requester did.DID, authServerURL string, scopes string,
 	useDPoP bool, credentials []vc.VerifiableCredential) (*oauth.TokenResponse, error) {
 	iamClient := c.httpClient
-	metadata, err := c.AuthorizationServerMetadata(ctx, oauthIssuer.String())
+	metadata, err := c.AuthorizationServerMetadata(ctx, authServerURL)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, requeste
 	}
 
 	params := holder.BuildParams{
-		Audience: verifier.String(),
+		Audience: authServerURL,
 		Expires:  time.Now().Add(time.Second * 5),
 		Nonce:    nutsCrypto.GenerateNonce(),
 	}

--- a/auth/client/iam/openid4vp_test.go
+++ b/auth/client/iam/openid4vp_test.go
@@ -241,7 +241,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 		ctx := createClientServerTestContext(t)
 		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), walletDID, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
 
-		response, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierDID, ctx.verifierURL, scopes, false, nil)
+		response, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierURL.String(), scopes, false, nil)
 
 		assert.NoError(t, err)
 		require.NotNil(t, response)
@@ -304,7 +304,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 			credentials[i] = *credPtr
 		}
 
-		response, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierDID, ctx.verifierURL, scopes, false, credentials)
+		response, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierURL.String(), scopes, false, credentials)
 
 		assert.NoError(t, err)
 		require.NotNil(t, response)
@@ -317,7 +317,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 		ctx.jwtSigner.EXPECT().SignDPoP(context.Background(), gomock.Any(), kid.String()).Return("dpop", nil)
 		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), walletDID, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
 
-		response, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierDID, ctx.verifierURL, scopes, true, nil)
+		response, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierURL.String(), scopes, true, nil)
 
 		assert.NoError(t, err)
 		require.NotNil(t, response)
@@ -338,7 +338,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 		}
 		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), walletDID, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
 
-		_, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierDID, ctx.verifierURL, scopes, false, nil)
+		_, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierURL.String(), scopes, false, nil)
 
 		require.Error(t, err)
 		oauthError, ok := err.(oauth.OAuth2Error)
@@ -349,7 +349,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 		ctx := createClientServerTestContext(t)
 		ctx.presentationDefinition = nil
 
-		_, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierDID, ctx.verifierURL, scopes, false, nil)
+		_, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierURL.String(), scopes, false, nil)
 
 		assert.Error(t, err)
 		assert.EqualError(t, err, "failed to retrieve presentation definition: server returned HTTP 404 (expected: 200)")
@@ -358,7 +358,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 		ctx := createClientServerTestContext(t)
 		ctx.metadata = nil
 
-		_, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierDID, ctx.verifierURL, scopes, false, nil)
+		_, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierURL.String(), scopes, false, nil)
 
 		assert.Error(t, err)
 		assert.EqualError(t, err, "failed to retrieve remote OAuth Authorization Server metadata: server returned HTTP 404 (expected: 200)")
@@ -371,7 +371,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 			_, _ = writer.Write([]byte("{"))
 		}
 
-		_, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierDID, ctx.verifierURL, scopes, false, nil)
+		_, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierURL.String(), scopes, false, nil)
 
 		assert.Error(t, err)
 		assert.EqualError(t, err, "failed to retrieve presentation definition: unable to unmarshal response: unexpected end of JSON input")
@@ -381,7 +381,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 
 		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), walletDID, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(nil, nil, assert.AnError)
 
-		_, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierDID, ctx.verifierURL, scopes, false, nil)
+		_, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierURL.String(), scopes, false, nil)
 
 		assert.Error(t, err)
 	})

--- a/docs/_static/auth/v2.yaml
+++ b/docs/_static/auth/v2.yaml
@@ -271,6 +271,9 @@ paths:
               properties:
                 issuer:
                   type: string
+                  description: |
+                    The OAuth Authorization Server's identifier, that issues the Verifiable Credentials, as specified in RFC 8414 (section 2),
+                    used to locate the OAuth2 Authorization Server metadata.
                   example: did:web:issuer.example.com
                 authorization_details:
                   type: array
@@ -382,12 +385,15 @@ components:
       type: object
       description: Request for an access token for a service.
       required:
-        - verifier
+        - authorization_server
         - scope
       properties:
-        verifier:
+        authorization_server:
+          description: |
+            The OAuth Authorization Server's identifier as specified in RFC 8414 (section 2),
+            used to locate the OAuth2 Authorization Server metadata.
           type: string
-          example: did:web:example.com
+          example: https://example.com/oauth2
         scope:
           type: string
           description: The scope that will be the service for which this access token can be used.
@@ -429,14 +435,16 @@ components:
       type: object
       description: Request for an access token for a user.
       required:
+        - authorization_server
         - redirect_uri
         - scope
-        - verifier
       properties:
-        verifier:
+        authorization_server:
+          description: |
+            The OAuth Authorization Server's identifier as specified in RFC 8414 (section 2),
+            used to locate the OAuth2 Authorization Server metadata.
           type: string
-          description: The DID of the verifier, the relying party for which this access token is requested.
-          example: did:web:example.com
+          example: https://example.com/oauth2
         scope:
           type: string
           description: The scope that will be the service for which this access token can be used.

--- a/e2e-tests/browser/client/iam/generated.go
+++ b/e2e-tests/browser/client/iam/generated.go
@@ -127,6 +127,10 @@ type RedirectResponseWithID struct {
 
 // ServiceAccessTokenRequest Request for an access token for a service.
 type ServiceAccessTokenRequest struct {
+	// AuthorizationServer The OAuth Authorization Server's identifier as specified in RFC 8414 (section 2),
+	// used to locate the OAuth2 Authorization Server metadata.
+	AuthorizationServer string `json:"authorization_server"`
+
 	// Credentials Additional credentials to present (if required by the authorizer), in addition to those in the requester's wallet.
 	// They must be in the form of a Verifiable Credential in JSON form.
 	// The serialized form (JWT or JSON-LD) in the resulting Verifiable Presentation depends on the capability of the authorizing party.
@@ -143,7 +147,6 @@ type ServiceAccessTokenRequest struct {
 
 	// TokenType The type of access token that is preferred, default: DPoP
 	TokenType *ServiceAccessTokenRequestTokenType `json:"token_type,omitempty"`
-	Verifier  string                              `json:"verifier"`
 }
 
 // ServiceAccessTokenRequestTokenType The type of access token that is preferred, default: DPoP
@@ -157,6 +160,10 @@ type TokenIntrospectionRequest struct {
 
 // UserAccessTokenRequest Request for an access token for a user.
 type UserAccessTokenRequest struct {
+	// AuthorizationServer The OAuth Authorization Server's identifier as specified in RFC 8414 (section 2),
+	// used to locate the OAuth2 Authorization Server metadata.
+	AuthorizationServer string `json:"authorization_server"`
+
 	// PreauthorizedUser Claims about the authorized user.
 	PreauthorizedUser *UserDetails `json:"preauthorized_user,omitempty"`
 
@@ -170,9 +177,6 @@ type UserAccessTokenRequest struct {
 
 	// TokenType The type of access token that is prefered. Supported values: [Bearer, DPoP], default: DPoP
 	TokenType *UserAccessTokenRequestTokenType `json:"token_type,omitempty"`
-
-	// Verifier The DID of the verifier, the relying party for which this access token is requested.
-	Verifier string `json:"verifier"`
 }
 
 // UserAccessTokenRequestTokenType The type of access token that is prefered. Supported values: [Bearer, DPoP], default: DPoP
@@ -199,7 +203,10 @@ type Cnf struct {
 // RequestOpenid4VCICredentialIssuanceJSONBody defines parameters for RequestOpenid4VCICredentialIssuance.
 type RequestOpenid4VCICredentialIssuanceJSONBody struct {
 	AuthorizationDetails []map[string]interface{} `json:"authorization_details"`
-	Issuer               string                   `json:"issuer"`
+
+	// Issuer The OAuth Authorization Server's identifier, that issues the Verifiable Credentials, as specified in RFC 8414 (section 2),
+	// used to locate the OAuth2 Authorization Server metadata.
+	Issuer string `json:"issuer"`
 
 	// RedirectUri The URL to which the user-agent will be redirected after the authorization request.
 	RedirectUri string `json:"redirect_uri"`

--- a/e2e-tests/browser/openid4vp_employeecredential/openid4vp.go
+++ b/e2e-tests/browser/openid4vp_employeecredential/openid4vp.go
@@ -35,10 +35,10 @@ type OpenID4VP struct {
 
 func (o OpenID4VP) RequesterUserAccessToken(requesterDID, verifierDID did.DID, user iam.UserDetails, scope string) (*iam.RedirectResponseWithID, error) {
 	httpResponse, err := o.iamClient.RequestUserAccessToken(o.ctx, requesterDID.String(), iam.RequestUserAccessTokenJSONRequestBody{
-		PreauthorizedUser: &user,
-		RedirectUri:       "https://nodeA", // doesn't really matter where we redirect to
-		Scope:             scope,
-		Verifier:          verifierDID.String(),
+		PreauthorizedUser:   &user,
+		RedirectUri:         "https://nodeA", // doesn't really matter where we redirect to
+		Scope:               scope,
+		AuthorizationServer: "https://nodeA/oauth2/" + verifierDID.String(),
 	})
 	if err != nil {
 		return nil, err

--- a/e2e-tests/oauth-flow/openid4vp/do-test.sh
+++ b/e2e-tests/oauth-flow/openid4vp/do-test.sh
@@ -46,7 +46,7 @@ echo "---------------------------------------"
 echo "Request access token call"
 echo "---------------------------------------"
 # Request access token
-REQUEST="{\"verifier\":\"${PARTY_A_DID}\",\"scope\":\"test\", \"preauthorized_user\":{\"id\":\"1\", \"name\": \"John Doe\", \"role\": \"Janitor\"}, \"redirect_uri\":\"http://callback\"}"
+REQUEST="{\"authorization_server\":\"https://nodeA/oauth2/${PARTY_A_DID}\",\"scope\":\"test\", \"preauthorized_user\":{\"id\":\"1\", \"name\": \"John Doe\", \"role\": \"Janitor\"}, \"redirect_uri\":\"http://callback\"}"
 RESPONSE=$(echo $REQUEST | curl -X POST -s --data-binary @- http://localhost:28081/internal/auth/v2/${PARTY_B_DID}/request-user-access-token -H "Content-Type:application/json")
 if echo $RESPONSE | grep -q "redirect_uri"; then
   LOCATION=$(echo $RESPONSE | sed -E 's/.*"redirect_uri":"([^"]*).*/\1/')

--- a/e2e-tests/oauth-flow/rfc021/do-test.sh
+++ b/e2e-tests/oauth-flow/rfc021/do-test.sh
@@ -67,7 +67,7 @@ echo "---------------------------------------"
 REQUEST=$(
 cat << EOF
 {
-  "verifier": "${VENDOR_A_DID}",
+  "authorization_server": "https://nodeA/oauth2/${VENDOR_A_DID}",
   "scope": "test",
   "credentials": [
       {

--- a/makefile
+++ b/makefile
@@ -55,7 +55,6 @@ gen-mocks:
 	mockgen -destination=vcr/verifier/mock.go -package=verifier -source=vcr/verifier/interface.go
 	mockgen -destination=vdr/didnuts/ambassador_mock.go -package=didnuts -source=vdr/didnuts/ambassador.go
 	mockgen -destination=vdr/didnuts/didstore/mock.go -package=didstore -source=vdr/didnuts/didstore/interface.go
-	mockgen -destination=vdr/didweb/store_mock.go -package=didweb -source=vdr/didweb/store.go
 	mockgen -destination=vdr/mock.go -package=vdr -source=vdr/interface.go
 	mockgen -destination=vdr/resolver/did_mock.go -package=resolver -source=vdr/resolver/did.go
 	mockgen -destination=vdr/resolver/service_mock.go -package=resolver -source=vdr/resolver/service.go

--- a/vdr/api/v2/generated.go
+++ b/vdr/api/v2/generated.go
@@ -29,8 +29,7 @@ const (
 	String FilterServicesParamsEndpointType = "string"
 )
 
-// CreateDIDOptions Options for the DID creation. If neither `did` nor `tenant` is given, a random UUID is used as tenant.
-// It's invalid to provide both `did` and `tenant` at the same time.
+// CreateDIDOptions Options for the DID creation.
 type CreateDIDOptions struct {
 	// Root Can be used to create a root web:did.
 	//


### PR DESCRIPTION
To support other DID methods. Next step is to change audience from AS's DID to AS URL.

@JorisHeadease @rolandgroen this also changes the OpenID4VCI's `issuer` parameter in `RequestCredential()` from the DID to issuer URL.