### PR TITLE
Auth: remove check wallet supports 'did' in supported_client_auth_methods

### DIFF
--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -234,7 +234,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 			RequireSignedRequestObject: true,
 		}
 		ctx.policy.EXPECT().PresentationDefinitions(gomock.Any(), "test").Return(pe.WalletOwnerMapping{pe.WalletOwnerOrganization: pe.PresentationDefinition{Id: "test"}}, nil)
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), holderURL).Return(&serverMetadata, nil).Times(2)
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(gomock.Any(), holderURL).Return(&serverMetadata, nil)
 		ctx.jar.EXPECT().Create(verifierDID, holderURL, gomock.Any()).DoAndReturn(func(client did.DID, authServerURL string, modifier requestObjectModifier) jarRequest {
 			req := createJarRequest(client, authServerURL, modifier)
 			params := req.Claims


### PR DESCRIPTION
When initiating OpenID4VP through Authorized Code Flow. Check can't be done at this point, since it requires dereferencing the client_id into OAuth2 Authorization Server metadata, which is only possible for `did:web` DIDs.

It is also unnecessary: the same check can be done in future when the client retrieves the OpenID4VP authorization request (which uses JAR), since it then provides its metadata (which can contain the supported client ID schemes property).