### PR TITLE
Change supported_client_id_did_methods to did_methods_supported

### DIFF
--- a/auth/api/iam/metadata.go
+++ b/auth/api/iam/metadata.go
@@ -34,7 +34,7 @@ func authorizationServerMetadata(ownedDID did.DID, issuerURL *url.URL, supported
 	metadata := &oauth.AuthorizationServerMetadata{
 		AuthorizationEndpoint:                      "openid4vp:",
 		ClientIdSchemesSupported:                   clientIdSchemesSupported,
-		SupportedDIDMethods:                        supportedDIDMethods,
+		DIDMethodsSupported:                        supportedDIDMethods,
 		DPoPSigningAlgValuesSupported:              jwx.SupportedAlgorithmsAsStrings(),
 		GrantTypesSupported:                        grantTypesSupported,
 		Issuer:                                     issuerURL.String(),

--- a/auth/api/iam/metadata_test.go
+++ b/auth/api/iam/metadata_test.go
@@ -36,7 +36,7 @@ func Test_authorizationServerMetadata(t *testing.T) {
 	baseExpected := oauth.AuthorizationServerMetadata{
 		AuthorizationEndpoint:                      "openid4vp:",
 		ClientIdSchemesSupported:                   []string{"did"},
-		SupportedDIDMethods:                        []string{"test"},
+		DIDMethodsSupported:                        []string{"test"},
 		DPoPSigningAlgValuesSupported:              jwx.SupportedAlgorithmsAsStrings(),
 		GrantTypesSupported:                        []string{"authorization_code", "vp_token-bearer"},
 		Issuer:                                     "https://example.com/oauth2/" + didExample.String(),

--- a/auth/oauth/types.go
+++ b/auth/oauth/types.go
@@ -282,9 +282,9 @@ type AuthorizationServerMetadata struct {
 	// If omitted, the default value is `pre-registered` (referring to the client), which is currently not supported.
 	ClientIdSchemesSupported []string `json:"client_id_schemes_supported,omitempty"`
 
-	// SupportedDIDMethods is a JSON array containing a list of the DID methods that are supported by the Authorization Server.
+	// DIDMethodsSupported is a JSON array containing a list of the DID Methods (without scheme 'did:') that are supported by the Authorization Server.
 	// Note: this is a custom parameter, not part of the OpenID4VC specifications.
-	SupportedDIDMethods []string `json:"supported_did_methods,omitempty"`
+	DIDMethodsSupported []string `json:"did_methods_supported,omitempty"`
 
 	// DPoPSigningAlgValuesSupported is a JSON array containing a list of the DPoP proof JWS signing algorithms ("alg" values) supported by the token endpoint.
 	DPoPSigningAlgValuesSupported []string `json:"dpop_signing_alg_values_supported,omitempty"`


### PR DESCRIPTION
The field now also only contains the DID Method names without the `did:` scheme.
Changed to `_supported` postfix to match OAuth naming convention