### PR TITLE
Fix dev image persistent tunnel

### DIFF
--- a/development/dev-image/Dockerfile
+++ b/development/dev-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM nutsfoundation/nuts-node:master as nutsnode
+FROM nutsfoundation/nuts-node:master AS nutsnode
 FROM debian:buster-slim
 
 RUN apt-get update && apt-get install -y curl sudo musl

--- a/development/dev-image/entrypoint.sh
+++ b/development/dev-image/entrypoint.sh
@@ -1,39 +1,41 @@
 #!/bin/bash
 
 source ~/.bashrc
+
+NUTS_TUNNEL_PATH="./config/nuts-devtunnel"
 # mkdir if not mounted
-mkdir -p /devtunnel
+mkdir -p $NUTS_TUNNEL_PATH
 
 # login with github user
 devtunnel user login -d -g
 
 # clear log without error if does not exist
-rm -f /devtunnel/tunnel.log
+rm -f ${NUTS_TUNNEL_PATH}/tunnel.log
 
-# read from /devtunnel/tunnelid
+# read from ${NUTS_TUNNEL_PATH}/tunnel.id
 # if it does not exist, create a new tunnel
-if [ ! -f /devtunnel/tunnel.id ]; then
+if [ ! -f ${NUTS_TUNNEL_PATH}/tunnel.id ]; then
   # create persistent tunnel. We could set our own TUNNEL_ID, but a random one seems more fault tolerant.
   # calling "devtunnel host" without TUNNEL_ID creates a temporary tunnel, so we need to create a persistent tunnel first.
   # https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/faq#how-can-i-create-a-persistent-tunnel
-  devtunnel create -a >> /devtunnel/tunnel.log 2>&1
+  devtunnel create -a >> ${NUTS_TUNNEL_PATH}/tunnel.log 2>&1
   # add port 8080 to most recent tunnel. (can't be done in a single call unfortunately)
-  devtunnel port create -p 8080 >> /devtunnel/tunnel.log 2>&1
+  devtunnel port create -p 8080 >> ${NUTS_TUNNEL_PATH}/tunnel.log 2>&1
   # save the TUNNEL_ID
-  grep "Tunnel ID" /devtunnel/tunnel.log | head -1 | awk '{print $4}' > /devtunnel/tunnel.id
+  grep "Tunnel ID" ${NUTS_TUNNEL_PATH}/tunnel.log | head -1 | awk '{print $4}' > ${NUTS_TUNNEL_PATH}/tunnel.id
 fi
 
 # Execute the devtunnel host command and write the output to a log file
-devtunnel host $(cat /devtunnel/tunnel.id) >> /devtunnel/tunnel.log 2>&1 &
+devtunnel host $(cat ${NUTS_TUNNEL_PATH}/tunnel.id) >> ${NUTS_TUNNEL_PATH}/tunnel.log 2>&1 &
 # safe the pid for later
-echo $! > /devtunnel/tunnel.pid
+echo $! > ${NUTS_TUNNEL_PATH}/tunnel.pid
 
 # Try 30 times to read the tunnel URL from the log file.
 # The format is "your url is:" followed by the URL.
 echo "Waiting for devurl URL (time-out in 10s)..."
 for i in $(seq 1 10); do
-  TUNNEL_URL=$(grep "Connect via browser:" /devtunnel/tunnel.log | awk '{print $5}')
-  TUNNEL_ID=$(grep "Ready to accept connections for tunnel:" /devtunnel/tunnel.log | awk '{print $7}')
+  TUNNEL_URL=$(grep "Connect via browser:" ${NUTS_TUNNEL_PATH}/tunnel.log | awk '{print $5}')
+  TUNNEL_ID=$(grep "Ready to accept connections for tunnel:" ${NUTS_TUNNEL_PATH}/tunnel.log | awk '{print $7}')
   if [ -n "$TUNNEL_URL" ]; then
     break
   fi
@@ -43,15 +45,15 @@ done
 # Check whether we retrieved the URL and if not, exit with an error.
 if [ -z "$TUNNEL_URL" ]; then
   echo "Failed to retrieve the devtunnel URL"
-  cat /devtunnel/tunnel.log
+  cat ${NUTS_TUNNEL_PATH}/tunnel.log
   exit 1
 fi
 
-# store the tunnel id in /devtunnel/tunnel.id
-echo $TUNNEL_ID > /devtunnel/tunnel.id
+# store the tunnel id in ${NUTS_TUNNEL_PATH}/tunnel.id
+echo $TUNNEL_ID > ${NUTS_TUNNEL_PATH}/tunnel.id
 echo Your Nuts node URL is: ${TUNNEL_URL}
 
 NUTS_URL="${TUNNEL_URL}" NUTS_STRICTMODE=false NUTS_AUTH_CONTRACTVALIDATORS=dummy NUTS_HTTP_INTERNAL_ADDRESS=:8081 exec /usr/bin/nuts server
 
 # Kill the localtunnel process when the container stops
-kill $(cat /devtunnel/tunnel.pid)
+kill $(cat ${NUTS_TUNNEL_PATH}/tunnel.pid)

--- a/development/dev-image/entrypoint.sh
+++ b/development/dev-image/entrypoint.sh
@@ -6,8 +6,11 @@ NUTS_TUNNEL_PATH="./config/nuts-devtunnel"
 # mkdir if not mounted
 mkdir -p $NUTS_TUNNEL_PATH
 
-# login with github user
-devtunnel user login -d -g
+# login with github user if no session exists
+# by default devtunnel stores session data in ~/DevTunnels/...
+if ! devtunnel user show | grep -q "Logged in as"; then
+  devtunnel user login -d -g
+fi
 
 # clear log without error if does not exist
 rm -f ${NUTS_TUNNEL_PATH}/tunnel.log

--- a/docs/pages/deployment/docker.rst
+++ b/docs/pages/deployment/docker.rst
@@ -94,5 +94,11 @@ You can also build the development image yourself by running the following comma
 
 When starting up the development image, it'll block and requires you to authenticate with Github.
 It'll print a URL to visit in your browser and a code to enter. After authenticating, the tunnel will be established and the Nuts Node will start.
-To save the tunnel configuration, mount a directory to ``/devtunnel`` inside the container. The last used tunnel is stored in ``/devtunnel/tunnel.id``.
-``devtunnel/tunnel.log`` contains the logs of the tunnel including the public accessible URL. This URL is also printed to the console.
+The container stores the last used tunnel in ``/nuts/config/devtunnel/tunnel.id``.
+``/nuts/config/devtunnel/tunnel.log`` contains the logs of the tunnel including the public accessible URL. This URL is also printed to the console.
+Devtunnel also stores some session information in ``/nuts/DevTunnel``.
+
+To persist a tunnel URL over node restarts, mount a directory at ``/nuts/config/devtunnel`` (or one of its parents) inside the container.
+Mounting ``/nuts`` would also persist the current Github session over container restarts.
+
+For trouble shooting devtunnel issues, see the `documentation <https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/>`_ and tunnel usage `limits <https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#dev-tunnels-limits>`_.


### PR DESCRIPTION
This PR contains 3 changes to the `entrypoint.sh` script. I'm happy to only merge the ones that make sense
- commit 1: fix script to first [create a persistent tunnel before hosting](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/faq#how-can-i-create-a-persistent-tunnel) it. Calling `devtunnel host` without a `TUNNEL_ID` should create a temporary tunnel, but the behavior seems inconsistent as the tunnel is not always deleted. This commit should fix the inconsistency and always persist the created tunnel.
- commit 2: move tunnel variables from `/devtunnel/...` to `~/config/nuts-devtunnel`. It is likely that the `./config` folder is mounted anyway, so this saves a volume mount. However, the `config` directory inside the `nuts-node` is defined relative to the configured `datadir`, which could be set to a different path as the current working directory at the start of the container. This could be confusing so I'm not sure if it's worth the trouble.
- commit 3: devtunnel stores its user session info in `/nuts/DevTunnel`. When mounting `/nuts` (the default nuts datadir), this session info is also persisted over restarts, so we can check if there is a session and only prompt for a login if there is no session.

devtunnel has several [service limits](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#dev-tunnels-limits). The one I think we are most likely to hit first during a hackathon is 
> Active connections	20 per port

TODO in documentation
- [x] commit 2 and 3 require updates if approved
- [x] add link to service limits
- [x] link to devtunnel docs in case the devtunnel fails (not mounting `/devtunnel` may exceed max tunnels if the container is restarted often enough)