### PR TITLE
Discovery Service: change client to manage subjects, not DIDs

### DIFF
--- a/discovery/api/server/client/http.go
+++ b/discovery/api/server/client/http.go
@@ -49,7 +49,10 @@ type DefaultHTTPClient struct {
 }
 
 func (h DefaultHTTPClient) Register(ctx context.Context, serviceEndpointURL string, presentation vc.VerifiablePresentation) error {
-	requestBody, _ := json.Marshal(presentation)
+	requestBody, err := json.Marshal(presentation)
+	if err != nil {
+		return err
+	}
 	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, serviceEndpointURL, bytes.NewReader(requestBody))
 	if err != nil {
 		return err

--- a/discovery/client.go
+++ b/discovery/client.go
@@ -30,14 +30,16 @@ import (
 	"github.com/nuts-foundation/nuts-node/vcr"
 	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"github.com/nuts-foundation/nuts-node/vcr/signature/proof"
+	"github.com/nuts-foundation/nuts-node/vdr/didsubject"
+	"strings"
 	"time"
 )
 
 // clientRegistrationManager is a client component, responsible for managing registrations on a Discovery Service.
 // It can refresh registered Verifiable Presentations when they are about to expire.
 type clientRegistrationManager interface {
-	activate(ctx context.Context, serviceID string, subjectDID did.DID) error
-	deactivate(ctx context.Context, serviceID string, subjectDID did.DID) error
+	activate(ctx context.Context, serviceID, subjectID string) error
+	deactivate(ctx context.Context, serviceID, subjectID string) error
 	// refresh checks which Verifiable Presentations that are about to expire, and should be refreshed on the Discovery Service.
 	refresh(ctx context.Context, now time.Time) error
 }
@@ -45,79 +47,114 @@ type clientRegistrationManager interface {
 var _ clientRegistrationManager = &defaultClientRegistrationManager{}
 
 type defaultClientRegistrationManager struct {
-	services map[string]ServiceDefinition
-	store    *sqlStore
-	client   client.HTTPClient
-	vcr      vcr.VCR
+	services       map[string]ServiceDefinition
+	store          *sqlStore
+	client         client.HTTPClient
+	vcr            vcr.VCR
+	subjectManager didsubject.SubjectManager
 }
 
-func newRegistrationManager(services map[string]ServiceDefinition, store *sqlStore, client client.HTTPClient, vcr vcr.VCR) *defaultClientRegistrationManager {
-	instance := &defaultClientRegistrationManager{
-		services: services,
-		store:    store,
-		client:   client,
-		vcr:      vcr,
+func newRegistrationManager(services map[string]ServiceDefinition, store *sqlStore, client client.HTTPClient, vcr vcr.VCR, subjectManager didsubject.SubjectManager) *defaultClientRegistrationManager {
+	return &defaultClientRegistrationManager{
+		services:       services,
+		store:          store,
+		client:         client,
+		vcr:            vcr,
+		subjectManager: subjectManager,
 	}
-	return instance
 }
 
-func (r *defaultClientRegistrationManager) activate(ctx context.Context, serviceID string, subjectDID did.DID) error {
+func (r *defaultClientRegistrationManager) activate(ctx context.Context, serviceID, subjectID string) error {
 	service, serviceExists := r.services[serviceID]
 	if !serviceExists {
 		return ErrServiceNotFound
 	}
-	var asSoonAsPossible time.Time
-	if err := r.store.updatePresentationRefreshTime(serviceID, subjectDID, &asSoonAsPossible); err != nil {
+	subjectDIDs, err := r.subjectManager.List(ctx, subjectID)
+	if err != nil {
 		return err
 	}
-	log.Logger().Debugf("Registering Verifiable Presentation on Discovery Service (service=%s, did=%s)", service.ID, subjectDID)
-	err := r.registerPresentation(ctx, subjectDID, service)
-	if err != nil {
-		// failed, will be retried on next scheduled refresh
-		return fmt.Errorf("%w: %w", ErrPresentationRegistrationFailed, err)
+	var asSoonAsPossible time.Time
+	if err := r.store.updatePresentationRefreshTime(serviceID, subjectID, &asSoonAsPossible); err != nil {
+		return err
 	}
-	log.Logger().Debugf("Successfully registered Verifiable Presentation on Discovery Service (service=%s, did=%s)", serviceID, subjectDID)
+	log.Logger().Debugf("Registering Verifiable Presentation on Discovery Service (service=%s, subject=%s)", service.ID, subjectID)
+
+	var registeredDIDs []string
+	var loopErrs []error
+	for _, subjectDID := range subjectDIDs {
+		err := r.registerPresentation(ctx, subjectDID, service)
+		if err != nil {
+			loopErrs = append(loopErrs, err)
+		} else {
+			registeredDIDs = append(registeredDIDs, subjectDID.String())
+		}
+	}
+	if len(registeredDIDs) == 0 {
+		// registration failed for all subjectDIDs, will be retried on next scheduled refresh
+		return fmt.Errorf("%w: %w", ErrPresentationRegistrationFailed, errors.Join(loopErrs...))
+	}
+	log.Logger().Debugf("Successfully registered Verifiable Presentation on Discovery Service (service=%s, subject=%s, dids=[%s])", serviceID, subjectID, strings.Join(registeredDIDs, ","))
 
 	// Set presentation to be refreshed before it expires
-	// TODO: When to refresh? For now, we refresh when the registration is about to expire (75% of max age)
-	refreshVPAfter := time.Now().Add(time.Duration(float64(service.PresentationMaxValidity)*0.75) * time.Second)
-	if err := r.store.updatePresentationRefreshTime(serviceID, subjectDID, &refreshVPAfter); err != nil {
+	// TODO: When to refresh? For now, we refresh when the registration is about at 45% of max age. This means a refresh can fail once without consequence.
+	refreshVPAfter := time.Now().Add(time.Duration(float64(service.PresentationMaxValidity)*0.45) * time.Second)
+	if err := r.store.updatePresentationRefreshTime(serviceID, subjectID, &refreshVPAfter); err != nil {
 		return fmt.Errorf("unable to update Verifiable Presentation refresh time: %w", err)
 	}
 	return nil
 }
 
-func (r *defaultClientRegistrationManager) deactivate(ctx context.Context, serviceID string, subjectDID did.DID) error {
+func (r *defaultClientRegistrationManager) deactivate(ctx context.Context, serviceID, subjectID string) error {
 	// delete DID/service combination from DB, so it won't be registered again
-	err := r.store.updatePresentationRefreshTime(serviceID, subjectDID, nil)
+	err := r.store.updatePresentationRefreshTime(serviceID, subjectID, nil)
 	if err != nil {
 		return err
 	}
+	// subject is now successfully deactivated for the service, anything after this point is best effort
+	subjectDIDs, err := r.subjectManager.List(ctx, subjectID)
+	if err != nil {
+		// this could be a didsubject.ErrSubjectNotFound after the subject has been deactivated
+		// still fail in this case since we no longer have the keys to sign a retraction
+		return err
+	}
 
-	// if the DID has an active registration, retract it
-	presentations, err := r.store.search(serviceID, map[string]string{
-		"credentialSubject.id": subjectDID.String(),
-	})
+	// find all active presentations
+	vps2D, err := r.store.getSubjectVPsOnService(serviceID, subjectDIDs)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrPresentationRegistrationFailed, err)
 	}
-	if len(presentations) == 0 {
-		// no registration, nothing to do
-		return nil
-	}
-	// found an active registration, try to delete it from the discovery server
+
+	// retract active registrations for all DIDs
+	// failures are collected and merged into a single error
 	service := r.services[serviceID]
+	var loopErrs []error
+	for ind, vps := range vps2D {
+		for _, vp := range vps {
+			if vp.IsType(retractionPresentationType) {
+				// is already retracted
+				continue
+			}
+			err = r.deregisterPresentation(ctx, subjectDIDs[ind], service, vp)
+			if err != nil {
+				loopErrs = append(loopErrs, err)
+			}
+		}
+	}
+	if len(loopErrs) > 0 {
+		return fmt.Errorf("%w: %w", ErrPresentationRegistrationFailed, errors.Join(loopErrs...))
+	}
+
+	return nil
+}
+
+func (r *defaultClientRegistrationManager) deregisterPresentation(ctx context.Context, subjectDID did.DID, service ServiceDefinition, vp vc.VerifiablePresentation) error {
 	presentation, err := r.buildPresentation(ctx, subjectDID, service, nil, map[string]interface{}{
-		"retract_jti": presentations[0].ID.String(),
+		"retract_jti": vp.ID.String(),
 	})
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrPresentationRegistrationFailed, err)
+		return err
 	}
-	err = r.client.Register(ctx, service.Endpoint, *presentation)
-	if err != nil {
-		return fmt.Errorf("%w: %w", ErrPresentationRegistrationFailed, err)
-	}
-	return nil
+	return r.client.Register(ctx, service.Endpoint, *presentation)
 }
 
 func (r *defaultClientRegistrationManager) registerPresentation(ctx context.Context, subjectDID did.DID, service ServiceDefinition) error {
@@ -162,17 +199,32 @@ func (r *defaultClientRegistrationManager) buildPresentation(ctx context.Context
 
 func (r *defaultClientRegistrationManager) refresh(ctx context.Context, now time.Time) error {
 	log.Logger().Debug("Refreshing own registered Verifiable Presentations on Discovery Services")
-	serviceIDs, dids, err := r.store.getPresentationsToBeRefreshed(now)
+	refreshCandidates, err := r.store.getSubjectsToBeRefreshed(now)
 	if err != nil {
 		return err
 	}
-	var result error = nil
-	for i, serviceID := range serviceIDs {
-		if err := r.activate(ctx, serviceID, dids[i]); err != nil {
-			result = errors.Join(result, fmt.Errorf("failed to refresh Verifiable Presentation (service=%s, did=%s): %w", serviceID, dids[i], err))
+	var loopErrs []error
+	for _, candidate := range refreshCandidates {
+		if err = r.activate(ctx, candidate.ServiceID, candidate.SubjectID); err != nil {
+			var loopErr error
+			if errors.Is(err, didsubject.ErrSubjectNotFound) {
+				// Subject has probably been deactivated. Remove from service or registration will be retried every refresh interval.
+				err = r.store.updatePresentationRefreshTime(candidate.ServiceID, candidate.SubjectID, nil)
+				if err != nil {
+					loopErr = fmt.Errorf("failed to remove unknown subject (service=%s, subject=%s): %w", candidate.ServiceID, candidate.SubjectID, err)
+				} else {
+					loopErr = fmt.Errorf("removed unknown subject (service=%s, subject=%s)", candidate.ServiceID, candidate.SubjectID)
+				}
+			} else {
+				loopErr = fmt.Errorf("failed to refresh Verifiable Presentation (service=%s, subject=%s): %w", candidate.ServiceID, candidate.SubjectID, err)
+			}
+			loopErrs = append(loopErrs, loopErr)
 		}
 	}
-	return result
+	if len(loopErrs) > 0 {
+		return errors.Join(loopErrs...)
+	}
+	return nil
 }
 
 // clientUpdater is responsible for updating the local copy of Discovery Services

--- a/discovery/client_test.go
+++ b/discovery/client_test.go
@@ -94,7 +94,7 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject)
 
 		require.ErrorIs(t, err, ErrPresentationRegistrationFailed)
-		assert.ErrorContains(t, err, "DID wallet does not have credentials required for registration on Discovery Service (service=usecase_v1, did=did:example:alice)")
+		require.ErrorIs(t, err, errMissingCredential)
 	})
 	t.Run("subject with 2 DIDs, one registers and other fails", func(t *testing.T) {
 		subjectDIDs := []did.DID{aliceDID, bobDID}
@@ -323,7 +323,7 @@ func Test_defaultClientRegistrationManager_refresh(t *testing.T) {
 
 		err := manager.refresh(audit.TestContext(), time.Now())
 
-		assert.EqualError(t, err, "failed to refresh Verifiable Presentation (service=usecase_v1, subject=alice): registration of Verifiable Presentation on remote Discovery Service failed: remote error")
+		assert.EqualError(t, err, "failed to refresh Verifiable Presentation (service=usecase_v1, subject=alice): registration of Verifiable Presentation on remote Discovery Service failed: did:example:alice: remote error")
 	})
 	t.Run("deactivate unknown subject", func(t *testing.T) {
 		store := setupStore(t, storageEngine.GetSQLDatabase())

--- a/discovery/client_test.go
+++ b/discovery/client_test.go
@@ -21,6 +21,8 @@ package discovery
 import (
 	"context"
 	"errors"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/audit"
 	"github.com/nuts-foundation/nuts-node/discovery/api/server/client"
@@ -28,6 +30,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/vcr"
 	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
+	"github.com/nuts-foundation/nuts-node/vdr/didsubject"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -35,7 +38,7 @@ import (
 	"time"
 )
 
-func Test_scheduledRegistrationManager_register(t *testing.T) {
+func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 	storageEngine := storage.NewTestStorageEngine(t)
 	require.NoError(t, storageEngine.Start())
 
@@ -43,15 +46,17 @@ func Test_scheduledRegistrationManager_register(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		invoker := client.NewMockHTTPClient(ctrl)
 		invoker.EXPECT().Register(gomock.Any(), "http://example.com/usecase", vpAlice)
-		mockVCR := vcr.NewMockVCR(ctrl)
 		wallet := holder.NewMockWallet(ctrl)
 		wallet.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vc.VerifiableCredential{vcAlice}, nil)
 		wallet.EXPECT().BuildPresentation(gomock.Any(), []vc.VerifiableCredential{vcAlice}, gomock.Any(), gomock.Any(), false).Return(&vpAlice, nil)
+		mockVCR := vcr.NewMockVCR(ctrl)
 		mockVCR.EXPECT().Wallet().Return(wallet).AnyTimes()
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().List(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
 		store := setupStore(t, storageEngine.GetSQLDatabase())
-		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR)
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
 
-		err := manager.activate(audit.TestContext(), testServiceID, aliceDID)
+		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject)
 
 		assert.NoError(t, err)
 	})
@@ -59,15 +64,17 @@ func Test_scheduledRegistrationManager_register(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		invoker := client.NewMockHTTPClient(ctrl)
 		invoker.EXPECT().Register(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("invoker error"))
-		mockVCR := vcr.NewMockVCR(ctrl)
 		wallet := holder.NewMockWallet(ctrl)
 		wallet.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vc.VerifiableCredential{vcAlice}, nil)
 		wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), false).Return(&vpAlice, nil)
+		mockVCR := vcr.NewMockVCR(ctrl)
 		mockVCR.EXPECT().Wallet().Return(wallet).AnyTimes()
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().List(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
 		store := setupStore(t, storageEngine.GetSQLDatabase())
-		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR)
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
 
-		err := manager.activate(audit.TestContext(), testServiceID, aliceDID)
+		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject)
 
 		require.ErrorIs(t, err, ErrPresentationRegistrationFailed)
 		assert.ErrorContains(t, err, "invoker error")
@@ -75,17 +82,42 @@ func Test_scheduledRegistrationManager_register(t *testing.T) {
 	t.Run("no matching credentials", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		invoker := client.NewMockHTTPClient(ctrl)
-		mockVCR := vcr.NewMockVCR(ctrl)
 		wallet := holder.NewMockWallet(ctrl)
 		wallet.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil)
+		mockVCR := vcr.NewMockVCR(ctrl)
 		mockVCR.EXPECT().Wallet().Return(wallet).AnyTimes()
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().List(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
 		store := setupStore(t, storageEngine.GetSQLDatabase())
-		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR)
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
 
-		err := manager.activate(audit.TestContext(), testServiceID, aliceDID)
+		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject)
 
 		require.ErrorIs(t, err, ErrPresentationRegistrationFailed)
 		assert.ErrorContains(t, err, "DID wallet does not have credentials required for registration on Discovery Service (service=usecase_v1, did=did:example:alice)")
+	})
+	t.Run("subject with 2 DIDs, one registers and other fails", func(t *testing.T) {
+		subjectDIDs := []did.DID{aliceDID, bobDID}
+		ctrl := gomock.NewController(t)
+		invoker := client.NewMockHTTPClient(ctrl)
+		invoker.EXPECT().Register(gomock.Any(), "http://example.com/usecase", vpAlice)
+		wallet := holder.NewMockWallet(ctrl)
+		mockVCR := vcr.NewMockVCR(ctrl)
+		mockVCR.EXPECT().Wallet().Return(wallet).AnyTimes()
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().List(gomock.Any(), aliceSubject).Return(subjectDIDs, nil)
+		store := setupStore(t, storageEngine.GetSQLDatabase())
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
+
+		// aliceDID registers
+		wallet.EXPECT().List(gomock.Any(), aliceDID).Return([]vc.VerifiableCredential{vcAlice}, nil)
+		wallet.EXPECT().BuildPresentation(gomock.Any(), []vc.VerifiableCredential{vcAlice}, gomock.Any(), &aliceDID, false).Return(&vpAlice, nil)
+		// bobDID has no credentials, so builds no presentation
+		wallet.EXPECT().List(gomock.Any(), bobDID).Return(nil, nil)
+
+		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject)
+
+		assert.NoError(t, err)
 	})
 	t.Run("ok without credentials", func(t *testing.T) {
 		emptyDefinition := map[string]ServiceDefinition{
@@ -106,10 +138,12 @@ func Test_scheduledRegistrationManager_register(t *testing.T) {
 		wallet.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil)
 		wallet.EXPECT().BuildPresentation(gomock.Any(), []vc.VerifiableCredential{}, gomock.Any(), gomock.Any(), false).Return(&vpAlice, nil)
 		mockVCR.EXPECT().Wallet().Return(wallet).AnyTimes()
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().List(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
 		store := setupStore(t, storageEngine.GetSQLDatabase())
-		manager := newRegistrationManager(emptyDefinition, store, invoker, mockVCR)
+		manager := newRegistrationManager(emptyDefinition, store, invoker, mockVCR, mockSubjectManager)
 
-		err := manager.activate(audit.TestContext(), testServiceID, aliceDID)
+		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject)
 
 		assert.NoError(t, err)
 	})
@@ -118,15 +152,28 @@ func Test_scheduledRegistrationManager_register(t *testing.T) {
 		invoker := client.NewMockHTTPClient(ctrl)
 		mockVCR := vcr.NewMockVCR(ctrl)
 		store := setupStore(t, storageEngine.GetSQLDatabase())
-		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR)
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, nil)
 
-		err := manager.activate(audit.TestContext(), "unknown", aliceDID)
+		err := manager.activate(audit.TestContext(), "unknown", aliceSubject)
 
 		assert.EqualError(t, err, "discovery service not found")
 	})
+	t.Run("unknown subject", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		invoker := client.NewMockHTTPClient(ctrl)
+		mockVCR := vcr.NewMockVCR(ctrl)
+		store := setupStore(t, storageEngine.GetSQLDatabase())
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().List(gomock.Any(), aliceSubject).Return([]did.DID{}, didsubject.ErrSubjectNotFound)
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
+
+		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject)
+
+		assert.ErrorIs(t, err, didsubject.ErrSubjectNotFound)
+	})
 }
 
-func Test_scheduledRegistrationManager_deregister(t *testing.T) {
+func Test_defaultClientRegistrationManager_deactivate(t *testing.T) {
 	storageEngine := storage.NewTestStorageEngine(t)
 	require.NoError(t, storageEngine.Start())
 
@@ -134,10 +181,12 @@ func Test_scheduledRegistrationManager_deregister(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		invoker := client.NewMockHTTPClient(ctrl)
 		mockVCR := vcr.NewMockVCR(ctrl)
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().List(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
 		store := setupStore(t, storageEngine.GetSQLDatabase())
-		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR)
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
 
-		err := manager.deactivate(audit.TestContext(), testServiceID, aliceDID)
+		err := manager.deactivate(audit.TestContext(), testServiceID, aliceSubject)
 
 		assert.NoError(t, err)
 	})
@@ -145,15 +194,38 @@ func Test_scheduledRegistrationManager_deregister(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		invoker := client.NewMockHTTPClient(ctrl)
 		invoker.EXPECT().Register(gomock.Any(), gomock.Any(), gomock.Any())
-		mockVCR := vcr.NewMockVCR(ctrl)
 		wallet := holder.NewMockWallet(ctrl)
 		wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), false).Return(&vpAlice, nil)
+		mockVCR := vcr.NewMockVCR(ctrl)
 		mockVCR.EXPECT().Wallet().Return(wallet).AnyTimes()
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().List(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
 		store := setupStore(t, storageEngine.GetSQLDatabase())
-		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR)
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
 		require.NoError(t, store.add(testServiceID, vpAlice, 1))
 
-		err := manager.deactivate(audit.TestContext(), testServiceID, aliceDID)
+		err := manager.deactivate(audit.TestContext(), testServiceID, aliceSubject)
+
+		assert.NoError(t, err)
+	})
+	t.Run("already deactivated", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		invoker := client.NewMockHTTPClient(ctrl)
+		mockVCR := vcr.NewMockVCR(ctrl)
+		mockVCR.EXPECT().Wallet().Return(holder.NewMockWallet(ctrl)).AnyTimes()
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().List(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
+		store := setupStore(t, storageEngine.GetSQLDatabase())
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
+
+		vpAliceDeactivated := createPresentationCustom(aliceDID, func(claims map[string]interface{}, vp *vc.VerifiablePresentation) {
+			claims[jwt.AudienceKey] = []string{testServiceID}
+			claims["retract_jti"] = vpAlice.ID.String()
+			vp.Type = append(vp.Type, retractionPresentationType)
+		}, vcAlice)
+		require.NoError(t, store.add(testServiceID, vpAliceDeactivated, 1))
+
+		err := manager.deactivate(audit.TestContext(), testServiceID, aliceSubject)
 
 		assert.NoError(t, err)
 	})
@@ -161,22 +233,54 @@ func Test_scheduledRegistrationManager_deregister(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		invoker := client.NewMockHTTPClient(ctrl)
 		invoker.EXPECT().Register(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("remote error"))
-		mockVCR := vcr.NewMockVCR(ctrl)
 		wallet := holder.NewMockWallet(ctrl)
 		wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), false).Return(&vpAlice, nil)
+		mockVCR := vcr.NewMockVCR(ctrl)
 		mockVCR.EXPECT().Wallet().Return(wallet).AnyTimes()
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().List(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
 		store := setupStore(t, storageEngine.GetSQLDatabase())
-		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR)
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
 		require.NoError(t, store.add(testServiceID, vpAlice, 1))
 
-		err := manager.deactivate(audit.TestContext(), testServiceID, aliceDID)
+		err := manager.deactivate(audit.TestContext(), testServiceID, aliceSubject)
 
 		require.ErrorIs(t, err, ErrPresentationRegistrationFailed)
 		require.ErrorContains(t, err, "remote error")
 	})
+	t.Run("building presentation fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		invoker := client.NewMockHTTPClient(ctrl)
+		wallet := holder.NewMockWallet(ctrl)
+		wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), false).Return(nil, assert.AnError)
+		mockVCR := vcr.NewMockVCR(ctrl)
+		mockVCR.EXPECT().Wallet().Return(wallet).AnyTimes()
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().List(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
+		store := setupStore(t, storageEngine.GetSQLDatabase())
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
+		require.NoError(t, store.add(testServiceID, vpAlice, 1))
+
+		err := manager.deactivate(audit.TestContext(), testServiceID, aliceSubject)
+
+		assert.ErrorIs(t, err, assert.AnError)
+	})
+	t.Run("unknown subject", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		invoker := client.NewMockHTTPClient(ctrl)
+		mockVCR := vcr.NewMockVCR(ctrl)
+		store := setupStore(t, storageEngine.GetSQLDatabase())
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().List(gomock.Any(), aliceSubject).Return([]did.DID{}, didsubject.ErrSubjectNotFound)
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
+
+		err := manager.deactivate(audit.TestContext(), testServiceID, aliceSubject)
+
+		assert.ErrorIs(t, err, didsubject.ErrSubjectNotFound)
+	})
 }
 
-func Test_scheduledRegistrationManager_refresh(t *testing.T) {
+func Test_defaultClientRegistrationManager_refresh(t *testing.T) {
 	storageEngine := storage.NewTestStorageEngine(t)
 	require.NoError(t, storageEngine.Start())
 
@@ -184,8 +288,9 @@ func Test_scheduledRegistrationManager_refresh(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		invoker := client.NewMockHTTPClient(ctrl)
 		mockVCR := vcr.NewMockVCR(ctrl)
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
 		store := setupStore(t, storageEngine.GetSQLDatabase())
-		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR)
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
 
 		err := manager.refresh(audit.TestContext(), time.Now())
 
@@ -199,22 +304,40 @@ func Test_scheduledRegistrationManager_refresh(t *testing.T) {
 			invoker.EXPECT().Register(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("remote error")),
 			invoker.EXPECT().Register(gomock.Any(), gomock.Any(), gomock.Any()),
 		)
-		mockVCR := vcr.NewMockVCR(ctrl)
 		wallet := holder.NewMockWallet(ctrl)
+		mockVCR := vcr.NewMockVCR(ctrl)
 		mockVCR.EXPECT().Wallet().Return(wallet).AnyTimes()
-		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR)
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
+
 		// Alice
-		_ = store.updatePresentationRefreshTime(testServiceID, aliceDID, &time.Time{})
+		_ = store.updatePresentationRefreshTime(testServiceID, aliceSubject, &time.Time{})
+		mockSubjectManager.EXPECT().List(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
 		wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), &aliceDID, false).Return(&vpAlice, nil)
 		wallet.EXPECT().List(gomock.Any(), aliceDID).Return([]vc.VerifiableCredential{vcAlice}, nil)
 		// Bob
-		_ = store.updatePresentationRefreshTime(testServiceID, bobDID, &time.Time{})
+		_ = store.updatePresentationRefreshTime(testServiceID, bobSubject, &time.Time{})
+		mockSubjectManager.EXPECT().List(gomock.Any(), bobSubject).Return([]did.DID{bobDID}, nil)
 		wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), &bobDID, false).Return(&vpBob, nil)
 		wallet.EXPECT().List(gomock.Any(), bobDID).Return([]vc.VerifiableCredential{vcBob}, nil)
 
 		err := manager.refresh(audit.TestContext(), time.Now())
 
-		assert.EqualError(t, err, "failed to refresh Verifiable Presentation (service=usecase_v1, did=did:example:alice): registration of Verifiable Presentation on remote Discovery Service failed: remote error")
+		assert.EqualError(t, err, "failed to refresh Verifiable Presentation (service=usecase_v1, subject=alice): registration of Verifiable Presentation on remote Discovery Service failed: remote error")
+	})
+	t.Run("deactivate unknown subject", func(t *testing.T) {
+		store := setupStore(t, storageEngine.GetSQLDatabase())
+		ctrl := gomock.NewController(t)
+		invoker := client.NewMockHTTPClient(ctrl)
+		mockVCR := vcr.NewMockVCR(ctrl)
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().List(gomock.Any(), aliceSubject).Return(nil, didsubject.ErrSubjectNotFound)
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
+		_ = store.updatePresentationRefreshTime(testServiceID, aliceSubject, &time.Time{})
+
+		err := manager.refresh(audit.TestContext(), time.Now())
+
+		assert.EqualError(t, err, "removed unknown subject (service=usecase_v1, subject=alice)")
 	})
 }
 

--- a/discovery/interface.go
+++ b/discovery/interface.go
@@ -21,7 +21,6 @@ package discovery
 import (
 	"context"
 	"errors"
-	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
 )
 
@@ -52,24 +51,26 @@ type Client interface {
 	// Query parameters are formatted as simple JSON paths, e.g. "issuer" or "credentialSubject.name".
 	Search(serviceID string, query map[string]string) ([]SearchResult, error)
 
-	// ActivateServiceForDID causes a DID, in the form of a Verifiable Presentation, to be registered on a Discovery Service.
-	// Registration will be attempted immediately, and automatically refreshed.
-	// If the initial registration fails with ErrPresentationRegistrationFailed, registration will be retried.
+	// ActivateServiceForSubject causes a subject to be registered for a Discovery Service.
+	// Registration of all DIDs of the subject will be attempted immediately, and automatically refreshed.
+	// If the initial registration for all DIDs fails with ErrPresentationRegistrationFailed, registration will be retried.
 	// If the function is called again for the same service/DID combination, it will try to refresh the registration.
-	// It returns an error if the service or DID is invalid/unknown.
-	ActivateServiceForDID(ctx context.Context, serviceID string, subjectDID did.DID) error
+	// It returns an error if the service or subject is invalid/unknown.
+	ActivateServiceForSubject(ctx context.Context, serviceID, subjectID string) error
 
-	// DeactivateServiceForDID removes the registration of a DID on a Discovery Service.
-	// It returns an error if the service or DID is invalid/unknown.
-	DeactivateServiceForDID(ctx context.Context, serviceID string, subjectDID did.DID) error
+	// DeactivateServiceForSubject stops registration of a subject on a Discovery Service.
+	// It also tries to remove all active registrations of the subject from the Discovery Service.
+	// If removal of one or more active registration fails a ErrPresentationRegistrationFailed may be returned. The failed registrations will be removed when they expire.
+	// It returns an error if the service or subject is invalid/unknown.
+	DeactivateServiceForSubject(ctx context.Context, serviceID, subjectID string) error
 
 	// Services returns the list of services that are registered on this client.
 	Services() []ServiceDefinition
 
-	// GetServiceActivation returns the activation status of a DID on a Discovery Service.
-	// The boolean indicates whether the DID is activated on the Discovery Service (ActivateServiceForDID() has been called).
-	// It also returns the Verifiable Presentation that is registered on the Discovery Service, if any.
-	GetServiceActivation(ctx context.Context, serviceID string, subjectDID did.DID) (bool, *vc.VerifiablePresentation, error)
+	// GetServiceActivation returns the activation status of a subject on a Discovery Service.
+	// The boolean indicates whether the subject is activated on the Discovery Service (ActivateServiceForSubject() has been called).
+	// It also returns the Verifiable Presentations for all DIDs of the subject that are registered on the Discovery Service, if any.
+	GetServiceActivation(ctx context.Context, serviceID, subjectID string) (bool, []vc.VerifiablePresentation, error)
 }
 
 // SearchResult is a single result of a search operation.

--- a/discovery/interface.go
+++ b/discovery/interface.go
@@ -34,6 +34,9 @@ var ErrPresentationAlreadyExists = errors.New("presentation already exists")
 // ErrPresentationRegistrationFailed indicates registration of a presentation on a remote Discovery Service failed.
 var ErrPresentationRegistrationFailed = errors.New("registration of Verifiable Presentation on remote Discovery Service failed")
 
+// errMissingCredential indicates that a VP does not have the credentials required to fulfill the Presentation Definition of a Discovery Service.
+var errMissingCredential = errors.New("missing credential")
+
 // Server defines the API for Discovery Servers.
 type Server interface {
 	// Register registers a presentation on the given Discovery Service.

--- a/discovery/mock.go
+++ b/discovery/mock.go
@@ -13,7 +13,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	did "github.com/nuts-foundation/go-did/did"
 	vc "github.com/nuts-foundation/go-did/vc"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -94,48 +93,48 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// ActivateServiceForDID mocks base method.
-func (m *MockClient) ActivateServiceForDID(ctx context.Context, serviceID string, subjectDID did.DID) error {
+// ActivateServiceForSubject mocks base method.
+func (m *MockClient) ActivateServiceForSubject(ctx context.Context, serviceID, subjectID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ActivateServiceForDID", ctx, serviceID, subjectDID)
+	ret := m.ctrl.Call(m, "ActivateServiceForSubject", ctx, serviceID, subjectID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ActivateServiceForDID indicates an expected call of ActivateServiceForDID.
-func (mr *MockClientMockRecorder) ActivateServiceForDID(ctx, serviceID, subjectDID any) *gomock.Call {
+// ActivateServiceForSubject indicates an expected call of ActivateServiceForSubject.
+func (mr *MockClientMockRecorder) ActivateServiceForSubject(ctx, serviceID, subjectID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActivateServiceForDID", reflect.TypeOf((*MockClient)(nil).ActivateServiceForDID), ctx, serviceID, subjectDID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActivateServiceForSubject", reflect.TypeOf((*MockClient)(nil).ActivateServiceForSubject), ctx, serviceID, subjectID)
 }
 
-// DeactivateServiceForDID mocks base method.
-func (m *MockClient) DeactivateServiceForDID(ctx context.Context, serviceID string, subjectDID did.DID) error {
+// DeactivateServiceForSubject mocks base method.
+func (m *MockClient) DeactivateServiceForSubject(ctx context.Context, serviceID, subjectID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeactivateServiceForDID", ctx, serviceID, subjectDID)
+	ret := m.ctrl.Call(m, "DeactivateServiceForSubject", ctx, serviceID, subjectID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeactivateServiceForDID indicates an expected call of DeactivateServiceForDID.
-func (mr *MockClientMockRecorder) DeactivateServiceForDID(ctx, serviceID, subjectDID any) *gomock.Call {
+// DeactivateServiceForSubject indicates an expected call of DeactivateServiceForSubject.
+func (mr *MockClientMockRecorder) DeactivateServiceForSubject(ctx, serviceID, subjectID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeactivateServiceForDID", reflect.TypeOf((*MockClient)(nil).DeactivateServiceForDID), ctx, serviceID, subjectDID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeactivateServiceForSubject", reflect.TypeOf((*MockClient)(nil).DeactivateServiceForSubject), ctx, serviceID, subjectID)
 }
 
 // GetServiceActivation mocks base method.
-func (m *MockClient) GetServiceActivation(ctx context.Context, serviceID string, subjectDID did.DID) (bool, *vc.VerifiablePresentation, error) {
+func (m *MockClient) GetServiceActivation(ctx context.Context, serviceID, subjectID string) (bool, []vc.VerifiablePresentation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServiceActivation", ctx, serviceID, subjectDID)
+	ret := m.ctrl.Call(m, "GetServiceActivation", ctx, serviceID, subjectID)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(*vc.VerifiablePresentation)
+	ret1, _ := ret[1].([]vc.VerifiablePresentation)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
 // GetServiceActivation indicates an expected call of GetServiceActivation.
-func (mr *MockClientMockRecorder) GetServiceActivation(ctx, serviceID, subjectDID any) *gomock.Call {
+func (mr *MockClientMockRecorder) GetServiceActivation(ctx, serviceID, subjectID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceActivation", reflect.TypeOf((*MockClient)(nil).GetServiceActivation), ctx, serviceID, subjectDID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceActivation", reflect.TypeOf((*MockClient)(nil).GetServiceActivation), ctx, serviceID, subjectID)
 }
 
 // Search mocks base method.

--- a/discovery/module.go
+++ b/discovery/module.go
@@ -364,7 +364,7 @@ func (m *Module) Services() []ServiceDefinition {
 	return result
 }
 
-// GetServiceActivation is a Discovery Client function that retrieves the activation status of a service for a DID.
+// GetServiceActivation is a Discovery Client function that retrieves the activation status of a service for a subject.
 // See interface.go for more information.
 func (m *Module) GetServiceActivation(ctx context.Context, serviceID, subjectID string) (bool, []vc.VerifiablePresentation, error) {
 	refreshTime, err := m.store.getPresentationRefreshTime(serviceID, subjectID)

--- a/discovery/store.go
+++ b/discovery/store.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/vcr/credential/store"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -80,8 +81,8 @@ func (p credentialRecord) TableName() string {
 type presentationRefreshRecord struct {
 	// ServiceID refers to the entry record in discovery_service
 	ServiceID string `gorm:"primaryKey"`
-	// Did is Did that should be registered on the service.
-	Did string `gorm:"primaryKey"`
+	// SubjectID is the ID of the subject that should be registered on the service.
+	SubjectID string `gorm:"primaryKey"`
 	// NextRefresh is the Timestamp (seconds since Unix epoch) when the registration on the Discovery Service should be refreshed.
 	NextRefresh int64
 }
@@ -295,20 +296,20 @@ func (s *sqlStore) removeExpired() (int, error) {
 
 // updatePresentationRefreshTime creates/updates the next refresh time for a Verifiable Presentation on a Discovery Service.
 // If nextRegistration is nil, the entry will be removed from the database.
-func (s *sqlStore) updatePresentationRefreshTime(serviceID string, subjectDID did.DID, nextRefresh *time.Time) error {
+func (s *sqlStore) updatePresentationRefreshTime(serviceID string, subjectID string, nextRefresh *time.Time) error {
 	return s.db.Transaction(func(tx *gorm.DB) error {
 		if nextRefresh == nil {
 			// Delete registration
-			return tx.Delete(&presentationRefreshRecord{}, "service_id = ? AND did = ?", serviceID, subjectDID.String()).Error
+			return tx.Delete(&presentationRefreshRecord{}, "service_id = ? AND subject_id = ?", serviceID, subjectID).Error
 		}
 		// Create or update it
-		return tx.Save(presentationRefreshRecord{Did: subjectDID.String(), ServiceID: serviceID, NextRefresh: nextRefresh.Unix()}).Error
+		return tx.Save(presentationRefreshRecord{SubjectID: subjectID, ServiceID: serviceID, NextRefresh: nextRefresh.Unix()}).Error
 	})
 }
 
-func (s *sqlStore) getPresentationRefreshTime(serviceID string, subjectDID did.DID) (*time.Time, error) {
+func (s *sqlStore) getPresentationRefreshTime(serviceID string, subjectID string) (*time.Time, error) {
 	var row presentationRefreshRecord
-	if err := s.db.Find(&row, "service_id = ? AND did = ?", serviceID, subjectDID.String()).Error; err != nil {
+	if err := s.db.Find(&row, "service_id = ? AND subject_id = ?", serviceID, subjectID).Error; err != nil {
 		return nil, err
 	}
 	if row.NextRefresh == 0 {
@@ -318,25 +319,21 @@ func (s *sqlStore) getPresentationRefreshTime(serviceID string, subjectDID did.D
 	return &result, nil
 }
 
-// getPresentationsToBeRefreshed returns all DID discovery service registrations that are due for refreshing.
-// It returns a slice of service IDs and associated DIDs.
-func (s *sqlStore) getPresentationsToBeRefreshed(now time.Time) ([]string, []did.DID, error) {
-	var rows []presentationRefreshRecord
-	if err := s.db.Find(&rows, "next_refresh < ?", now.Unix()).Error; err != nil {
-		return nil, nil, err
+// getSubjectsToBeRefreshed returns all registered subject-service combinations that are due for refreshing.
+func (s *sqlStore) getSubjectsToBeRefreshed(now time.Time) ([]refreshCandidate, error) {
+	var candidates []refreshCandidate
+	if err := s.db.Model(&presentationRefreshRecord{}).Find(&candidates, "next_refresh < ?", now.Unix()).Error; err != nil {
+		return nil, err
 	}
-	var dids []did.DID
-	var serviceIDs []string
-	for _, row := range rows {
-		parsedDID, err := did.ParseDID(row.Did)
-		if err != nil {
-			log.Logger().WithError(err).Errorf("Invalid DID in discovery presentation refresh table: %s", row.Did)
-			continue
-		}
-		dids = append(dids, *parsedDID)
-		serviceIDs = append(serviceIDs, row.ServiceID)
-	}
-	return serviceIDs, dids, nil
+	return candidates, nil
+}
+
+// refreshCandidate is a subset of presentationRefreshRecord
+type refreshCandidate struct {
+	// ServiceID is the presentationRefreshRecord.ServiceID
+	ServiceID string
+	// SubjectID is the presentationRefreshRecord.SubjectID
+	SubjectID string
 }
 
 func (s *sqlStore) getTimestamp(serviceID string) (int, error) {
@@ -348,4 +345,64 @@ func (s *sqlStore) getTimestamp(serviceID string) (int, error) {
 		return 0, fmt.Errorf("query service '%s': %w", serviceID, err)
 	}
 	return service.LastLamportTimestamp, nil
+}
+
+// getSubjectVPsOnService finds all VPs in the service that contain a credential issued to any of the subjectDIDs.
+// It returns a (potentially empty) list of VPs for each of the subjectDIDs.
+// The list should not contain retractions since these do not contain any credentials.
+func (s *sqlStore) getSubjectVPsOnService(serviceID string, subjectDIDs []did.DID) ([][]vc.VerifiablePresentation, error) {
+	// this assumes Presentation Definitions for a service uses the subject wallet, meaning that a DID in a subject can
+	// fulfill the PD using credentials issued to any of the subjectDIDs.
+	// This complicates the search since we cannot filter on VP signer
+	//
+	// Example: a subject has 2 DIDs, did:web and did:nuts.
+	// did:web has an organization credential
+	// did:nuts has a use-case credential
+	// The Presentation Definition of the use-case requires both credentials
+	// The Discovery Service will contain VPs:
+	// 	- VP with ID=123 that is signed by did:web and both credentials
+	//  - VP with ID=abc that is signed by did:nuts and both credentials
+	// since we can only filter on credential contents, a search on either DID will find both VPs.
+
+	// get all VPs with a credential that has one of subjectDIDs as credentialSubject.id
+	var vps []vc.VerifiablePresentation
+	for _, subjectDID := range subjectDIDs {
+		loopVPs, err := s.search(serviceID, map[string]string{
+			"credentialSubject.id": subjectDID.String(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		vps = append(vps, loopVPs...)
+	}
+
+	// deduplicate results by VP.ID and create a list of VPs per signer
+	signerToVPs := map[string][]vc.VerifiablePresentation{} // signerToVPs maps all VPs to their signer.
+	var uniqueVPIDs []string                                // keeps track of known VP.IDs
+	for _, vp := range vps {
+		vpID := vp.ID.String() // must be set according to Discovery Service RFC
+		if slices.Contains(uniqueVPIDs, vpID) {
+			// already in the map
+			continue
+		}
+
+		signer, err := credential.PresentationSigner(vp)
+		if err != nil {
+			// this should not happen for VPs valid according to the Discovery Service RFC
+			log.Logger().WithError(err).Warn("Could not determine signer of Verifiable Presentation")
+			continue
+		}
+
+		// update loop vars at the same time
+		uniqueVPIDs = append(uniqueVPIDs, vpID)
+		signerToVPs[signer.String()] = append(signerToVPs[signer.String()], vp)
+	}
+
+	// TODO: confirm that there can only be one VP per discovery service-signer combination, meaning that results can be flattened.
+	results := make([][]vc.VerifiablePresentation, len(subjectDIDs))
+	for ind, subjectDID := range subjectDIDs {
+		// also set empty sets to maintain index with subjectDIDs
+		results[ind] = signerToVPs[subjectDID.String()]
+	}
+	return results, nil
 }

--- a/discovery/store_test.go
+++ b/discovery/store_test.go
@@ -296,12 +296,12 @@ func Test_sqlStore_getSubjectVPsOnService(t *testing.T) {
 	t.Run("ok - single", func(t *testing.T) {
 		vps, err := c.getSubjectVPsOnService(testServiceID, []did.DID{aliceDID})
 		require.NoError(t, err)
-		assert.Equal(t, [][]vc.VerifiablePresentation{{vpAlice2}}, vps)
+		assert.Equal(t, map[did.DID][]vc.VerifiablePresentation{aliceDID: {vpAlice2}}, vps)
 	})
 	t.Run("ok - multi", func(t *testing.T) {
 		vps, err := c.getSubjectVPsOnService(testServiceID, []did.DID{aliceDID, unsupportedDID, bobDID})
 		require.NoError(t, err)
-		assert.Equal(t, [][]vc.VerifiablePresentation{{vpAlice2}, []vc.VerifiablePresentation(nil), {vpBob2}}, vps)
+		assert.Equal(t, map[did.DID][]vc.VerifiablePresentation{aliceDID: {vpAlice2}, unsupportedDID: {}, unsupportedDID: nil, bobDID: {vpBob2}}, vps)
 	})
 }
 

--- a/discovery/test.go
+++ b/discovery/test.go
@@ -38,9 +38,11 @@ import (
 
 var keyPairs map[string]*ecdsa.PrivateKey
 var authorityDID did.DID
+var aliceSubject string
 var aliceDID did.DID
 var vcAlice vc.VerifiableCredential
 var vpAlice vc.VerifiablePresentation
+var bobSubject string
 var bobDID did.DID
 var vcBob vc.VerifiableCredential
 var vpBob vc.VerifiablePresentation
@@ -104,8 +106,10 @@ func init() {
 	keyPairs = make(map[string]*ecdsa.PrivateKey)
 	authorityDID = did.MustParseDID("did:example:authority")
 	keyPairs[authorityDID.String()], _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	aliceSubject = "alice"
 	aliceDID = did.MustParseDID("did:example:alice")
 	keyPairs[aliceDID.String()], _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	bobSubject = "bob"
 	bobDID = did.MustParseDID("did:example:bob")
 	keyPairs[bobDID.String()], _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	unsupportedDID = did.MustParseDID("did:web:example.com")

--- a/docs/_static/discovery/v1.yaml
+++ b/docs/_static/discovery/v1.yaml
@@ -84,35 +84,32 @@ paths:
                   $ref: "#/components/schemas/SearchResult"
         default:
           $ref: "../common/error_response.yaml"
-  /internal/discovery/v1/{serviceID}/{did}:
+  /internal/discovery/v1/{serviceID}/{subjectID}:
     description: |
-      APIs to manage the activation of a DID on a Discovery Service.
-      When a service has been activated for a DID, the Discovery Client will automatically register the DID on the Discovery Service.
+      APIs to manage the activation of a DID subject on a Discovery Service.
+      When a service has been activated for a subject, the Discovery Client will automatically register all qualifying DIDs of that subject on the Discovery Service.
     parameters:
       - name: serviceID
         in: path
         required: true
         schema:
           type: string
-      - name: did
+      - name: subjectID
         in: path
+        description: URL encoded subject.
         required: true
         content:
           plain/text:
             schema:
               type: string
-              example:
-                - did:web:example.com
-                - did:web:example.com:iam:user
-                - did:web:example.com%3A9443
-                - did:web:example.com%3A9443:iam:user
+              example: "tenant-123"
     get:
-      summary: Retrieves the activation status a DID on a Discovery Service.
+      summary: Retrieves the activation status of a subject on a Discovery Service.
       description: |
         An API provided by the Discovery Client,
-        used to check whether the client is managing the given DID on the specified Discovery Service (service has been activated for the DID).
-        It will return true after successfully calling the activateServiceForDID API, and false after calling the deactivateServiceForDID API.
-        It also returns the active Verifiable Presentation, if any.
+        used to check whether the client is managing the given subject on the specified Discovery Service (service has been activated for the subject).
+        It will return true after successfully calling the activateServiceForSubject API, and false after calling the deactivateServiceForSubject API.
+        It also returns the active Verifiable Presentations, if any.
       operationId: getServiceActivation
       tags:
         - discovery
@@ -128,25 +125,30 @@ paths:
                 properties:
                   activated:
                     type: boolean
-                    description: Whether the DID is activated on the Discovery Service.
+                    description: Whether the Discovery Service is activated for the given subject
                   vp:
-                    $ref: "#/components/schemas/VerifiablePresentation"
+                    description: |
+                      List of VPs on the Discovery Service for the subject. One per DID method registered on the Service.
+                      The list can be empty even if activated==true if none of the DIDs of a subject is actually registered on the Discovery Service.
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/VerifiablePresentation"
         default:
           $ref: "../common/error_response.yaml"
     post:
-      summary: Client API to activate a DID on the specified Discovery Service.
+      summary: Client API to activate a subject on the specified Discovery Service.
       description: |
-        An API provided by the discovery client that will cause the given DID to be registered on the specified Discovery Service.
-        Registration of a Verifiable Presentation will be attempted immediately, and it will be automatically refreshed.
-        Application only need to call this API once for every service/DID combination, until the registration is explicitly deleted through this API.
+        An API provided by the discovery client that will cause all qualifying DIDs of a subject to be registered on the specified Discovery Service.
+        A DID qualifies for registration if it meets the requirements defined the Presentation Definition of the Discovery Service.
+        Registration of all DIDs of a subject will be attempted immediately, and they will be automatically refreshed.
+        Applications only need to call this API once for every service/subject combination, until the registration is explicitly deleted through this API.
         
-        For successful registration on the Discovery Server, the DID's credential wallet must contain the credentials specified by the Discovery Service definition.
-        If initial registration fails this API returns the error indicating what failed, but will retry at a later moment.
+        If initial registration fails, this API returns the error indicating what failed and periodically retry registration.
         Applications can force a retry by calling this API again.
         
         error returns:
-        * 400 - incorrect input: invalid/unknown service or DID.
-      operationId: activateServiceForDID
+        * 400 - incorrect input: invalid/unknown service or subject.
+      operationId: activateServiceForSubject
       tags:
         - discovery
       responses:
@@ -169,14 +171,14 @@ paths:
         default:
           $ref: "../common/error_response.yaml"
     delete:
-      summary: Client API to deactivate the given DID from the Discovery Service.
+      summary: Client API to deactivate the given subject from the Discovery Service.
       description: |
-        An API provided by the discovery client that will cause the given DID to be not to be registered any more on the specified Discovery Service.
-        It will try to delete the existing registration at the Discovery Service, if any.
+        An API provided by the discovery client that will cancel the periodic registration of a subject on the specified Discovery Service.
+        It will also try to delete all the existing registrations on the Discovery Service, if any.
         
         error returns:
-        * 400 - incorrect input: invalid/unknown service or DID.
-      operationId: deactivateServiceForDID
+        * 400 - incorrect input: invalid/unknown service or subject.
+      operationId: deactivateServiceForSubject
       tags:
         - discovery
       responses:
@@ -210,14 +212,14 @@ components:
       type: object
       required:
         - id
-        - subject_id
+        - credential_subject_id
         - vp
         - fields
       properties:
         id:
           type: string
           description: The ID of the Verifiable Presentation.
-        subject_id:
+        credential_subject_id:
           type: string
           description: The ID of the Verifiable Credential subject (holder), typically a DID.
         vp:

--- a/e2e-tests/discovery/run-test.sh
+++ b/e2e-tests/discovery/run-test.sh
@@ -20,8 +20,10 @@ docker compose up --wait nodeB-backend nodeB
 echo "------------------------------------"
 echo "Registering care organization..."
 echo "------------------------------------"
-DIDDOC=$(docker compose exec nodeB-backend nuts vdr create-did --v2)
-DID=$(echo $DIDDOC | jq -r .[0].id)
+RESPONSE=$(curl --insecure -s -X POST http://localhost:28081/internal/vdr/v2/subject -H "Content-Type:application/json")
+SUBJECT=$(echo $RESPONSE | jq -r .subject)
+echo SUBJECT: $SUBJECT
+DID=$(echo $RESPONSE | jq -r .documents[0].id)
 echo DID: $DID
 
 REQUEST="{\"type\":\"NutsOrganizationCredential\",\"issuer\":\"${DID}\", \"credentialSubject\": {\"id\":\"${DID}\", \"organization\":{\"name\":\"Caresoft B.V.\", \"city\":\"Caretown\"}},\"withStatusList2021Revocation\": false}"
@@ -46,7 +48,7 @@ fi
 echo "---------------------------------------"
 echo "Registering care organization on Discovery Service..."
 echo "---------------------------------------"
-curl --insecure -s -X POST http://localhost:28081/internal/discovery/v1/dev:eOverdracht2023/${DID}
+curl --insecure -s -X POST http://localhost:28081/internal/discovery/v1/dev:eOverdracht2023/${SUBJECT}
 # Start Discovery Server
 docker compose up --wait nodeA-backend nodeA
 # Registration refresh interval is 500ms, wait some to make sure the registration is refreshed

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/dlclark/regexp2 v1.11.4
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-redis/redismock/v9 v9.2.0
-	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/goodsign/monday v1.0.2
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/vault/api v1.14.0
@@ -104,6 +103,7 @@ require (
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/storage/sql_migrations/004_discoveryservice_client_registration.sql
+++ b/storage/sql_migrations/004_discoveryservice_client_registration.sql
@@ -5,12 +5,12 @@ create table discovery_presentation_refresh
     -- service_id is the ID of the Discover Service that the DID should be registered on.
     -- It comes from the service definition.
     service_id   varchar(200) not null,
-    -- did is the DID that should be registered on the Discovery Service.
-    did          varchar(370) not null,
+    -- subject_id is the subject that should be registered on the Discovery Service.
+    subject_id   varchar(370) not null,
     -- next_refresh is the timestamp (seconds since Unix epoch) when the registration on the
     -- Discovery Service should be refreshed.
     next_refresh integer      not null,
-    primary key (service_id, did),
+    primary key (service_id, subject_id),
     constraint fk_discovery_presentation_refresh_service foreign key (service_id) references discovery_service (id) on delete cascade
 );
 -- index for the next_registration column, used when checking which registrations need to be refreshed

--- a/vdr/didsubject/did.go
+++ b/vdr/didsubject/did.go
@@ -72,9 +72,9 @@ func (s SqlDIDManager) DeleteAll(subject string) error {
 	return s.tx.Where("subject = ?", subject).Delete(&orm.DID{}).Error
 }
 
-func (d SqlDIDManager) Find(id did.DID) (*orm.DID, error) {
+func (s SqlDIDManager) Find(id did.DID) (*orm.DID, error) {
 	var did orm.DID
-	err := d.tx.Preload("Aka").First(&did, "id = ?", id.String()).Error
+	err := s.tx.Preload("Aka").First(&did, "id = ?", id.String()).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -84,9 +84,9 @@ func (d SqlDIDManager) Find(id did.DID) (*orm.DID, error) {
 	return &did, nil
 }
 
-func (d SqlDIDManager) FindBySubject(subject string) ([]orm.DID, error) {
+func (s SqlDIDManager) FindBySubject(subject string) ([]orm.DID, error) {
 	dids := make([]orm.DID, 0)
-	err := d.tx.Preload("Aka").Find(&dids, "subject = ?", subject).Error
+	err := s.tx.Preload("Aka").Find(&dids, "subject = ?", subject).Error
 	if err != nil {
 		return nil, err
 	}

--- a/vdr/didsubject/management.go
+++ b/vdr/didsubject/management.go
@@ -33,12 +33,6 @@ var ErrInvalidService = errors.New("invalid DID document service")
 // ErrUnsupportedDIDMethod is returned when a DID method is not supported.
 var ErrUnsupportedDIDMethod = errors.New("unsupported DID method")
 
-// ErrSubjectAlreadyExists is returned when a subject already exists.
-var ErrSubjectAlreadyExists = errors.New("subject already exists")
-
-// ErrSubjectNotFound is returned when a subject is not found.
-var ErrSubjectNotFound = errors.New("subject not found")
-
 // MethodManager keeps DID method specific state in sync with the DID sql database.
 type MethodManager interface {
 	// NewDocument generates a new DID document for the given subject.

--- a/vdr/didsubject/management.go
+++ b/vdr/didsubject/management.go
@@ -33,8 +33,11 @@ var ErrInvalidService = errors.New("invalid DID document service")
 // ErrUnsupportedDIDMethod is returned when a DID method is not supported.
 var ErrUnsupportedDIDMethod = errors.New("unsupported DID method")
 
-// ErrDIDAlreadyExists is returned when a DID already exists.
-var ErrDIDAlreadyExists = errors.New("DID already exists")
+// ErrSubjectAlreadyExists is returned when a subject already exists.
+var ErrSubjectAlreadyExists = errors.New("subject already exists")
+
+// ErrSubjectNotFound is returned when a subject is not found.
+var ErrSubjectNotFound = errors.New("subject not found")
 
 // MethodManager keeps DID method specific state in sync with the DID sql database.
 type MethodManager interface {

--- a/vdr/didsubject/manager.go
+++ b/vdr/didsubject/manager.go
@@ -37,6 +37,14 @@ import (
 	"time"
 )
 
+// ErrSubjectAlreadyExists is returned when a subject already exists.
+var ErrSubjectAlreadyExists = errors.New("subject already exists")
+
+// ErrSubjectNotFound is returned when a subject is not found.
+var ErrSubjectNotFound = errors.New("subject not found")
+
+var _ SubjectManager = (*Manager)(nil)
+
 type Manager struct {
 	DB             *gorm.DB
 	MethodManagers map[string]MethodManager

--- a/vdr/didsubject/manager.go
+++ b/vdr/didsubject/manager.go
@@ -37,12 +37,6 @@ import (
 	"time"
 )
 
-// ErrSubjectAlreadyExists is returned when a subject already exists.
-var ErrSubjectAlreadyExists = errors.New("subject already exists")
-
-// ErrSubjectNotFound is returned when a subject is not found.
-var ErrSubjectNotFound = errors.New("subject not found")
-
 type Manager struct {
 	DB             *gorm.DB
 	MethodManagers map[string]MethodManager


### PR DESCRIPTION
fixes #3265 
This change lets the Discovery Service client manage Subjects rather than individual DIDs.

During activation/refresh it tries to register every DID in a subject. If 1 DID is successfully registered on the service, the operation is considered successful and a refresh is scheduled at 45% of the max_presentation_validitiy. This means that if a second DID fails that should not fail, it will not be retried until the next scheduled refresh. So it will be retried again at 90% of max_presentation_validity. If everything fails, the refresh/activation will be retried at the next configured refresh interval.