### PR TITLE
remove legacy API auth bearer token

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -283,7 +283,6 @@ func addSubCommands(system *core.System, root *cobra.Command) {
 		createServerCommand(system),
 		createPrintConfigCommand(system),
 		cryptoCmd.ServerCmd(),
-		httpCmd.ServerCmd(),
 	}
 	flagSet := serverConfigFlags()
 	registerFlags(serverCommands, flagSet)

--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -17,6 +17,7 @@ Breaking changes
   When migrating from v5, change the owner of the data directory on the host to that of the container's user. (``chown -R 18081:18081 /path/to/host/data-dir``)
 - Docker image tags have been changed: previously version tags had were prefixed with ``v`` (e.g., ``v5.0.0``), this prefix has been dropped to better adhere to industry standards.
 - The VDR v1 ``createDID`` (``POST /internal/vdr/v1/did``) no longer supports the ``controller`` and ``selfControl`` fields. All did:nuts documents are now self controlled. All existing documents will be migrated to self controlled at startup.
+- Removed legacy API authentication tokens.
 
 ============
 New Features

--- a/http/cmd/cmd.go
+++ b/http/cmd/cmd.go
@@ -19,17 +19,9 @@
 package cmd
 
 import (
-	"crypto"
 	"fmt"
-	"github.com/lestrrat-go/jwx/v2/jwt"
-	"github.com/nuts-foundation/nuts-node/audit"
-	cryptoCmd "github.com/nuts-foundation/nuts-node/crypto/cmd"
 	"github.com/nuts-foundation/nuts-node/http"
-	"github.com/nuts-foundation/nuts-node/network"
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"strconv"
-	"time"
 )
 
 // FlagSet defines the set of flags that sets the engine configuration
@@ -46,68 +38,4 @@ func FlagSet() *pflag.FlagSet {
 	flags.Int("http.cache.maxbytes", defs.ResponseCacheSize, "HTTP client maximum size of the response cache in bytes. If 0, the HTTP client does not cache responses.")
 
 	return flags
-}
-
-// ServerCmd contains sub-commands for the HTTP engine
-func ServerCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "http",
-		Short: "http commands",
-	}
-	cmd.AddCommand(createTokenCommand())
-	return cmd
-}
-
-func createTokenCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "gen-token [user name] [days valid]",
-		Short: "Generates an access token for administrative operations.",
-		Args:  cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := audit.Context(cmd.Context(), "app-cli", network.ModuleName, cmd.Name())
-
-			daysValid, err := strconv.Atoi(args[1])
-			if err != nil {
-				return err
-			}
-			user := args[0]
-
-			cmd.Println(fmt.Sprintf("Generating API token for user %s, valid for %d days...", user, daysValid))
-
-			instance, err := cryptoCmd.LoadCryptoModule(cmd)
-			if err != nil {
-				return err
-			}
-
-			exists, err := instance.Exists(cmd.Context(), http.AdminTokenSigningKID)
-			if err != nil {
-				return err
-			}
-			if !exists {
-				cmd.Println("Token signing key not found, generating new key...")
-				_, err := instance.New(ctx, func(key crypto.PublicKey) (string, error) {
-					return http.AdminTokenSigningKID, nil
-				})
-				if err != nil {
-					return err
-				}
-			}
-			token, err := instance.SignJWT(ctx, map[string]interface{}{
-				jwt.SubjectKey:    user,
-				jwt.ExpirationKey: time.Now().AddDate(0, 0, daysValid),
-			}, nil, http.AdminTokenSigningKID)
-			if err != nil {
-				return err
-			}
-			cmd.Println()
-			cmd.Println("Token:")
-			cmd.Println()
-			cmd.Println(token)
-			cmd.Println()
-			cmd.Println("You can provide it manually when executing CLI commands (using --token), " +
-				"or save it in a file and use --token-file to have the CLI read it.")
-
-			return nil
-		},
-	}
 }

--- a/http/cmd/cmd_test.go
+++ b/http/cmd/cmd_test.go
@@ -19,48 +19,11 @@
 package cmd
 
 import (
-	"bytes"
-	"github.com/lestrrat-go/jwx/v2/jwt"
-	"github.com/nuts-foundation/nuts-node/core"
-	"github.com/nuts-foundation/nuts-node/test/io"
-	"github.com/stretchr/testify/require"
-	"regexp"
-	"strconv"
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestFlagSet(t *testing.T) {
 	flags := FlagSet()
 	assert.NotEmpty(t, flags)
-}
-
-func TestGenToken(t *testing.T) {
-	const daysValid = 365
-	testDirectory := io.TestDirectory(t)
-	t.Setenv("NUTS_DATADIR", testDirectory)
-	t.Setenv("NUTS_CRYPTO_STORAGE", "fs")
-
-	outBuf := new(bytes.Buffer)
-	cmd := ServerCmd()
-	cmd.Commands()[0].Flags().AddFlagSet(core.FlagSet())
-	cmd.SetOut(outBuf)
-	cmd.SetArgs([]string{"gen-token", "admin", strconv.Itoa(daysValid)})
-
-	err := cmd.Execute()
-
-	output := outBuf.String()
-	println(output)
-	assert.NoError(t, err)
-
-	matches := regexp.MustCompile("Token:\n\n(.*)\n").FindStringSubmatch(output)
-	assert.Len(t, matches, 2)
-	token := matches[1]
-	parsedToken, err := jwt.Parse([]byte(token), jwt.WithVerify(false))
-	require.NoError(t, err)
-	assert.Less(t, parsedToken.Expiration(), time.Now().AddDate(0, 0, daysValid+1))
-	assert.Greater(t, parsedToken.Expiration(), time.Now().AddDate(0, 0, daysValid-1))
-	assert.Equal(t, "admin", parsedToken.Subject())
 }


### PR DESCRIPTION
Already designated legacy, for v6 removed.