### PR TITLE
v5.4: fix error message in private key existence check

### DIFF
--- a/auth/services/oauth/authz_server.go
+++ b/auth/services/oauth/authz_server.go
@@ -510,7 +510,7 @@ func (s *authzServer) parseAndValidateJwtBearerToken(context *validationContext)
 func (s *authzServer) IntrospectAccessToken(ctx context.Context, accessToken string) (*services.NutsAccessToken, error) {
 	token, err := nutsCrypto.ParseJWT(accessToken, func(kid string) (crypto.PublicKey, error) {
 		if !s.privateKeyStore.Exists(ctx, kid) {
-			return nil, fmt.Errorf("JWT signing key not present on this node (kid=%s)", kid)
+			return nil, fmt.Errorf("could not check if JWT signing key exists (kid=%s)", kid)
 		}
 		return s.keyResolver.ResolveSigningKey(kid, nil)
 	}, jwt.WithAcceptableSkew(s.clockSkew))

--- a/crypto/interface.go
+++ b/crypto/interface.go
@@ -40,7 +40,7 @@ type KeyCreator interface {
 // KeyResolver is the interface for resolving keys.
 type KeyResolver interface {
 	// Exists returns if the specified private key exists.
-	// If an error occurs, false is also returned
+	// If an error occurs or the context is cancelled/expired, false is also returned
 	Exists(ctx context.Context, kid string) bool
 	// Resolve returns a Key for the given KID. ErrPrivateKeyNotFound is returned for an unknown KID.
 	Resolve(ctx context.Context, kid string) (Key, error)


### PR DESCRIPTION
aligned the message with v6. 
In V6 `Exists` also returns an error clarifying this even further.