### PR TITLE
map NoMatchingCredentials error to 419 status code

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/nuts-foundation/nuts-node/http/cache"
 	"github.com/nuts-foundation/nuts-node/http/user"
+	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"html/template"
 	"net/http"
 	"net/url"
@@ -200,6 +201,7 @@ func (r Wrapper) ResolveStatusCode(err error) int {
 	return core.ResolveStatusCode(err, map[error]int{
 		vcrTypes.ErrNotFound:                http.StatusNotFound,
 		resolver.ErrDIDNotManagedByThisNode: http.StatusBadRequest,
+		holder.ErrNoCredentials:             http.StatusPreconditionFailed,
 	})
 }
 

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -978,15 +978,16 @@ func TestWrapper_RequestServiceAccessToken(t *testing.T) {
 
 		require.EqualError(t, err, "invalid DID: invalid DID")
 	})
-	t.Run("error - verifier error", func(t *testing.T) {
+	t.Run("error - no matching credentials", func(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.vdr.EXPECT().IsOwner(nil, walletDID).Return(true, nil)
-		ctx.iamClient.EXPECT().RequestRFC021AccessToken(nil, walletDID, verifierURL.String(), "first second", true, nil).Return(nil, core.Error(http.StatusPreconditionFailed, "no matching credentials"))
+		ctx.iamClient.EXPECT().RequestRFC021AccessToken(nil, walletDID, verifierURL.String(), "first second", true, nil).Return(nil, holder.ErrNoCredentials)
 
 		_, err := ctx.client.RequestServiceAccessToken(nil, RequestServiceAccessTokenRequestObject{Did: walletDID.String(), Body: body})
 
 		require.Error(t, err)
-		assert.EqualError(t, err, "no matching credentials")
+		assert.Equal(t, err, holder.ErrNoCredentials)
+		assert.Equal(t, http.StatusPreconditionFailed, statusCodeFrom(err))
 	})
 }
 


### PR DESCRIPTION
fixes #3203 
also changed existing test since the error comes from the own node, not from the other node.