### PR TITLE
Auth: replace DID with subject in OAuth2 client_id and URLs

### DIFF
--- a/auth/api/iam/access_token.go
+++ b/auth/api/iam/access_token.go
@@ -60,7 +60,7 @@ type AccessToken struct {
 }
 
 // createAccessToken is used in both the s2s and openid4vp flows
-func (r Wrapper) createAccessToken(issuer did.DID, walletDID did.DID, issueTime time.Time, scope string, pexState PEXConsumer, dpopToken *dpop.DPoP) (*oauth.TokenResponse, error) {
+func (r Wrapper) createAccessToken(subjectID string, walletDID did.DID, issueTime time.Time, scope string, pexState PEXConsumer, dpopToken *dpop.DPoP) (*oauth.TokenResponse, error) {
 	credentialMap, err := pexState.credentialMap()
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func (r Wrapper) createAccessToken(issuer did.DID, walletDID did.DID, issueTime 
 	accessToken := AccessToken{
 		DPoP:                           dpopToken,
 		Token:                          crypto.GenerateNonce(),
-		Issuer:                         issuer.String(),
+		Issuer:                         subjectID,
 		IssuedAt:                       issueTime,
 		ClientId:                       walletDID.String(),
 		Expiration:                     issueTime.Add(accessTokenValidity),

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -67,11 +67,11 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-var rootWebDID = did.MustParseDID("did:web:example.com")
-var rootURL = test.MustParseURL("https://example.com/oauth2/" + rootWebDID.String())
+var subjectID = "subby"
 var webDID = did.MustParseDID("did:web:example.com:iam:123")
+var verifierSubjectID = "verifier"
 var verifierDID = did.MustParseDID("did:web:example.com:iam:verifier")
-var verifierURL = test.MustParseURL("https://example.com/oauth2/" + verifierDID.String())
+var verifierURL = test.MustParseURL("https://example.com/oauth2/" + verifierSubjectID)
 
 func TestWrapper_OAuthAuthorizationServerMetadata(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
@@ -79,7 +79,7 @@ func TestWrapper_OAuthAuthorizationServerMetadata(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.documentOwner.EXPECT().IsOwner(nil, webDID).Return(true, nil)
 
-		res, err := ctx.client.OAuthAuthorizationServerMetadata(nil, OAuthAuthorizationServerMetadataRequestObject{Did: webDID.String()})
+		res, err := ctx.client.OAuthAuthorizationServerMetadata(nil, OAuthAuthorizationServerMetadataRequestObject{Subject: subjectID})
 
 		require.NoError(t, err)
 		assert.IsType(t, OAuthAuthorizationServerMetadata200JSONResponse{}, res)
@@ -90,7 +90,7 @@ func TestWrapper_OAuthAuthorizationServerMetadata(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.documentOwner.EXPECT().IsOwner(nil, webDID)
 
-		res, err := ctx.client.OAuthAuthorizationServerMetadata(nil, OAuthAuthorizationServerMetadataRequestObject{Did: webDID.String()})
+		res, err := ctx.client.OAuthAuthorizationServerMetadata(nil, OAuthAuthorizationServerMetadataRequestObject{Subject: subjectID})
 
 		assert.Equal(t, 400, statusCodeFrom(err))
 		assert.EqualError(t, err, "DID document not managed by this node")
@@ -101,7 +101,7 @@ func TestWrapper_OAuthAuthorizationServerMetadata(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.documentOwner.EXPECT().IsOwner(nil, webDID).Return(false, errors.New("unknown error"))
 
-		res, err := ctx.client.OAuthAuthorizationServerMetadata(nil, OAuthAuthorizationServerMetadataRequestObject{Did: webDID.String()})
+		res, err := ctx.client.OAuthAuthorizationServerMetadata(nil, OAuthAuthorizationServerMetadataRequestObject{Subject: subjectID})
 
 		assert.Equal(t, 500, statusCodeFrom(err))
 		assert.EqualError(t, err, "DID resolution failed: unknown error")
@@ -114,7 +114,7 @@ func TestWrapper_GetOAuthClientMetadata(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.documentOwner.EXPECT().IsOwner(nil, webDID).Return(true, nil)
 
-		res, err := ctx.client.OAuthClientMetadata(nil, OAuthClientMetadataRequestObject{Did: webDID.String()})
+		res, err := ctx.client.OAuthClientMetadata(nil, OAuthClientMetadataRequestObject{Subject: subjectID})
 
 		require.NoError(t, err)
 		assert.IsType(t, OAuthClientMetadata200JSONResponse{}, res)
@@ -123,7 +123,7 @@ func TestWrapper_GetOAuthClientMetadata(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.documentOwner.EXPECT().IsOwner(nil, webDID)
 
-		res, err := ctx.client.OAuthClientMetadata(nil, OAuthClientMetadataRequestObject{Did: webDID.String()})
+		res, err := ctx.client.OAuthClientMetadata(nil, OAuthClientMetadataRequestObject{Subject: subjectID})
 
 		assert.Equal(t, 400, statusCodeFrom(err))
 		assert.Nil(t, res)
@@ -132,7 +132,7 @@ func TestWrapper_GetOAuthClientMetadata(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.documentOwner.EXPECT().IsOwner(nil, webDID).Return(false, errors.New("unknown error"))
 
-		res, err := ctx.client.OAuthClientMetadata(nil, OAuthClientMetadataRequestObject{Did: webDID.String()})
+		res, err := ctx.client.OAuthClientMetadata(nil, OAuthClientMetadataRequestObject{Subject: subjectID})
 
 		assert.Equal(t, 500, statusCodeFrom(err))
 		assert.EqualError(t, err, "DID resolution failed: unknown error")
@@ -148,7 +148,7 @@ func TestWrapper_PresentationDefinition(t *testing.T) {
 		test := newTestClient(t)
 		test.policy.EXPECT().PresentationDefinitions(gomock.Any(), "example-scope").Return(walletOwnerMapping, nil)
 
-		response, err := test.client.PresentationDefinition(ctx, PresentationDefinitionRequestObject{Did: webDID.String(), Params: PresentationDefinitionParams{Scope: "example-scope"}})
+		response, err := test.client.PresentationDefinition(ctx, PresentationDefinitionRequestObject{Subject: subjectID, Params: PresentationDefinitionParams{Scope: "example-scope"}})
 
 		require.NoError(t, err)
 		require.NotNil(t, response)
@@ -159,7 +159,7 @@ func TestWrapper_PresentationDefinition(t *testing.T) {
 	t.Run("ok - missing scope", func(t *testing.T) {
 		test := newTestClient(t)
 
-		response, err := test.client.PresentationDefinition(ctx, PresentationDefinitionRequestObject{Did: webDID.String(), Params: PresentationDefinitionParams{}})
+		response, err := test.client.PresentationDefinition(ctx, PresentationDefinitionRequestObject{Subject: subjectID, Params: PresentationDefinitionParams{}})
 
 		require.NoError(t, err)
 		require.NotNil(t, response)
@@ -173,7 +173,7 @@ func TestWrapper_PresentationDefinition(t *testing.T) {
 		test := newTestClient(t)
 		test.policy.EXPECT().PresentationDefinitions(gomock.Any(), "example-scope").Return(walletOwnerMapping, nil)
 
-		response, err := test.client.PresentationDefinition(ctx, PresentationDefinitionRequestObject{Did: webDID.String(), Params: PresentationDefinitionParams{Scope: "example-scope", WalletOwnerType: &userWalletType}})
+		response, err := test.client.PresentationDefinition(ctx, PresentationDefinitionRequestObject{Subject: subjectID, Params: PresentationDefinitionParams{Scope: "example-scope", WalletOwnerType: &userWalletType}})
 
 		require.NoError(t, err)
 		require.NotNil(t, response)
@@ -185,7 +185,7 @@ func TestWrapper_PresentationDefinition(t *testing.T) {
 		test := newTestClient(t)
 		test.policy.EXPECT().PresentationDefinitions(gomock.Any(), "example-scope").Return(walletOwnerMapping, nil)
 
-		response, err := test.client.PresentationDefinition(ctx, PresentationDefinitionRequestObject{Did: webDID.String(), Params: PresentationDefinitionParams{Scope: "example-scope", WalletOwnerType: &userWalletType}})
+		response, err := test.client.PresentationDefinition(ctx, PresentationDefinitionRequestObject{Subject: subjectID, Params: PresentationDefinitionParams{Scope: "example-scope", WalletOwnerType: &userWalletType}})
 
 		require.Error(t, err)
 		assert.Nil(t, response)
@@ -196,7 +196,7 @@ func TestWrapper_PresentationDefinition(t *testing.T) {
 		test := newTestClient(t)
 		test.policy.EXPECT().PresentationDefinitions(gomock.Any(), "unknown").Return(nil, policy.ErrNotFound)
 
-		response, err := test.client.PresentationDefinition(ctx, PresentationDefinitionRequestObject{Did: webDID.String(), Params: PresentationDefinitionParams{Scope: "unknown"}})
+		response, err := test.client.PresentationDefinition(ctx, PresentationDefinitionRequestObject{Subject: subjectID, Params: PresentationDefinitionParams{Scope: "unknown"}})
 
 		require.Error(t, err)
 		assert.Nil(t, response)
@@ -242,15 +242,15 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 			assert.NotEmpty(t, params[oauth.NonceParam])
 			assert.Equal(t, didClientIDScheme, params[oauth.ClientIDSchemeParam])
 			assert.Equal(t, oauth.VPTokenResponseType, params[oauth.ResponseTypeParam])
-			assert.Equal(t, "https://example.com/oauth2/did:web:example.com:iam:verifier/response", params[oauth.ResponseURIParam])
-			assert.Equal(t, "https://example.com/oauth2/did:web:example.com:iam:verifier/oauth-client", params[oauth.ClientMetadataURIParam])
+			assert.Equal(t, "https://example.com/oauth2/verifier/response", params[oauth.ResponseURIParam])
+			assert.Equal(t, "https://example.com/oauth2/verifier/oauth-client", params[oauth.ClientMetadataURIParam])
 			assert.Equal(t, responseModeDirectPost, params[oauth.ResponseModeParam])
 			assert.NotEmpty(t, params[oauth.StateParam])
 			return req
 		})
 
 		res, err := ctx.client.HandleAuthorizeRequest(requestContext(map[string]interface{}{"key": "test_value"}),
-			HandleAuthorizeRequestRequestObject{Did: verifierDID.String()})
+			HandleAuthorizeRequestRequestObject{Subject: subjectID})
 
 		require.NoError(t, err)
 		require.IsType(t, HandleAuthorizeRequest302Response{}, res)
@@ -274,8 +274,8 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 			oauth.ClientIDSchemeParam:     didClientIDScheme,
 			oauth.ClientMetadataURIParam:  "https://example.com/.well-known/authorization-server/oauth2/verifier",
 			oauth.NonceParam:              "nonce",
-			oauth.PresentationDefUriParam: "https://example.com/oauth2/did:web:example.com:iam:verifier/presentation_definition?scope=test",
-			oauth.ResponseURIParam:        "https://example.com/oauth2/did:web:example.com:iam:verifier/response",
+			oauth.PresentationDefUriParam: "https://example.com/oauth2/verifier/presentation_definition?scope=test",
+			oauth.ResponseURIParam:        "https://example.com/oauth2/verifier/response",
 			oauth.ResponseModeParam:       responseModeDirectPost,
 			oauth.ResponseTypeParam:       oauth.VPTokenResponseType,
 			oauth.ScopeParam:              "test",
@@ -289,20 +289,20 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 			// this is the state from the holder that was stored at the creation of the first authorization request to the verifier
 			ClientID:    holderDID.String(),
 			Scope:       "test",
-			OwnDID:      &holderDID,
+			SubjectDID:  holderDID,
 			ClientState: "state",
 			RedirectURI: "https://example.com/iam/holder/cb",
 		})
-		callCtx, _ := user.CreateTestSession(requestContext(nil), holderDID)
+		callCtx, _ := user.CreateTestSession(requestContext(nil), subjectID)
 		clientMetadata := oauth.OAuthClientMetadata{VPFormats: oauth.DefaultOpenIDSupportedFormats()}
 		ctx.iamClient.EXPECT().ClientMetadata(gomock.Any(), "https://example.com/.well-known/authorization-server/oauth2/verifier").Return(&clientMetadata, nil)
-		pdEndpoint := "https://example.com/oauth2/did:web:example.com:iam:verifier/presentation_definition?scope=test"
+		pdEndpoint := "https://example.com/oauth2/verifier/presentation_definition?scope=test"
 		ctx.iamClient.EXPECT().PresentationDefinition(gomock.Any(), pdEndpoint).Return(&pe.PresentationDefinition{}, nil)
 		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), holderDID, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
-		ctx.iamClient.EXPECT().PostAuthorizationResponse(gomock.Any(), vc.VerifiablePresentation{}, pe.PresentationSubmission{}, "https://example.com/oauth2/did:web:example.com:iam:verifier/response", "state").Return("https://example.com/iam/holder/redirect", nil)
+		ctx.iamClient.EXPECT().PostAuthorizationResponse(gomock.Any(), vc.VerifiablePresentation{}, pe.PresentationSubmission{}, "https://example.com/oauth2/verifier/response", "state").Return("https://example.com/iam/holder/redirect", nil)
 
 		res, err := ctx.client.HandleAuthorizeRequest(callCtx, HandleAuthorizeRequestRequestObject{
-			Did: holderDID.String(),
+			Subject: subjectID,
 		})
 
 		require.NoError(t, err)
@@ -320,7 +320,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), verifierDID).Return(true, nil)
 
 		res, err := ctx.client.HandleAuthorizeRequest(requestContext(map[string]interface{}{}),
-			HandleAuthorizeRequestRequestObject{Did: verifierDID.String()})
+			HandleAuthorizeRequestRequestObject{Subject: subjectID})
 
 		requireOAuthError(t, err, oauth.UnsupportedResponseType, "")
 		assert.Nil(t, res)
@@ -333,7 +333,7 @@ func TestWrapper_HandleTokenRequest(t *testing.T) {
 		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), webDID).Return(true, nil)
 
 		res, err := ctx.client.HandleTokenRequest(nil, HandleTokenRequestRequestObject{
-			Did: webDID.String(),
+			Subject: subjectID,
 			Body: &HandleTokenRequestFormdataRequestBody{
 				GrantType: "unsupported",
 			},
@@ -356,7 +356,7 @@ func TestWrapper_Callback(t *testing.T) {
 	session := OAuthSession{
 		ClientFlow:    "access_token_request",
 		SessionID:     "token",
-		OwnDID:        &holderDID,
+		SubjectDID:    holderDID,
 		RedirectURI:   redirectURI.String(),
 		OtherDID:      &verifierDID,
 		TokenEndpoint: "https://example.com/token",
@@ -368,7 +368,7 @@ func TestWrapper_Callback(t *testing.T) {
 		putState(ctx, "state", session)
 
 		res, err := ctx.client.Callback(nil, CallbackRequestObject{
-			Did: holderDID.String(),
+			Subject: subjectID,
 			Params: CallbackParams{
 				State:            &state,
 				Error:            &errorCode,
@@ -393,10 +393,10 @@ func TestWrapper_Callback(t *testing.T) {
 		putToken(ctx, token)
 		codeVerifier := getState(ctx, state).PKCEParams.Verifier
 		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
-		ctx.iamClient.EXPECT().AccessToken(gomock.Any(), code, session.TokenEndpoint, "https://example.com/oauth2/did:web:example.com:iam:holder/callback", holderDID, codeVerifier, true).Return(&oauth.TokenResponse{AccessToken: "access"}, nil)
+		ctx.iamClient.EXPECT().AccessToken(gomock.Any(), code, session.TokenEndpoint, "https://example.com/oauth2/holder/callback", holderDID, codeVerifier, true).Return(&oauth.TokenResponse{AccessToken: "access"}, nil)
 
 		res, err := ctx.client.Callback(nil, CallbackRequestObject{
-			Did: holderDID.String(),
+			Subject: subjectID,
 			Params: CallbackParams{
 				Code:  &code,
 				State: &state,
@@ -417,7 +417,7 @@ func TestWrapper_Callback(t *testing.T) {
 		ctx := newTestClient(t)
 		_ = ctx.client.oauthClientStateStore().Put(state, OAuthSession{
 			ClientFlow:    "access_token_request",
-			OwnDID:        &holderDID,
+			SubjectDID:    holderDID,
 			PKCEParams:    generatePKCEParams(),
 			RedirectURI:   "https://example.com/iam/holder/cb",
 			SessionID:     "token",
@@ -428,10 +428,10 @@ func TestWrapper_Callback(t *testing.T) {
 		putToken(ctx, token)
 		codeVerifier := getState(ctx, state).PKCEParams.Verifier
 		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
-		ctx.iamClient.EXPECT().AccessToken(gomock.Any(), code, session.TokenEndpoint, "https://example.com/oauth2/did:web:example.com:iam:holder/callback", holderDID, codeVerifier, false).Return(&oauth.TokenResponse{AccessToken: "access"}, nil)
+		ctx.iamClient.EXPECT().AccessToken(gomock.Any(), code, session.TokenEndpoint, "https://example.com/oauth2/holder/callback", holderDID, codeVerifier, false).Return(&oauth.TokenResponse{AccessToken: "access"}, nil)
 
 		res, err := ctx.client.Callback(nil, CallbackRequestObject{
-			Did: holderDID.String(),
+			Subject: subjectID,
 			Params: CallbackParams{
 				Code:  &code,
 				State: &state,
@@ -446,7 +446,7 @@ func TestWrapper_Callback(t *testing.T) {
 		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), holderDID).Return(false, nil)
 
 		res, err := ctx.client.Callback(nil, CallbackRequestObject{
-			Did: holderDID.String(),
+			Subject: subjectID,
 		})
 
 		assert.EqualError(t, err, "DID document not managed by this node")
@@ -458,7 +458,7 @@ func TestWrapper_Callback(t *testing.T) {
 		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), webDID).Return(true, nil)
 
 		res, err := ctx.client.Callback(nil, CallbackRequestObject{
-			Did: webDID.String(),
+			Subject: subjectID,
 			Params: CallbackParams{
 				Code:  &code,
 				State: &state,
@@ -474,7 +474,7 @@ func TestWrapper_Callback(t *testing.T) {
 		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
 
 		_, err := ctx.client.Callback(nil, CallbackRequestObject{
-			Did: holderDID.String(),
+			Subject: subjectID,
 			Params: CallbackParams{
 				Code: &code,
 			},
@@ -487,7 +487,7 @@ func TestWrapper_Callback(t *testing.T) {
 		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
 
 		_, err := ctx.client.Callback(nil, CallbackRequestObject{
-			Did: holderDID.String(),
+			Subject: subjectID,
 			Params: CallbackParams{
 				Error:            &errorCode,
 				ErrorDescription: &errorDescription,
@@ -502,7 +502,7 @@ func TestWrapper_Callback(t *testing.T) {
 		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), webDID).Return(true, nil)
 
 		_, err := ctx.client.Callback(nil, CallbackRequestObject{
-			Did: webDID.String(),
+			Subject: subjectID,
 			Params: CallbackParams{
 				Code:  &code,
 				State: &state,
@@ -517,7 +517,7 @@ func TestWrapper_Callback(t *testing.T) {
 		putState(ctx, "state", session)
 
 		_, err := ctx.client.Callback(nil, CallbackRequestObject{
-			Did: holderDID.String(),
+			Subject: subjectID,
 			Params: CallbackParams{
 				State: &state,
 			},
@@ -529,12 +529,12 @@ func TestWrapper_Callback(t *testing.T) {
 		ctx := newTestClient(t)
 		_ = ctx.client.oauthClientStateStore().Put(state, OAuthSession{
 			ClientFlow: "",
-			OwnDID:     &holderDID,
+			SubjectDID: holderDID,
 		})
 		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
 
 		_, err := ctx.client.Callback(nil, CallbackRequestObject{
-			Did: holderDID.String(),
+			Subject: subjectID,
 			Params: CallbackParams{
 				Code:  &code,
 				State: &state,
@@ -826,7 +826,7 @@ func TestWrapper_toOwnedDID(t *testing.T) {
 
 func TestWrapper_RequestServiceAccessToken(t *testing.T) {
 	walletDID := did.MustParseDID("did:web:test.test:iam:123")
-	verifierURL := test.MustParseURL("https://test.test/oauth2/did:web:test.test:iam:456")
+	verifierURL := test.MustParseURL("https://test.test/oauth2/456")
 	body := &RequestServiceAccessTokenJSONRequestBody{
 		AuthorizationServer: verifierURL.String(),
 		Scope:               "first second",
@@ -837,7 +837,7 @@ func TestWrapper_RequestServiceAccessToken(t *testing.T) {
 		ctx.documentOwner.EXPECT().IsOwner(nil, walletDID).Return(true, nil)
 		ctx.iamClient.EXPECT().RequestRFC021AccessToken(nil, walletDID, verifierURL.String(), "first second", true, nil).Return(&oauth.TokenResponse{}, nil)
 
-		_, err := ctx.client.RequestServiceAccessToken(nil, RequestServiceAccessTokenRequestObject{Did: walletDID.String(), Body: body})
+		_, err := ctx.client.RequestServiceAccessToken(nil, RequestServiceAccessTokenRequestObject{Subject: subjectID, Body: body})
 
 		require.NoError(t, err)
 	})
@@ -852,32 +852,25 @@ func TestWrapper_RequestServiceAccessToken(t *testing.T) {
 		ctx.documentOwner.EXPECT().IsOwner(nil, walletDID).Return(true, nil)
 		ctx.iamClient.EXPECT().RequestRFC021AccessToken(nil, walletDID, verifierURL.String(), "first second", false, nil).Return(&oauth.TokenResponse{}, nil)
 
-		_, err := ctx.client.RequestServiceAccessToken(nil, RequestServiceAccessTokenRequestObject{Did: walletDID.String(), Body: body})
+		_, err := ctx.client.RequestServiceAccessToken(nil, RequestServiceAccessTokenRequestObject{Subject: subjectID, Body: body})
 
 		require.NoError(t, err)
 	})
-	t.Run("error - DID not owned", func(t *testing.T) {
+	t.Run("error - unknown subject", func(t *testing.T) {
 		ctx := newTestClient(t)
-		ctx.documentOwner.EXPECT().IsOwner(nil, walletDID).Return(false, nil)
+		ctx.subjectManager.EXPECT().List(gomock.Any(), subjectID).Return(nil, nil)
 
-		_, err := ctx.client.RequestServiceAccessToken(nil, RequestServiceAccessTokenRequestObject{Did: walletDID.String(), Body: body})
+		_, err := ctx.client.RequestServiceAccessToken(nil, RequestServiceAccessTokenRequestObject{Subject: subjectID, Body: body})
 
 		require.Error(t, err)
 		assert.EqualError(t, err, "DID document not managed by this node")
-	})
-	t.Run("error - invalid DID", func(t *testing.T) {
-		ctx := newTestClient(t)
-
-		_, err := ctx.client.RequestServiceAccessToken(nil, RequestServiceAccessTokenRequestObject{Did: "invalid", Body: body})
-
-		require.EqualError(t, err, "invalid DID: invalid DID")
 	})
 	t.Run("error - no matching credentials", func(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.documentOwner.EXPECT().IsOwner(nil, walletDID).Return(true, nil)
 		ctx.iamClient.EXPECT().RequestRFC021AccessToken(nil, walletDID, verifierURL.String(), "first second", true, nil).Return(nil, holder.ErrNoCredentials)
 
-		_, err := ctx.client.RequestServiceAccessToken(nil, RequestServiceAccessTokenRequestObject{Did: walletDID.String(), Body: body})
+		_, err := ctx.client.RequestServiceAccessToken(nil, RequestServiceAccessTokenRequestObject{Subject: subjectID, Body: body})
 
 		require.Error(t, err)
 		assert.Equal(t, err, holder.ErrNoCredentials)
@@ -906,7 +899,7 @@ func TestWrapper_RequestUserAccessToken(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.documentOwner.EXPECT().IsOwner(nil, walletDID).Return(true, nil)
 
-		response, err := ctx.client.RequestUserAccessToken(nil, RequestUserAccessTokenRequestObject{Did: walletDID.String(), Body: body})
+		response, err := ctx.client.RequestUserAccessToken(nil, RequestUserAccessTokenRequestObject{Subject: subjectID, Body: body})
 
 		// assert token
 		require.NoError(t, err)
@@ -919,7 +912,7 @@ func TestWrapper_RequestUserAccessToken(t *testing.T) {
 		redirectURI, _ := url.Parse(redirectResponse.RedirectUri)
 		err = ctx.client.userRedirectStore().Get(redirectURI.Query().Get("token"), &target)
 		require.NoError(t, err)
-		assert.Equal(t, walletDID, target.OwnDID)
+		assert.Equal(t, subjectID, target.SubjectID)
 		require.NotNil(t, target.AccessTokenRequest)
 		require.NotNil(t, target.AccessTokenRequest.Body.TokenType)
 		assert.Equal(t, tokenType, *target.AccessTokenRequest.Body.TokenType)
@@ -940,7 +933,7 @@ func TestWrapper_RequestUserAccessToken(t *testing.T) {
 				RedirectUri:         redirectURI,
 			}
 
-			_, err := ctx.client.RequestUserAccessToken(nil, RequestUserAccessTokenRequestObject{Did: walletDID.String(), Body: body})
+			_, err := ctx.client.RequestUserAccessToken(nil, RequestUserAccessTokenRequestObject{Subject: subjectID, Body: body})
 
 			require.EqualError(t, err, "missing preauthorized_user")
 		})
@@ -952,7 +945,7 @@ func TestWrapper_RequestUserAccessToken(t *testing.T) {
 				RedirectUri:         redirectURI,
 			}
 
-			_, err := ctx.client.RequestUserAccessToken(nil, RequestUserAccessTokenRequestObject{Did: walletDID.String(), Body: body})
+			_, err := ctx.client.RequestUserAccessToken(nil, RequestUserAccessTokenRequestObject{Subject: subjectID, Body: body})
 
 			require.EqualError(t, err, "missing preauthorized_user.id")
 		})
@@ -964,7 +957,7 @@ func TestWrapper_RequestUserAccessToken(t *testing.T) {
 				RedirectUri:         redirectURI,
 			}
 
-			_, err := ctx.client.RequestUserAccessToken(nil, RequestUserAccessTokenRequestObject{Did: walletDID.String(), Body: body})
+			_, err := ctx.client.RequestUserAccessToken(nil, RequestUserAccessTokenRequestObject{Subject: subjectID, Body: body})
 
 			require.EqualError(t, err, "missing preauthorized_user.name")
 		})
@@ -976,7 +969,7 @@ func TestWrapper_RequestUserAccessToken(t *testing.T) {
 				RedirectUri:         redirectURI,
 			}
 
-			_, err := ctx.client.RequestUserAccessToken(nil, RequestUserAccessTokenRequestObject{Did: walletDID.String(), Body: body})
+			_, err := ctx.client.RequestUserAccessToken(nil, RequestUserAccessTokenRequestObject{Subject: subjectID, Body: body})
 
 			require.EqualError(t, err, "missing preauthorized_user.role")
 		})
@@ -985,7 +978,7 @@ func TestWrapper_RequestUserAccessToken(t *testing.T) {
 	t.Run("error - invalid DID", func(t *testing.T) {
 		ctx := newTestClient(t)
 
-		_, err := ctx.client.RequestUserAccessToken(nil, RequestUserAccessTokenRequestObject{Did: "invalid", Body: body})
+		_, err := ctx.client.RequestUserAccessToken(nil, RequestUserAccessTokenRequestObject{Subject: "invalid", Body: body})
 
 		require.EqualError(t, err, "invalid DID: invalid DID")
 	})
@@ -1029,7 +1022,7 @@ func TestWrapper_GetRequestJWT(t *testing.T) {
 		require.NoError(t, ctx.client.authzRequestObjectStore().Put(requestID, ro))
 		ctx.jar.EXPECT().Sign(cont, ro.Claims).Return(expectedToken, nil)
 
-		response, err := ctx.client.RequestJWTByGet(cont, RequestJWTByGetRequestObject{Did: webDID.String(), Id: requestID})
+		response, err := ctx.client.RequestJWTByGet(cont, RequestJWTByGetRequestObject{Subject: subjectID, Id: requestID})
 
 		assert.NoError(t, err)
 		assert.Equal(t, RequestJWTByGet200ApplicationoauthAuthzReqJwtResponse{
@@ -1054,7 +1047,7 @@ func TestWrapper_GetRequestJWT(t *testing.T) {
 		ro := jar{}.Create(webDID, holderURL, func(claims map[string]string) {})
 		require.NoError(t, ctx.client.authzRequestObjectStore().Put(requestID, ro))
 
-		response, err := ctx.client.RequestJWTByGet(cont, RequestJWTByGetRequestObject{Did: holderDID.String(), Id: requestID})
+		response, err := ctx.client.RequestJWTByGet(cont, RequestJWTByGetRequestObject{Subject: subjectID, Id: requestID})
 
 		assert.Nil(t, response)
 		assert.EqualError(t, err, "invalid_request - client_id does not match request")
@@ -1067,7 +1060,7 @@ func TestWrapper_GetRequestJWT(t *testing.T) {
 		ro.RequestURIMethod = "post"
 		require.NoError(t, ctx.client.authzRequestObjectStore().Put(requestID, ro))
 
-		response, err := ctx.client.RequestJWTByGet(cont, RequestJWTByGetRequestObject{Did: webDID.String(), Id: requestID})
+		response, err := ctx.client.RequestJWTByGet(cont, RequestJWTByGetRequestObject{Subject: subjectID, Id: requestID})
 
 		assert.Nil(t, response)
 		assert.EqualError(t, err, "invalid_request - wrong 'request_uri_method' authorization server or wallet probably does not support 'request_uri_method' - used request_uri_method 'get' on a 'post' request_uri")
@@ -1080,7 +1073,7 @@ func TestWrapper_GetRequestJWT(t *testing.T) {
 		require.NoError(t, ctx.client.authzRequestObjectStore().Put(requestID, ro))
 		ctx.jar.EXPECT().Sign(cont, ro.Claims).Return("", errors.New("fail"))
 
-		response, err := ctx.client.RequestJWTByGet(cont, RequestJWTByGetRequestObject{Did: webDID.String(), Id: requestID})
+		response, err := ctx.client.RequestJWTByGet(cont, RequestJWTByGetRequestObject{Subject: subjectID, Id: requestID})
 
 		assert.Nil(t, response)
 		assert.EqualError(t, err, "server_error - failed to sign authorization Request Object: fail - unable to create Request Object")
@@ -1109,7 +1102,7 @@ func TestWrapper_PostRequestJWT(t *testing.T) {
 		require.NoError(t, ctx.client.authzRequestObjectStore().Put(requestID, ro))
 		ctx.jar.EXPECT().Sign(cont, ro.Claims).Return(expectedToken, nil)
 
-		response, err := ctx.client.RequestJWTByPost(cont, RequestJWTByPostRequestObject{Did: webDID.String(), Id: requestID})
+		response, err := ctx.client.RequestJWTByPost(cont, RequestJWTByPostRequestObject{Subject: subjectID, Id: requestID})
 
 		assert.NoError(t, err)
 		assert.Equal(t, RequestJWTByPost200ApplicationoauthAuthzReqJwtResponse{
@@ -1130,7 +1123,7 @@ func TestWrapper_PostRequestJWT(t *testing.T) {
 			WalletNonce:    &wallet_nonce,
 		})
 
-		response, err := ctx.client.RequestJWTByPost(cont, RequestJWTByPostRequestObject{Did: webDID.String(), Id: requestID, Body: &body})
+		response, err := ctx.client.RequestJWTByPost(cont, RequestJWTByPostRequestObject{Subject: subjectID, Id: requestID, Body: &body})
 
 		assert.NoError(t, err)
 		assert.Equal(t, RequestJWTByPost200ApplicationoauthAuthzReqJwtResponse{
@@ -1154,7 +1147,7 @@ func TestWrapper_PostRequestJWT(t *testing.T) {
 		ctx := newTestClient(t)
 		require.NoError(t, ctx.client.authzRequestObjectStore().Put(requestID, newReqObj("", "")))
 
-		response, err := ctx.client.RequestJWTByPost(cont, RequestJWTByPostRequestObject{Did: holderDID.String(), Id: requestID})
+		response, err := ctx.client.RequestJWTByPost(cont, RequestJWTByPostRequestObject{Subject: subjectID, Id: requestID})
 
 		assert.Nil(t, response)
 		assert.EqualError(t, err, "invalid_request - client_id does not match request")
@@ -1167,7 +1160,7 @@ func TestWrapper_PostRequestJWT(t *testing.T) {
 		ro.RequestURIMethod = "get"
 		require.NoError(t, ctx.client.authzRequestObjectStore().Put(requestID, ro))
 
-		response, err := ctx.client.RequestJWTByPost(cont, RequestJWTByPostRequestObject{Did: webDID.String(), Id: requestID})
+		response, err := ctx.client.RequestJWTByPost(cont, RequestJWTByPostRequestObject{Subject: subjectID, Id: requestID})
 
 		assert.Nil(t, response)
 		assert.EqualError(t, err, "invalid_request - used request_uri_method 'post' on a 'get' request_uri")
@@ -1180,7 +1173,7 @@ func TestWrapper_PostRequestJWT(t *testing.T) {
 		require.NoError(t, ctx.client.authzRequestObjectStore().Put(requestID, ro))
 		ctx.jar.EXPECT().Sign(cont, ro.Claims).Return("", errors.New("fail"))
 
-		response, err := ctx.client.RequestJWTByPost(cont, RequestJWTByPostRequestObject{Did: webDID.String(), Id: requestID})
+		response, err := ctx.client.RequestJWTByPost(cont, RequestJWTByPostRequestObject{Subject: subjectID, Id: requestID})
 
 		assert.Nil(t, response)
 		assert.EqualError(t, err, "server_error - failed to sign authorization Request Object: fail - unable to create Request Object")
@@ -1212,7 +1205,7 @@ func TestWrapper_CreateAuthorizationRequest(t *testing.T) {
 			return expectedJarReq
 		})
 
-		redirectURL, err := ctx.client.createAuthorizationRequest(context.Background(), clientDID, issuerURL, modifier)
+		redirectURL, err := ctx.client.createAuthorizationRequest(context.Background(), subjectID, issuerURL, modifier)
 
 		// return
 		assert.NoError(t, err)
@@ -1234,7 +1227,7 @@ func TestWrapper_CreateAuthorizationRequest(t *testing.T) {
 			return expectedJarReq
 		})
 
-		redirectURL, err := ctx.client.createAuthorizationRequest(context.Background(), clientDID, "", modifier)
+		redirectURL, err := ctx.client.createAuthorizationRequest(context.Background(), subjectID, "", modifier)
 
 		assert.NoError(t, err)
 		assert.Equal(t, "value", redirectURL.Query().Get("custom"))
@@ -1246,7 +1239,7 @@ func TestWrapper_CreateAuthorizationRequest(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), issuerURL).Return(&oauth.AuthorizationServerMetadata{}, nil)
 
-		_, err := ctx.client.createAuthorizationRequest(context.Background(), clientDID, issuerURL, modifier)
+		_, err := ctx.client.createAuthorizationRequest(context.Background(), subjectID, issuerURL, modifier)
 
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "no authorization endpoint found in metadata for")
@@ -1255,7 +1248,7 @@ func TestWrapper_CreateAuthorizationRequest(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), issuerURL).Return(nil, assert.AnError)
 
-		_, err := ctx.client.createAuthorizationRequest(context.Background(), clientDID, issuerURL, modifier)
+		_, err := ctx.client.createAuthorizationRequest(context.Background(), subjectID, issuerURL, modifier)
 
 		assert.Error(t, err)
 	})
@@ -1263,44 +1256,23 @@ func TestWrapper_CreateAuthorizationRequest(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), issuerURL).Return(&oauth.AuthorizationServerMetadata{AuthorizationEndpoint: ":"}, nil)
 
-		_, err := ctx.client.createAuthorizationRequest(context.Background(), clientDID, issuerURL, modifier)
+		_, err := ctx.client.createAuthorizationRequest(context.Background(), subjectID, issuerURL, modifier)
 
 		assert.ErrorContains(t, err, "failed to parse authorization endpoint URL")
 	})
 }
 
 func Test_createOAuth2BaseURL(t *testing.T) {
-	t.Run("no endpoint", func(t *testing.T) {
-		webDID := did.MustParseDID("did:web:example.com:iam:holder")
-		actual, err := createOAuth2BaseURL(webDID)
 
-		require.NoError(t, err)
-		require.NotNil(t, actual)
-		assert.Equal(t, "https://example.com/oauth2/did:web:example.com:iam:holder", actual.String())
-	})
 	t.Run("ok", func(t *testing.T) {
-		webDID := did.MustParseDID("did:web:example.com:iam:holder")
-		actual, err := createOAuth2BaseURL(webDID)
-
-		require.NoError(t, err)
-		require.NotNil(t, actual)
-		assert.Equal(t, "https://example.com/oauth2/did:web:example.com:iam:holder", actual.String())
-	})
-	t.Run("did:web with port", func(t *testing.T) {
-		const didAsString = "did:web:example.com%3A8080:iam:holder"
-		webDID := did.MustParseDID(didAsString)
-
-		actual, err := createOAuth2BaseURL(webDID)
-
-		require.NoError(t, err)
-		require.NotNil(t, actual)
-		assert.Equal(t, "https://example.com:8080/oauth2/did:web:example.com%3A8080:iam:holder", actual.String())
-	})
-	t.Run("error - invalid DID", func(t *testing.T) {
-		_, err := createOAuth2BaseURL(did.DID{})
-
-		require.Error(t, err)
-		assert.EqualError(t, err, "failed to convert DID to URL: URL does not represent a Web DID\nunsupported DID method: ")
+		ctrl := gomock.NewController(t)
+		authServices := auth.NewMockAuthenticationServices(ctrl)
+		authServices.EXPECT().PublicURL().Return(test.MustParseURL("https://example.com")).AnyTimes()
+		w := Wrapper{
+			auth: authServices,
+		}
+		actual := w.createOAuth2BaseURL(subjectID)
+		assert.Equal(t, "https://example.com/oauth2/"+subjectID, actual.String())
 	})
 }
 
@@ -1405,22 +1377,23 @@ func statusCodeFrom(err error) int {
 }
 
 type testCtx struct {
-	authnServices *auth.MockAuthenticationServices
-	ctrl          *gomock.Controller
-	client        *Wrapper
-	documentOwner *didsubject.MockDocumentOwner
-	iamClient     *iam.MockClient
-	jwtSigner     *cryptoNuts.MockJWTSigner
-	keyResolver   *resolver.MockKeyResolver
-	policy        *policy.MockPDPBackend
-	resolver      *resolver.MockDIDResolver
-	relyingParty  *oauthServices.MockRelyingParty
-	vcr           *vcr.MockVCR
-	vdr           *vdr.MockVDR
-	vcIssuer      *issuer.MockIssuer
-	vcVerifier    *verifier.MockVerifier
-	wallet        *holder.MockWallet
-	jar           *MockJAR
+	authnServices  *auth.MockAuthenticationServices
+	ctrl           *gomock.Controller
+	client         *Wrapper
+	documentOwner  *didsubject.MockDocumentOwner
+	iamClient      *iam.MockClient
+	jwtSigner      *cryptoNuts.MockJWTSigner
+	keyResolver    *resolver.MockKeyResolver
+	policy         *policy.MockPDPBackend
+	resolver       *resolver.MockDIDResolver
+	relyingParty   *oauthServices.MockRelyingParty
+	vcr            *vcr.MockVCR
+	vdr            *vdr.MockVDR
+	vcIssuer       *issuer.MockIssuer
+	vcVerifier     *verifier.MockVerifier
+	wallet         *holder.MockWallet
+	subjectManager *didsubject.MockSubjectManager
+	jar            *MockJAR
 }
 
 func newTestClient(t testing.TB) *testCtx {
@@ -1438,6 +1411,7 @@ func newTestClientWithBaseURL(t testing.TB, publicURL *url.URL) *testCtx {
 	vcIssuer := issuer.NewMockIssuer(ctrl)
 	vcVerifier := verifier.NewMockVerifier(ctrl)
 	iamClient := iam.NewMockClient(ctrl)
+	subjectManager := didsubject.NewMockSubjectManager(ctrl)
 	mockVDR := vdr.NewMockVDR(ctrl)
 	mockDocumentOwner := didsubject.NewMockDocumentOwner(ctrl)
 	mockVCR := vcr.NewMockVCR(ctrl)
@@ -1455,31 +1429,37 @@ func newTestClientWithBaseURL(t testing.TB, publicURL *url.URL) *testCtx {
 	mockVDR.EXPECT().Resolver().Return(mockResolver).AnyTimes()
 	mockVDR.EXPECT().DocumentOwner().Return(mockDocumentOwner).AnyTimes()
 
+	subjectManager.EXPECT().List(gomock.Any(), verifierSubjectID).Return([]did.DID{verifierDID}, nil).AnyTimes()
+	subjectManager.EXPECT().List(gomock.Any(), issuerSubjectID).Return([]did.DID{issuerDID}, nil).AnyTimes()
+	subjectManager.EXPECT().List(gomock.Any(), holderSubjectID).Return([]did.DID{holderDID}, nil).AnyTimes()
+
 	return &testCtx{
-		ctrl:          ctrl,
-		authnServices: authnServices,
-		policy:        policyInstance,
-		relyingParty:  relyingPary,
-		vcIssuer:      vcIssuer,
-		vcVerifier:    vcVerifier,
-		resolver:      mockResolver,
-		vdr:           mockVDR,
-		documentOwner: mockDocumentOwner,
-		iamClient:     iamClient,
-		vcr:           mockVCR,
-		wallet:        mockWallet,
-		keyResolver:   keyResolver,
-		jwtSigner:     jwtSigner,
-		jar:           mockJAR,
+		ctrl:           ctrl,
+		authnServices:  authnServices,
+		policy:         policyInstance,
+		relyingParty:   relyingPary,
+		vcIssuer:       vcIssuer,
+		vcVerifier:     vcVerifier,
+		resolver:       mockResolver,
+		vdr:            mockVDR,
+		documentOwner:  mockDocumentOwner,
+		subjectManager: subjectManager,
+		iamClient:      iamClient,
+		vcr:            mockVCR,
+		wallet:         mockWallet,
+		keyResolver:    keyResolver,
+		jwtSigner:      jwtSigner,
+		jar:            mockJAR,
 		client: &Wrapper{
-			auth:          authnServices,
-			vdr:           mockVDR,
-			vcr:           mockVCR,
-			storageEngine: storageEngine,
-			policyBackend: policyInstance,
-			keyResolver:   keyResolver,
-			jwtSigner:     jwtSigner,
-			jar:           mockJAR,
+			auth:           authnServices,
+			subjectManager: subjectManager,
+			vdr:            mockVDR,
+			vcr:            mockVCR,
+			storageEngine:  storageEngine,
+			policyBackend:  policyInstance,
+			keyResolver:    keyResolver,
+			jwtSigner:      jwtSigner,
+			jar:            mockJAR,
 		},
 	}
 }

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -541,9 +541,9 @@ func (a ExtendedTokenIntrospectionResponse) MarshalJSON() ([]byte, error) {
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
-	// Get the OAuth2 Authorization Server metadata for the specified DID.
-	// (GET /.well-known/oauth-authorization-server/oauth2/{did})
-	OAuthAuthorizationServerMetadata(ctx echo.Context, did string) error
+	// Get the OAuth2 Authorization Server metadata for the specified subject.
+	// (GET /.well-known/oauth-authorization-server/oauth2/{subject})
+	OAuthAuthorizationServerMetadata(ctx echo.Context, subject string) error
 	// Introspection endpoint to retrieve information from an Access Token as described by RFC7662.
 	// It returns fields derived from the credentials that were used during authentication.
 	// (POST /internal/auth/v2/accesstoken/introspect)
@@ -563,38 +563,38 @@ type ServerInterface interface {
 	// (POST /internal/auth/v2/{did}/dpop)
 	CreateDPoPProof(ctx echo.Context, did string) error
 	// Start the Oid4VCI authorization flow.
-	// (POST /internal/auth/v2/{did}/request-credential)
-	RequestOpenid4VCICredentialIssuance(ctx echo.Context, did string) error
+	// (POST /internal/auth/v2/{subject}/request-credential)
+	RequestOpenid4VCICredentialIssuance(ctx echo.Context, subject string) error
 	// Start the authorization flow to get an access token from a remote authorization server.
-	// (POST /internal/auth/v2/{did}/request-service-access-token)
-	RequestServiceAccessToken(ctx echo.Context, did string) error
+	// (POST /internal/auth/v2/{subject}/request-service-access-token)
+	RequestServiceAccessToken(ctx echo.Context, subject string) error
 	// Start the authorization code flow to get an access token from a remote authorization server when user context is required.
-	// (POST /internal/auth/v2/{did}/request-user-access-token)
-	RequestUserAccessToken(ctx echo.Context, did string) error
+	// (POST /internal/auth/v2/{subject}/request-user-access-token)
+	RequestUserAccessToken(ctx echo.Context, subject string) error
 	// Used by resource owners (the browser) to initiate the authorization code flow.
-	// (GET /oauth2/{did}/authorize)
-	HandleAuthorizeRequest(ctx echo.Context, did string, params HandleAuthorizeRequestParams) error
+	// (GET /oauth2/{subject}/authorize)
+	HandleAuthorizeRequest(ctx echo.Context, subject string, params HandleAuthorizeRequestParams) error
 	// The OAuth2 callback endpoint of the client.
-	// (GET /oauth2/{did}/callback)
-	Callback(ctx echo.Context, did string, params CallbackParams) error
+	// (GET /oauth2/{subject}/callback)
+	Callback(ctx echo.Context, subject string, params CallbackParams) error
 	// Get the OAuth2 Client metadata
-	// (GET /oauth2/{did}/oauth-client)
-	OAuthClientMetadata(ctx echo.Context, did string) error
+	// (GET /oauth2/{subject}/oauth-client)
+	OAuthClientMetadata(ctx echo.Context, subject string) error
 	// Used by relying parties to obtain a presentation definition for desired scopes as specified by Nuts RFC021.
-	// (GET /oauth2/{did}/presentation_definition)
-	PresentationDefinition(ctx echo.Context, did string, params PresentationDefinitionParams) error
+	// (GET /oauth2/{subject}/presentation_definition)
+	PresentationDefinition(ctx echo.Context, subject string, params PresentationDefinitionParams) error
 	// Get Request Object referenced in an authorization request to the Authorization Server.
-	// (GET /oauth2/{did}/request.jwt/{id})
-	RequestJWTByGet(ctx echo.Context, did string, id string) error
+	// (GET /oauth2/{subject}/request.jwt/{id})
+	RequestJWTByGet(ctx echo.Context, subject string, id string) error
 	// Provide missing information to Client to finish Authorization request's Request Object, which is then returned.
-	// (POST /oauth2/{did}/request.jwt/{id})
-	RequestJWTByPost(ctx echo.Context, did string, id string) error
+	// (POST /oauth2/{subject}/request.jwt/{id})
+	RequestJWTByPost(ctx echo.Context, subject string, id string) error
 	// Used by wallets to post the authorization response or error to.
-	// (POST /oauth2/{did}/response)
-	HandleAuthorizeResponse(ctx echo.Context, did string) error
+	// (POST /oauth2/{subject}/response)
+	HandleAuthorizeResponse(ctx echo.Context, subject string) error
 	// Used by the OAuth2 client (backend, not the browser) to request access- or refresh tokens.
-	// (POST /oauth2/{did}/token)
-	HandleTokenRequest(ctx echo.Context, did string) error
+	// (POST /oauth2/{subject}/token)
+	HandleTokenRequest(ctx echo.Context, subject string) error
 	// Get the StatusList2021Credential for the given DID and page
 	// (GET /statuslist/{did}/{page})
 	StatusList(ctx echo.Context, did string, page int) error
@@ -608,18 +608,18 @@ type ServerInterfaceWrapper struct {
 // OAuthAuthorizationServerMetadata converts echo context to params.
 func (w *ServerInterfaceWrapper) OAuthAuthorizationServerMetadata(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
+	// ------------- Path parameter "subject" -------------
+	var subject string
 
-	err = runtime.BindStyledParameterWithOptions("simple", "did", ctx.Param("did"), &did, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "subject", ctx.Param("subject"), &subject, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter did: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter subject: %s", err))
 	}
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.OAuthAuthorizationServerMetadata(ctx, did)
+	err = w.Handler.OAuthAuthorizationServerMetadata(ctx, subject)
 	return err
 }
 
@@ -692,55 +692,55 @@ func (w *ServerInterfaceWrapper) CreateDPoPProof(ctx echo.Context) error {
 // RequestOpenid4VCICredentialIssuance converts echo context to params.
 func (w *ServerInterfaceWrapper) RequestOpenid4VCICredentialIssuance(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
+	// ------------- Path parameter "subject" -------------
+	var subject string
 
-	did = ctx.Param("did")
+	subject = ctx.Param("subject")
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.RequestOpenid4VCICredentialIssuance(ctx, did)
+	err = w.Handler.RequestOpenid4VCICredentialIssuance(ctx, subject)
 	return err
 }
 
 // RequestServiceAccessToken converts echo context to params.
 func (w *ServerInterfaceWrapper) RequestServiceAccessToken(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
+	// ------------- Path parameter "subject" -------------
+	var subject string
 
-	did = ctx.Param("did")
+	subject = ctx.Param("subject")
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.RequestServiceAccessToken(ctx, did)
+	err = w.Handler.RequestServiceAccessToken(ctx, subject)
 	return err
 }
 
 // RequestUserAccessToken converts echo context to params.
 func (w *ServerInterfaceWrapper) RequestUserAccessToken(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
+	// ------------- Path parameter "subject" -------------
+	var subject string
 
-	did = ctx.Param("did")
+	subject = ctx.Param("subject")
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.RequestUserAccessToken(ctx, did)
+	err = w.Handler.RequestUserAccessToken(ctx, subject)
 	return err
 }
 
 // HandleAuthorizeRequest converts echo context to params.
 func (w *ServerInterfaceWrapper) HandleAuthorizeRequest(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
+	// ------------- Path parameter "subject" -------------
+	var subject string
 
-	did = ctx.Param("did")
+	subject = ctx.Param("subject")
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
@@ -754,17 +754,17 @@ func (w *ServerInterfaceWrapper) HandleAuthorizeRequest(ctx echo.Context) error 
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.HandleAuthorizeRequest(ctx, did, params)
+	err = w.Handler.HandleAuthorizeRequest(ctx, subject, params)
 	return err
 }
 
 // Callback converts echo context to params.
 func (w *ServerInterfaceWrapper) Callback(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
+	// ------------- Path parameter "subject" -------------
+	var subject string
 
-	did = ctx.Param("did")
+	subject = ctx.Param("subject")
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
@@ -799,32 +799,32 @@ func (w *ServerInterfaceWrapper) Callback(ctx echo.Context) error {
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.Callback(ctx, did, params)
+	err = w.Handler.Callback(ctx, subject, params)
 	return err
 }
 
 // OAuthClientMetadata converts echo context to params.
 func (w *ServerInterfaceWrapper) OAuthClientMetadata(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
+	// ------------- Path parameter "subject" -------------
+	var subject string
 
-	did = ctx.Param("did")
+	subject = ctx.Param("subject")
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.OAuthClientMetadata(ctx, did)
+	err = w.Handler.OAuthClientMetadata(ctx, subject)
 	return err
 }
 
 // PresentationDefinition converts echo context to params.
 func (w *ServerInterfaceWrapper) PresentationDefinition(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
+	// ------------- Path parameter "subject" -------------
+	var subject string
 
-	did = ctx.Param("did")
+	subject = ctx.Param("subject")
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
@@ -845,17 +845,17 @@ func (w *ServerInterfaceWrapper) PresentationDefinition(ctx echo.Context) error 
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.PresentationDefinition(ctx, did, params)
+	err = w.Handler.PresentationDefinition(ctx, subject, params)
 	return err
 }
 
 // RequestJWTByGet converts echo context to params.
 func (w *ServerInterfaceWrapper) RequestJWTByGet(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
+	// ------------- Path parameter "subject" -------------
+	var subject string
 
-	did = ctx.Param("did")
+	subject = ctx.Param("subject")
 
 	// ------------- Path parameter "id" -------------
 	var id string
@@ -868,17 +868,17 @@ func (w *ServerInterfaceWrapper) RequestJWTByGet(ctx echo.Context) error {
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.RequestJWTByGet(ctx, did, id)
+	err = w.Handler.RequestJWTByGet(ctx, subject, id)
 	return err
 }
 
 // RequestJWTByPost converts echo context to params.
 func (w *ServerInterfaceWrapper) RequestJWTByPost(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
+	// ------------- Path parameter "subject" -------------
+	var subject string
 
-	did = ctx.Param("did")
+	subject = ctx.Param("subject")
 
 	// ------------- Path parameter "id" -------------
 	var id string
@@ -891,37 +891,37 @@ func (w *ServerInterfaceWrapper) RequestJWTByPost(ctx echo.Context) error {
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.RequestJWTByPost(ctx, did, id)
+	err = w.Handler.RequestJWTByPost(ctx, subject, id)
 	return err
 }
 
 // HandleAuthorizeResponse converts echo context to params.
 func (w *ServerInterfaceWrapper) HandleAuthorizeResponse(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
+	// ------------- Path parameter "subject" -------------
+	var subject string
 
-	did = ctx.Param("did")
+	subject = ctx.Param("subject")
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.HandleAuthorizeResponse(ctx, did)
+	err = w.Handler.HandleAuthorizeResponse(ctx, subject)
 	return err
 }
 
 // HandleTokenRequest converts echo context to params.
 func (w *ServerInterfaceWrapper) HandleTokenRequest(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
+	// ------------- Path parameter "subject" -------------
+	var subject string
 
-	did = ctx.Param("did")
+	subject = ctx.Param("subject")
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.HandleTokenRequest(ctx, did)
+	err = w.Handler.HandleTokenRequest(ctx, subject)
 	return err
 }
 
@@ -976,29 +976,29 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 		Handler: si,
 	}
 
-	router.GET(baseURL+"/.well-known/oauth-authorization-server/oauth2/:did", wrapper.OAuthAuthorizationServerMetadata)
+	router.GET(baseURL+"/.well-known/oauth-authorization-server/oauth2/:subject", wrapper.OAuthAuthorizationServerMetadata)
 	router.POST(baseURL+"/internal/auth/v2/accesstoken/introspect", wrapper.IntrospectAccessToken)
 	router.POST(baseURL+"/internal/auth/v2/accesstoken/introspect_extended", wrapper.IntrospectAccessTokenExtended)
 	router.GET(baseURL+"/internal/auth/v2/accesstoken/:sessionID", wrapper.RetrieveAccessToken)
 	router.POST(baseURL+"/internal/auth/v2/dpop_validate", wrapper.ValidateDPoPProof)
 	router.POST(baseURL+"/internal/auth/v2/:did/dpop", wrapper.CreateDPoPProof)
-	router.POST(baseURL+"/internal/auth/v2/:did/request-credential", wrapper.RequestOpenid4VCICredentialIssuance)
-	router.POST(baseURL+"/internal/auth/v2/:did/request-service-access-token", wrapper.RequestServiceAccessToken)
-	router.POST(baseURL+"/internal/auth/v2/:did/request-user-access-token", wrapper.RequestUserAccessToken)
-	router.GET(baseURL+"/oauth2/:did/authorize", wrapper.HandleAuthorizeRequest)
-	router.GET(baseURL+"/oauth2/:did/callback", wrapper.Callback)
-	router.GET(baseURL+"/oauth2/:did/oauth-client", wrapper.OAuthClientMetadata)
-	router.GET(baseURL+"/oauth2/:did/presentation_definition", wrapper.PresentationDefinition)
-	router.GET(baseURL+"/oauth2/:did/request.jwt/:id", wrapper.RequestJWTByGet)
-	router.POST(baseURL+"/oauth2/:did/request.jwt/:id", wrapper.RequestJWTByPost)
-	router.POST(baseURL+"/oauth2/:did/response", wrapper.HandleAuthorizeResponse)
-	router.POST(baseURL+"/oauth2/:did/token", wrapper.HandleTokenRequest)
+	router.POST(baseURL+"/internal/auth/v2/:subject/request-credential", wrapper.RequestOpenid4VCICredentialIssuance)
+	router.POST(baseURL+"/internal/auth/v2/:subject/request-service-access-token", wrapper.RequestServiceAccessToken)
+	router.POST(baseURL+"/internal/auth/v2/:subject/request-user-access-token", wrapper.RequestUserAccessToken)
+	router.GET(baseURL+"/oauth2/:subject/authorize", wrapper.HandleAuthorizeRequest)
+	router.GET(baseURL+"/oauth2/:subject/callback", wrapper.Callback)
+	router.GET(baseURL+"/oauth2/:subject/oauth-client", wrapper.OAuthClientMetadata)
+	router.GET(baseURL+"/oauth2/:subject/presentation_definition", wrapper.PresentationDefinition)
+	router.GET(baseURL+"/oauth2/:subject/request.jwt/:id", wrapper.RequestJWTByGet)
+	router.POST(baseURL+"/oauth2/:subject/request.jwt/:id", wrapper.RequestJWTByPost)
+	router.POST(baseURL+"/oauth2/:subject/response", wrapper.HandleAuthorizeResponse)
+	router.POST(baseURL+"/oauth2/:subject/token", wrapper.HandleTokenRequest)
 	router.GET(baseURL+"/statuslist/:did/:page", wrapper.StatusList)
 
 }
 
 type OAuthAuthorizationServerMetadataRequestObject struct {
-	Did string `json:"did"`
+	Subject string `json:"subject"`
 }
 
 type OAuthAuthorizationServerMetadataResponseObject interface {
@@ -1188,8 +1188,8 @@ func (response CreateDPoPProof401Response) VisitCreateDPoPProofResponse(w http.R
 }
 
 type RequestOpenid4VCICredentialIssuanceRequestObject struct {
-	Did  string `json:"did"`
-	Body *RequestOpenid4VCICredentialIssuanceJSONRequestBody
+	Subject string `json:"subject"`
+	Body    *RequestOpenid4VCICredentialIssuanceJSONRequestBody
 }
 
 type RequestOpenid4VCICredentialIssuanceResponseObject interface {
@@ -1227,8 +1227,8 @@ func (response RequestOpenid4VCICredentialIssuancedefaultApplicationProblemPlusJ
 }
 
 type RequestServiceAccessTokenRequestObject struct {
-	Did  string `json:"did"`
-	Body *RequestServiceAccessTokenJSONRequestBody
+	Subject string `json:"subject"`
+	Body    *RequestServiceAccessTokenJSONRequestBody
 }
 
 type RequestServiceAccessTokenResponseObject interface {
@@ -1266,8 +1266,8 @@ func (response RequestServiceAccessTokendefaultApplicationProblemPlusJSONRespons
 }
 
 type RequestUserAccessTokenRequestObject struct {
-	Did  string `json:"did"`
-	Body *RequestUserAccessTokenJSONRequestBody
+	Subject string `json:"subject"`
+	Body    *RequestUserAccessTokenJSONRequestBody
 }
 
 type RequestUserAccessTokenResponseObject interface {
@@ -1305,8 +1305,8 @@ func (response RequestUserAccessTokendefaultApplicationProblemPlusJSONResponse) 
 }
 
 type HandleAuthorizeRequestRequestObject struct {
-	Did    string `json:"did"`
-	Params HandleAuthorizeRequestParams
+	Subject string `json:"subject"`
+	Params  HandleAuthorizeRequestParams
 }
 
 type HandleAuthorizeRequestResponseObject interface {
@@ -1347,8 +1347,8 @@ func (response HandleAuthorizeRequest302Response) VisitHandleAuthorizeRequestRes
 }
 
 type CallbackRequestObject struct {
-	Did    string `json:"did"`
-	Params CallbackParams
+	Subject string `json:"subject"`
+	Params  CallbackParams
 }
 
 type CallbackResponseObject interface {
@@ -1391,7 +1391,7 @@ func (response CallbackdefaultApplicationProblemPlusJSONResponse) VisitCallbackR
 }
 
 type OAuthClientMetadataRequestObject struct {
-	Did string `json:"did"`
+	Subject string `json:"subject"`
 }
 
 type OAuthClientMetadataResponseObject interface {
@@ -1429,8 +1429,8 @@ func (response OAuthClientMetadatadefaultApplicationProblemPlusJSONResponse) Vis
 }
 
 type PresentationDefinitionRequestObject struct {
-	Did    string `json:"did"`
-	Params PresentationDefinitionParams
+	Subject string `json:"subject"`
+	Params  PresentationDefinitionParams
 }
 
 type PresentationDefinitionResponseObject interface {
@@ -1468,8 +1468,8 @@ func (response PresentationDefinitiondefaultApplicationProblemPlusJSONResponse) 
 }
 
 type RequestJWTByGetRequestObject struct {
-	Did string `json:"did"`
-	Id  string `json:"id"`
+	Subject string `json:"subject"`
+	Id      string `json:"id"`
 }
 
 type RequestJWTByGetResponseObject interface {
@@ -1517,9 +1517,9 @@ func (response RequestJWTByGetdefaultApplicationProblemPlusJSONResponse) VisitRe
 }
 
 type RequestJWTByPostRequestObject struct {
-	Did  string `json:"did"`
-	Id   string `json:"id"`
-	Body *RequestJWTByPostFormdataRequestBody
+	Subject string `json:"subject"`
+	Id      string `json:"id"`
+	Body    *RequestJWTByPostFormdataRequestBody
 }
 
 type RequestJWTByPostResponseObject interface {
@@ -1567,8 +1567,8 @@ func (response RequestJWTByPostdefaultApplicationProblemPlusJSONResponse) VisitR
 }
 
 type HandleAuthorizeResponseRequestObject struct {
-	Did  string `json:"did"`
-	Body *HandleAuthorizeResponseFormdataRequestBody
+	Subject string `json:"subject"`
+	Body    *HandleAuthorizeResponseFormdataRequestBody
 }
 
 type HandleAuthorizeResponseResponseObject interface {
@@ -1585,8 +1585,8 @@ func (response HandleAuthorizeResponse200JSONResponse) VisitHandleAuthorizeRespo
 }
 
 type HandleTokenRequestRequestObject struct {
-	Did  string `json:"did"`
-	Body *HandleTokenRequestFormdataRequestBody
+	Subject string `json:"subject"`
+	Body    *HandleTokenRequestFormdataRequestBody
 }
 
 type HandleTokenRequestResponseObject interface {
@@ -1655,8 +1655,8 @@ func (response StatusListdefaultApplicationProblemPlusJSONResponse) VisitStatusL
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
-	// Get the OAuth2 Authorization Server metadata for the specified DID.
-	// (GET /.well-known/oauth-authorization-server/oauth2/{did})
+	// Get the OAuth2 Authorization Server metadata for the specified subject.
+	// (GET /.well-known/oauth-authorization-server/oauth2/{subject})
 	OAuthAuthorizationServerMetadata(ctx context.Context, request OAuthAuthorizationServerMetadataRequestObject) (OAuthAuthorizationServerMetadataResponseObject, error)
 	// Introspection endpoint to retrieve information from an Access Token as described by RFC7662.
 	// It returns fields derived from the credentials that were used during authentication.
@@ -1677,37 +1677,37 @@ type StrictServerInterface interface {
 	// (POST /internal/auth/v2/{did}/dpop)
 	CreateDPoPProof(ctx context.Context, request CreateDPoPProofRequestObject) (CreateDPoPProofResponseObject, error)
 	// Start the Oid4VCI authorization flow.
-	// (POST /internal/auth/v2/{did}/request-credential)
+	// (POST /internal/auth/v2/{subject}/request-credential)
 	RequestOpenid4VCICredentialIssuance(ctx context.Context, request RequestOpenid4VCICredentialIssuanceRequestObject) (RequestOpenid4VCICredentialIssuanceResponseObject, error)
 	// Start the authorization flow to get an access token from a remote authorization server.
-	// (POST /internal/auth/v2/{did}/request-service-access-token)
+	// (POST /internal/auth/v2/{subject}/request-service-access-token)
 	RequestServiceAccessToken(ctx context.Context, request RequestServiceAccessTokenRequestObject) (RequestServiceAccessTokenResponseObject, error)
 	// Start the authorization code flow to get an access token from a remote authorization server when user context is required.
-	// (POST /internal/auth/v2/{did}/request-user-access-token)
+	// (POST /internal/auth/v2/{subject}/request-user-access-token)
 	RequestUserAccessToken(ctx context.Context, request RequestUserAccessTokenRequestObject) (RequestUserAccessTokenResponseObject, error)
 	// Used by resource owners (the browser) to initiate the authorization code flow.
-	// (GET /oauth2/{did}/authorize)
+	// (GET /oauth2/{subject}/authorize)
 	HandleAuthorizeRequest(ctx context.Context, request HandleAuthorizeRequestRequestObject) (HandleAuthorizeRequestResponseObject, error)
 	// The OAuth2 callback endpoint of the client.
-	// (GET /oauth2/{did}/callback)
+	// (GET /oauth2/{subject}/callback)
 	Callback(ctx context.Context, request CallbackRequestObject) (CallbackResponseObject, error)
 	// Get the OAuth2 Client metadata
-	// (GET /oauth2/{did}/oauth-client)
+	// (GET /oauth2/{subject}/oauth-client)
 	OAuthClientMetadata(ctx context.Context, request OAuthClientMetadataRequestObject) (OAuthClientMetadataResponseObject, error)
 	// Used by relying parties to obtain a presentation definition for desired scopes as specified by Nuts RFC021.
-	// (GET /oauth2/{did}/presentation_definition)
+	// (GET /oauth2/{subject}/presentation_definition)
 	PresentationDefinition(ctx context.Context, request PresentationDefinitionRequestObject) (PresentationDefinitionResponseObject, error)
 	// Get Request Object referenced in an authorization request to the Authorization Server.
-	// (GET /oauth2/{did}/request.jwt/{id})
+	// (GET /oauth2/{subject}/request.jwt/{id})
 	RequestJWTByGet(ctx context.Context, request RequestJWTByGetRequestObject) (RequestJWTByGetResponseObject, error)
 	// Provide missing information to Client to finish Authorization request's Request Object, which is then returned.
-	// (POST /oauth2/{did}/request.jwt/{id})
+	// (POST /oauth2/{subject}/request.jwt/{id})
 	RequestJWTByPost(ctx context.Context, request RequestJWTByPostRequestObject) (RequestJWTByPostResponseObject, error)
 	// Used by wallets to post the authorization response or error to.
-	// (POST /oauth2/{did}/response)
+	// (POST /oauth2/{subject}/response)
 	HandleAuthorizeResponse(ctx context.Context, request HandleAuthorizeResponseRequestObject) (HandleAuthorizeResponseResponseObject, error)
 	// Used by the OAuth2 client (backend, not the browser) to request access- or refresh tokens.
-	// (POST /oauth2/{did}/token)
+	// (POST /oauth2/{subject}/token)
 	HandleTokenRequest(ctx context.Context, request HandleTokenRequestRequestObject) (HandleTokenRequestResponseObject, error)
 	// Get the StatusList2021Credential for the given DID and page
 	// (GET /statuslist/{did}/{page})
@@ -1727,10 +1727,10 @@ type strictHandler struct {
 }
 
 // OAuthAuthorizationServerMetadata operation middleware
-func (sh *strictHandler) OAuthAuthorizationServerMetadata(ctx echo.Context, did string) error {
+func (sh *strictHandler) OAuthAuthorizationServerMetadata(ctx echo.Context, subject string) error {
 	var request OAuthAuthorizationServerMetadataRequestObject
 
-	request.Did = did
+	request.Subject = subject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.OAuthAuthorizationServerMetadata(ctx.Request().Context(), request.(OAuthAuthorizationServerMetadataRequestObject))
@@ -1903,10 +1903,10 @@ func (sh *strictHandler) CreateDPoPProof(ctx echo.Context, did string) error {
 }
 
 // RequestOpenid4VCICredentialIssuance operation middleware
-func (sh *strictHandler) RequestOpenid4VCICredentialIssuance(ctx echo.Context, did string) error {
+func (sh *strictHandler) RequestOpenid4VCICredentialIssuance(ctx echo.Context, subject string) error {
 	var request RequestOpenid4VCICredentialIssuanceRequestObject
 
-	request.Did = did
+	request.Subject = subject
 
 	var body RequestOpenid4VCICredentialIssuanceJSONRequestBody
 	if err := ctx.Bind(&body); err != nil {
@@ -1934,10 +1934,10 @@ func (sh *strictHandler) RequestOpenid4VCICredentialIssuance(ctx echo.Context, d
 }
 
 // RequestServiceAccessToken operation middleware
-func (sh *strictHandler) RequestServiceAccessToken(ctx echo.Context, did string) error {
+func (sh *strictHandler) RequestServiceAccessToken(ctx echo.Context, subject string) error {
 	var request RequestServiceAccessTokenRequestObject
 
-	request.Did = did
+	request.Subject = subject
 
 	var body RequestServiceAccessTokenJSONRequestBody
 	if err := ctx.Bind(&body); err != nil {
@@ -1965,10 +1965,10 @@ func (sh *strictHandler) RequestServiceAccessToken(ctx echo.Context, did string)
 }
 
 // RequestUserAccessToken operation middleware
-func (sh *strictHandler) RequestUserAccessToken(ctx echo.Context, did string) error {
+func (sh *strictHandler) RequestUserAccessToken(ctx echo.Context, subject string) error {
 	var request RequestUserAccessTokenRequestObject
 
-	request.Did = did
+	request.Subject = subject
 
 	var body RequestUserAccessTokenJSONRequestBody
 	if err := ctx.Bind(&body); err != nil {
@@ -1996,10 +1996,10 @@ func (sh *strictHandler) RequestUserAccessToken(ctx echo.Context, did string) er
 }
 
 // HandleAuthorizeRequest operation middleware
-func (sh *strictHandler) HandleAuthorizeRequest(ctx echo.Context, did string, params HandleAuthorizeRequestParams) error {
+func (sh *strictHandler) HandleAuthorizeRequest(ctx echo.Context, subject string, params HandleAuthorizeRequestParams) error {
 	var request HandleAuthorizeRequestRequestObject
 
-	request.Did = did
+	request.Subject = subject
 	request.Params = params
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
@@ -2022,10 +2022,10 @@ func (sh *strictHandler) HandleAuthorizeRequest(ctx echo.Context, did string, pa
 }
 
 // Callback operation middleware
-func (sh *strictHandler) Callback(ctx echo.Context, did string, params CallbackParams) error {
+func (sh *strictHandler) Callback(ctx echo.Context, subject string, params CallbackParams) error {
 	var request CallbackRequestObject
 
-	request.Did = did
+	request.Subject = subject
 	request.Params = params
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
@@ -2048,10 +2048,10 @@ func (sh *strictHandler) Callback(ctx echo.Context, did string, params CallbackP
 }
 
 // OAuthClientMetadata operation middleware
-func (sh *strictHandler) OAuthClientMetadata(ctx echo.Context, did string) error {
+func (sh *strictHandler) OAuthClientMetadata(ctx echo.Context, subject string) error {
 	var request OAuthClientMetadataRequestObject
 
-	request.Did = did
+	request.Subject = subject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.OAuthClientMetadata(ctx.Request().Context(), request.(OAuthClientMetadataRequestObject))
@@ -2073,10 +2073,10 @@ func (sh *strictHandler) OAuthClientMetadata(ctx echo.Context, did string) error
 }
 
 // PresentationDefinition operation middleware
-func (sh *strictHandler) PresentationDefinition(ctx echo.Context, did string, params PresentationDefinitionParams) error {
+func (sh *strictHandler) PresentationDefinition(ctx echo.Context, subject string, params PresentationDefinitionParams) error {
 	var request PresentationDefinitionRequestObject
 
-	request.Did = did
+	request.Subject = subject
 	request.Params = params
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
@@ -2099,10 +2099,10 @@ func (sh *strictHandler) PresentationDefinition(ctx echo.Context, did string, pa
 }
 
 // RequestJWTByGet operation middleware
-func (sh *strictHandler) RequestJWTByGet(ctx echo.Context, did string, id string) error {
+func (sh *strictHandler) RequestJWTByGet(ctx echo.Context, subject string, id string) error {
 	var request RequestJWTByGetRequestObject
 
-	request.Did = did
+	request.Subject = subject
 	request.Id = id
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
@@ -2125,10 +2125,10 @@ func (sh *strictHandler) RequestJWTByGet(ctx echo.Context, did string, id string
 }
 
 // RequestJWTByPost operation middleware
-func (sh *strictHandler) RequestJWTByPost(ctx echo.Context, did string, id string) error {
+func (sh *strictHandler) RequestJWTByPost(ctx echo.Context, subject string, id string) error {
 	var request RequestJWTByPostRequestObject
 
-	request.Did = did
+	request.Subject = subject
 	request.Id = id
 
 	if form, err := ctx.FormParams(); err == nil {
@@ -2161,10 +2161,10 @@ func (sh *strictHandler) RequestJWTByPost(ctx echo.Context, did string, id strin
 }
 
 // HandleAuthorizeResponse operation middleware
-func (sh *strictHandler) HandleAuthorizeResponse(ctx echo.Context, did string) error {
+func (sh *strictHandler) HandleAuthorizeResponse(ctx echo.Context, subject string) error {
 	var request HandleAuthorizeResponseRequestObject
 
-	request.Did = did
+	request.Subject = subject
 
 	if form, err := ctx.FormParams(); err == nil {
 		var body HandleAuthorizeResponseFormdataRequestBody
@@ -2196,10 +2196,10 @@ func (sh *strictHandler) HandleAuthorizeResponse(ctx echo.Context, did string) e
 }
 
 // HandleTokenRequest operation middleware
-func (sh *strictHandler) HandleTokenRequest(ctx echo.Context, did string) error {
+func (sh *strictHandler) HandleTokenRequest(ctx echo.Context, subject string) error {
 	var request HandleTokenRequestRequestObject
 
-	request.Did = did
+	request.Subject = subject
 
 	if form, err := ctx.FormParams(); err == nil {
 		var body HandleTokenRequestFormdataRequestBody

--- a/auth/api/iam/jar.go
+++ b/auth/api/iam/jar.go
@@ -62,7 +62,7 @@ type JAR interface {
 	Sign(ctx context.Context, claims oauthParameters) (string, error)
 	// Parse and validate an incoming authorization request.
 	// Requests that do not conform to RFC9101 or OpenID4VP result in an error.
-	Parse(ctx context.Context, ownDID did.DID, q url.Values) (oauthParameters, error)
+	Parse(ctx context.Context, clientMetadata oauth.AuthorizationServerMetadata, q url.Values) (oauthParameters, error)
 }
 
 func (j jar) Create(client did.DID, authServerURL string, modifier requestObjectModifier) jarRequest {
@@ -108,7 +108,7 @@ func (j jar) Sign(ctx context.Context, claims oauthParameters) (string, error) {
 	return j.jwtSigner.SignJWT(ctx, claims, nil, keyId.String())
 }
 
-func (j jar) Parse(ctx context.Context, ownDID did.DID, q url.Values) (oauthParameters, error) {
+func (j jar) Parse(ctx context.Context, clientMetadata oauth.AuthorizationServerMetadata, q url.Values) (oauthParameters, error) {
 	var rawRequestObject string
 	var err error
 	if rawRequestObject = q.Get(oauth.RequestParam); rawRequestObject != "" {
@@ -123,13 +123,11 @@ func (j jar) Parse(ctx context.Context, ownDID did.DID, q url.Values) (oauthPara
 				return nil, oauth.OAuth2Error{Code: oauth.InvalidRequestURI, Description: "failed to get Request Object", InternalError: err}
 			}
 		case "post":
-			issuerURL := ownDID.URI().URL
-			md, err := authorizationServerMetadata(ownDID, &issuerURL)
 			if err != nil {
 				// DB error
 				return nil, err
 			}
-			rawRequestObject, err = j.auth.IAMClient().RequestObjectByPost(ctx, requestURI, *md)
+			rawRequestObject, err = j.auth.IAMClient().RequestObjectByPost(ctx, requestURI, clientMetadata)
 			if err != nil {
 				return nil, oauth.OAuth2Error{Code: oauth.InvalidRequestURI, Description: "failed to get Request Object", InternalError: err}
 			}

--- a/auth/api/iam/jar_mock.go
+++ b/auth/api/iam/jar_mock.go
@@ -15,6 +15,7 @@ import (
 	reflect "reflect"
 
 	did "github.com/nuts-foundation/go-did/did"
+	oauth "github.com/nuts-foundation/nuts-node/auth/oauth"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -56,18 +57,18 @@ func (mr *MockJARMockRecorder) Create(client, authServerURL, modifier any) *gomo
 }
 
 // Parse mocks base method.
-func (m *MockJAR) Parse(ctx context.Context, ownDID did.DID, q url.Values) (oauthParameters, error) {
+func (m *MockJAR) Parse(ctx context.Context, clientMetadata oauth.AuthorizationServerMetadata, q url.Values) (oauthParameters, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Parse", ctx, ownDID, q)
+	ret := m.ctrl.Call(m, "Parse", ctx, clientMetadata, q)
 	ret0, _ := ret[0].(oauthParameters)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Parse indicates an expected call of Parse.
-func (mr *MockJARMockRecorder) Parse(ctx, ownDID, q any) *gomock.Call {
+func (mr *MockJARMockRecorder) Parse(ctx, clientMetadata, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parse", reflect.TypeOf((*MockJAR)(nil).Parse), ctx, ownDID, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parse", reflect.TypeOf((*MockJAR)(nil).Parse), ctx, clientMetadata, q)
 }
 
 // Sign mocks base method.

--- a/auth/api/iam/jar_test.go
+++ b/auth/api/iam/jar_test.go
@@ -117,13 +117,15 @@ func TestJar_Parse(t *testing.T) {
 	token := string(bytes)
 	walletIssuerURL := test.MustParseURL(walletDID.String())
 	ctx := newJarTestCtx(t)
+
+	verifierMetadata := authorizationServerMetadata(test.MustParseURL("https://example.com/verifier"))
 	t.Run("request_uri_method", func(t *testing.T) {
 
 		t.Run("ok - get", func(t *testing.T) {
 			ctx.iamClient.EXPECT().RequestObjectByGet(context.Background(), "request_uri").Return(token, nil)
 			ctx.keyResolver.EXPECT().ResolveKeyByID(kid, nil, resolver.AssertionMethod).Return(privateKey.Public(), nil)
 
-			res, err := ctx.jar.Parse(context.Background(), verifierDID,
+			res, err := ctx.jar.Parse(context.Background(), verifierMetadata,
 				map[string][]string{
 					oauth.ClientIDParam:         {holderDID.String()},
 					oauth.RequestURIParam:       {"request_uri"},
@@ -137,7 +139,7 @@ func TestJar_Parse(t *testing.T) {
 			ctx.iamClient.EXPECT().RequestObjectByGet(context.Background(), "request_uri").Return(token, nil)
 			ctx.keyResolver.EXPECT().ResolveKeyByID(kid, nil, resolver.AssertionMethod).Return(privateKey.Public(), nil)
 
-			res, err := ctx.jar.Parse(context.Background(), verifierDID,
+			res, err := ctx.jar.Parse(context.Background(), verifierMetadata,
 				map[string][]string{
 					oauth.ClientIDParam:         {holderDID.String()},
 					oauth.RequestURIParam:       {"request_uri"},
@@ -148,11 +150,11 @@ func TestJar_Parse(t *testing.T) {
 			require.NotNil(t, res)
 		})
 		t.Run("ok - post", func(t *testing.T) {
-			md, _ := authorizationServerMetadata(walletDID, walletIssuerURL)
-			ctx.iamClient.EXPECT().RequestObjectByPost(context.Background(), "request_uri", *md).Return(token, nil)
+			md := authorizationServerMetadata(walletIssuerURL)
+			ctx.iamClient.EXPECT().RequestObjectByPost(context.Background(), "request_uri", md).Return(token, nil)
 			ctx.keyResolver.EXPECT().ResolveKeyByID(kid, nil, resolver.AssertionMethod).Return(privateKey.Public(), nil)
 
-			res, err := ctx.jar.Parse(context.Background(), walletDID,
+			res, err := ctx.jar.Parse(context.Background(), md,
 				map[string][]string{
 					oauth.ClientIDParam:         {holderDID.String()},
 					oauth.RequestURIParam:       {"request_uri"},
@@ -163,7 +165,7 @@ func TestJar_Parse(t *testing.T) {
 			require.NotNil(t, res)
 		})
 		t.Run("error - unsupported method", func(t *testing.T) {
-			res, err := ctx.jar.Parse(context.Background(), verifierDID,
+			res, err := ctx.jar.Parse(context.Background(), verifierMetadata,
 				map[string][]string{
 					oauth.ClientIDParam:         {holderDID.String()},
 					oauth.RequestURIParam:       {"request_uri"},
@@ -177,7 +179,7 @@ func TestJar_Parse(t *testing.T) {
 	t.Run("ok - 'request'", func(t *testing.T) {
 		ctx.keyResolver.EXPECT().ResolveKeyByID(kid, nil, resolver.AssertionMethod).Return(privateKey.Public(), nil)
 
-		res, err := ctx.jar.Parse(context.Background(), verifierDID,
+		res, err := ctx.jar.Parse(context.Background(), verifierMetadata,
 			map[string][]string{
 				oauth.ClientIDParam: {holderDID.String()},
 				oauth.RequestParam:  {token},
@@ -189,7 +191,7 @@ func TestJar_Parse(t *testing.T) {
 	t.Run("server error", func(t *testing.T) {
 		t.Run("get", func(t *testing.T) {
 			ctx.iamClient.EXPECT().RequestObjectByGet(context.Background(), "request_uri").Return("", errors.New("server error"))
-			res, err := ctx.jar.Parse(context.Background(), verifierDID,
+			res, err := ctx.jar.Parse(context.Background(), verifierMetadata,
 				map[string][]string{
 					oauth.RequestURIParam: {"request_uri"},
 				})
@@ -198,9 +200,9 @@ func TestJar_Parse(t *testing.T) {
 			assert.Nil(t, res)
 		})
 		t.Run("post (made by wallet)", func(t *testing.T) {
-			md, _ := authorizationServerMetadata(walletDID, walletIssuerURL)
-			ctx.iamClient.EXPECT().RequestObjectByPost(context.Background(), "request_uri", *md).Return("", errors.New("server error"))
-			res, err := ctx.jar.Parse(context.Background(), walletDID,
+			md := authorizationServerMetadata(walletIssuerURL)
+			ctx.iamClient.EXPECT().RequestObjectByPost(context.Background(), "request_uri", md).Return("", errors.New("server error"))
+			res, err := ctx.jar.Parse(context.Background(), md,
 				map[string][]string{
 					oauth.RequestURIParam:       {"request_uri"},
 					oauth.RequestURIMethodParam: {"post"},
@@ -211,7 +213,7 @@ func TestJar_Parse(t *testing.T) {
 		})
 	})
 	t.Run("error - both 'request' and 'request_uri'", func(t *testing.T) {
-		res, err := ctx.jar.Parse(context.Background(), verifierDID,
+		res, err := ctx.jar.Parse(context.Background(), verifierMetadata,
 			map[string][]string{
 				oauth.RequestParam:    {"request"},
 				oauth.RequestURIParam: {"request_uri"},
@@ -221,13 +223,13 @@ func TestJar_Parse(t *testing.T) {
 		assert.Nil(t, res)
 	})
 	t.Run("error - no 'request' or 'request_uri'", func(t *testing.T) {
-		res, err := ctx.jar.Parse(context.Background(), verifierDID, map[string][]string{})
+		res, err := ctx.jar.Parse(context.Background(), verifierMetadata, map[string][]string{})
 
 		requireOAuthError(t, err, oauth.InvalidRequest, "authorization request are required to use signed request objects (RFC9101)")
 		assert.Nil(t, res)
 	})
 	t.Run("error - request signature validation failed", func(t *testing.T) {
-		res, err := ctx.jar.Parse(context.Background(), verifierDID,
+		res, err := ctx.jar.Parse(context.Background(), verifierMetadata,
 			map[string][]string{
 				oauth.ClientIDParam: {"invalid"},
 				oauth.RequestParam:  {"invalid"},
@@ -239,7 +241,7 @@ func TestJar_Parse(t *testing.T) {
 	t.Run("error - client_id does not match", func(t *testing.T) {
 		ctx.keyResolver.EXPECT().ResolveKeyByID(kid, nil, resolver.AssertionMethod).Return(privateKey.Public(), nil)
 
-		res, err := ctx.jar.Parse(context.Background(), verifierDID,
+		res, err := ctx.jar.Parse(context.Background(), verifierMetadata,
 			map[string][]string{
 				oauth.ClientIDParam: {"invalid"},
 				oauth.RequestParam:  {token},
@@ -256,7 +258,7 @@ func TestJar_Parse(t *testing.T) {
 		require.NoError(t, err)
 		ctx.keyResolver.EXPECT().ResolveKeyByID(kid, nil, resolver.AssertionMethod).Return(privateKey.Public(), nil)
 
-		res, err := ctx.jar.Parse(context.Background(), verifierDID,
+		res, err := ctx.jar.Parse(context.Background(), verifierMetadata,
 			map[string][]string{
 				oauth.ClientIDParam: {verifierDID.String()},
 				oauth.RequestParam:  {string(bytes)},

--- a/auth/api/iam/metadata_test.go
+++ b/auth/api/iam/metadata_test.go
@@ -19,7 +19,6 @@
 package iam
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/nuts-foundation/go-did/did"
@@ -49,9 +48,8 @@ func Test_authorizationServerMetadata(t *testing.T) {
 		RequestObjectSigningAlgValuesSupported:     jwx.SupportedAlgorithmsAsStrings(),
 	}
 	t.Run("base", func(t *testing.T) {
-		md, err := authorizationServerMetadata(didExample, test.MustParseURL("https://example.com/oauth2/"+didExample.String()))
-		assert.NoError(t, err)
-		assert.Equal(t, baseExpected, *md)
+		md := authorizationServerMetadata(test.MustParseURL("https://example.com/oauth2/" + didExample.String()))
+		assert.Equal(t, baseExpected, md)
 	})
 	t.Run("did:web", func(t *testing.T) {
 		didWeb := did.MustParseDID("did:web:example.com:iam:123")
@@ -86,5 +84,5 @@ func Test_clientMetadata(t *testing.T) {
 		VPFormats:               oauth.DefaultOpenIDSupportedFormats(),
 		ClientIdScheme:          "did",
 	}
-	assert.Equal(t, expected, clientMetadata(url.URL{}))
+	assert.Equal(t, expected, clientMetadata())
 }

--- a/auth/api/iam/s2s_vptoken.go
+++ b/auth/api/iam/s2s_vptoken.go
@@ -43,7 +43,7 @@ const s2sMaxClockSkew = 5 * time.Second
 
 // handleS2SAccessTokenRequest handles the /token request with vp_token bearer grant type, intended for service-to-service exchanges.
 // It performs cheap checks first (parameter presence and validity, matching VCs to the presentation definition), then the more expensive ones (checking signatures).
-func (r Wrapper) handleS2SAccessTokenRequest(ctx context.Context, issuer did.DID, scope string, submissionJSON string, assertionJSON string) (HandleTokenRequestResponseObject, error) {
+func (r Wrapper) handleS2SAccessTokenRequest(ctx context.Context, subjectID string, scope string, submissionJSON string, assertionJSON string) (HandleTokenRequestResponseObject, error) {
 	pexEnvelope, err := pe.ParseEnvelope([]byte(assertionJSON))
 	if err != nil {
 		return nil, oauth.OAuth2Error{
@@ -51,7 +51,6 @@ func (r Wrapper) handleS2SAccessTokenRequest(ctx context.Context, issuer did.DID
 			Description: "assertion parameter is invalid: " + err.Error(),
 		}
 	}
-	issuerURL, _ := createOAuth2BaseURL(issuer)
 
 	submission, err := pe.ParsePresentationSubmission([]byte(submissionJSON))
 	if err != nil {
@@ -71,7 +70,7 @@ func (r Wrapper) handleS2SAccessTokenRequest(ctx context.Context, issuer did.DID
 		} else {
 			credentialSubjectID = *subjectDID
 		}
-		if err := r.validatePresentationAudience(presentation, issuerURL.String()); err != nil {
+		if err := r.validatePresentationAudience(presentation, r.createOAuth2BaseURL(subjectID).String()); err != nil {
 			return nil, err
 		}
 	}
@@ -110,7 +109,7 @@ func (r Wrapper) handleS2SAccessTokenRequest(ctx context.Context, issuer did.DID
 	}
 
 	// All OK, allow access
-	response, err := r.createAccessToken(issuer, credentialSubjectID, time.Now(), scope, *pexConsumer, dpopProof)
+	response, err := r.createAccessToken(subjectID, credentialSubjectID, time.Now(), scope, *pexConsumer, dpopProof)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/api/iam/session.go
+++ b/auth/api/iam/session.go
@@ -37,7 +37,8 @@ type OAuthSession struct {
 	ClientID          string          `json:"client_id,omitempty"`
 	ClientState       string          `json:"client_state,omitempty"`
 	OpenID4VPVerifier *PEXConsumer    `json:"openid4vp_verifier,omitempty"`
-	OwnDID            *did.DID        `json:"own_did,omitempty"`
+	SubjectDID        did.DID         `json:"subject_did,omitempty"`
+	SubjectID         string          `json:"subject_id,omitempty"`
 	OtherDID          *did.DID        `json:"other_did,omitempty"`
 	PKCEParams        PKCEParams      `json:"pkce_params"`
 	RedirectURI       string          `json:"redirect_uri,omitempty"`
@@ -165,7 +166,7 @@ type RedirectSession struct {
 	AccessTokenRequest RequestUserAccessTokenRequestObject
 	// SessionID is used by the calling app to get the access token later on
 	SessionID string
-	OwnDID    did.DID
+	SubjectID string
 }
 
 func (s OAuthSession) CreateRedirectURI(params map[string]string) string {

--- a/auth/api/iam/user_test.go
+++ b/auth/api/iam/user_test.go
@@ -133,7 +133,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 		require.NoError(t, err)
 		// check for issued EmployeeCredential in session wallet
 		require.NoError(t, err)
-		assert.Equal(t, walletDID, userSession.TenantDID)
+		assert.Equal(t, walletDID, userSession.SubjectID)
 		require.Len(t, userSession.Wallet.Credentials, 1)
 		// check the JWK can be parsed and contains a private key
 		sessionKey, err := jwk.ParseKey(userSession.Wallet.JWK)

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -227,7 +227,7 @@ func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, requeste
 	}
 
 	params := holder.BuildParams{
-		Audience: authServerURL,
+		Audience: metadata.Issuer,
 		Expires:  time.Now().Add(time.Second * 5),
 		Nonce:    nutsCrypto.GenerateNonce(),
 	}

--- a/docs/_static/auth/iam.partial.yaml
+++ b/docs/_static/auth/iam.partial.yaml
@@ -1,6 +1,6 @@
 # Note: no code is directly generated from this file, it is merged into v2.yaml and then code is generated from the merged file.
 paths:
-  /oauth2/{did}/token:
+  /oauth2/{subject}/token:
     post:
       summary: Used by the OAuth2 client (backend, not the browser) to request access- or refresh tokens.
       description: |
@@ -10,15 +10,15 @@ paths:
       tags:
         - oauth2
       parameters:
-        - name: did
+        - name: subject
           in: path
           required: true
-          description: DID that is the subject of the token request
+          description: Subject of the token request
           content:
             plain/text:
               schema:
                 type: string
-                example: did:web:example.com
+                example: 59B4AE18-76F2-45A9-9D10-691B174478B7
       requestBody:
         content:
           application/x-www-form-urlencoded:
@@ -55,7 +55,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /oauth2/{did}/authorize:
+  /oauth2/{subject}/authorize:
     get:
       summary: Used by resource owners (the browser) to initiate the authorization code flow.
       description: Specified by https://datatracker.ietf.org/doc/html/rfc6749#section-3.1
@@ -63,15 +63,15 @@ paths:
       tags:
         - oauth2
       parameters:
-        - name: did
+        - name: subject
           in: path
           required: true
-          description: DID that is the subject of the authorization request
+          description: Subject of the authorization request
           content:
             plain/text:
               schema:
                 type: string
-                example: did:web:example.com
+                example: 59B4AE18-76F2-45A9-9D10-691B174478B7
         # Way to specify dynamic query parameters
         # See https://stackoverflow.com/questions/49582559/how-to-document-dynamic-query-parameter-names-in-openapi-swagger
         - in: query
@@ -97,17 +97,17 @@ paths:
               schema:
                 type: string
                 format: uri
-  /oauth2/{did}/request.jwt/{id}:
+  /oauth2/{subject}/request.jwt/{id}:
     parameters:
-      - name: did
+      - name: subject
         in: path
         required: true
-        description: DID acting as the client for the authorization request
+        description: Subject acting as the client for the authorization request
         content:
           plain/text:
             schema:
               type: string
-              example: did:web:example.com
+              example: 59B4AE18-76F2-45A9-9D10-691B174478B7
       - name: id
         in: path
         required: true
@@ -159,7 +159,7 @@ paths:
                 "$ref": "#/components/schemas/RequestObjectResponse"
         default:
           $ref: '../common/error_response.yaml'
-  /oauth2/{did}/callback:
+  /oauth2/{subject}/callback:
     get:
       summary: The OAuth2 callback endpoint of the client.
       description: |
@@ -172,10 +172,10 @@ paths:
       tags:
         - oauth2
       parameters:
-        - name: did
+        - name: subject
           in: path
           required: true
-          description: DID that is the subject of the callback
+          description: Subject of the callback
           content:
             plain/text:
               schema:
@@ -211,7 +211,7 @@ paths:
                 format: uri
         "default":
           $ref: '../common/error_response.yaml'
-  /oauth2/{did}/presentation_definition:
+  /oauth2/{subject}/presentation_definition:
     get:
       summary: Used by relying parties to obtain a presentation definition for desired scopes as specified by Nuts RFC021.
       description: |
@@ -223,15 +223,15 @@ paths:
       tags:
         - oauth2
       parameters:
-        - name: did
+        - name: subject
           in: path
           required: true
-          description: DID that holds the presentation definition.
+          description: Subject that requests a Verifiable Presentation through the Presentation Definition.
           content:
             plain/text:
               schema:
                 type: string
-                example: did:web:example.com
+                example: 59B4AE18-76F2-45A9-9D10-691B174478B7
         - name: scope
           in: query
           required: true
@@ -253,7 +253,7 @@ paths:
                 "$ref": "#/components/schemas/PresentationDefinition"
         "default":
           $ref: '../common/error_response.yaml'
-  /oauth2/{did}/response:
+  /oauth2/{subject}/response:
     post:
       summary: Used by wallets to post the authorization response or error to.
       description: |
@@ -264,15 +264,15 @@ paths:
       tags:
         - oauth2
       parameters:
-        - name: did
+        - name: subject
           in: path
           required: true
-          description: DID that is the subject of the authorization response
+          description: Subject of the authorization response
           content:
             plain/text:
               schema:
                 type: string
-                example: did:web:example.com
+                example: 59B4AE18-76F2-45A9-9D10-691B174478B7
       requestBody:
         required: true
         content:
@@ -308,28 +308,28 @@ paths:
   #    $ref: '#/paths/~1.well-known~1oauth-authorization-server~1oauth2~1{did}'
   #  /oauth2/{did}/.well-known/oauth-authorization-server:
   #    $ref: '#/paths/~1.well-known~1oauth-authorization-server~1oauth2~1{did}'
-  /.well-known/oauth-authorization-server/oauth2/{did}:
+  /.well-known/oauth-authorization-server/oauth2/{subject}:
     get:
       tags:
         - well-known
-      summary: Get the OAuth2 Authorization Server metadata for the specified DID.
+      summary: Get the OAuth2 Authorization Server metadata for the specified subject.
       description: >
         Specified by https://www.rfc-editor.org/info/rfc8414
         The well-known path is the default specified by https://www.rfc-editor.org/rfc/rfc8414.html#section-3
 
         error returns:
         * 400 - invalid input
-        * 404 - DID not found; possibly be non-existing, deactivated, or not managed by this node
+        * 404 - Subject not found; possibly be non-existing, deactivated, or not managed by this node
         * 500 - internal server error
       operationId: OAuthAuthorizationServerMetadata
       parameters:
-        - name: did
+        - name: subject
           in: path
           required: true
-          description: The DID of the metadata subject.
+          description: Subject of the metadata.
           schema:
             type: string
-            example: did:web:example.com
+            example: 59B4AE18-76F2-45A9-9D10-691B174478B7
       responses:
         "200":
           description: OK
@@ -339,7 +339,7 @@ paths:
                 "$ref": "#/components/schemas/OAuthAuthorizationServerMetadata"
         default:
           $ref: '../common/error_response.yaml'
-  /oauth2/{did}/oauth-client:
+  /oauth2/{subject}/oauth-client:
     get:
       tags:
         - well-known
@@ -351,19 +351,19 @@ paths:
         
         error returns:
         * 400 - invalid input
-        * 404 - DID not found; possibly be non-existing, deactivated, or not managed by this node
+        * 404 - Subject not found; possibly be non-existing, deactivated, or not managed by this node
         * 500 - internal server error
       operationId: OAuthClientMetadata
       parameters:
-        - name: did
+        - name: subject
           in: path
           required: true
-          description: DID that serves the metadata
+          description: Subject of the metadata.
           content:
             plain/text:
               schema:
                 type: string
-                example: did:web:example.com
+                example: 59B4AE18-76F2-45A9-9D10-691B174478B7
       responses:
         "200":
           description: OK

--- a/docs/_static/auth/v2.yaml
+++ b/docs/_static/auth/v2.yaml
@@ -8,7 +8,7 @@ servers:
   - url: http://localhost:8080
     description: For public-facing endpoints.
 paths:
-  /internal/auth/v2/{did}/request-service-access-token:
+  /internal/auth/v2/{subject}/request-service-access-token:
     post:
       operationId: requestServiceAccessToken
       summary: Start the authorization flow to get an access token from a remote authorization server.
@@ -23,15 +23,15 @@ paths:
       tags:
         - auth
       parameters:
-        - name: did
+        - name: subject
           in: path
           required: true
-          description: The DID of the requester, a Wallet owner at this node.
+          description: Subject of the requester, a wallet owner at this node.
           content:
             plain/text:
               schema:
                 type: string
-                example: did:web:example.com
+                example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
       requestBody:
         required: true
         content:
@@ -47,7 +47,7 @@ paths:
                 $ref: '#/components/schemas/TokenResponse'
         default:
           $ref: '../common/error_response.yaml'
-  /internal/auth/v2/{did}/request-user-access-token:
+  /internal/auth/v2/{subject}/request-user-access-token:
     post:
       operationId: requestUserAccessToken
       summary: Start the authorization code flow to get an access token from a remote authorization server when user context is required.
@@ -63,15 +63,15 @@ paths:
       tags:
         - auth
       parameters:
-        - name: did
+        - name: subject
           in: path
           required: true
-          description: The DID of the requester, a wallet owner at this node.
+          description: Subject of the requester, a wallet owner at this node.
           content:
             plain/text:
               schema:
                 type: string
-                example: did:web:example.com
+                example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
       requestBody:
         required: true
         content:
@@ -236,7 +236,7 @@ paths:
                 $ref: "#/components/schemas/DPoPValidateResponse"
         default:
           $ref: '../common/error_response.yaml'
-  /internal/auth/v2/{did}/request-credential:
+  /internal/auth/v2/{subject}/request-credential:
     post:
       operationId: requestOpenid4VCICredentialIssuance
       summary: Start the Oid4VCI authorization flow.
@@ -250,15 +250,15 @@ paths:
       tags:
         - auth
       parameters:
-        - name: did
+        - name: subject
           in: path
           required: true
-          description: The DID of the requester, a Wallet owner at this node.
+          description: Subject ID of the wallet owner at this node.
           content:
             plain/text:
               schema:
                 type: string
-                example: did:web:example.com
+                example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
       requestBody:
         required: true
         content:

--- a/e2e-tests/browser/client/iam/generated.go
+++ b/e2e-tests/browser/client/iam/generated.go
@@ -561,19 +561,19 @@ type ClientInterface interface {
 	CreateDPoPProof(ctx context.Context, did string, body CreateDPoPProofJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RequestOpenid4VCICredentialIssuanceWithBody request with any body
-	RequestOpenid4VCICredentialIssuanceWithBody(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	RequestOpenid4VCICredentialIssuanceWithBody(ctx context.Context, subject string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	RequestOpenid4VCICredentialIssuance(ctx context.Context, did string, body RequestOpenid4VCICredentialIssuanceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	RequestOpenid4VCICredentialIssuance(ctx context.Context, subject string, body RequestOpenid4VCICredentialIssuanceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RequestServiceAccessTokenWithBody request with any body
-	RequestServiceAccessTokenWithBody(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	RequestServiceAccessTokenWithBody(ctx context.Context, subject string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	RequestServiceAccessToken(ctx context.Context, did string, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	RequestServiceAccessToken(ctx context.Context, subject string, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RequestUserAccessTokenWithBody request with any body
-	RequestUserAccessTokenWithBody(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	RequestUserAccessTokenWithBody(ctx context.Context, subject string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	RequestUserAccessToken(ctx context.Context, did string, body RequestUserAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	RequestUserAccessToken(ctx context.Context, subject string, body RequestUserAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) IntrospectAccessTokenWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -684,8 +684,8 @@ func (c *Client) CreateDPoPProof(ctx context.Context, did string, body CreateDPo
 	return c.Client.Do(req)
 }
 
-func (c *Client) RequestOpenid4VCICredentialIssuanceWithBody(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewRequestOpenid4VCICredentialIssuanceRequestWithBody(c.Server, did, contentType, body)
+func (c *Client) RequestOpenid4VCICredentialIssuanceWithBody(ctx context.Context, subject string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRequestOpenid4VCICredentialIssuanceRequestWithBody(c.Server, subject, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -696,8 +696,8 @@ func (c *Client) RequestOpenid4VCICredentialIssuanceWithBody(ctx context.Context
 	return c.Client.Do(req)
 }
 
-func (c *Client) RequestOpenid4VCICredentialIssuance(ctx context.Context, did string, body RequestOpenid4VCICredentialIssuanceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewRequestOpenid4VCICredentialIssuanceRequest(c.Server, did, body)
+func (c *Client) RequestOpenid4VCICredentialIssuance(ctx context.Context, subject string, body RequestOpenid4VCICredentialIssuanceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRequestOpenid4VCICredentialIssuanceRequest(c.Server, subject, body)
 	if err != nil {
 		return nil, err
 	}
@@ -708,8 +708,8 @@ func (c *Client) RequestOpenid4VCICredentialIssuance(ctx context.Context, did st
 	return c.Client.Do(req)
 }
 
-func (c *Client) RequestServiceAccessTokenWithBody(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewRequestServiceAccessTokenRequestWithBody(c.Server, did, contentType, body)
+func (c *Client) RequestServiceAccessTokenWithBody(ctx context.Context, subject string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRequestServiceAccessTokenRequestWithBody(c.Server, subject, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -720,8 +720,8 @@ func (c *Client) RequestServiceAccessTokenWithBody(ctx context.Context, did stri
 	return c.Client.Do(req)
 }
 
-func (c *Client) RequestServiceAccessToken(ctx context.Context, did string, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewRequestServiceAccessTokenRequest(c.Server, did, body)
+func (c *Client) RequestServiceAccessToken(ctx context.Context, subject string, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRequestServiceAccessTokenRequest(c.Server, subject, body)
 	if err != nil {
 		return nil, err
 	}
@@ -732,8 +732,8 @@ func (c *Client) RequestServiceAccessToken(ctx context.Context, did string, body
 	return c.Client.Do(req)
 }
 
-func (c *Client) RequestUserAccessTokenWithBody(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewRequestUserAccessTokenRequestWithBody(c.Server, did, contentType, body)
+func (c *Client) RequestUserAccessTokenWithBody(ctx context.Context, subject string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRequestUserAccessTokenRequestWithBody(c.Server, subject, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -744,8 +744,8 @@ func (c *Client) RequestUserAccessTokenWithBody(ctx context.Context, did string,
 	return c.Client.Do(req)
 }
 
-func (c *Client) RequestUserAccessToken(ctx context.Context, did string, body RequestUserAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewRequestUserAccessTokenRequest(c.Server, did, body)
+func (c *Client) RequestUserAccessToken(ctx context.Context, subject string, body RequestUserAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRequestUserAccessTokenRequest(c.Server, subject, body)
 	if err != nil {
 		return nil, err
 	}
@@ -955,23 +955,23 @@ func NewCreateDPoPProofRequestWithBody(server string, did string, contentType st
 }
 
 // NewRequestOpenid4VCICredentialIssuanceRequest calls the generic RequestOpenid4VCICredentialIssuance builder with application/json body
-func NewRequestOpenid4VCICredentialIssuanceRequest(server string, did string, body RequestOpenid4VCICredentialIssuanceJSONRequestBody) (*http.Request, error) {
+func NewRequestOpenid4VCICredentialIssuanceRequest(server string, subject string, body RequestOpenid4VCICredentialIssuanceJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewRequestOpenid4VCICredentialIssuanceRequestWithBody(server, did, "application/json", bodyReader)
+	return NewRequestOpenid4VCICredentialIssuanceRequestWithBody(server, subject, "application/json", bodyReader)
 }
 
 // NewRequestOpenid4VCICredentialIssuanceRequestWithBody generates requests for RequestOpenid4VCICredentialIssuance with any type of body
-func NewRequestOpenid4VCICredentialIssuanceRequestWithBody(server string, did string, contentType string, body io.Reader) (*http.Request, error) {
+func NewRequestOpenid4VCICredentialIssuanceRequestWithBody(server string, subject string, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0 = did
+	pathParam0 = subject
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
@@ -999,23 +999,23 @@ func NewRequestOpenid4VCICredentialIssuanceRequestWithBody(server string, did st
 }
 
 // NewRequestServiceAccessTokenRequest calls the generic RequestServiceAccessToken builder with application/json body
-func NewRequestServiceAccessTokenRequest(server string, did string, body RequestServiceAccessTokenJSONRequestBody) (*http.Request, error) {
+func NewRequestServiceAccessTokenRequest(server string, subject string, body RequestServiceAccessTokenJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewRequestServiceAccessTokenRequestWithBody(server, did, "application/json", bodyReader)
+	return NewRequestServiceAccessTokenRequestWithBody(server, subject, "application/json", bodyReader)
 }
 
 // NewRequestServiceAccessTokenRequestWithBody generates requests for RequestServiceAccessToken with any type of body
-func NewRequestServiceAccessTokenRequestWithBody(server string, did string, contentType string, body io.Reader) (*http.Request, error) {
+func NewRequestServiceAccessTokenRequestWithBody(server string, subject string, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0 = did
+	pathParam0 = subject
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
@@ -1043,23 +1043,23 @@ func NewRequestServiceAccessTokenRequestWithBody(server string, did string, cont
 }
 
 // NewRequestUserAccessTokenRequest calls the generic RequestUserAccessToken builder with application/json body
-func NewRequestUserAccessTokenRequest(server string, did string, body RequestUserAccessTokenJSONRequestBody) (*http.Request, error) {
+func NewRequestUserAccessTokenRequest(server string, subject string, body RequestUserAccessTokenJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewRequestUserAccessTokenRequestWithBody(server, did, "application/json", bodyReader)
+	return NewRequestUserAccessTokenRequestWithBody(server, subject, "application/json", bodyReader)
 }
 
 // NewRequestUserAccessTokenRequestWithBody generates requests for RequestUserAccessToken with any type of body
-func NewRequestUserAccessTokenRequestWithBody(server string, did string, contentType string, body io.Reader) (*http.Request, error) {
+func NewRequestUserAccessTokenRequestWithBody(server string, subject string, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0 = did
+	pathParam0 = subject
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
@@ -1153,19 +1153,19 @@ type ClientWithResponsesInterface interface {
 	CreateDPoPProofWithResponse(ctx context.Context, did string, body CreateDPoPProofJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDPoPProofResponse, error)
 
 	// RequestOpenid4VCICredentialIssuanceWithBodyWithResponse request with any body
-	RequestOpenid4VCICredentialIssuanceWithBodyWithResponse(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestOpenid4VCICredentialIssuanceResponse, error)
+	RequestOpenid4VCICredentialIssuanceWithBodyWithResponse(ctx context.Context, subject string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestOpenid4VCICredentialIssuanceResponse, error)
 
-	RequestOpenid4VCICredentialIssuanceWithResponse(ctx context.Context, did string, body RequestOpenid4VCICredentialIssuanceJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestOpenid4VCICredentialIssuanceResponse, error)
+	RequestOpenid4VCICredentialIssuanceWithResponse(ctx context.Context, subject string, body RequestOpenid4VCICredentialIssuanceJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestOpenid4VCICredentialIssuanceResponse, error)
 
 	// RequestServiceAccessTokenWithBodyWithResponse request with any body
-	RequestServiceAccessTokenWithBodyWithResponse(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error)
+	RequestServiceAccessTokenWithBodyWithResponse(ctx context.Context, subject string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error)
 
-	RequestServiceAccessTokenWithResponse(ctx context.Context, did string, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error)
+	RequestServiceAccessTokenWithResponse(ctx context.Context, subject string, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error)
 
 	// RequestUserAccessTokenWithBodyWithResponse request with any body
-	RequestUserAccessTokenWithBodyWithResponse(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestUserAccessTokenResponse, error)
+	RequestUserAccessTokenWithBodyWithResponse(ctx context.Context, subject string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestUserAccessTokenResponse, error)
 
-	RequestUserAccessTokenWithResponse(ctx context.Context, did string, body RequestUserAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestUserAccessTokenResponse, error)
+	RequestUserAccessTokenWithResponse(ctx context.Context, subject string, body RequestUserAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestUserAccessTokenResponse, error)
 }
 
 type IntrospectAccessTokenResponse struct {
@@ -1472,16 +1472,16 @@ func (c *ClientWithResponses) CreateDPoPProofWithResponse(ctx context.Context, d
 }
 
 // RequestOpenid4VCICredentialIssuanceWithBodyWithResponse request with arbitrary body returning *RequestOpenid4VCICredentialIssuanceResponse
-func (c *ClientWithResponses) RequestOpenid4VCICredentialIssuanceWithBodyWithResponse(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestOpenid4VCICredentialIssuanceResponse, error) {
-	rsp, err := c.RequestOpenid4VCICredentialIssuanceWithBody(ctx, did, contentType, body, reqEditors...)
+func (c *ClientWithResponses) RequestOpenid4VCICredentialIssuanceWithBodyWithResponse(ctx context.Context, subject string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestOpenid4VCICredentialIssuanceResponse, error) {
+	rsp, err := c.RequestOpenid4VCICredentialIssuanceWithBody(ctx, subject, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseRequestOpenid4VCICredentialIssuanceResponse(rsp)
 }
 
-func (c *ClientWithResponses) RequestOpenid4VCICredentialIssuanceWithResponse(ctx context.Context, did string, body RequestOpenid4VCICredentialIssuanceJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestOpenid4VCICredentialIssuanceResponse, error) {
-	rsp, err := c.RequestOpenid4VCICredentialIssuance(ctx, did, body, reqEditors...)
+func (c *ClientWithResponses) RequestOpenid4VCICredentialIssuanceWithResponse(ctx context.Context, subject string, body RequestOpenid4VCICredentialIssuanceJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestOpenid4VCICredentialIssuanceResponse, error) {
+	rsp, err := c.RequestOpenid4VCICredentialIssuance(ctx, subject, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -1489,16 +1489,16 @@ func (c *ClientWithResponses) RequestOpenid4VCICredentialIssuanceWithResponse(ct
 }
 
 // RequestServiceAccessTokenWithBodyWithResponse request with arbitrary body returning *RequestServiceAccessTokenResponse
-func (c *ClientWithResponses) RequestServiceAccessTokenWithBodyWithResponse(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error) {
-	rsp, err := c.RequestServiceAccessTokenWithBody(ctx, did, contentType, body, reqEditors...)
+func (c *ClientWithResponses) RequestServiceAccessTokenWithBodyWithResponse(ctx context.Context, subject string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error) {
+	rsp, err := c.RequestServiceAccessTokenWithBody(ctx, subject, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseRequestServiceAccessTokenResponse(rsp)
 }
 
-func (c *ClientWithResponses) RequestServiceAccessTokenWithResponse(ctx context.Context, did string, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error) {
-	rsp, err := c.RequestServiceAccessToken(ctx, did, body, reqEditors...)
+func (c *ClientWithResponses) RequestServiceAccessTokenWithResponse(ctx context.Context, subject string, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error) {
+	rsp, err := c.RequestServiceAccessToken(ctx, subject, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -1506,16 +1506,16 @@ func (c *ClientWithResponses) RequestServiceAccessTokenWithResponse(ctx context.
 }
 
 // RequestUserAccessTokenWithBodyWithResponse request with arbitrary body returning *RequestUserAccessTokenResponse
-func (c *ClientWithResponses) RequestUserAccessTokenWithBodyWithResponse(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestUserAccessTokenResponse, error) {
-	rsp, err := c.RequestUserAccessTokenWithBody(ctx, did, contentType, body, reqEditors...)
+func (c *ClientWithResponses) RequestUserAccessTokenWithBodyWithResponse(ctx context.Context, subject string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestUserAccessTokenResponse, error) {
+	rsp, err := c.RequestUserAccessTokenWithBody(ctx, subject, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseRequestUserAccessTokenResponse(rsp)
 }
 
-func (c *ClientWithResponses) RequestUserAccessTokenWithResponse(ctx context.Context, did string, body RequestUserAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestUserAccessTokenResponse, error) {
-	rsp, err := c.RequestUserAccessToken(ctx, did, body, reqEditors...)
+func (c *ClientWithResponses) RequestUserAccessTokenWithResponse(ctx context.Context, subject string, body RequestUserAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestUserAccessTokenResponse, error) {
+	rsp, err := c.RequestUserAccessToken(ctx, subject, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/http/user/session_test.go
+++ b/http/user/session_test.go
@@ -76,12 +76,12 @@ func TestMiddleware_Handle(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.NotNil(t, capturedSession)
-		assert.Equal(t, tenantDID, capturedSession.TenantDID)
+		assert.Equal(t, tenantDID, capturedSession.SubjectID)
 		// Assert stored session
 		var storedSession = new(Session)
 		cookie := httpResponse.Result().Cookies()[0]
 		require.NoError(t, sessionStore.Get(cookie.Value, storedSession))
-		assert.Equal(t, tenantDID, storedSession.TenantDID)
+		assert.Equal(t, tenantDID, storedSession.SubjectID)
 		assert.NotNil(t, capturedSession.Save)
 	})
 	t.Run("ok - existing session", func(t *testing.T) {
@@ -104,7 +104,7 @@ func TestMiddleware_Handle(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.NotNil(t, capturedSession)
-		assert.Equal(t, expected.TenantDID, capturedSession.TenantDID)
+		assert.Equal(t, expected.SubjectID, capturedSession.SubjectID)
 		assert.NotNil(t, capturedSession.Save)
 		// Make sure no new cookie is set, which indicates session creation
 		assert.Empty(t, httpResponse.Result().Cookies())
@@ -174,7 +174,7 @@ func TestMiddleware_Handle(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.NotNil(t, capturedSession)
-		assert.Equal(t, tenantDID, capturedSession.TenantDID)
+		assert.Equal(t, tenantDID, capturedSession.SubjectID)
 		// Assert stored session
 		assert.Len(t, httpResponse.Result().Cookies(), 1)
 	})
@@ -188,7 +188,7 @@ func TestMiddleware_loadUserSession(t *testing.T) {
 
 		actualID, actualData, err := instance.loadUserSession((*testCookieReader)(&sessionCookie), tenantDID)
 		require.NoError(t, err)
-		assert.Equal(t, expected.TenantDID, actualData.TenantDID)
+		assert.Equal(t, expected.SubjectID, actualData.SubjectID)
 		assert.Equal(t, sessionCookie.Value, actualID)
 	})
 	t.Run("error - no session cookie", func(t *testing.T) {
@@ -210,7 +210,7 @@ func TestMiddleware_loadUserSession(t *testing.T) {
 	t.Run("error - session belongs to a different tenant", func(t *testing.T) {
 		instance, sessionStore := createInstance(t)
 		expected, _ := createUserSession(tenantDID, time.Hour)
-		expected.TenantDID = did.MustParseDID("did:web:someone-else")
+		expected.SubjectID = did.MustParseDID("did:web:someone-else")
 		_ = sessionStore.Put(sessionCookie.Value, expected)
 
 		_, actual, err := instance.loadUserSession((*testCookieReader)(&sessionCookie), tenantDID)
@@ -221,7 +221,7 @@ func TestMiddleware_loadUserSession(t *testing.T) {
 	t.Run("error - expired", func(t *testing.T) {
 		instance, sessionStore := createInstance(t)
 		expected := Session{
-			TenantDID: tenantDID,
+			SubjectID: tenantDID,
 			Wallet: Wallet{
 				DID: userDID,
 			},

--- a/http/user/test.go
+++ b/http/user/test.go
@@ -20,12 +20,11 @@ package user
 
 import (
 	"context"
-	"github.com/nuts-foundation/go-did/did"
 	"time"
 )
 
-func CreateTestSession(ctx context.Context, tenantDID did.DID) (context.Context, *Session) {
-	session, _ := createUserSession(tenantDID, time.Hour)
+func CreateTestSession(ctx context.Context, subjectID string) (context.Context, *Session) {
+	session, _ := createUserSession(subjectID, time.Hour)
 	session.Save = func() error {
 		return nil
 	}

--- a/vdr/interface.go
+++ b/vdr/interface.go
@@ -27,6 +27,7 @@ import (
 
 // VDR defines the public end facing methods for the Verifiable Data Registry.
 type VDR interface {
+	didsubject.SubjectManager
 	// NutsDocumentManager returns the nuts document manager.
 	NutsDocumentManager() didsubject.DocumentManager
 	// DocumentOwner returns the document owner.

--- a/vdr/mock.go
+++ b/vdr/mock.go
@@ -10,10 +10,13 @@
 package vdr
 
 import (
+	context "context"
 	url "net/url"
 	reflect "reflect"
 
+	ssi "github.com/nuts-foundation/go-did"
 	did "github.com/nuts-foundation/go-did/did"
+	orm "github.com/nuts-foundation/nuts-node/storage/orm"
 	didsubject "github.com/nuts-foundation/nuts-node/vdr/didsubject"
 	resolver "github.com/nuts-foundation/nuts-node/vdr/resolver"
 	gomock "go.uber.org/mock/gomock"
@@ -42,6 +45,21 @@ func (m *MockVDR) EXPECT() *MockVDRMockRecorder {
 	return m.recorder
 }
 
+// AddVerificationMethod mocks base method.
+func (m *MockVDR) AddVerificationMethod(ctx context.Context, subject string, keyUsage orm.DIDKeyFlags) ([]did.VerificationMethod, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddVerificationMethod", ctx, subject, keyUsage)
+	ret0, _ := ret[0].([]did.VerificationMethod)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddVerificationMethod indicates an expected call of AddVerificationMethod.
+func (mr *MockVDRMockRecorder) AddVerificationMethod(ctx, subject, keyUsage any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddVerificationMethod", reflect.TypeOf((*MockVDR)(nil).AddVerificationMethod), ctx, subject, keyUsage)
+}
+
 // ConflictedDocuments mocks base method.
 func (m *MockVDR) ConflictedDocuments() ([]did.Document, []resolver.DocumentMetadata, error) {
 	m.ctrl.T.Helper()
@@ -58,6 +76,65 @@ func (mr *MockVDRMockRecorder) ConflictedDocuments() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConflictedDocuments", reflect.TypeOf((*MockVDR)(nil).ConflictedDocuments))
 }
 
+// Create mocks base method.
+func (m *MockVDR) Create(ctx context.Context, options didsubject.CreationOptions) ([]did.Document, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, options)
+	ret0, _ := ret[0].([]did.Document)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockVDRMockRecorder) Create(ctx, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockVDR)(nil).Create), ctx, options)
+}
+
+// CreateService mocks base method.
+func (m *MockVDR) CreateService(ctx context.Context, subject string, service did.Service) ([]did.Service, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateService", ctx, subject, service)
+	ret0, _ := ret[0].([]did.Service)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateService indicates an expected call of CreateService.
+func (mr *MockVDRMockRecorder) CreateService(ctx, subject, service any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateService", reflect.TypeOf((*MockVDR)(nil).CreateService), ctx, subject, service)
+}
+
+// Deactivate mocks base method.
+func (m *MockVDR) Deactivate(ctx context.Context, subject string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Deactivate", ctx, subject)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Deactivate indicates an expected call of Deactivate.
+func (mr *MockVDRMockRecorder) Deactivate(ctx, subject any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deactivate", reflect.TypeOf((*MockVDR)(nil).Deactivate), ctx, subject)
+}
+
+// DeleteService mocks base method.
+func (m *MockVDR) DeleteService(ctx context.Context, subject string, serviceID ssi.URI) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteService", ctx, subject, serviceID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteService indicates an expected call of DeleteService.
+func (mr *MockVDRMockRecorder) DeleteService(ctx, subject, serviceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteService", reflect.TypeOf((*MockVDR)(nil).DeleteService), ctx, subject, serviceID)
+}
+
 // DocumentOwner mocks base method.
 func (m *MockVDR) DocumentOwner() didsubject.DocumentOwner {
 	m.ctrl.T.Helper()
@@ -70,6 +147,36 @@ func (m *MockVDR) DocumentOwner() didsubject.DocumentOwner {
 func (mr *MockVDRMockRecorder) DocumentOwner() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DocumentOwner", reflect.TypeOf((*MockVDR)(nil).DocumentOwner))
+}
+
+// FindServices mocks base method.
+func (m *MockVDR) FindServices(ctx context.Context, subject string, serviceType *string) ([]did.Service, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindServices", ctx, subject, serviceType)
+	ret0, _ := ret[0].([]did.Service)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindServices indicates an expected call of FindServices.
+func (mr *MockVDRMockRecorder) FindServices(ctx, subject, serviceType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindServices", reflect.TypeOf((*MockVDR)(nil).FindServices), ctx, subject, serviceType)
+}
+
+// List mocks base method.
+func (m *MockVDR) List(ctx context.Context, subject string) ([]did.DID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List", ctx, subject)
+	ret0, _ := ret[0].([]did.DID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List.
+func (mr *MockVDRMockRecorder) List(ctx, subject any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockVDR)(nil).List), ctx, subject)
 }
 
 // NutsDocumentManager mocks base method.
@@ -141,4 +248,19 @@ func (m *MockVDR) SupportedMethods() []string {
 func (mr *MockVDRMockRecorder) SupportedMethods() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedMethods", reflect.TypeOf((*MockVDR)(nil).SupportedMethods))
+}
+
+// UpdateService mocks base method.
+func (m *MockVDR) UpdateService(ctx context.Context, subject string, serviceID ssi.URI, service did.Service) ([]did.Service, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateService", ctx, subject, serviceID, service)
+	ret0, _ := ret[0].([]did.Service)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateService indicates an expected call of UpdateService.
+func (mr *MockVDRMockRecorder) UpdateService(ctx, subject, serviceID, service any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateService", reflect.TypeOf((*MockVDR)(nil).UpdateService), ctx, subject, serviceID, service)
 }


### PR DESCRIPTION
Fixes https://github.com/nuts-foundation/nuts-node/issues/3262

TODO:
- [ ] Move `selectDID()`, which's result is used to construct redirect URLs, to service/business layer (instead of API), e.g. by checking the Presentation Definition.
- [ ] Re-enable disabled user session checks (search for `#3264`)