### PR TITLE
change SignJWS and SignJWT signatures

### DIFF
--- a/auth/api/iam/dpop_test.go
+++ b/auth/api/iam/dpop_test.go
@@ -25,6 +25,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/base64"
+	"github.com/nuts-foundation/nuts-node/crypto/storage/spi"
 	"net/http"
 	"testing"
 
@@ -32,7 +33,6 @@ import (
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
-	cryptoNuts "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/crypto/dpop"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,7 +53,7 @@ func TestWrapper_CreateDPoPProof(t *testing.T) {
 	}
 	didDocument := did.Document{ID: holderDID}
 	vmId := did.MustParseDIDURL(webDID.String() + "#key1")
-	key := cryptoNuts.NewTestKey(vmId.String())
+	key, _ := spi.GenerateKeyPair()
 	vm, _ := did.NewVerificationMethod(vmId, ssi.JsonWebKey2020, webDID, key.Public())
 	didDocument.AddAssertionMethod(vm)
 	dpopToken := dpop.New(*request)

--- a/auth/api/iam/user_test.go
+++ b/auth/api/iam/user_test.go
@@ -21,6 +21,7 @@ package iam
 import (
 	"context"
 	"github.com/nuts-foundation/nuts-node/audit"
+	"github.com/nuts-foundation/nuts-node/crypto/storage/spi"
 	"github.com/nuts-foundation/nuts-node/http/user"
 	"net/http"
 	"strings"
@@ -33,7 +34,6 @@ import (
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
-	cryptoNuts "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/mock"
 	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/nuts-foundation/nuts-node/vcr/issuer"
@@ -78,7 +78,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 		Fragment:        "key",
 		DecodedFragment: "key",
 	}
-	key := cryptoNuts.NewTestKey(vmId.String())
+	key, _ := spi.GenerateKeyPair()
 	didDocument := did.Document{ID: walletDID}
 	vm, _ := did.NewVerificationMethod(vmId, ssi.JsonWebKey2020, did.DID{}, key.Public())
 	didDocument.AddAssertionMethod(vm)

--- a/auth/services/selfsigned/test/generate_test.go
+++ b/auth/services/selfsigned/test/generate_test.go
@@ -47,13 +47,10 @@ func Test_GenerateTestData(t *testing.T) {
 	require.NoError(t, err)
 	privateKey, err := util.PemToPrivateKey(privateKeyData)
 	require.NoError(t, err)
-	key := crypto.TestKey{
-		PrivateKey: privateKey,
-		Kid:        keyID,
-	}
+
 	cryptoStorage := crypto.NewMemoryStorage()
 	cryptoInstance := crypto.NewTestCryptoInstance(cryptoStorage)
-	err = cryptoStorage.SavePrivateKey(context.Background(), keyID, key.PrivateKey)
+	err = cryptoStorage.SavePrivateKey(context.Background(), keyID, privateKey)
 	require.NoError(t, err)
 
 	jws2020 := signature.JSONWebSignature2020{ContextLoader: contextLoader, Signer: cryptoInstance}

--- a/crypto/interface.go
+++ b/crypto/interface.go
@@ -75,16 +75,16 @@ type Decrypter interface {
 // JWTSigner is the interface used to sign authorization tokens.
 type JWTSigner interface {
 	// SignJWT creates a signed JWT using the indicated key and map of claims and additional headers.
-	// The key can be its KID (key ID) or an instance of Key, the context is used to pass audit information.
+	// The KID is the external facing Key ID (eg: from the DID Document). the context is used to pass audit information.
 	// The headers can be used to add/override headers in the JWT.
 	// Returns ErrPrivateKeyNotFound when the private key is not present.
-	SignJWT(ctx context.Context, claims map[string]interface{}, headers map[string]interface{}, key interface{}) (string, error)
+	SignJWT(ctx context.Context, claims map[string]interface{}, headers map[string]interface{}, kid string) (string, error)
 	// SignJWS creates a signed JWS using the indicated key and map of headers and payload as bytes.
 	// The detached boolean indicates if the body needs to be excluded from the response (detached mode).
-	// The key can be its KID (key ID) or an instance of Key,
+	// The KID is the external facing Key ID (eg: from the DID Document).
 	// context is used to pass audit information.
 	// Returns ErrPrivateKeyNotFound when the private key is not present.
-	SignJWS(ctx context.Context, payload []byte, headers map[string]interface{}, key interface{}, detached bool) (string, error)
+	SignJWS(ctx context.Context, payload []byte, headers map[string]interface{}, kid string, detached bool) (string, error)
 	// SignDPoP signs a DPoP token for the given kid.
 	// It adds the requested key as jwk header to the DPoP token.
 	SignDPoP(ctx context.Context, token dpop.DPoP, kid string) (string, error)

--- a/crypto/memory.go
+++ b/crypto/memory.go
@@ -37,16 +37,12 @@ type MemoryJWTSigner struct {
 	Key jwk.Key
 }
 
-func (m MemoryJWTSigner) SignJWT(_ context.Context, claims map[string]interface{}, headers map[string]interface{}, rawKey interface{}) (string, error) {
+func (m MemoryJWTSigner) SignJWT(ctx context.Context, claims map[string]interface{}, headers map[string]interface{}, kid string) (string, error) {
 	// copy headers so we don't change the input
 	headersLocal := make(map[string]interface{})
 	maps.Copy(headersLocal, headers)
 
-	keyID, ok := rawKey.(string)
-	if !ok {
-		return "", errors.New("key should be string (key ID)")
-	}
-	if keyID != m.Key.KeyID() {
+	if kid != m.Key.KeyID() {
 		return "", ErrPrivateKeyNotFound
 	}
 	var signer crypto.Signer
@@ -58,11 +54,11 @@ func (m MemoryJWTSigner) SignJWT(_ context.Context, claims map[string]interface{
 		return "", err
 	}
 
-	headersLocal["kid"] = keyID
-	return signJWT(signer, alg, claims, headersLocal)
+	headersLocal["kid"] = kid
+	return SignJWT(ctx, signer, alg, claims, headersLocal)
 }
 
-func (m MemoryJWTSigner) SignJWS(_ context.Context, _ []byte, _ map[string]interface{}, _ interface{}, _ bool) (string, error) {
+func (m MemoryJWTSigner) SignJWS(_ context.Context, _ []byte, _ map[string]interface{}, _ string, _ bool) (string, error) {
 	return "", errNotSupportedForInMemoryKeyStore
 }
 

--- a/crypto/memory_test.go
+++ b/crypto/memory_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"github.com/nuts-foundation/nuts-node/audit"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -30,7 +31,7 @@ import (
 )
 
 func TestMemoryKeyStore_SignJWS(t *testing.T) {
-	_, err := MemoryJWTSigner{}.SignJWS(context.Background(), nil, nil, nil, false)
+	_, err := MemoryJWTSigner{}.SignJWS(context.Background(), nil, nil, "", false)
 	assert.ErrorIs(t, err, errNotSupportedForInMemoryKeyStore)
 }
 
@@ -44,14 +45,14 @@ func TestMemoryKeyStore_SignJWT(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		signedJWT, err := MemoryJWTSigner{
 			Key: privateKeyJWK,
-		}.SignJWT(context.Background(), nil, nil, "123")
+		}.SignJWT(audit.TestContext(), nil, nil, "123")
 		assert.NoError(t, err)
 		assert.NotEmpty(t, signedJWT)
 	})
 	t.Run("unknown key", func(t *testing.T) {
 		_, err := MemoryJWTSigner{
 			Key: privateKeyJWK,
-		}.SignJWT(context.Background(), nil, nil, "456")
+		}.SignJWT(audit.TestContext(), nil, nil, "456")
 		assert.ErrorIs(t, err, ErrPrivateKeyNotFound)
 	})
 }

--- a/crypto/mock.go
+++ b/crypto/mock.go
@@ -281,33 +281,33 @@ func (mr *MockKeyStoreMockRecorder) SignDPoP(ctx, token, kid any) *gomock.Call {
 }
 
 // SignJWS mocks base method.
-func (m *MockKeyStore) SignJWS(ctx context.Context, payload []byte, headers map[string]any, key any, detached bool) (string, error) {
+func (m *MockKeyStore) SignJWS(ctx context.Context, payload []byte, headers map[string]any, kid string, detached bool) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SignJWS", ctx, payload, headers, key, detached)
+	ret := m.ctrl.Call(m, "SignJWS", ctx, payload, headers, kid, detached)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SignJWS indicates an expected call of SignJWS.
-func (mr *MockKeyStoreMockRecorder) SignJWS(ctx, payload, headers, key, detached any) *gomock.Call {
+func (mr *MockKeyStoreMockRecorder) SignJWS(ctx, payload, headers, kid, detached any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWS", reflect.TypeOf((*MockKeyStore)(nil).SignJWS), ctx, payload, headers, key, detached)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWS", reflect.TypeOf((*MockKeyStore)(nil).SignJWS), ctx, payload, headers, kid, detached)
 }
 
 // SignJWT mocks base method.
-func (m *MockKeyStore) SignJWT(ctx context.Context, claims, headers map[string]any, key any) (string, error) {
+func (m *MockKeyStore) SignJWT(ctx context.Context, claims, headers map[string]any, kid string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SignJWT", ctx, claims, headers, key)
+	ret := m.ctrl.Call(m, "SignJWT", ctx, claims, headers, kid)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SignJWT indicates an expected call of SignJWT.
-func (mr *MockKeyStoreMockRecorder) SignJWT(ctx, claims, headers, key any) *gomock.Call {
+func (mr *MockKeyStoreMockRecorder) SignJWT(ctx, claims, headers, kid any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWT", reflect.TypeOf((*MockKeyStore)(nil).SignJWT), ctx, claims, headers, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWT", reflect.TypeOf((*MockKeyStore)(nil).SignJWT), ctx, claims, headers, kid)
 }
 
 // MockDecrypter is a mock of Decrypter interface.
@@ -387,33 +387,33 @@ func (mr *MockJWTSignerMockRecorder) SignDPoP(ctx, token, kid any) *gomock.Call 
 }
 
 // SignJWS mocks base method.
-func (m *MockJWTSigner) SignJWS(ctx context.Context, payload []byte, headers map[string]any, key any, detached bool) (string, error) {
+func (m *MockJWTSigner) SignJWS(ctx context.Context, payload []byte, headers map[string]any, kid string, detached bool) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SignJWS", ctx, payload, headers, key, detached)
+	ret := m.ctrl.Call(m, "SignJWS", ctx, payload, headers, kid, detached)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SignJWS indicates an expected call of SignJWS.
-func (mr *MockJWTSignerMockRecorder) SignJWS(ctx, payload, headers, key, detached any) *gomock.Call {
+func (mr *MockJWTSignerMockRecorder) SignJWS(ctx, payload, headers, kid, detached any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWS", reflect.TypeOf((*MockJWTSigner)(nil).SignJWS), ctx, payload, headers, key, detached)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWS", reflect.TypeOf((*MockJWTSigner)(nil).SignJWS), ctx, payload, headers, kid, detached)
 }
 
 // SignJWT mocks base method.
-func (m *MockJWTSigner) SignJWT(ctx context.Context, claims, headers map[string]any, key any) (string, error) {
+func (m *MockJWTSigner) SignJWT(ctx context.Context, claims, headers map[string]any, kid string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SignJWT", ctx, claims, headers, key)
+	ret := m.ctrl.Call(m, "SignJWT", ctx, claims, headers, kid)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SignJWT indicates an expected call of SignJWT.
-func (mr *MockJWTSignerMockRecorder) SignJWT(ctx, claims, headers, key any) *gomock.Call {
+func (mr *MockJWTSignerMockRecorder) SignJWT(ctx, claims, headers, kid any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWT", reflect.TypeOf((*MockJWTSigner)(nil).SignJWT), ctx, claims, headers, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWT", reflect.TypeOf((*MockJWTSigner)(nil).SignJWT), ctx, claims, headers, kid)
 }
 
 // MockJsonWebEncryptor is a mock of JsonWebEncryptor interface.

--- a/crypto/test.go
+++ b/crypto/test.go
@@ -106,6 +106,7 @@ func (m memoryStorage) SavePrivateKey(_ context.Context, kid string, key crypto.
 	return nil
 }
 
+// NewTestKey creates a new TestKey with a given kid
 func NewTestKey(kid string) *TestKey {
 	key, err := NewEphemeralKey(func(key crypto.PublicKey) (string, error) {
 		return kid, nil
@@ -139,26 +140,4 @@ func (t TestKey) Public() crypto.PublicKey {
 
 func (t TestKey) Private() crypto.PrivateKey {
 	return t.PrivateKey
-}
-
-// TestPublicKey is a Key impl for testing purposes that only contains a public key. It can't be used for signing.
-type TestPublicKey struct {
-	Kid       string
-	PublicKey crypto.PublicKey
-}
-
-func (t TestPublicKey) Signer() crypto.Signer {
-	panic("test public key is not for signing")
-}
-
-func (t TestPublicKey) KID() string {
-	return t.Kid
-}
-
-func (t TestPublicKey) Public() crypto.PublicKey {
-	return t.PublicKey
-}
-
-func (t TestPublicKey) Private() crypto.PrivateKey {
-	panic("test public key is not for signing")
 }

--- a/e2e-tests/oauth-flow/rfc021/sqlserver.yml
+++ b/e2e-tests/oauth-flow/rfc021/sqlserver.yml
@@ -13,7 +13,8 @@ services:
       NUTS_STORAGE_SQL_CONNECTION: sqlserver://sa:MyStrong(!)Password@db:1433?database=node_b
   db:
     # image: mcr.microsoft.com/azure-sql-edge:latest <-- "The sqlcmd utility is not included in the ARM64 version of the SQL Edge container" - https://github.com/microsoft/mssql-docker/issues/734
-    image: mcr.microsoft.com/mssql/server:2022-latest
+    # image mcr.microsoft.com/mssql/server:2022-latest <-- They broke the sqlcmd path - https://github.com/microsoft/mssql-docker/issues/892
+    image: mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04
     restart: always
     ports:
       - "1433:1433"

--- a/network/dag/signing.go
+++ b/network/dag/signing.go
@@ -97,8 +97,7 @@ func (d transactionSigner) Sign(ctx context.Context, input UnsignedTransaction, 
 	} else {
 		headerMap[jws.KeyIDKey] = d.key.KID()
 	}
-
-	data, err := d.signer.SignJWS(ctx, []byte(input.PayloadHash().String()), headerMap, d.key, false)
+	data, err := d.signer.SignJWS(ctx, []byte(input.PayloadHash().String()), headerMap, d.key.KID(), false)
 	if err != nil {
 		return nil, fmt.Errorf(errSigningTransactionFmt, err)
 	}

--- a/network/dag/signing_test.go
+++ b/network/dag/signing_test.go
@@ -19,8 +19,6 @@
 package dag
 
 import (
-	"crypto/sha1"
-	"encoding/base32"
 	"github.com/nuts-foundation/nuts-node/audit"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -34,9 +32,6 @@ import (
 
 func TestTransactionSigner(t *testing.T) {
 	payloadHash, _ := hash2.ParseHex("452d9e89d5bd5d9225fb6daecd579e7388a166c7661ca04e47fd3cd8446e4620")
-	key := generateKey()
-	kidAsArray := sha1.Sum(key.X.Bytes())
-	kid := base32.HexEncoding.EncodeToString(kidAsArray[:])
 	prev1, _ := hash2.ParseHex("3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986")
 	prev2, _ := hash2.ParseHex("b3f2c3c396da1a949d214e4c2fe0fc9fb5f2a68ff1860df4ef10c9835e62e7c1")
 	expectedPrevs := []hash2.SHA256Hash{prev1, prev2}
@@ -44,11 +39,11 @@ func TestTransactionSigner(t *testing.T) {
 	moment := time.Date(2020, 10, 23, 13, 0, 0, 0, time.FixedZone("test", 1))
 	jwxSigner := crypto.NewMemoryCryptoInstance()
 	ctx := audit.TestContext()
+	key, _ := jwxSigner.New(ctx, crypto.StringNamingFunc("kid"))
 	t.Run("ok - attach key", func(t *testing.T) {
 		tx, err := NewTransaction(payloadHash, contentType, expectedPrevs, nil, 0)
 		require.NoError(t, err)
 
-		key := crypto.NewTestKey(kid)
 		signedTx, err := NewTransactionSigner(jwxSigner, key, true).Sign(ctx, tx, moment)
 		require.NoError(t, err)
 		// JWS headers
@@ -70,22 +65,21 @@ func TestTransactionSigner(t *testing.T) {
 		tx, err := NewTransaction(payloadHash, contentType, expectedPrevs, nil, 0)
 		require.NoError(t, err)
 
-		key := crypto.NewTestKey(kid)
 		signedTx, err := NewTransactionSigner(jwxSigner, key, false).Sign(ctx, tx, moment)
 		require.NoError(t, err)
-		assert.Equal(t, kid, signedTx.SigningKeyID())
+		assert.Equal(t, "kid", signedTx.SigningKeyID())
 		assert.Nil(t, signedTx.SigningKey())
 		assert.NotEmpty(t, signedTx.Data())
 	})
 	t.Run("signing time is zero", func(t *testing.T) {
 		tx, _ := NewTransaction(payloadHash, contentType, expectedPrevs, nil, 0)
-		signedTransaction, err := NewTransactionSigner(jwxSigner, crypto.NewTestKey(kid), false).Sign(ctx, tx, time.Time{})
+		signedTransaction, err := NewTransactionSigner(jwxSigner, key, false).Sign(ctx, tx, time.Time{})
 		assert.Empty(t, signedTransaction)
 		assert.EqualError(t, err, "signing time is zero")
 	})
 	t.Run("already signed", func(t *testing.T) {
 		tx, _ := NewTransaction(payloadHash, contentType, expectedPrevs, nil, 0)
-		signer := NewTransactionSigner(jwxSigner, crypto.NewTestKey(kid), false)
+		signer := NewTransactionSigner(jwxSigner, key, false)
 		signedTransaction, _ := signer.Sign(ctx, tx, time.Now())
 		signedTransaction2, err := signer.Sign(ctx, signedTransaction, time.Now())
 		assert.Nil(t, signedTransaction2)

--- a/network/dag/test.go
+++ b/network/dag/test.go
@@ -50,8 +50,9 @@ func CreateSignedTestTransaction(payloadNum uint32, signingTime time.Time, pal [
 	lamportClock := calculateLamportClock(prevs)
 	unsignedTransaction, _ := NewTransaction(payloadHash, payloadType, prevHashes(prevs), pal, lamportClock)
 
-	key := nutsCrypto.NewTestKey(fmt.Sprintf("%d", payloadNum))
+	kid := fmt.Sprintf("%d", payloadNum)
 	cryptoInstance := nutsCrypto.NewMemoryCryptoInstance()
+	key, _ := cryptoInstance.New(audit.TestContext(), nutsCrypto.StringNamingFunc(kid))
 	signedTransaction, err := NewTransactionSigner(cryptoInstance, key, attach).Sign(audit.TestContext(), unsignedTransaction, signingTime)
 	if err != nil {
 		panic(err)
@@ -65,8 +66,8 @@ func CreateTestTransactionEx(num uint32, payloadHash hash.SHA256Hash, participan
 	lamportClock := calculateLamportClock(prevs)
 	unsignedTransaction, _ := NewTransaction(payloadHash, "application/did+json", prevHashes(prevs), participants, lamportClock)
 	kid := fmt.Sprintf("%d", num)
-	key := nutsCrypto.NewTestKey(kid)
 	cryptoInstance := nutsCrypto.NewMemoryCryptoInstance()
+	key, _ := cryptoInstance.New(audit.TestContext(), nutsCrypto.StringNamingFunc(kid))
 	signedTransaction, err := NewTransactionSigner(cryptoInstance, key, false).Sign(audit.TestContext(), unsignedTransaction, time.Now())
 	if err != nil {
 		panic(err)

--- a/network/dag/verifier_test.go
+++ b/network/dag/verifier_test.go
@@ -73,8 +73,9 @@ func Test_PrevTransactionVerifier(t *testing.T) {
 
 		// malformed TX with LC = 2
 		unsignedTransaction, _ := NewTransaction(hash.EmptyHash(), "application/did+json", []hash.SHA256Hash{root.Ref()}, nil, 2)
-		signer := nutsCrypto.NewTestKey("1")
-		signedTransaction, _ := NewTransactionSigner(nutsCrypto.NewMemoryCryptoInstance(), signer, true).Sign(audit.TestContext(), unsignedTransaction, time.Now())
+		cryptoInstance := nutsCrypto.NewMemoryCryptoInstance()
+		key, _ := cryptoInstance.New(audit.TestContext(), nutsCrypto.StringNamingFunc("key"))
+		signedTransaction, _ := NewTransactionSigner(cryptoInstance, key, true).Sign(audit.TestContext(), unsignedTransaction, time.Now())
 
 		_ = testState.db.Read(ctx, func(dbTx stoabs.ReadTx) error {
 			err := NewPrevTransactionsVerifier()(dbTx, signedTransaction)

--- a/vcr/ambassador_test.go
+++ b/vcr/ambassador_test.go
@@ -113,7 +113,7 @@ func TestAmbassador_handleReprocessEvent(t *testing.T) {
 	// load key
 	pem, _ := os.ReadFile("test/private.pem")
 	signer, _ := util.PemToPrivateKey(pem)
-	key := crypto.NewTestKey(fmt.Sprintf("%s#1", vc.Issuer.String()))
+	key, _ := ctx.crypto.New(audit.TestContext(), crypto.StringNamingFunc(fmt.Sprintf("%s#1", vc.Issuer.String())))
 
 	// trust otherwise Resolve won't work
 	ctx.vcr.Trust(vc.Type[0], vc.Issuer)

--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -257,7 +257,7 @@ func (i issuer) buildAndSignVC(ctx context.Context, template vc.VerifiableCreden
 	switch options.Format {
 	case vc.JWTCredentialProofFormat:
 		return vc.CreateJWTVerifiableCredential(ctx, unsignedCredential, func(ctx context.Context, claims map[string]interface{}, headers map[string]interface{}) (string, error) {
-			return i.keyStore.SignJWT(ctx, claims, headers, key)
+			return i.keyStore.SignJWT(ctx, claims, headers, key.KID())
 		})
 	case "":
 		fallthrough

--- a/vcr/issuer/openid_test.go
+++ b/vcr/issuer/openid_test.go
@@ -139,7 +139,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 		}
 	}
 	createRequest := func(headers, claims map[string]interface{}) openid4vci.CredentialRequest {
-		proof, err := keyStore.SignJWT(ctx, claims, headers, headers["kid"])
+		proof, err := keyStore.SignJWT(ctx, claims, headers, headers["kid"].(string))
 		require.NoError(t, err)
 		return openid4vci.CredentialRequest{
 			Format: vc.JSONLDCredentialProofFormat,

--- a/vcr/verifier/signature_verifier_test.go
+++ b/vcr/verifier/signature_verifier_test.go
@@ -89,7 +89,7 @@ func TestSignatureVerifier_VerifySignature(t *testing.T) {
 		template.Issuer = did.MustParseDIDURL(key.KID()).DID.URI()
 
 		cred, err := vc.CreateJWTVerifiableCredential(audit.TestContext(), template, func(ctx context.Context, claims map[string]interface{}, headers map[string]interface{}) (string, error) {
-			return keyStore.SignJWT(ctx, claims, headers, key)
+			return keyStore.SignJWT(ctx, claims, headers, key.KID())
 		})
 		require.NoError(t, err)
 
@@ -104,7 +104,7 @@ func TestSignatureVerifier_VerifySignature(t *testing.T) {
 			sv, mockKeyResolver := signatureVerifierTestSetup(t)
 
 			cred, err := vc.CreateJWTVerifiableCredential(audit.TestContext(), template, func(ctx context.Context, claims map[string]interface{}, headers map[string]interface{}) (string, error) {
-				return keyStore.SignJWT(ctx, claims, headers, key)
+				return keyStore.SignJWT(ctx, claims, headers, key.KID())
 			})
 			require.NoError(t, err)
 			cred.Issuer = ssi.MustParseURI("did:example:test")

--- a/vcr/verifier/verifier_test.go
+++ b/vcr/verifier/verifier_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/nuts-foundation/nuts-node/crypto/storage/spi"
 	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/nuts-foundation/nuts-node/vcr/revocation"
 	"github.com/nuts-foundation/nuts-node/vcr/test"
@@ -378,7 +379,7 @@ func Test_verifier_CheckAndStoreRevocation(t *testing.T) {
 
 	t.Run("it handles an invalid signature error", func(t *testing.T) {
 		sut := newMockContext(t)
-		otherKey := crypto.NewTestKey("did:nuts:123#abc").Public()
+		otherKey, _ := spi.GenerateKeyPair()
 		sut.keyResolver.EXPECT().ResolveKeyByID(revocation.Proof.VerificationMethod.String(), &revocation.Date, resolver.NutsSigningKeyType).Return(otherKey, nil)
 		err := sut.verifier.RegisterRevocation(revocation)
 		assert.EqualError(t, err, "unable to verify revocation signature: invalid proof signature: failed to verify signature using ecdsa")

--- a/vdr/didnuts/ambassador_test.go
+++ b/vdr/didnuts/ambassador_test.go
@@ -90,11 +90,11 @@ func (m *mockKeyStore) List(ctx context.Context) []string {
 	panic("not implemented")
 }
 
-func (m *mockKeyStore) SignJWT(ctx context.Context, claims map[string]interface{}, headers map[string]interface{}, key interface{}) (string, error) {
+func (m *mockKeyStore) SignJWT(ctx context.Context, claims map[string]interface{}, headers map[string]interface{}, kid string) (string, error) {
 	panic("not implemented")
 }
 
-func (m *mockKeyStore) SignJWS(ctx context.Context, payload []byte, headers map[string]interface{}, key interface{}, detached bool) (string, error) {
+func (m *mockKeyStore) SignJWS(ctx context.Context, payload []byte, headers map[string]interface{}, kid string, detached bool) (string, error) {
 	panic("not implemented")
 }
 

--- a/vdr/didnuts/manager_test.go
+++ b/vdr/didnuts/manager_test.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/nuts-foundation/nuts-node/crypto/storage/spi"
 	"strings"
 	"testing"
 
@@ -119,8 +120,8 @@ func TestManager_Create(t *testing.T) {
 func TestManager_RemoveVerificationMethod(t *testing.T) {
 	id123, _ := did.ParseDID("did:nuts:123")
 	id123Method, _ := did.ParseDIDURL("did:nuts:123#method-1")
-	publicKey := nutsCrypto.NewTestKey("did:nuts:123").Public()
-	vm, _ := did.NewVerificationMethod(*id123Method, ssi.JsonWebKey2020, did.DID{}, publicKey)
+	key, _ := spi.GenerateKeyPair()
+	vm, _ := did.NewVerificationMethod(*id123Method, ssi.JsonWebKey2020, did.DID{}, key.Public())
 	doc := &did.Document{ID: *id123}
 	doc.AddCapabilityInvocation(vm)
 	doc.AddCapabilityDelegation(vm)

--- a/vdr/vdr_test.go
+++ b/vdr/vdr_test.go
@@ -57,7 +57,7 @@ type vdrTestCtx struct {
 	vdr                 Module
 	mockStore           *didstore.MockStore
 	mockNetwork         *network.MockTransactions
-	mockKeyStore        *nutsCrypto.MockKeyStore
+	keyStore            nutsCrypto.KeyStore
 	mockAmbassador      *didnuts.MockAmbassador
 	ctx                 context.Context
 	mockDocumentManager *didsubject.MockDocumentManager
@@ -70,11 +70,11 @@ func newVDRTestCtx(t *testing.T) vdrTestCtx {
 	mockAmbassador := didnuts.NewMockAmbassador(ctrl)
 	mockStore := didstore.NewMockStore(ctrl)
 	mockNetwork := network.NewMockTransactions(ctrl)
-	mockKeyStore := nutsCrypto.NewMockKeyStore(ctrl)
+	keyStore := nutsCrypto.NewMemoryCryptoInstance()
 	mockDocumentManager := didsubject.NewMockDocumentManager(ctrl)
 	mockDocumentOwner := didsubject.NewMockDocumentOwner(ctrl)
 	resolverRouter := &resolver.DIDResolverRouter{}
-	vdr := NewVDR(mockKeyStore, mockNetwork, mockStore, nil, nil)
+	vdr := NewVDR(keyStore, mockNetwork, mockStore, nil, nil)
 	vdr.networkAmbassador = mockAmbassador
 	vdr.nutsDocumentManager = mockDocumentManager
 	vdr.documentOwner = mockDocumentOwner
@@ -90,7 +90,7 @@ func newVDRTestCtx(t *testing.T) vdrTestCtx {
 		mockAmbassador:      mockAmbassador,
 		mockStore:           mockStore,
 		mockNetwork:         mockNetwork,
-		mockKeyStore:        mockKeyStore,
+		keyStore:            keyStore,
 		mockDocumentManager: mockDocumentManager,
 		mockDocumentOwner:   mockDocumentOwner,
 		ctx:                 audit.TestContext(),
@@ -186,32 +186,23 @@ func TestVDR_ConflictingDocuments(t *testing.T) {
 		t.Run("ok - 1 owned conflict in controlled document", func(t *testing.T) {
 			// vendor
 			test := newVDRTestCtx(t)
-			keyVendor := nutsCrypto.NewTestKey("did:nuts:vendor#keyVendor-1")
+			keyVendor, _ := test.keyStore.New(audit.TestContext(), nutsCrypto.StringNamingFunc("did:nuts:vendor#keyVendor-1"))
 
 			didDocVendor := &did.Document{ID: did.MustParseDID("did:nuts:vendor")}
 			vendorVM, err := did.NewVerificationMethod(did.MustParseDIDURL(keyVendor.KID()), ssi.JsonWebKey2020, didDocVendor.ID, keyVendor.Public())
 			require.NoError(t, err)
 			didDocVendor.AddCapabilityInvocation(vendorVM)
-			test.mockDocumentManager.EXPECT().Create(gomock.Any(), gomock.Any()).Return(didDocVendor, keyVendor, nil)
-			test.mockNetwork.EXPECT().CreateTransaction(test.ctx, gomock.Any()).AnyTimes()
-			didDocVendor, _, err = test.vdr.NutsDocumentManager().Create(test.ctx, didsubject.DefaultCreationOptions())
-			require.NoError(t, err)
 
 			// organization
-			keyOrg := nutsCrypto.NewTestKey("did:nuts:org#keyOrg-1")
+			keyOrg, _ := test.keyStore.New(audit.TestContext(), nutsCrypto.StringNamingFunc("did:nuts:org#keyOrg-1"))
 			didDocOrg := &did.Document{ID: did.MustParseDID("did:nuts:org")}
 			didDocOrg.Controller = []did.DID{didDocVendor.ID}
 			orgVM, err := did.NewVerificationMethod(did.MustParseDIDURL(keyOrg.KID()), ssi.JsonWebKey2020, didDocOrg.ID, keyOrg.Public())
 			require.NoError(t, err)
 			didDocOrg.AddCapabilityInvocation(orgVM)
-			test.mockDocumentManager.EXPECT().Create(gomock.Any(), gomock.Any()).Return(didDocOrg, keyOrg, nil)
-			didDocOrg, _, err = test.vdr.NutsDocumentManager().Create(test.ctx, didsubject.DefaultCreationOptions())
-			require.NoError(t, err)
 
-			client := nutsCrypto.NewMemoryCryptoInstance()
-			_, _ = client.New(audit.TestContext(), nutsCrypto.StringNamingFunc(keyVendor.KID()))
-			_, _ = client.New(audit.TestContext(), nutsCrypto.StringNamingFunc(keyOrg.KID()))
-			vdr := NewVDR(client, nil, didstore.NewTestStore(t), nil, storage.NewTestStorageEngine(t))
+			// change vdr to allow for Configure()
+			vdr := NewVDR(test.keyStore, nil, didstore.NewTestStore(t), nil, storage.NewTestStorageEngine(t))
 			tmpResolver := vdr.didResolver
 			vdr.Config().(*Config).DIDMethods = []string{"web", "nuts"}
 			_ = vdr.Configure(*core.NewServerConfig())


### PR DESCRIPTION
This PR is to prepare for the separation of `KID` (frontend) and `KeyName/Version` (backend). Two main things:

- Change signature of SignJWS and SignJWT so they are 'public' facing and always work on the kid.
- Reduce the usage of the TestKey for internal purposes:
  - the TestKey has a kid which is not always required
  - used real keys from the `memoryKeyStore` so key and keyStore are actually consistent in test.
- found some dead code.