### PR TITLE
Auth: have jar.Parse() take metadata instead of DID

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -433,8 +433,12 @@ func (r Wrapper) HandleAuthorizeRequest(ctx context.Context, request HandleAutho
 // handleAuthorizeRequest handles calls to the authorization endpoint for starting an authorization code flow.
 // The caller must ensure ownDID is actually owned by this node.
 func (r Wrapper) handleAuthorizeRequest(ctx context.Context, ownDID did.DID, request url.URL) (HandleAuthorizeRequestResponseObject, error) {
+	metadata, err := r.oauthAuthorizationServerMetadata(ctx, ownDID.String())
+	if err != nil {
+		return nil, err
+	}
 	// parse and validate as JAR (RFC9101, JWT Authorization Request)
-	requestObject, err := r.jar.Parse(ctx, ownDID, request.Query())
+	requestObject, err := r.jar.Parse(ctx, *metadata, request.Query())
 	if err != nil {
 		// already an oauth.OAuth2Error
 		return nil, err
@@ -596,7 +600,8 @@ func (r Wrapper) oauthAuthorizationServerMetadata(ctx context.Context, didAsStri
 	if err != nil {
 		return nil, err
 	}
-	return authorizationServerMetadata(*ownDID, issuerURL)
+	md := authorizationServerMetadata(*ownDID, issuerURL)
+	return &md, nil
 }
 
 // OAuthClientMetadata returns the OAuth2 Client metadata for the request.Id if it is managed by this node.

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -423,22 +423,22 @@ func (r Wrapper) HandleAuthorizeRequest(ctx context.Context, request HandleAutho
 	if err != nil {
 		return nil, err
 	}
+	metadata, err := r.oauthAuthorizationServerMetadata(ownDID)
+	if err != nil {
+		return nil, err
+	}
 
 	// Workaround: deepmap codegen doesn't support dynamic query parameters.
 	//             See https://github.com/deepmap/oapi-codegen/issues/1129
 	httpRequest := ctx.Value(httpRequestContextKey{}).(*http.Request)
-	return r.handleAuthorizeRequest(ctx, *ownDID, *httpRequest.URL)
+	return r.handleAuthorizeRequest(ctx, *ownDID, *metadata, *httpRequest.URL)
 }
 
 // handleAuthorizeRequest handles calls to the authorization endpoint for starting an authorization code flow.
 // The caller must ensure ownDID is actually owned by this node.
-func (r Wrapper) handleAuthorizeRequest(ctx context.Context, ownDID did.DID, request url.URL) (HandleAuthorizeRequestResponseObject, error) {
-	metadata, err := r.oauthAuthorizationServerMetadata(ctx, ownDID.String())
-	if err != nil {
-		return nil, err
-	}
+func (r Wrapper) handleAuthorizeRequest(ctx context.Context, ownDID did.DID, ownMetadata oauth.AuthorizationServerMetadata, request url.URL) (HandleAuthorizeRequestResponseObject, error) {
 	// parse and validate as JAR (RFC9101, JWT Authorization Request)
-	requestObject, err := r.jar.Parse(ctx, *metadata, request.Query())
+	requestObject, err := r.jar.Parse(ctx, ownMetadata, request.Query())
 	if err != nil {
 		// already an oauth.OAuth2Error
 		return nil, err
@@ -584,18 +584,18 @@ func (r Wrapper) RequestJWTByPost(ctx context.Context, request RequestJWTByPostR
 
 // OAuthAuthorizationServerMetadata returns the Authorization Server's metadata
 func (r Wrapper) OAuthAuthorizationServerMetadata(ctx context.Context, request OAuthAuthorizationServerMetadataRequestObject) (OAuthAuthorizationServerMetadataResponseObject, error) {
-	md, err := r.oauthAuthorizationServerMetadata(ctx, request.Did)
+	ownDID, err := r.toOwnedDID(ctx, request.Did)
+	if err != nil {
+		return nil, err
+	}
+	md, err := r.oauthAuthorizationServerMetadata(ownDID)
 	if err != nil {
 		return nil, err
 	}
 	return OAuthAuthorizationServerMetadata200JSONResponse(*md), nil
 }
 
-func (r Wrapper) oauthAuthorizationServerMetadata(ctx context.Context, didAsString string) (*oauth.AuthorizationServerMetadata, error) {
-	ownDID, err := r.toOwnedDID(ctx, didAsString)
-	if err != nil {
-		return nil, err
-	}
+func (r Wrapper) oauthAuthorizationServerMetadata(ownDID *did.DID) (*oauth.AuthorizationServerMetadata, error) {
 	issuerURL, err := createOAuth2BaseURL(*ownDID)
 	if err != nil {
 		return nil, err

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -297,7 +297,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 			oauth.ScopeParam:              "test",
 			oauth.StateParam:              "state",
 		}
-		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil).Times(2)
+		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
 		ctx.jar.EXPECT().Parse(gomock.Any(), gomock.Any(), gomock.Any()).Return(requestParams, nil)
 
 		// handleAuthorizeRequestFromVerifier

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -238,8 +238,8 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 			oauth.CodeChallengeParam:       "code_challenge",
 			oauth.CodeChallengeMethodParam: "S256",
 		}
-		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), verifierDID).Return(true, nil)
-		ctx.jar.EXPECT().Parse(gomock.Any(), verifierDID, url.Values{"key": []string{"test_value"}}).Return(requestParams, nil)
+		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), verifierDID).Return(true, nil).MinTimes(1)
+		ctx.jar.EXPECT().Parse(gomock.Any(), gomock.Any(), url.Values{"key": []string{"test_value"}}).Return(requestParams, nil)
 
 		// handleAuthorizeRequestFromHolder
 		expectedURL := "https://example.com/authorize?client_id=did%3Aweb%3Aexample.com%3Aiam%3Averifier&request_uri=https://example.com/oauth2/" + verifierDID.String() + "/request.jwt/&request_uri_method=get"
@@ -297,8 +297,8 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 			oauth.ScopeParam:              "test",
 			oauth.StateParam:              "state",
 		}
-		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
-		ctx.jar.EXPECT().Parse(gomock.Any(), holderDID, gomock.Any()).Return(requestParams, nil)
+		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil).Times(2)
+		ctx.jar.EXPECT().Parse(gomock.Any(), gomock.Any(), gomock.Any()).Return(requestParams, nil)
 
 		// handleAuthorizeRequestFromVerifier
 		_ = ctx.client.storageEngine.GetSessionDatabase().GetStore(oAuthFlowTimeout, oauthClientStateKey...).Put("state", OAuthSession{
@@ -332,8 +332,8 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 			oauth.ClientIDParam:     holderDID.String(),
 			oauth.ResponseTypeParam: "unsupported",
 		}
-		ctx.jar.EXPECT().Parse(gomock.Any(), verifierDID, gomock.Any()).Return(requestParams, nil)
-		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), verifierDID).Return(true, nil)
+		ctx.jar.EXPECT().Parse(gomock.Any(), gomock.Any(), gomock.Any()).Return(requestParams, nil)
+		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), verifierDID).Return(true, nil).MinTimes(1)
 
 		res, err := ctx.client.HandleAuthorizeRequest(requestContext(map[string]interface{}{}),
 			HandleAuthorizeRequestRequestObject{Did: verifierDID.String()})

--- a/auth/api/iam/jar_mock.go
+++ b/auth/api/iam/jar_mock.go
@@ -15,6 +15,7 @@ import (
 	reflect "reflect"
 
 	did "github.com/nuts-foundation/go-did/did"
+	oauth "github.com/nuts-foundation/nuts-node/auth/oauth"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -56,18 +57,18 @@ func (mr *MockJARMockRecorder) Create(client, authServerURL, modifier any) *gomo
 }
 
 // Parse mocks base method.
-func (m *MockJAR) Parse(ctx context.Context, ownDID did.DID, q url.Values) (oauthParameters, error) {
+func (m *MockJAR) Parse(ctx context.Context, ownMetadata oauth.AuthorizationServerMetadata, q url.Values) (oauthParameters, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Parse", ctx, ownDID, q)
+	ret := m.ctrl.Call(m, "Parse", ctx, ownMetadata, q)
 	ret0, _ := ret[0].(oauthParameters)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Parse indicates an expected call of Parse.
-func (mr *MockJARMockRecorder) Parse(ctx, ownDID, q any) *gomock.Call {
+func (mr *MockJARMockRecorder) Parse(ctx, ownMetadata, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parse", reflect.TypeOf((*MockJAR)(nil).Parse), ctx, ownDID, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parse", reflect.TypeOf((*MockJAR)(nil).Parse), ctx, ownMetadata, q)
 }
 
 // Sign mocks base method.

--- a/auth/api/iam/metadata.go
+++ b/auth/api/iam/metadata.go
@@ -30,7 +30,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/crypto/jwx"
 )
 
-func authorizationServerMetadata(ownedDID did.DID, issuerURL *url.URL) (*oauth.AuthorizationServerMetadata, error) {
+func authorizationServerMetadata(ownedDID did.DID, issuerURL *url.URL) oauth.AuthorizationServerMetadata {
 	metadata := &oauth.AuthorizationServerMetadata{
 		AuthorizationEndpoint:                      "openid4vp:",
 		ClientIdSchemesSupported:                   clientIdSchemesSupported,
@@ -52,7 +52,7 @@ func authorizationServerMetadata(ownedDID did.DID, issuerURL *url.URL) (*oauth.A
 		metadata.PresentationDefinitionEndpoint = issuerURL.JoinPath("presentation_definition").String()
 		metadata.TokenEndpoint = issuerURL.JoinPath("token").String()
 	}
-	return metadata, nil
+	return *metadata
 }
 
 // staticAuthorizationServerMetadata is used in the OpenID4VP flow when authorization server (wallet) issuer is unknown.

--- a/auth/api/iam/metadata_test.go
+++ b/auth/api/iam/metadata_test.go
@@ -49,9 +49,8 @@ func Test_authorizationServerMetadata(t *testing.T) {
 		RequestObjectSigningAlgValuesSupported:     jwx.SupportedAlgorithmsAsStrings(),
 	}
 	t.Run("base", func(t *testing.T) {
-		md, err := authorizationServerMetadata(didExample, test.MustParseURL("https://example.com/oauth2/"+didExample.String()))
-		assert.NoError(t, err)
-		assert.Equal(t, baseExpected, *md)
+		md := authorizationServerMetadata(didExample, test.MustParseURL("https://example.com/oauth2/"+didExample.String()))
+		assert.Equal(t, baseExpected, md)
 	})
 	t.Run("did:web", func(t *testing.T) {
 		didWeb := did.MustParseDID("did:web:example.com:iam:123")
@@ -63,9 +62,8 @@ func Test_authorizationServerMetadata(t *testing.T) {
 		webExpected.PresentationDefinitionEndpoint = oauth2Base.String() + "/presentation_definition"
 		webExpected.TokenEndpoint = oauth2Base.String() + "/token"
 
-		md, err := authorizationServerMetadata(didWeb, oauth2Base)
-		assert.NoError(t, err)
-		assert.Equal(t, webExpected, *md)
+		md := authorizationServerMetadata(didWeb, oauth2Base)
+		assert.Equal(t, webExpected, md)
 	})
 }
 

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -408,7 +408,9 @@ func (r Wrapper) sendAndHandleDirectPost(ctx context.Context, userWalletDID did.
 		// Dispatch a new HTTP request to the local OpenID4VP wallet's authorization endpoint that includes request parameters,
 		// but with openid4vp: as scheme.
 		// The context contains data from the previous request. Usage by the handler will probably result in incorrect behavior.
-		response, err := r.handleAuthorizeRequest(ctx, userWalletDID, *parsedRedirectURI)
+		issuerURL := userWalletDID.URI().URL
+		userWalletMetadata := authorizationServerMetadata(userWalletDID, &issuerURL)
+		response, err := r.handleAuthorizeRequest(ctx, userWalletDID, userWalletMetadata, *parsedRedirectURI)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
For forwards compatibility with other DID methods, and easier (future) enabling/disabling of Authorization Endpoint in metadata.