### PR TITLE
VDR refactor part trois: implement SubjectManager interface for nuts and web

### DIFF
--- a/vdr/didnuts/ambassador_test.go
+++ b/vdr/didnuts/ambassador_test.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/audit"
+	"github.com/nuts-foundation/nuts-node/crypto/dpop"
 	"github.com/nuts-foundation/nuts-node/network"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 	"testing"
@@ -45,6 +46,65 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
+
+// mockKeyStore creates a single new key
+type mockKeyStore struct {
+	key crypto.Key
+}
+
+// New creates a new valid key with the correct KID
+func (m *mockKeyStore) New(_ context.Context, fn crypto.KIDNamingFunc) (crypto.Key, error) {
+	if m.key == nil {
+		privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		kid, _ := fn(privateKey.Public())
+
+		m.key = &crypto.TestKey{
+			PrivateKey: privateKey,
+			Kid:        kid,
+		}
+	}
+	return m.key, nil
+}
+
+func (m *mockKeyStore) Decrypt(ctx context.Context, kid string, ciphertext []byte) ([]byte, error) {
+	panic("not implemented")
+}
+
+func (m *mockKeyStore) EncryptJWE(ctx context.Context, payload []byte, headers map[string]interface{}, publicKey interface{}) (string, error) {
+	panic("not implemented")
+}
+
+func (m *mockKeyStore) DecryptJWE(ctx context.Context, message string) (body []byte, headers map[string]interface{}, err error) {
+	panic("not implemented")
+}
+
+func (m *mockKeyStore) Exists(ctx context.Context, kid string) (bool, error) {
+	panic("not implemented")
+}
+
+func (m *mockKeyStore) Resolve(ctx context.Context, kid string) (crypto.Key, error) {
+	return m.key, nil
+}
+
+func (m *mockKeyStore) List(ctx context.Context) []string {
+	panic("not implemented")
+}
+
+func (m *mockKeyStore) SignJWT(ctx context.Context, claims map[string]interface{}, headers map[string]interface{}, key interface{}) (string, error) {
+	panic("not implemented")
+}
+
+func (m *mockKeyStore) SignJWS(ctx context.Context, payload []byte, headers map[string]interface{}, key interface{}, detached bool) (string, error) {
+	panic("not implemented")
+}
+
+func (m *mockKeyStore) SignDPoP(ctx context.Context, token dpop.DPoP, kid string) (string, error) {
+	panic("not implemented")
+}
+
+func (m *mockKeyStore) Delete(ctx context.Context, kid string) error {
+	panic("not implemented")
+}
 
 // mockKeyCreator creates a single new key
 type mockKeyCreator struct {
@@ -106,7 +166,7 @@ func (s testTransaction) PayloadType() string {
 	return s.payloadType
 }
 func (s testTransaction) SigningAlgorithm() string {
-	panic("implement me")
+	panic("not implemented")
 }
 
 func (s testTransaction) Previous() []hash.SHA256Hash {
@@ -114,11 +174,11 @@ func (s testTransaction) Previous() []hash.SHA256Hash {
 }
 
 func (s testTransaction) Version() dag.Version {
-	panic("implement me")
+	panic("not implemented")
 }
 
 func (s testTransaction) MarshalJSON() ([]byte, error) {
-	panic("implement me")
+	panic("not implemented")
 }
 
 func (s testTransaction) Data() []byte {

--- a/vdr/didnuts/creator.go
+++ b/vdr/didnuts/creator.go
@@ -85,8 +85,8 @@ func KeyFlag(flags management.DIDKeyFlags) management.CreationOption {
 	return keyFlagCreationOption(flags)
 }
 
-// didKIDNamingFunc is a function used to name a key used in newly generated DID Documents.
-func didKIDNamingFunc(pKey crypto.PublicKey) (string, error) {
+// DIDKIDNamingFunc is a function used to name a key used in newly generated DID Documents.
+func DIDKIDNamingFunc(pKey crypto.PublicKey) (string, error) {
 	return getKIDName(pKey, nutsCrypto.Thumbprint)
 }
 
@@ -177,7 +177,7 @@ func (n Creator) create(ctx context.Context, flags management.DIDKeyFlags) (*did
 	// Currently, always keep the key in the keystore. This allows us to change the transaction format and regenerate transactions at a later moment.
 	// Relevant issue:
 	// https://github.com/nuts-foundation/nuts-node/issues/1947
-	key, err := n.KeyStore.New(ctx, didKIDNamingFunc)
+	key, err := n.KeyStore.New(ctx, DIDKIDNamingFunc)
 	// } else {
 	// 	key, err = nutsCrypto.NewEphemeralKey(didKIDNamingFunc)
 	// }

--- a/vdr/didnuts/creator_test.go
+++ b/vdr/didnuts/creator_test.go
@@ -169,7 +169,7 @@ func Test_didKIDNamingFunc(t *testing.T) {
 		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		require.NoError(t, err)
 
-		keyID, err := didKIDNamingFunc(privateKey.PublicKey)
+		keyID, err := DIDKIDNamingFunc(privateKey.PublicKey)
 		require.NoError(t, err)
 		assert.NotEmpty(t, keyID)
 		assert.Contains(t, keyID, "did:nuts")
@@ -179,13 +179,13 @@ func Test_didKIDNamingFunc(t *testing.T) {
 		pub, err := jwkToPublicKey(t, jwkString)
 		require.NoError(t, err)
 
-		keyID, err := didKIDNamingFunc(pub)
+		keyID, err := DIDKIDNamingFunc(pub)
 		require.NoError(t, err)
 		assert.Equal(t, keyID, "did:nuts:3gU9z3j7j4VCboc3qq3Vc5mVVGDNGjfg32xokeX8c8Zn#J9O6wvqtYOVwjc8JtZ4aodRdbPv_IKAjLkEq9uHlDdE", keyID)
 	})
 
 	t.Run("nok - wrong key type", func(t *testing.T) {
-		keyID, err := didKIDNamingFunc(unknownPublicKey{})
+		keyID, err := DIDKIDNamingFunc(unknownPublicKey{})
 		assert.EqualError(t, err, "could not generate kid: invalid key type 'didnuts.unknownPublicKey' for jwk.New")
 		assert.Empty(t, keyID)
 	})

--- a/vdr/didnuts/manager.go
+++ b/vdr/didnuts/manager.go
@@ -20,17 +20,38 @@ package didnuts
 
 import (
 	"context"
+	"crypto"
+	"encoding/json"
+	"errors"
 	"fmt"
+	didnutsStore "github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
+	"github.com/nuts-foundation/nuts-node/vdr/log"
+	"time"
+
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
-	"github.com/nuts-foundation/nuts-node/crypto"
+	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	"github.com/nuts-foundation/nuts-node/network"
+	"github.com/nuts-foundation/nuts-node/vdr/didsubject"
 	"github.com/nuts-foundation/nuts-node/vdr/management"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
+	"gorm.io/gorm"
 )
 
+var _ didsubject.MethodManager = (*Manager)(nil)
+
 // NewManager creates a new Manager instance.
-func NewManager(creator management.DocCreator, owner management.DocumentOwner) *Manager {
+func NewManager(DB *gorm.DB, cryptoClient nutsCrypto.KeyStore, networkClient network.Transactions, didStore didnutsStore.Store, didResolver resolver.DIDResolver,
+	// deprecated
+	creator management.DocCreator, owner management.DocumentOwner) *Manager {
 	return &Manager{
+		DB:            DB,
+		KeyStore:      cryptoClient,
+		NetworkClient: networkClient,
+		Resolver:      didResolver,
+		Store:         didStore,
+		// deprecated
 		Creator:       creator,
 		DocumentOwner: owner,
 	}
@@ -39,6 +60,13 @@ func NewManager(creator management.DocCreator, owner management.DocumentOwner) *
 var _ management.DocumentManager = (*Manager)(nil)
 
 type Manager struct {
+	DB            *gorm.DB
+	KeyStore      nutsCrypto.KeyStore
+	NetworkClient network.Transactions
+	Resolver      resolver.DIDResolver
+	Store         didnutsStore.Store
+
+	// deprecated
 	Creator       management.DocCreator
 	DocumentOwner management.DocumentOwner
 	Manipulator   management.DocManipulator
@@ -48,7 +76,7 @@ func (m Manager) Deactivate(ctx context.Context, id did.DID) error {
 	return m.Manipulator.Deactivate(ctx, id)
 }
 
-func (m Manager) Create(ctx context.Context, options management.CreationOptions) (*did.Document, crypto.Key, error) {
+func (m Manager) Create(ctx context.Context, options management.CreationOptions) (*did.Document, nutsCrypto.Key, error) {
 	return m.Creator.Create(ctx, options)
 }
 
@@ -66,4 +94,194 @@ func (m Manager) UpdateService(_ context.Context, _ did.DID, _ ssi.URI, _ did.Se
 
 func (m Manager) DeleteService(_ context.Context, _ did.DID, _ ssi.URI) error {
 	return fmt.Errorf("DeleteService() is not supported for did:%s", MethodName)
+}
+
+func (m Manager) NewDocument(ctx context.Context, keyFlags didsubject.DIDKeyFlags) (*didsubject.DIDDocument, error) {
+	// First, generate a new keyPair with the correct kid
+	// Currently, always keep the key in the keystore. This allows us to change the transaction format and regenerate transactions at a later moment.
+	// Relevant issue:
+	// https://github.com/nuts-foundation/nuts-node/issues/1947
+	key, err := m.KeyStore.New(ctx, didKIDNamingFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	keyID, err := did.ParseDIDURL(key.KID())
+	if err != nil {
+		return nil, err
+	}
+
+	didID, _ := resolver.GetDIDFromURL(key.KID())
+	var verificationMethod *did.VerificationMethod
+	// Add VerificationMethod using generated key
+	verificationMethod, err = did.NewVerificationMethod(*keyID, ssi.JsonWebKey2020, didID, key.Public())
+	if err != nil {
+		return nil, err
+	}
+	vmAsJson, _ := json.Marshal(verificationMethod)
+	now := time.Now().Unix()
+	sqlDoc := didsubject.DIDDocument{
+		DID: didsubject.DID{
+			ID: didID.String(),
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		VerificationMethods: []didsubject.VerificationMethod{
+			{
+				ID:       verificationMethod.ID.String(),
+				KeyTypes: didsubject.VerificationMethodKeyType(keyFlags),
+				Data:     vmAsJson,
+			},
+		},
+	}
+
+	return &sqlDoc, nil
+}
+
+func (m Manager) NewVerificationMethod(ctx context.Context, controller did.DID, _ didsubject.DIDKeyFlags) (*did.VerificationMethod, error) {
+	// did:nuts uses EC keys for everything so it doesn't use the DIDKeyFlags
+	return CreateNewVerificationMethodForDID(ctx, controller, m.KeyStore)
+}
+
+func (m Manager) Commit(ctx context.Context, change didsubject.DIDChangeLog) error {
+	var err error
+	switch change.Type {
+	case didsubject.DIDChangeCreated:
+		err = m.onCreate(ctx, change)
+	case didsubject.DIDChangeDeactivated:
+		err = m.onDeactivate(ctx, change)
+	case didsubject.DIDChangeUpdated:
+		err = m.onUpdate(ctx, change)
+	default:
+		err = fmt.Errorf("unknown event type: %s", change.Type)
+	}
+	return err
+}
+
+func (m Manager) IsCommitted(_ context.Context, change didsubject.DIDChangeLog) (bool, error) {
+	// get the latest from the didStore
+	_, meta, err := m.Store.Resolve(change.DID(), &resolver.ResolveMetadata{AllowDeactivated: true})
+	if err != nil {
+		return false, err
+	}
+	changeHash := hash.SHA256Sum([]byte(change.DIDDocumentVersion.Raw))
+	return meta.Hash.Equals(changeHash), nil
+}
+
+func (m Manager) onCreate(ctx context.Context, event didsubject.DIDChangeLog) error {
+	return m.DB.Transaction(func(tx *gorm.DB) error {
+		didDocument, err := event.DIDDocumentVersion.ToDIDDocument()
+		if err != nil {
+			return err
+		}
+		// publish
+		payload, err := json.Marshal(didDocument)
+		if err != nil {
+			return err
+		}
+
+		// extract the transaction refs from the controller metadata
+		refs := make([]hash.SHA256Hash, 0)
+		key := cryptoKey{vm: *didDocument.VerificationMethod[0]}
+		networkTx := network.TransactionTemplate(DIDDocumentType, payload, key).WithAttachKey().WithAdditionalPrevs(refs)
+		_, err = m.NetworkClient.CreateTransaction(ctx, networkTx)
+		if err != nil {
+			return fmt.Errorf("could not publish DID document on the network: %w", err)
+		}
+		return nil
+	})
+}
+
+func (m Manager) onUpdate(ctx context.Context, event didsubject.DIDChangeLog) error {
+	id := event.DID()
+	resolverMetadata := &resolver.ResolveMetadata{
+		AllowDeactivated: true,
+	}
+
+	currentDIDDocument, currentMeta, err := m.Resolver.Resolve(id, resolverMetadata)
+	if err != nil {
+		return err
+	}
+	if resolver.IsDeactivated(*currentDIDDocument) {
+		// should not occur
+		// we're not using the deactivated flag in the resolver metadata since there could be conflicted docs
+		log.Logger().Warnf("document (%s) is deactivated, won't update", currentDIDDocument.ID.String())
+		return nil
+	}
+	next, err := event.DIDDocumentVersion.ToDIDDocument()
+	if err != nil {
+		return err
+	}
+
+	// Validate document. No more changes should be made to the document after this point.
+	serviceResolver := resolver.DIDServiceResolver{Resolver: m.Resolver}
+	if err = ManagedDocumentValidator(serviceResolver).Validate(next); err != nil {
+		return err
+	}
+
+	payload, err := json.Marshal(next)
+	if err != nil {
+		return err
+	}
+
+	controller, key, err := m.resolveControllerWithKey(ctx, *currentDIDDocument)
+	if err != nil {
+		return err
+	}
+
+	// for the metadata
+	_, controllerMeta, err := m.Resolver.Resolve(controller.ID, nil)
+	if err != nil {
+		return err
+	}
+
+	// a DIDDocument update must point to its previous version, current heads and the controller TX (for signing key transaction ordering)
+	previousTransactions := append(currentMeta.SourceTransactions, controllerMeta.SourceTransactions...)
+
+	networkTransaction := network.TransactionTemplate(DIDDocumentType, payload, key).WithAdditionalPrevs(previousTransactions)
+	_, err = m.NetworkClient.CreateTransaction(ctx, networkTransaction)
+	return err
+}
+
+func (m Manager) onDeactivate(ctx context.Context, event didsubject.DIDChangeLog) error {
+	return m.Deactivate(ctx, event.DID())
+}
+
+type cryptoKey struct {
+	vm did.VerificationMethod
+}
+
+func (c cryptoKey) KID() string {
+	return c.vm.ID.String()
+}
+
+func (c cryptoKey) Public() crypto.PublicKey {
+	pk, _ := c.vm.PublicKey() // todo
+	return pk
+}
+
+func (m Manager) resolveControllerWithKey(ctx context.Context, doc did.Document) (did.Document, nutsCrypto.Key, error) {
+	controllers, err := ResolveControllers(m.Store, doc, nil)
+	if err != nil {
+		return did.Document{}, nil, fmt.Errorf("error while finding controllers for document: %w", err)
+	}
+	if len(controllers) == 0 {
+		return did.Document{}, nil, fmt.Errorf("could not find any controllers for document")
+	}
+
+	var key nutsCrypto.Key
+	for _, c := range controllers {
+		for _, cik := range c.CapabilityInvocation {
+			key, err = m.KeyStore.Resolve(ctx, cik.ID.String())
+			if err == nil {
+				return c, key, nil
+			}
+		}
+	}
+
+	if errors.Is(err, nutsCrypto.ErrPrivateKeyNotFound) {
+		// log
+	}
+
+	return did.Document{}, nil, fmt.Errorf("could not find capabilityInvocation key for updating the DID document: %w", err)
 }

--- a/vdr/didnuts/manager.go
+++ b/vdr/didnuts/manager.go
@@ -100,7 +100,7 @@ func (m Manager) NewDocument(ctx context.Context, keyFlags didsubject.DIDKeyFlag
 	// Currently, always keep the key in the keystore. This allows us to change the transaction format and regenerate transactions at a later moment.
 	// Relevant issue:
 	// https://github.com/nuts-foundation/nuts-node/issues/1947
-	key, err := m.keyStore.New(ctx, didKIDNamingFunc)
+	key, err := m.keyStore.New(ctx, DIDKIDNamingFunc)
 	if err != nil {
 		return nil, err
 	}

--- a/vdr/didnuts/manager_test.go
+++ b/vdr/didnuts/manager_test.go
@@ -123,7 +123,7 @@ func TestManager_UpdateService(t *testing.T) {
 	assert.EqualError(t, err, "UpdateService() is not supported for did:nuts")
 }
 
-func TestManager_GenerateDocument(t *testing.T) {
+func TestManager_NewDocument(t *testing.T) {
 	keyStore := nutsCrypto.NewMemoryCryptoInstance()
 	ctx := audit.TestContext()
 	db := testDB(t)

--- a/vdr/didnuts/manager_test.go
+++ b/vdr/didnuts/manager_test.go
@@ -19,19 +19,79 @@
 package didnuts
 
 import (
+	"context"
+	"crypto"
+	"encoding/json"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/lestrrat-go/jwx/v2/jwk"
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/nuts-node/audit"
+	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
+	"github.com/nuts-foundation/nuts-node/crypto/hash"
+	"github.com/nuts-foundation/nuts-node/network"
+	"github.com/nuts-foundation/nuts-node/network/dag"
+	"github.com/nuts-foundation/nuts-node/storage"
+	"github.com/nuts-foundation/nuts-node/vdr/didnuts/didstore"
+	"github.com/nuts-foundation/nuts-node/vdr/didsubject"
 	"github.com/nuts-foundation/nuts-node/vdr/management"
+	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"gorm.io/gorm"
+	"strings"
 	"testing"
 )
 
+type testContext struct {
+	ctrl          *gomock.Controller
+	manager       *Manager
+	networkClient *network.MockTransactions
+	didStore      *didstore.MockStore
+	didResolver   *resolver.MockDIDResolver
+	db            *gorm.DB
+	ctx           context.Context
+	keyStore      *nutsCrypto.MockKeyStore
+}
+
+func newTestContext(t *testing.T) *testContext {
+	ctrl := gomock.NewController(t)
+	networkClient := network.NewMockTransactions(ctrl)
+	didStore := didstore.NewMockStore(ctrl)
+	didResolver := resolver.NewMockDIDResolver(ctrl)
+	ctx := audit.TestContext()
+	db := testDB(t)
+	keyStore := nutsCrypto.NewMockKeyStore(ctrl)
+	manager := NewManager(db, keyStore, networkClient, didStore, didResolver, nil, nil)
+
+	return &testContext{
+		ctrl:          ctrl,
+		manager:       manager,
+		networkClient: networkClient,
+		didStore:      didStore,
+		didResolver:   didResolver,
+		db:            db,
+		ctx:           ctx,
+		keyStore:      keyStore,
+	}
+}
+
+func testDB(t *testing.T) *gorm.DB {
+	//logrus.SetLevel(logrus.TraceLevel)
+	storageEngine := storage.NewTestStorageEngine(t)
+	require.NoError(t, storageEngine.Start())
+	db := storageEngine.GetSQLDatabase()
+	return db
+}
+
+// todo remove at the end of #3208
 func TestManager_Create(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	creator := management.NewMockDocCreator(ctrl)
 	owner := management.NewMockDocumentOwner(ctrl)
-	manager := NewManager(creator, owner)
+	manager := NewManager(nil, nil, nil, nil, nil, creator, owner)
 	creator.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil, nil, nil)
 
 	_, _, err := manager.Create(nil, DefaultCreationOptions())
@@ -39,22 +99,200 @@ func TestManager_Create(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// todo remove at the end of #3208
 func TestManager_Resolve(t *testing.T) {
 	_, _, err := Manager{}.Resolve(did.DID{}, nil)
 	assert.EqualError(t, err, "Resolve() is not supported for did:nuts")
 }
 
+// todo remove at the end of #3208
 func TestManager_CreateService(t *testing.T) {
 	_, err := Manager{}.CreateService(nil, did.DID{}, did.Service{})
 	assert.EqualError(t, err, "CreateService() is not supported for did:nuts")
 }
 
+// todo remove at the end of #3208
 func TestManager_DeleteService(t *testing.T) {
 	err := Manager{}.DeleteService(nil, did.DID{}, ssi.MustParseURI("https://example.com"))
 	assert.EqualError(t, err, "DeleteService() is not supported for did:nuts")
 }
 
+// todo remove at the end of #3208
 func TestManager_UpdateService(t *testing.T) {
 	_, err := Manager{}.UpdateService(nil, did.DID{}, ssi.MustParseURI("https://example.com"), did.Service{})
 	assert.EqualError(t, err, "UpdateService() is not supported for did:nuts")
+}
+
+func TestManager_GenerateDocument(t *testing.T) {
+	keyStore := nutsCrypto.NewMemoryCryptoInstance()
+	ctx := audit.TestContext()
+	db := testDB(t)
+	manager := NewManager(db, keyStore, nil, nil, nil, nil, nil)
+
+	t.Run("ok", func(t *testing.T) {
+		doc, err := manager.NewDocument(ctx, didsubject.AssertionKeyUsage())
+
+		require.NoError(t, err)
+		assert.NotNil(t, doc)
+		assert.True(t, strings.HasPrefix(doc.DID.ID, "did:nuts:"))
+		assert.Len(t, doc.VerificationMethods, 1)
+
+		// check if ID of the verification method and DID match the key fingerprint
+		// the DID is named via base58(sha256(pub key))
+		// the kid is the DID appended with the SHA256 of the pub key
+		var verificationMethod did.VerificationMethod
+		_ = json.Unmarshal(doc.VerificationMethods[0].Data, &verificationMethod)
+		asJWK, err := verificationMethod.JWK()
+		require.NoError(t, err)
+		nutsThumbprint, err := nutsCrypto.Thumbprint(asJWK)
+		require.NoError(t, err)
+		_ = jwk.AssignKeyID(asJWK, jwk.WithThumbprintHash(crypto.SHA256))
+		assert.Equal(t, fmt.Sprintf("did:nuts:%s", nutsThumbprint), doc.DID.ID)
+		assert.Equal(t, fmt.Sprintf("did:nuts:%s#%s", nutsThumbprint, asJWK.KeyID()), verificationMethod.ID.String())
+
+		t.Run("additional verification method", func(t *testing.T) {
+			asDID := did.MustParseDID(doc.DID.ID)
+
+			verificationMethod, err := manager.NewVerificationMethod(ctx, asDID, didsubject.AssertionKeyUsage())
+
+			require.NoError(t, err)
+
+			asJWK, err := verificationMethod.JWK()
+			require.NoError(t, err)
+			_ = jwk.AssignKeyID(asJWK, jwk.WithThumbprintHash(crypto.SHA256))
+			assert.Equal(t, fmt.Sprintf("%s#%s", doc.DID.ID, asJWK.KeyID()), verificationMethod.ID.String())
+		})
+	})
+}
+
+func TestManager_Commit(t *testing.T) {
+	document, _, _ := newDidDoc()
+	data, _ := json.Marshal(document.VerificationMethod[0])
+	eventLog := didsubject.DIDChangeLog{
+		Type: didsubject.DIDChangeCreated,
+		DIDDocumentVersion: didsubject.DIDDocument{
+			ID: uuid.New().String(),
+			DID: didsubject.DID{
+				ID:      document.ID.String(),
+				Subject: "subject",
+			},
+			VerificationMethods: []didsubject.VerificationMethod{
+				{
+					ID:       document.VerificationMethod[0].ID.String(),
+					KeyTypes: didsubject.VerificationMethodKeyType(didsubject.AssertionKeyUsage()),
+					Data:     data,
+				},
+			},
+		},
+	}
+
+	t.Run("on created", func(t *testing.T) {
+		ctx := newTestContext(t)
+		ctx.networkClient.EXPECT().CreateTransaction(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, template network.Template) (dag.Transaction, error) {
+			var didDocument did.Document
+			_ = json.Unmarshal(template.Payload, &didDocument)
+			assert.Equal(t, "application/did+json", template.Type)
+			assert.True(t, template.AttachKey)
+			assert.Equal(t, eventLog.DIDDocumentVersion.DID.ID, didDocument.ID.String())
+			assert.Len(t, didDocument.VerificationMethod, 1)
+			return testTransaction{}, nil
+		})
+		require.NoError(t, ctx.db.Save(&eventLog).Error)
+
+		err := ctx.manager.Commit(ctx.ctx, eventLog)
+
+		assert.NoError(t, err)
+	})
+	t.Run("on deactivated", func(t *testing.T) {
+		t.Skip("todo re-enable after DocumentManager change")
+		ctx := newTestContext(t)
+		logCopy := eventLog
+		logCopy.Type = didsubject.DIDChangeDeactivated
+		didDocument, _ := eventLog.DIDDocumentVersion.ToDIDDocument()
+		metadata := resolver.DocumentMetadata{
+			SourceTransactions: []hash.SHA256Hash{hash.EmptyHash()},
+		}
+		ctx.didResolver.EXPECT().Resolve(eventLog.DID(), gomock.Any()).Return(&didDocument, &metadata, nil).AnyTimes()
+		ctx.didStore.EXPECT().Resolve(eventLog.DID(), gomock.Any()).Return(&didDocument, &metadata, nil)
+		ctx.didStore.EXPECT().Add(gomock.Any(), gomock.Any()).Return(nil)
+		ctx.keyStore.EXPECT().Resolve(gomock.Any(), document.VerificationMethod[0].ID.String()).Return(nutsCrypto.TestKey{}, nil)
+		ctx.networkClient.EXPECT().CreateTransaction(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, template network.Template) (dag.Transaction, error) {
+			assert.Len(t, template.AdditionalPrevs, 2) // previous and controller
+			assert.False(t, template.AttachKey)
+			return testTransaction{}, nil
+		})
+		require.NoError(t, ctx.db.Save(&logCopy).Error)
+
+		err := ctx.manager.Commit(ctx.ctx, logCopy)
+
+		assert.NoError(t, err)
+	})
+	t.Run("on update", func(t *testing.T) {
+		ctx := newTestContext(t)
+		logCopy := eventLog
+		logCopy.Type = didsubject.DIDChangeUpdated
+		didDocument, _ := eventLog.DIDDocumentVersion.ToDIDDocument()
+		metadata := resolver.DocumentMetadata{
+			SourceTransactions: []hash.SHA256Hash{hash.EmptyHash()},
+		}
+		ctx.didResolver.EXPECT().Resolve(eventLog.DID(), gomock.Any()).Return(&didDocument, &metadata, nil).AnyTimes()
+		ctx.didStore.EXPECT().Resolve(eventLog.DID(), gomock.Any()).Return(&didDocument, &metadata, nil).AnyTimes()
+		ctx.keyStore.EXPECT().Resolve(gomock.Any(), document.VerificationMethod[0].ID.String()).Return(nutsCrypto.TestKey{}, nil)
+		ctx.networkClient.EXPECT().CreateTransaction(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, template network.Template) (dag.Transaction, error) {
+			assert.Len(t, template.AdditionalPrevs, 2) // previous and controller
+			assert.False(t, template.AttachKey)
+			return testTransaction{}, nil
+		})
+		require.NoError(t, ctx.db.Save(&logCopy).Error)
+
+		err := ctx.manager.Commit(ctx.ctx, logCopy)
+
+		assert.NoError(t, err)
+	})
+}
+
+func TestManager_IsCommitted(t *testing.T) {
+	document, _, _ := newDidDoc()
+	documentData, _ := json.Marshal(document)
+	vmData, _ := json.Marshal(document.VerificationMethod[0])
+	eventLog := didsubject.DIDChangeLog{
+		Type: didsubject.DIDChangeCreated,
+		DIDDocumentVersion: didsubject.DIDDocument{
+			ID: uuid.New().String(),
+			DID: didsubject.DID{
+				ID:      document.ID.String(),
+				Subject: "subject",
+			},
+			VerificationMethods: []didsubject.VerificationMethod{
+				{
+					ID:       document.VerificationMethod[0].ID.String(),
+					KeyTypes: didsubject.VerificationMethodKeyType(didsubject.AssertionKeyUsage()),
+					Data:     vmData,
+				},
+			},
+			Raw: string(documentData),
+		},
+	}
+	changeHash := hash.SHA256Sum(documentData)
+
+	t.Run("false", func(t *testing.T) {
+		ctx := newTestContext(t)
+		ctx.didStore.EXPECT().Resolve(eventLog.DID(), gomock.Any()).Return(&document, &resolver.DocumentMetadata{Hash: hash.RandomHash()}, nil)
+		require.NoError(t, ctx.db.Save(&eventLog).Error)
+
+		ok, err := ctx.manager.IsCommitted(ctx.ctx, eventLog)
+
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+	t.Run("true", func(t *testing.T) {
+		ctx := newTestContext(t)
+		ctx.didStore.EXPECT().Resolve(eventLog.DID(), gomock.Any()).Return(&document, &resolver.DocumentMetadata{Hash: changeHash}, nil)
+		require.NoError(t, ctx.db.Save(&eventLog).Error)
+
+		ok, err := ctx.manager.IsCommitted(ctx.ctx, eventLog)
+
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
 }

--- a/vdr/didweb/manager_test.go
+++ b/vdr/didweb/manager_test.go
@@ -318,7 +318,7 @@ func TestManager_Deactivate(t *testing.T) {
 	})
 }
 
-func TestManager_GenerateDocument(t *testing.T) {
+func TestManager_NewDocument(t *testing.T) {
 	rootDID := did.MustParseDID("did:example:123")
 	keyStore := nutsCrypto.NewMemoryCryptoInstance()
 	ctx := audit.TestContext()

--- a/vdr/didweb/manager_test.go
+++ b/vdr/didweb/manager_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/audit"
 	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/storage"
+	"github.com/nuts-foundation/nuts-node/vdr/didsubject"
 	"github.com/nuts-foundation/nuts-node/vdr/management"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 	"github.com/nuts-foundation/nuts-node/vdr/sql"
@@ -314,5 +315,23 @@ func TestManager_Deactivate(t *testing.T) {
 		err = m.Deactivate(ctx, document.ID)
 
 		require.EqualError(t, err, "did:web DID deleted, but could not remove one or more private keys\nverification method '"+document.VerificationMethod[0].ID.String()+"': private key not found")
+	})
+}
+
+func TestManager_GenerateDocument(t *testing.T) {
+	rootDID := did.MustParseDID("did:example:123")
+	keyStore := nutsCrypto.NewMemoryCryptoInstance()
+	ctx := audit.TestContext()
+	db := testDB(t)
+	manager := NewManager(rootDID, "iam", keyStore, db)
+
+	t.Run("random id", func(t *testing.T) {
+		doc, err := manager.NewDocument(ctx, didsubject.AssertionKeyUsage())
+
+		require.NoError(t, err)
+		assert.NotNil(t, doc)
+		assert.True(t, strings.HasPrefix(doc.DID.ID, "did:example:123:iam:"))
+		require.Len(t, doc.VerificationMethods, 1)
+		assert.True(t, strings.HasPrefix(doc.VerificationMethods[0].ID, "did:example:123:iam:"))
 	})
 }

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -123,15 +123,17 @@ func (r *Module) Configure(config core.ServerConfig) error {
 
 	// Methods we can produce from the Nuts node
 	// did:nuts
+	nutsManager := didnuts.NewManager(r.db, r.keyStore, r.network, r.store, r.didResolver,
+		// deprecated
+		didnuts.Creator{
+			KeyStore:      r.keyStore,
+			NetworkClient: r.network,
+			DIDResolver:   r.store,
+		},
+		// deprecated
+		newCachingDocumentOwner(privateKeyDocumentOwner{keyResolver: r.keyStore}, r.didResolver))
 	r.documentManagers = map[string]management.DocumentManager{
-		didnuts.MethodName: didnuts.NewManager(
-			didnuts.Creator{
-				KeyStore:      r.keyStore,
-				NetworkClient: r.network,
-				DIDResolver:   r.store,
-			},
-			newCachingDocumentOwner(privateKeyDocumentOwner{keyResolver: r.keyStore}, r.didResolver),
-		),
+		didnuts.MethodName: nutsManager,
 	}
 	r.documentOwner = &MultiDocumentOwner{
 		DocumentOwners: []didsubject.DocumentOwner{


### PR DESCRIPTION
part of #3208

This PR adds the implementation of the SubjectManager to did:nuts and did:web. They are not yet called by anyone.