### PR TITLE
VCR: Prepare wallet to perform on multiple DIDs

### DIFF
--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -331,7 +331,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 		ctx.iamClient.EXPECT().ClientMetadata(gomock.Any(), "https://example.com/.well-known/authorization-server/oauth2/verifier").Return(&clientMetadata, nil)
 		pdEndpoint := "https://example.com/oauth2/did:web:example.com:iam:verifier/presentation_definition?scope=test"
 		ctx.iamClient.EXPECT().PresentationDefinition(gomock.Any(), pdEndpoint).Return(&pe.PresentationDefinition{}, nil)
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), holderDID, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{holderDID}, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
 		ctx.iamClient.EXPECT().PostAuthorizationResponse(gomock.Any(), vc.VerifiablePresentation{}, pe.PresentationSubmission{}, "https://example.com/oauth2/did:web:example.com:iam:verifier/response", "state").Return("https://example.com/iam/holder/redirect", nil)
 
 		res, err := ctx.client.HandleAuthorizeRequest(callCtx, HandleAuthorizeRequestRequestObject{

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -315,7 +315,7 @@ func (r Wrapper) handleAuthorizeRequestFromVerifier(ctx context.Context, tenantD
 			map[did.DID][]vc.VerifiableCredential{userSession.Wallet.DID: userSession.Wallet.Credentials},
 		)
 	}
-	vp, submission, err := targetWallet.BuildSubmission(ctx, walletDID, *presentationDefinition, metadata.VPFormats, buildParams)
+	vp, submission, err := targetWallet.BuildSubmission(ctx, []did.DID{walletDID}, *presentationDefinition, metadata.VPFormats, buildParams)
 	if err != nil {
 		if errors.Is(err, holder.ErrNoCredentials) {
 			return r.sendAndHandleDirectPostError(ctx, oauth.OAuth2Error{Code: oauth.InvalidRequest, Description: fmt.Sprintf("wallet does not contain the required credentials (PD ID: %s, wallet: %s)", presentationDefinition.Id, walletDID)}, responseURI, state)

--- a/auth/api/iam/openid4vp_test.go
+++ b/auth/api/iam/openid4vp_test.go
@@ -297,7 +297,7 @@ func TestWrapper_handleAuthorizeRequestFromVerifier(t *testing.T) {
 		putState(ctx, "state", authzCodeSession)
 		ctx.iamClient.EXPECT().ClientMetadata(gomock.Any(), "https://example.com/.well-known/authorization-server/iam/verifier").Return(&clientMetadata, nil)
 		ctx.iamClient.EXPECT().PresentationDefinition(gomock.Any(), pdEndpoint).Return(&pe.PresentationDefinition{}, nil)
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), holderDID, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(nil, nil, assert.AnError)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{holderDID}, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(nil, nil, assert.AnError)
 		expectPostError(t, ctx, oauth.ServerError, assert.AnError.Error(), responseURI, "state")
 
 		_, err := ctx.client.handleAuthorizeRequestFromVerifier(httpRequestCtx, holderDID, params, pe.WalletOwnerOrganization)
@@ -310,7 +310,7 @@ func TestWrapper_handleAuthorizeRequestFromVerifier(t *testing.T) {
 		putState(ctx, "state", authzCodeSession)
 		ctx.iamClient.EXPECT().ClientMetadata(gomock.Any(), "https://example.com/.well-known/authorization-server/iam/verifier").Return(&clientMetadata, nil)
 		ctx.iamClient.EXPECT().PresentationDefinition(gomock.Any(), pdEndpoint).Return(&pe.PresentationDefinition{}, nil)
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), holderDID, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(nil, nil, holder.ErrNoCredentials)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{holderDID}, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(nil, nil, holder.ErrNoCredentials)
 		expectPostError(t, ctx, oauth.InvalidRequest, "wallet does not contain the required credentials (PD ID: , wallet: did:web:example.com:iam:holder)", responseURI, "state")
 
 		_, err := ctx.client.handleAuthorizeRequestFromVerifier(httpRequestCtx, holderDID, params, pe.WalletOwnerOrganization)

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -247,7 +247,7 @@ func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, requeste
 		}
 	}
 
-	vp, submission, err := targetWallet.BuildSubmission(ctx, requester, *presentationDefinition, metadata.VPFormatsSupported, params)
+	vp, submission, err := targetWallet.BuildSubmission(ctx, []did.DID{requester}, *presentationDefinition, metadata.VPFormatsSupported, params)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/client/iam/openid4vp_test.go
+++ b/auth/client/iam/openid4vp_test.go
@@ -237,7 +237,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		ctx := createClientServerTestContext(t)
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), walletDID, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{walletDID}, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
 
 		response, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierURL.String(), scopes, false, nil)
 
@@ -313,7 +313,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 		ctx := createClientServerTestContext(t)
 		ctx.keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.NutsSigningKeyType).Return(kid, nil, nil)
 		ctx.jwtSigner.EXPECT().SignDPoP(context.Background(), gomock.Any(), kid).Return("dpop", nil)
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), walletDID, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{walletDID}, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
 
 		response, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierURL.String(), scopes, true, nil)
 
@@ -334,7 +334,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 			writer.WriteHeader(http.StatusBadRequest)
 			_, _ = writer.Write(oauthErrorBytes)
 		}
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), walletDID, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{walletDID}, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
 
 		_, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierURL.String(), scopes, false, nil)
 
@@ -377,7 +377,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 	t.Run("error - failed to build vp", func(t *testing.T) {
 		ctx := createClientServerTestContext(t)
 
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), walletDID, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(nil, nil, assert.AnError)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{walletDID}, gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(nil, nil, assert.AnError)
 
 		_, err := ctx.client.RequestRFC021AccessToken(context.Background(), walletDID, ctx.verifierURL.String(), scopes, false, nil)
 

--- a/vcr/holder/interface.go
+++ b/vcr/holder/interface.go
@@ -49,7 +49,7 @@ type Wallet interface {
 	BuildPresentation(ctx context.Context, credentials []vc.VerifiableCredential, options PresentationOptions, signerDID *did.DID, validateVC bool) (*vc.VerifiablePresentation, error)
 
 	// BuildSubmission builds a Verifiable Presentation based on the given presentation definition.
-	BuildSubmission(ctx context.Context, walletDID did.DID, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error)
+	BuildSubmission(ctx context.Context, walletDIDs []did.DID, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error)
 
 	// List returns all credentials in the wallet for the given holder.
 	// If the wallet does not contain any credentials for the given holder, it returns an empty list.

--- a/vcr/holder/memory_wallet.go
+++ b/vcr/holder/memory_wallet.go
@@ -58,12 +58,16 @@ func (m memoryWallet) BuildPresentation(ctx context.Context, credentials []vc.Ve
 	}.buildPresentation(ctx, signerDID, credentials, options)
 }
 
-func (m memoryWallet) BuildSubmission(ctx context.Context, walletDID did.DID, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
+func (m memoryWallet) BuildSubmission(ctx context.Context, walletDIDs []did.DID, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
+	wallets := make(map[did.DID][]vc.VerifiableCredential)
+	for _, walletDID := range walletDIDs {
+		wallets[walletDID] = m.credentials[walletDID]
+	}
 	return presenter{
 		documentLoader: m.documentLoader,
 		signer:         m.signer,
 		keyResolver:    m.keyResolver,
-	}.buildSubmission(ctx, walletDID, m.credentials[walletDID], presentationDefinition, acceptedFormats, params)
+	}.buildSubmission(ctx, wallets, presentationDefinition, acceptedFormats, params)
 }
 
 func (m memoryWallet) List(_ context.Context, holderDID did.DID) ([]vc.VerifiableCredential, error) {

--- a/vcr/holder/mock.go
+++ b/vcr/holder/mock.go
@@ -60,9 +60,9 @@ func (mr *MockWalletMockRecorder) BuildPresentation(ctx, credentials, options, s
 }
 
 // BuildSubmission mocks base method.
-func (m *MockWallet) BuildSubmission(ctx context.Context, walletDID did.DID, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
+func (m *MockWallet) BuildSubmission(ctx context.Context, walletDIDs []did.DID, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildSubmission", ctx, walletDID, presentationDefinition, acceptedFormats, params)
+	ret := m.ctrl.Call(m, "BuildSubmission", ctx, walletDIDs, presentationDefinition, acceptedFormats, params)
 	ret0, _ := ret[0].(*vc.VerifiablePresentation)
 	ret1, _ := ret[1].(*pe.PresentationSubmission)
 	ret2, _ := ret[2].(error)
@@ -70,9 +70,9 @@ func (m *MockWallet) BuildSubmission(ctx context.Context, walletDID did.DID, pre
 }
 
 // BuildSubmission indicates an expected call of BuildSubmission.
-func (mr *MockWalletMockRecorder) BuildSubmission(ctx, walletDID, presentationDefinition, acceptedFormats, params any) *gomock.Call {
+func (mr *MockWalletMockRecorder) BuildSubmission(ctx, walletDIDs, presentationDefinition, acceptedFormats, params any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildSubmission", reflect.TypeOf((*MockWallet)(nil).BuildSubmission), ctx, walletDID, presentationDefinition, acceptedFormats, params)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildSubmission", reflect.TypeOf((*MockWallet)(nil).BuildSubmission), ctx, walletDIDs, presentationDefinition, acceptedFormats, params)
 }
 
 // Diagnostics mocks base method.

--- a/vcr/holder/presenter.go
+++ b/vcr/holder/presenter.go
@@ -47,14 +47,16 @@ type presenter struct {
 	keyResolver    resolver.KeyResolver
 }
 
-func (p presenter) buildSubmission(ctx context.Context, holderDID did.DID, credentials []vc.VerifiableCredential, presentationDefinition pe.PresentationDefinition,
+func (p presenter) buildSubmission(ctx context.Context, credentials map[did.DID][]vc.VerifiableCredential, presentationDefinition pe.PresentationDefinition,
 	acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
 	// match against the wallet's credentials
 	// if there's a match, create a VP and call the token endpoint
 	// If the token endpoint succeeds, return the access token
 	// If no presentation definition matches, return a 412 "no matching credentials" error
 	builder := presentationDefinition.PresentationSubmissionBuilder()
-	builder.AddWallet(holderDID, credentials)
+	for holderDID, creds := range credentials {
+		builder.AddWallet(holderDID, creds)
+	}
 
 	// Find supported VP format, matching support from:
 	// - what the local Nuts node supports
@@ -80,6 +82,12 @@ func (p presenter) buildSubmission(ctx context.Context, holderDID did.DID, crede
 			return nil, nil, ErrNoCredentials
 		}
 		// add empty sign instruction
+		// TODO: If the verifier doesn't require any credentials, it also can't signal which DID methods it supports/requires?
+		var holderDID did.DID
+		for holder, _ := range credentials {
+			holderDID = holder
+			break
+		}
 		signInstructions = append(signInstructions, pe.SignInstruction{Holder: holderDID})
 		presentationSubmission = pe.PresentationSubmission{
 			Id:            uuid.NewString(),
@@ -88,11 +96,16 @@ func (p presenter) buildSubmission(ctx context.Context, holderDID did.DID, crede
 		}
 	}
 
-	// todo: support multiple wallets
-	holder := holderDID.URI()
-	vp, err := p.buildPresentation(ctx, &holderDID, signInstructions[0].VerifiableCredentials, PresentationOptions{
+	if len(signInstructions) > 1 {
+		// todo: support multiple wallets
+		return nil, nil, errors.New("multiple sign instructions not supported")
+	}
+	signInstruction := signInstructions[0]
+
+	holderDID := signInstruction.Holder.URI()
+	vp, err := p.buildPresentation(ctx, &signInstruction.Holder, signInstruction.VerifiableCredentials, PresentationOptions{
 		Format: format,
-		Holder: &holder,
+		Holder: &holderDID,
 		ProofOptions: proof.ProofOptions{
 			Created:   time.Now(),
 			Challenge: &params.Nonce,

--- a/vcr/holder/presenter_test.go
+++ b/vcr/holder/presenter_test.go
@@ -267,9 +267,14 @@ func TestPresenter_buildPresentation(t *testing.T) {
 }
 
 func TestPresenter_buildSubmission(t *testing.T) {
-	credentials := []vc.VerifiableCredential{test.ValidNutsOrganizationCredential(t)}
-	// walletDID matches the subject of the ValidNutsOrganizationCredential
-	walletDID := did.MustParseDID("did:nuts:CuE3qeFGGLhEAS3gKzhMCeqd1dGa9at5JCbmCfyMU2Ey")
+	// nutsWalletDID matches the subject of the ValidNutsOrganizationCredential
+	nutsWalletDID := did.MustParseDID("did:nuts:CuE3qeFGGLhEAS3gKzhMCeqd1dGa9at5JCbmCfyMU2Ey")
+	webWalletDID := did.MustParseDID("did:web:example.com")
+	credentials := map[did.DID][]vc.VerifiableCredential{
+		nutsWalletDID: {test.ValidNutsOrganizationCredential(t)},
+		webWalletDID:  {createCredential("did:web:example.com#1")},
+	}
+
 	verifierDID := did.MustParseDID("did:web:example.com:iam:verifier")
 	presentationDefinition := pe.PresentationDefinition{InputDescriptors: []*pe.InputDescriptor{{Constraints: &pe.Constraints{Fields: []pe.Field{{Path: []string{"$.type"}}}}}}}
 	vpFormats := oauth.DefaultOpenIDSupportedFormats()
@@ -284,27 +289,27 @@ func TestPresenter_buildSubmission(t *testing.T) {
 	_ = keyStore.Link(ctx, key.KID, key.KID, "1")
 	storageEngine := storage.NewTestStorageEngine(t)
 
-	t.Run("ok", func(t *testing.T) {
+	t.Run("ok (did:nuts wallet matches)", func(t *testing.T) {
 		resetStore(t, storageEngine.GetSQLDatabase())
 		ctrl := gomock.NewController(t)
 		keyResolver := resolver.NewMockKeyResolver(ctrl)
-		keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.NutsSigningKeyType).Return(key.KID, key.PublicKey, nil)
+		keyResolver.EXPECT().ResolveKey(nutsWalletDID, nil, resolver.NutsSigningKeyType).Return(key.KID, key.PublicKey, nil)
 
 		w := presenter{documentLoader: jsonldManager.DocumentLoader(), signer: keyStore, keyResolver: keyResolver}
 
-		vp, submission, err := w.buildSubmission(ctx, walletDID, credentials, presentationDefinition, vpFormats, BuildParams{Audience: verifierDID.String(), Expires: time.Now().Add(time.Second), Nonce: ""})
+		vp, submission, err := w.buildSubmission(ctx, credentials, presentationDefinition, vpFormats, BuildParams{Audience: verifierDID.String(), Expires: time.Now().Add(time.Second), Nonce: ""})
 
 		assert.NoError(t, err)
 		require.NotNil(t, vp)
 		require.NotNil(t, submission)
-		assert.Equal(t, walletDID.String(), vp.Holder.String(), "holder must be the DID of the signer")
+		assert.Equal(t, nutsWalletDID.String(), vp.Holder.String(), "holder must be the DID of the signer")
 	})
 	t.Run("error - no matching credentials", func(t *testing.T) {
 		resetStore(t, storageEngine.GetSQLDatabase())
 
 		w := NewSQLWallet(nil, keyStore, nil, jsonldManager, storageEngine)
 
-		vp, submission, err := w.BuildSubmission(ctx, walletDID, presentationDefinition, vpFormats, BuildParams{Audience: verifierDID.String(), Expires: time.Now().Add(time.Second), Nonce: ""})
+		vp, submission, err := w.BuildSubmission(ctx, []did.DID{nutsWalletDID}, presentationDefinition, vpFormats, BuildParams{Audience: verifierDID.String(), Expires: time.Now().Add(time.Second), Nonce: ""})
 
 		assert.Equal(t, ErrNoCredentials, err)
 		assert.Nil(t, vp)
@@ -314,10 +319,10 @@ func TestPresenter_buildSubmission(t *testing.T) {
 		resetStore(t, storageEngine.GetSQLDatabase())
 		ctrl := gomock.NewController(t)
 		keyResolver := resolver.NewMockKeyResolver(ctrl)
-		keyResolver.EXPECT().ResolveKey(walletDID, nil, resolver.NutsSigningKeyType).Return(key.KID, key.PublicKey, nil)
+		keyResolver.EXPECT().ResolveKey(nutsWalletDID, nil, resolver.NutsSigningKeyType).Return(key.KID, key.PublicKey, nil)
 		w := presenter{documentLoader: jsonldManager.DocumentLoader(), signer: keyStore, keyResolver: keyResolver}
 
-		vp, submission, err := w.buildSubmission(ctx, walletDID, credentials, pe.PresentationDefinition{}, vpFormats, BuildParams{Audience: verifierDID.String(), Expires: time.Now().Add(time.Second), Nonce: ""})
+		vp, submission, err := w.buildSubmission(ctx, credentials, pe.PresentationDefinition{}, vpFormats, BuildParams{Audience: verifierDID.String(), Expires: time.Now().Add(time.Second), Nonce: ""})
 
 		assert.Nil(t, err)
 		assert.NotNil(t, vp)

--- a/vcr/holder/sql_wallet.go
+++ b/vcr/holder/sql_wallet.go
@@ -72,17 +72,21 @@ type BuildParams struct {
 	Nonce    string
 }
 
-func (h sqlWallet) BuildSubmission(ctx context.Context, walletDID did.DID, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
+func (h sqlWallet) BuildSubmission(ctx context.Context, walletDIDs []did.DID, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
 	// get VCs from own wallet
-	credentials, err := h.List(ctx, walletDID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to retrieve wallet credentials: %w", err)
+	credentials := make(map[did.DID][]vc.VerifiableCredential)
+	for _, walletDID := range walletDIDs {
+		creds, err := h.List(ctx, walletDID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to retrieve wallet credentials: %w", err)
+		}
+		credentials[walletDID] = creds
 	}
 	return presenter{
 		documentLoader: h.jsonldManager.DocumentLoader(),
 		signer:         h.keyStore,
 		keyResolver:    h.keyResolver,
-	}.buildSubmission(ctx, walletDID, credentials, presentationDefinition, acceptedFormats, params)
+	}.buildSubmission(ctx, credentials, presentationDefinition, acceptedFormats, params)
 }
 
 func (h sqlWallet) BuildPresentation(ctx context.Context, credentials []vc.VerifiableCredential, options PresentationOptions, signerDID *did.DID, validateVC bool) (*vc.VerifiablePresentation, error) {


### PR DESCRIPTION
To aid selection of DID based on Presentation Definition (required by DID -> subject refactor).

Note that this doesn't actually allow a submission with multiple VPs, just selecting the right one.