### PR TITLE
Replace did param in DPoP proof API to kid

### DIFF
--- a/auth/api/auth/v1/api_test.go
+++ b/auth/api/auth/v1/api_test.go
@@ -604,7 +604,7 @@ func TestWrapper_CreateAccessToken(t *testing.T) {
 		params := CreateAccessTokenRequest{GrantType: "urn:ietf:params:oauth:grant-type:jwt-bearer", Assertion: validJwt}
 
 		in800000 := 800000
-		pkgResponse := oauth2.NewTokenResponse("foo", "Bearer", in800000, "")
+		pkgResponse := oauth2.NewTokenResponse("foo", "Bearer", in800000, "", "")
 		ctx.authzServerMock.EXPECT().CreateAccessToken(gomock.Any(), services.CreateAccessTokenRequest{RawJwtBearerToken: validJwt}).Return(pkgResponse, nil)
 
 		expectedResponse := CreateAccessToken200JSONResponse{

--- a/auth/api/iam/access_token.go
+++ b/auth/api/iam/access_token.go
@@ -21,6 +21,7 @@ package iam
 import (
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
+	"github.com/nuts-foundation/nuts-node/core/to"
 	"github.com/nuts-foundation/nuts-node/crypto"
 	"time"
 
@@ -90,14 +91,15 @@ func (r Wrapper) createAccessToken(issuerURL string, clientID string, issueTime 
 		return nil, fmt.Errorf("unable to store access token: %w", err)
 	}
 	expiresIn := int(accessTokenValidity.Seconds())
-	tokenType := AccessTokenTypeDPoP
-	if dpopToken == nil {
-		tokenType = AccessTokenTypeBearer
-	}
-	return &oauth.TokenResponse{
+	tokenResponse := oauth.TokenResponse{
 		AccessToken: accessToken.Token,
 		ExpiresIn:   &expiresIn,
 		Scope:       &scope,
-		TokenType:   tokenType,
-	}, nil
+		TokenType:   AccessTokenTypeBearer,
+	}
+	if dpopToken != nil {
+		tokenResponse.TokenType = AccessTokenTypeDPoP
+		tokenResponse.DPoPKid = to.Ptr(dpopToken.Kid)
+	}
+	return &tokenResponse, nil
 }

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -707,24 +707,6 @@ func (r Wrapper) PresentationDefinition(ctx context.Context, request Presentatio
 	return PresentationDefinition200JSONResponse(result), nil
 }
 
-func (r Wrapper) toOwnedDID(ctx context.Context, didAsString string) (*did.DID, error) {
-	ownDID, err := did.ParseDID(didAsString)
-	if err != nil {
-		return nil, fmt.Errorf("invalid DID: %s", err)
-	}
-	owned, err := r.vdr.DocumentOwner().IsOwner(ctx, *ownDID)
-	if err != nil {
-		if resolver.IsFunctionalResolveError(err) {
-			return nil, fmt.Errorf("invalid issuer DID: %s", err)
-		}
-		return nil, fmt.Errorf("DID resolution failed: %w", err)
-	}
-	if !owned {
-		return nil, resolver.ErrDIDNotManagedByThisNode
-	}
-	return ownDID, nil
-}
-
 func (r Wrapper) RequestServiceAccessToken(ctx context.Context, request RequestServiceAccessTokenRequestObject) (RequestServiceAccessTokenResponseObject, error) {
 	err := r.subjectExists(ctx, request.SubjectID)
 	if err != nil {

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -842,41 +842,6 @@ func TestWrapper_middleware(t *testing.T) {
 
 }
 
-func TestWrapper_toOwnedDID(t *testing.T) {
-	t.Run("ok", func(t *testing.T) {
-		ctx := newTestClient(t)
-		ctx.documentOwner.EXPECT().IsOwner(nil, holderDID).Return(true, nil)
-
-		_, err := ctx.client.toOwnedDID(nil, holderDID.String())
-
-		assert.NoError(t, err)
-	})
-	t.Run("error - did not managed by this node", func(t *testing.T) {
-		ctx := newTestClient(t)
-		ctx.documentOwner.EXPECT().IsOwner(nil, holderDID)
-
-		_, err := ctx.client.toOwnedDID(nil, holderDID.String())
-
-		assert.EqualError(t, err, "DID document not managed by this node")
-	})
-	t.Run("DID does not exist (functional resolver error)", func(t *testing.T) {
-		ctx := newTestClient(t)
-		ctx.documentOwner.EXPECT().IsOwner(nil, holderDID).Return(false, resolver.ErrNotFound)
-
-		_, err := ctx.client.toOwnedDID(nil, holderDID.String())
-
-		assert.EqualError(t, err, "invalid issuer DID: unable to find the DID document")
-	})
-	t.Run("other resolver error", func(t *testing.T) {
-		ctx := newTestClient(t)
-		ctx.documentOwner.EXPECT().IsOwner(nil, holderDID).Return(false, errors.New("unknown error"))
-
-		_, err := ctx.client.toOwnedDID(nil, holderDID.String())
-
-		assert.EqualError(t, err, "DID resolution failed: unknown error")
-	})
-}
-
 func TestWrapper_RequestServiceAccessToken(t *testing.T) {
 	body := &RequestServiceAccessTokenJSONRequestBody{
 		AuthorizationServer: verifierURL.String(),

--- a/auth/api/iam/dpop_test.go
+++ b/auth/api/iam/dpop_test.go
@@ -47,12 +47,12 @@ func TestWrapper_CreateDPoPProof(t *testing.T) {
 		Token: accesstoken,
 		Htu:   "https://example.com",
 	}
+	vmId := did.MustParseDIDURL(holderDID.String() + "#key1")
 	requestObject := CreateDPoPProofRequestObject{
 		Body: &requestBody,
-		Did:  holderDID.String(),
+		Kid:  vmId.String(),
 	}
 	didDocument := did.Document{ID: holderDID}
-	vmId := did.MustParseDIDURL(holderDID.String() + "#key1")
 	key, _ := spi.GenerateKeyPair()
 	vm, _ := did.NewVerificationMethod(vmId, ssi.JsonWebKey2020, holderDID, key.Public())
 	didDocument.AddAssertionMethod(vm)
@@ -60,8 +60,6 @@ func TestWrapper_CreateDPoPProof(t *testing.T) {
 	dpopToken.GenerateProof(accesstoken)
 	t.Run("ok", func(t *testing.T) {
 		ctx := newTestClient(t)
-		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
-		ctx.resolver.EXPECT().Resolve(holderDID, gomock.Any()).Return(&didDocument, nil, nil)
 		ctx.jwtSigner.EXPECT().SignDPoP(gomock.Any(), gomock.Any(), vmId.String()).DoAndReturn(func(_ context.Context, token dpop.DPoP, _ string) (string, error) {
 			assert.Equal(t, dpopToken.String(), token.String())
 			return "dpop", nil
@@ -83,7 +81,6 @@ func TestWrapper_CreateDPoPProof(t *testing.T) {
 	})
 	t.Run("invalid method", func(t *testing.T) {
 		ctx := newTestClient(t)
-		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
 		requestBody.Htm = "\\"
 		defer (func() { requestBody.Htm = "GET" })()
 
@@ -109,18 +106,8 @@ func TestWrapper_CreateDPoPProof(t *testing.T) {
 
 		assert.EqualError(t, err, "missing url")
 	})
-	t.Run("did not owned", func(t *testing.T) {
-		ctx := newTestClient(t)
-		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), holderDID).Return(false, nil)
-
-		_, err := ctx.client.CreateDPoPProof(context.Background(), requestObject)
-
-		assert.EqualError(t, err, "DID document not managed by this node")
-	})
 	t.Run("proof error", func(t *testing.T) {
 		ctx := newTestClient(t)
-		ctx.documentOwner.EXPECT().IsOwner(gomock.Any(), holderDID).Return(true, nil)
-		ctx.resolver.EXPECT().Resolve(holderDID, gomock.Any()).Return(&didDocument, nil, nil)
 		ctx.jwtSigner.EXPECT().SignDPoP(gomock.Any(), gomock.Any(), vmId.String()).Return("dpop", assert.AnError)
 
 		_, err := ctx.client.CreateDPoPProof(context.Background(), requestObject)
@@ -242,8 +229,8 @@ func newSignedTestDPoP() (*dpop.DPoP, *dpop.DPoP, string) {
 	withProof := newTestDPoP()
 	keyPair, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	_ = withProof.GenerateProof("token")
-	_, _ = withProof.Sign(keyPair, jwa.ES256)
-	_, _ = dpopToken.Sign(keyPair, jwa.ES256)
+	_, _ = withProof.Sign("kid", keyPair, jwa.ES256)
+	_, _ = dpopToken.Sign("kid", keyPair, jwa.ES256)
 	thumbprintBytes, _ := dpopToken.Headers.JWK().Thumbprint(crypto2.SHA256)
 	thumbprint := base64.RawURLEncoding.EncodeToString(thumbprintBytes)
 	return dpopToken, withProof, thumbprint

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -570,8 +570,8 @@ type ServerInterface interface {
 	// (POST /internal/auth/v2/dpop_validate)
 	ValidateDPoPProof(ctx echo.Context) error
 	// Create a DPoP proof as specified by RFC9449 for a given access token. It is to be used as HTTP header when accessing resources.
-	// (POST /internal/auth/v2/{did}/dpop)
-	CreateDPoPProof(ctx echo.Context, did string) error
+	// (POST /internal/auth/v2/{kid}/dpop)
+	CreateDPoPProof(ctx echo.Context, kid string) error
 	// Start the Oid4VCI authorization flow.
 	// (POST /internal/auth/v2/{subjectID}/request-credential)
 	RequestOpenid4VCICredentialIssuance(ctx echo.Context, subjectID string) error
@@ -705,15 +705,18 @@ func (w *ServerInterfaceWrapper) ValidateDPoPProof(ctx echo.Context) error {
 // CreateDPoPProof converts echo context to params.
 func (w *ServerInterfaceWrapper) CreateDPoPProof(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
+	// ------------- Path parameter "kid" -------------
+	var kid string
 
-	did = ctx.Param("did")
+	err = runtime.BindStyledParameterWithOptions("simple", "kid", ctx.Param("kid"), &kid, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter kid: %s", err))
+	}
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.CreateDPoPProof(ctx, did)
+	err = w.Handler.CreateDPoPProof(ctx, kid)
 	return err
 }
 
@@ -723,7 +726,10 @@ func (w *ServerInterfaceWrapper) RequestOpenid4VCICredentialIssuance(ctx echo.Co
 	// ------------- Path parameter "subjectID" -------------
 	var subjectID string
 
-	subjectID = ctx.Param("subjectID")
+	err = runtime.BindStyledParameterWithOptions("simple", "subjectID", ctx.Param("subjectID"), &subjectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter subjectID: %s", err))
+	}
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
@@ -738,7 +744,10 @@ func (w *ServerInterfaceWrapper) RequestServiceAccessToken(ctx echo.Context) err
 	// ------------- Path parameter "subjectID" -------------
 	var subjectID string
 
-	subjectID = ctx.Param("subjectID")
+	err = runtime.BindStyledParameterWithOptions("simple", "subjectID", ctx.Param("subjectID"), &subjectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter subjectID: %s", err))
+	}
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
@@ -753,7 +762,10 @@ func (w *ServerInterfaceWrapper) RequestUserAccessToken(ctx echo.Context) error 
 	// ------------- Path parameter "subjectID" -------------
 	var subjectID string
 
-	subjectID = ctx.Param("subjectID")
+	err = runtime.BindStyledParameterWithOptions("simple", "subjectID", ctx.Param("subjectID"), &subjectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter subjectID: %s", err))
+	}
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
@@ -768,7 +780,10 @@ func (w *ServerInterfaceWrapper) HandleAuthorizeRequest(ctx echo.Context) error 
 	// ------------- Path parameter "subjectID" -------------
 	var subjectID string
 
-	subjectID = ctx.Param("subjectID")
+	err = runtime.BindStyledParameterWithOptions("simple", "subjectID", ctx.Param("subjectID"), &subjectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter subjectID: %s", err))
+	}
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
@@ -792,7 +807,10 @@ func (w *ServerInterfaceWrapper) Callback(ctx echo.Context) error {
 	// ------------- Path parameter "subjectID" -------------
 	var subjectID string
 
-	subjectID = ctx.Param("subjectID")
+	err = runtime.BindStyledParameterWithOptions("simple", "subjectID", ctx.Param("subjectID"), &subjectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter subjectID: %s", err))
+	}
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
@@ -837,7 +855,10 @@ func (w *ServerInterfaceWrapper) OAuthClientMetadata(ctx echo.Context) error {
 	// ------------- Path parameter "subjectID" -------------
 	var subjectID string
 
-	subjectID = ctx.Param("subjectID")
+	err = runtime.BindStyledParameterWithOptions("simple", "subjectID", ctx.Param("subjectID"), &subjectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter subjectID: %s", err))
+	}
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
@@ -852,7 +873,10 @@ func (w *ServerInterfaceWrapper) PresentationDefinition(ctx echo.Context) error 
 	// ------------- Path parameter "subjectID" -------------
 	var subjectID string
 
-	subjectID = ctx.Param("subjectID")
+	err = runtime.BindStyledParameterWithOptions("simple", "subjectID", ctx.Param("subjectID"), &subjectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter subjectID: %s", err))
+	}
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
@@ -883,7 +907,10 @@ func (w *ServerInterfaceWrapper) RequestJWTByGet(ctx echo.Context) error {
 	// ------------- Path parameter "subjectID" -------------
 	var subjectID string
 
-	subjectID = ctx.Param("subjectID")
+	err = runtime.BindStyledParameterWithOptions("simple", "subjectID", ctx.Param("subjectID"), &subjectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter subjectID: %s", err))
+	}
 
 	// ------------- Path parameter "id" -------------
 	var id string
@@ -906,7 +933,10 @@ func (w *ServerInterfaceWrapper) RequestJWTByPost(ctx echo.Context) error {
 	// ------------- Path parameter "subjectID" -------------
 	var subjectID string
 
-	subjectID = ctx.Param("subjectID")
+	err = runtime.BindStyledParameterWithOptions("simple", "subjectID", ctx.Param("subjectID"), &subjectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter subjectID: %s", err))
+	}
 
 	// ------------- Path parameter "id" -------------
 	var id string
@@ -944,7 +974,10 @@ func (w *ServerInterfaceWrapper) HandleTokenRequest(ctx echo.Context) error {
 	// ------------- Path parameter "subjectID" -------------
 	var subjectID string
 
-	subjectID = ctx.Param("subjectID")
+	err = runtime.BindStyledParameterWithOptions("simple", "subjectID", ctx.Param("subjectID"), &subjectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter subjectID: %s", err))
+	}
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
@@ -1010,7 +1043,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.POST(baseURL+"/internal/auth/v2/accesstoken/introspect_extended", wrapper.IntrospectAccessTokenExtended)
 	router.GET(baseURL+"/internal/auth/v2/accesstoken/:sessionID", wrapper.RetrieveAccessToken)
 	router.POST(baseURL+"/internal/auth/v2/dpop_validate", wrapper.ValidateDPoPProof)
-	router.POST(baseURL+"/internal/auth/v2/:did/dpop", wrapper.CreateDPoPProof)
+	router.POST(baseURL+"/internal/auth/v2/:kid/dpop", wrapper.CreateDPoPProof)
 	router.POST(baseURL+"/internal/auth/v2/:subjectID/request-credential", wrapper.RequestOpenid4VCICredentialIssuance)
 	router.POST(baseURL+"/internal/auth/v2/:subjectID/request-service-access-token", wrapper.RequestServiceAccessToken)
 	router.POST(baseURL+"/internal/auth/v2/:subjectID/request-user-access-token", wrapper.RequestUserAccessToken)
@@ -1230,7 +1263,7 @@ func (response ValidateDPoPProofdefaultApplicationProblemPlusJSONResponse) Visit
 }
 
 type CreateDPoPProofRequestObject struct {
-	Did  string `json:"did"`
+	Kid  string `json:"kid"`
 	Body *CreateDPoPProofJSONRequestBody
 }
 
@@ -1745,7 +1778,7 @@ type StrictServerInterface interface {
 	// (POST /internal/auth/v2/dpop_validate)
 	ValidateDPoPProof(ctx context.Context, request ValidateDPoPProofRequestObject) (ValidateDPoPProofResponseObject, error)
 	// Create a DPoP proof as specified by RFC9449 for a given access token. It is to be used as HTTP header when accessing resources.
-	// (POST /internal/auth/v2/{did}/dpop)
+	// (POST /internal/auth/v2/{kid}/dpop)
 	CreateDPoPProof(ctx context.Context, request CreateDPoPProofRequestObject) (CreateDPoPProofResponseObject, error)
 	// Start the Oid4VCI authorization flow.
 	// (POST /internal/auth/v2/{subjectID}/request-credential)
@@ -1968,10 +2001,10 @@ func (sh *strictHandler) ValidateDPoPProof(ctx echo.Context) error {
 }
 
 // CreateDPoPProof operation middleware
-func (sh *strictHandler) CreateDPoPProof(ctx echo.Context, did string) error {
+func (sh *strictHandler) CreateDPoPProof(ctx echo.Context, kid string) error {
 	var request CreateDPoPProofRequestObject
 
-	request.Did = did
+	request.Kid = kid
 
 	var body CreateDPoPProofJSONRequestBody
 	if err := ctx.Bind(&body); err != nil {

--- a/auth/api/iam/jar.go
+++ b/auth/api/iam/jar.go
@@ -27,6 +27,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/auth"
+	"github.com/nuts-foundation/nuts-node/auth/client/iam"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	cryptoNuts "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
@@ -48,6 +49,7 @@ type jar struct {
 	auth        auth.AuthenticationServices
 	jwtSigner   cryptoNuts.JWTSigner
 	keyResolver resolver.KeyResolver
+	client      iam.Client
 }
 
 type JAR interface {

--- a/auth/api/iam/openid4vci_test.go
+++ b/auth/api/iam/openid4vci_test.go
@@ -196,7 +196,7 @@ func TestWrapper_handleOpenID4VCICallback(t *testing.T) {
 		IssuerURL:                issuerClientID,
 		IssuerCredentialEndpoint: credEndpoint,
 	}
-	tokenResponse := oauth.NewTokenResponse(accessToken, "Bearer", 0, "").With("c_nonce", cNonce)
+	tokenResponse := oauth.NewTokenResponse(accessToken, "Bearer", 0, "", "").With("c_nonce", cNonce)
 	credentialResponse := iam.CredentialResponse{
 		Credential: verifiableCredential.Raw(),
 	}

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -261,8 +261,6 @@ func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, clientID
 		for _, curr := range credentials {
 			additionalCredentials[subjectDID] = append(additionalCredentials[subjectDID], autoCorrectSelfAttestedCredential(curr, subjectDID))
 		}
-		// We can fulfill the request with the VC set of this DID
-		break
 	}
 	vp, submission, err := c.wallet.BuildSubmission(ctx, subjectDIDs, additionalCredentials, *presentationDefinition, metadata.VPFormatsSupported, params)
 	if err != nil {

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -261,6 +261,8 @@ func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, clientID
 		for _, curr := range credentials {
 			additionalCredentials[subjectDID] = append(additionalCredentials[subjectDID], autoCorrectSelfAttestedCredential(curr, subjectDID))
 		}
+		// We can fulfill the request with the VC set of this DID
+		break
 	}
 	vp, submission, err := c.wallet.BuildSubmission(ctx, subjectDIDs, additionalCredentials, *presentationDefinition, metadata.VPFormatsSupported, params)
 	if err != nil {

--- a/auth/oauth/test.go
+++ b/auth/oauth/test.go
@@ -20,7 +20,7 @@ package oauth
 
 // NewTokenResponse is a convenience function for creating a TokenResponse with the given parameters.
 // expires_in and scope are only set if they are passed a valid value.
-func NewTokenResponse(accessToken, tokenType string, expiresIn int, scope string) *TokenResponse {
+func NewTokenResponse(accessToken, tokenType string, expiresIn int, scope string, dpopKid string) *TokenResponse {
 	tr := &TokenResponse{
 		AccessToken: accessToken,
 		TokenType:   tokenType,
@@ -30,6 +30,9 @@ func NewTokenResponse(accessToken, tokenType string, expiresIn int, scope string
 	}
 	if scope != "" {
 		tr.Scope = &scope
+	}
+	if dpopKid != "" {
+		tr.DPoPKid = &dpopKid
 	}
 	return tr
 }

--- a/auth/oauth/types.go
+++ b/auth/oauth/types.go
@@ -32,6 +32,7 @@ import (
 // Through With() and Get() additional parameters (for OpenID4VCI, for instance) can be set and retrieved.
 type TokenResponse struct {
 	AccessToken string  `json:"access_token"`
+	DPoPKid     *string `json:"dpop_kid,omitempty"`
 	ExpiresIn   *int    `json:"expires_in,omitempty"`
 	TokenType   string  `json:"token_type"`
 	Scope       *string `json:"scope,omitempty"`
@@ -56,6 +57,7 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	delete(additionalParams, "expires_in")
 	delete(additionalParams, "token_type")
 	delete(additionalParams, "scope")
+	delete(additionalParams, "dpop_kid")
 	*t = TokenResponse(result)
 	if len(additionalParams) > 0 {
 		t.additionalParams = additionalParams
@@ -72,6 +74,7 @@ func (t TokenResponse) MarshalJSON() ([]byte, error) {
 	result["expires_in"] = t.ExpiresIn
 	result["token_type"] = t.TokenType
 	result["scope"] = t.Scope
+	result["dpop_kid"] = t.DPoPKid
 
 	return json.Marshal(result)
 }

--- a/auth/oauth/types_test.go
+++ b/auth/oauth/types_test.go
@@ -67,12 +67,12 @@ func TestIssuerIdToWellKnown(t *testing.T) {
 }
 
 func TestTokenResponse_Marshalling(t *testing.T) {
-	expected := *NewTokenResponse("1234567", "bearer", 5, "abc").With("c_nonce", "hello")
+	expected := *NewTokenResponse("1234567", "bearer", 5, "abc", "kid").With("c_nonce", "hello")
 
 	t.Run("marshal", func(t *testing.T) {
 		data, err := json.Marshal(expected)
 		require.NoError(t, err)
-		assert.JSONEq(t, `{"access_token":"1234567","expires_in":5,"token_type":"bearer","scope":"abc","c_nonce":"hello"}`, string(data))
+		assert.JSONEq(t, `{"access_token":"1234567","expires_in":5,"token_type":"bearer","scope":"abc","dpop_kid":"kid", "c_nonce":"hello"}`, string(data))
 	})
 	t.Run("unmarshal", func(t *testing.T) {
 		data, _ := json.Marshal(expected)

--- a/crypto/dpop.go
+++ b/crypto/dpop.go
@@ -34,5 +34,5 @@ func (client *Crypto) SignDPoP(ctx context.Context, token dpop.DPoP, kid string)
 		return "", err
 	}
 
-	return token.Sign(privateKey, alg)
+	return token.Sign(kid, privateKey, alg)
 }

--- a/crypto/dpop/dpop.go
+++ b/crypto/dpop/dpop.go
@@ -59,6 +59,7 @@ const maxJtiLength = 256
 type DPoP struct {
 	raw     string
 	Headers jws.Headers `json:"-"`
+	Kid     string      `json:"-"`
 	Token   jwt.Token   `json:"-"`
 }
 
@@ -94,7 +95,7 @@ func generateID() string {
 
 // Sign the DPoP token with the given key
 // It also adds the jwk and alg header
-func (t *DPoP) Sign(key crypto.Signer, alg jwa.SignatureAlgorithm) (string, error) {
+func (t *DPoP) Sign(kid string, key crypto.Signer, alg jwa.SignatureAlgorithm) (string, error) {
 	if t.raw != "" {
 		return "", errors.New("already signed")
 	}
@@ -110,6 +111,7 @@ func (t *DPoP) Sign(key crypto.Signer, alg jwa.SignatureAlgorithm) (string, erro
 		return "", err
 	}
 	t.raw = string(sig)
+	t.Kid = kid
 
 	return t.raw, nil
 }

--- a/docs/_static/auth/iam.partial.yaml
+++ b/docs/_static/auth/iam.partial.yaml
@@ -14,11 +14,9 @@ paths:
           in: path
           required: true
           description: the subject of the token request
-          content:
-            plain/text:
-              schema:
-                type: string
-                example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
+          schema:
+            type: string
+            example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843CC
       requestBody:
         content:
           application/x-www-form-urlencoded:
@@ -67,11 +65,9 @@ paths:
           in: path
           required: true
           description: the subject of the authorization request
-          content:
-            plain/text:
-              schema:
-                type: string
-                example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
+          schema:
+            type: string
+            example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
         # Way to specify dynamic query parameters
         # See https://stackoverflow.com/questions/49582559/how-to-document-dynamic-query-parameter-names-in-openapi-swagger
         - in: query
@@ -103,11 +99,9 @@ paths:
         in: path
         required: true
         description: Subject acting as the client for the authorization request
-        content:
-          plain/text:
-            schema:
-              type: string
-              example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
+        schema:
+          type: string
+          example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
       - name: id
         in: path
         required: true
@@ -176,11 +170,9 @@ paths:
           in: path
           required: true
           description: the subject of the callback
-          content:
-            plain/text:
-              schema:
-                type: string
-                example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
+          schema:
+            type: string
+            example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
         - name: code
           in: query
           description: The authorization code received from the authorization server.
@@ -227,11 +219,9 @@ paths:
           in: path
           required: true
           description: Subject that holds the presentation definition.
-          content:
-            plain/text:
-              schema:
-                type: string
-                example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
+          schema:
+            type: string
+            example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
         - name: scope
           in: query
           required: true
@@ -394,11 +384,9 @@ paths:
           in: path
           required: true
           description: Subject that serves the metadata
-          content:
-            plain/text:
-              schema:
-                type: string
-                example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
+          schema:
+            type: string
+            example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
       responses:
         "200":
           description: OK

--- a/docs/_static/auth/v2.yaml
+++ b/docs/_static/auth/v2.yaml
@@ -27,11 +27,9 @@ paths:
           in: path
           required: true
           description: Subject of the requester, a wallet owner at this node.
-          content:
-            plain/text:
-              schema:
-                type: string
-                example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
+          schema:
+            type: string
+            example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
       requestBody:
         required: true
         content:
@@ -67,11 +65,9 @@ paths:
           in: path
           required: true
           description: Subject of the requester, a wallet owner at this node.
-          content:
-            plain/text:
-              schema:
-                type: string
-                example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
+          schema:
+            type: string
+            example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
       requestBody:
         required: true
         content:
@@ -174,22 +170,23 @@ paths:
           description: |
             This is returned when an OAuth2 Client is unauthorized to talk to the introspection endpoint.
             Note: introspection of an invalid or malformed token returns a 200 where with field 'active'=false
-  /internal/auth/v2/{did}/dpop:
+  /internal/auth/v2/{kid}/dpop:
     post:
       operationId: createDPoPProof
       summary: Create a DPoP proof as specified by RFC9449 for a given access token. It is to be used as HTTP header when accessing resources.
       tags:
         - oauth2
       parameters:
-        - name: did
+        - name: kid
           in: path
           required: true
-          description: The DID of the requester, a wallet owner at this node.
+          description: The kid used to create the DPoP proof returned by the access token request.
+          # we use the content hack so no unescaping happens in the generated code. This way we can handle web:did keys with port numbers.
           content:
             plain/text:
               schema:
                 type: string
-                example: did:web:example.com
+                example: did:web:example.com#1
       requestBody:
         required: true
         content:
@@ -254,11 +251,9 @@ paths:
           in: path
           required: true
           description: Subject ID of the wallet owner at this node.
-          content:
-            plain/text:
-              schema:
-                type: string
-                example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
+          schema:
+            type: string
+            example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
       requestBody:
         required: true
         content:
@@ -533,6 +528,11 @@ components:
           description: |
             The access token issued by the authorization server.
           example: "eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp..sHQ"
+        dpop_kid:
+          type: string
+          description: |
+            The kid of the DPoP key that is used to sign dpop headers.
+          example: "did:web:example.com:resource-owner#key-1"
         token_type:
           type: string
           description: |

--- a/e2e-tests/browser/client/iam/generated.go
+++ b/e2e-tests/browser/client/iam/generated.go
@@ -559,9 +559,9 @@ type ClientInterface interface {
 	ValidateDPoPProof(ctx context.Context, body ValidateDPoPProofJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateDPoPProofWithBody request with any body
-	CreateDPoPProofWithBody(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateDPoPProofWithBody(ctx context.Context, kid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	CreateDPoPProof(ctx context.Context, did string, body CreateDPoPProofJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateDPoPProof(ctx context.Context, kid string, body CreateDPoPProofJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RequestOpenid4VCICredentialIssuanceWithBody request with any body
 	RequestOpenid4VCICredentialIssuanceWithBody(ctx context.Context, subjectID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -663,8 +663,8 @@ func (c *Client) ValidateDPoPProof(ctx context.Context, body ValidateDPoPProofJS
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateDPoPProofWithBody(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateDPoPProofRequestWithBody(c.Server, did, contentType, body)
+func (c *Client) CreateDPoPProofWithBody(ctx context.Context, kid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDPoPProofRequestWithBody(c.Server, kid, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -675,8 +675,8 @@ func (c *Client) CreateDPoPProofWithBody(ctx context.Context, did string, conten
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateDPoPProof(ctx context.Context, did string, body CreateDPoPProofJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateDPoPProofRequest(c.Server, did, body)
+func (c *Client) CreateDPoPProof(ctx context.Context, kid string, body CreateDPoPProofJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDPoPProofRequest(c.Server, kid, body)
 	if err != nil {
 		return nil, err
 	}
@@ -914,23 +914,26 @@ func NewValidateDPoPProofRequestWithBody(server string, contentType string, body
 }
 
 // NewCreateDPoPProofRequest calls the generic CreateDPoPProof builder with application/json body
-func NewCreateDPoPProofRequest(server string, did string, body CreateDPoPProofJSONRequestBody) (*http.Request, error) {
+func NewCreateDPoPProofRequest(server string, kid string, body CreateDPoPProofJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewCreateDPoPProofRequestWithBody(server, did, "application/json", bodyReader)
+	return NewCreateDPoPProofRequestWithBody(server, kid, "application/json", bodyReader)
 }
 
 // NewCreateDPoPProofRequestWithBody generates requests for CreateDPoPProof with any type of body
-func NewCreateDPoPProofRequestWithBody(server string, did string, contentType string, body io.Reader) (*http.Request, error) {
+func NewCreateDPoPProofRequestWithBody(server string, kid string, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0 = did
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "kid", runtime.ParamLocationPath, kid)
+	if err != nil {
+		return nil, err
+	}
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
@@ -974,7 +977,10 @@ func NewRequestOpenid4VCICredentialIssuanceRequestWithBody(server string, subjec
 
 	var pathParam0 string
 
-	pathParam0 = subjectID
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "subjectID", runtime.ParamLocationPath, subjectID)
+	if err != nil {
+		return nil, err
+	}
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
@@ -1018,7 +1024,10 @@ func NewRequestServiceAccessTokenRequestWithBody(server string, subjectID string
 
 	var pathParam0 string
 
-	pathParam0 = subjectID
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "subjectID", runtime.ParamLocationPath, subjectID)
+	if err != nil {
+		return nil, err
+	}
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
@@ -1062,7 +1071,10 @@ func NewRequestUserAccessTokenRequestWithBody(server string, subjectID string, c
 
 	var pathParam0 string
 
-	pathParam0 = subjectID
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "subjectID", runtime.ParamLocationPath, subjectID)
+	if err != nil {
+		return nil, err
+	}
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
@@ -1151,9 +1163,9 @@ type ClientWithResponsesInterface interface {
 	ValidateDPoPProofWithResponse(ctx context.Context, body ValidateDPoPProofJSONRequestBody, reqEditors ...RequestEditorFn) (*ValidateDPoPProofResponse, error)
 
 	// CreateDPoPProofWithBodyWithResponse request with any body
-	CreateDPoPProofWithBodyWithResponse(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDPoPProofResponse, error)
+	CreateDPoPProofWithBodyWithResponse(ctx context.Context, kid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDPoPProofResponse, error)
 
-	CreateDPoPProofWithResponse(ctx context.Context, did string, body CreateDPoPProofJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDPoPProofResponse, error)
+	CreateDPoPProofWithResponse(ctx context.Context, kid string, body CreateDPoPProofJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDPoPProofResponse, error)
 
 	// RequestOpenid4VCICredentialIssuanceWithBodyWithResponse request with any body
 	RequestOpenid4VCICredentialIssuanceWithBodyWithResponse(ctx context.Context, subjectID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestOpenid4VCICredentialIssuanceResponse, error)
@@ -1458,16 +1470,16 @@ func (c *ClientWithResponses) ValidateDPoPProofWithResponse(ctx context.Context,
 }
 
 // CreateDPoPProofWithBodyWithResponse request with arbitrary body returning *CreateDPoPProofResponse
-func (c *ClientWithResponses) CreateDPoPProofWithBodyWithResponse(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDPoPProofResponse, error) {
-	rsp, err := c.CreateDPoPProofWithBody(ctx, did, contentType, body, reqEditors...)
+func (c *ClientWithResponses) CreateDPoPProofWithBodyWithResponse(ctx context.Context, kid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDPoPProofResponse, error) {
+	rsp, err := c.CreateDPoPProofWithBody(ctx, kid, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseCreateDPoPProofResponse(rsp)
 }
 
-func (c *ClientWithResponses) CreateDPoPProofWithResponse(ctx context.Context, did string, body CreateDPoPProofJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDPoPProofResponse, error) {
-	rsp, err := c.CreateDPoPProof(ctx, did, body, reqEditors...)
+func (c *ClientWithResponses) CreateDPoPProofWithResponse(ctx context.Context, kid string, body CreateDPoPProofJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDPoPProofResponse, error) {
+	rsp, err := c.CreateDPoPProof(ctx, kid, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e-tests/oauth-flow/openid4vp/do-test.sh
+++ b/e2e-tests/oauth-flow/openid4vp/do-test.sh
@@ -131,14 +131,15 @@ else
   echo $RESPONSE
   exitWithDockerLogs 1
 fi
-
+DPOP_KID=$(echo $RESPONSE | sed -E 's/.*"dpop_kid":"([^"]*).*/\1/')
+DPOP_KID=$(urlencode $DPOP_KID)
 ACCESS_TOKEN=$(cat ./node-B/accesstoken.txt)
 
 echo "------------------------------------"
 echo "Create DPoP header..."
 echo "------------------------------------"
 REQUEST="{\"htm\":\"GET\",\"htu\":\"https://resource:80/resource\", \"token\":\"$ACCESS_TOKEN\"}"
-RESPONSE=$(echo $REQUEST | curl -X POST -s --data-binary @- http://localhost:28081/internal/auth/v2/$PARTY_B_DID/dpop -H "Content-Type: application/json" -v)
+RESPONSE=$(echo $REQUEST | curl -X POST -s --data-binary @- http://localhost:28081/internal/auth/v2/$DPOP_KID/dpop -H "Content-Type: application/json" -v)
 if echo $RESPONSE | grep -q "dpop"; then
   echo $RESPONSE | sed -E 's/.*"dpop":"([^"]*).*/\1/' > ./node-B/dpop.txt
   echo "dpop token stored in ./node-B/dpop.txt"

--- a/e2e-tests/oauth-flow/rfc021/do-test.sh
+++ b/e2e-tests/oauth-flow/rfc021/do-test.sh
@@ -99,14 +99,15 @@ else
   echo $RESPONSE
   exitWithDockerLogs 1
 fi
-
+DPOP_KID=$(echo $RESPONSE | sed -E 's/.*"dpop_kid":"([^"]*).*/\1/')
+DPOP_KID=$(urlencode $DPOP_KID)
 ACCESS_TOKEN=$(cat ./node-B/accesstoken.txt)
 
 echo "------------------------------------"
 echo "Create DPoP header..."
 echo "------------------------------------"
 REQUEST="{\"htm\":\"GET\",\"htu\":\"https://nodeA:443/resource\", \"token\":\"$ACCESS_TOKEN\"}"
-RESPONSE=$(echo $REQUEST | curl -X POST -s --data-binary @- http://localhost:28081/internal/auth/v2/$VENDOR_B_DID/dpop -H "Content-Type: application/json")
+RESPONSE=$(echo $REQUEST | curl -X POST -s --data-binary @- http://localhost:28081/internal/auth/v2/$DPOP_KID/dpop -H "Content-Type: application/json")
 if echo $RESPONSE | grep -q "dpop"; then
   echo $RESPONSE | sed -E 's/.*"dpop":"([^"]*).*/\1/' > ./node-B/dpop.txt
   echo "dpop token stored in ./node-B/dpop.txt"

--- a/e2e-tests/util.sh
+++ b/e2e-tests/util.sh
@@ -179,3 +179,9 @@ function removeNodeDID() {
     sed -i '/nodedid: did:nuts:/d' $1
   fi
 }
+
+# Function to URL-encode a string
+urlencode() {
+    local raw="$1"
+    jq -nr --arg raw "$raw" '$raw|@uri'
+}

--- a/vcr/holder/openid_test.go
+++ b/vcr/holder/openid_test.go
@@ -77,7 +77,7 @@ func Test_wallet_HandleCredentialOffer(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		issuerAPIClient := openid4vci.NewMockIssuerAPIClient(ctrl)
 		issuerAPIClient.EXPECT().Metadata().Return(metadata)
-		tokenResponse := oauth.NewTokenResponse("access-token", "bearer", 0, "").With("c_nonce", nonce)
+		tokenResponse := oauth.NewTokenResponse("access-token", "bearer", 0, "", "").With("c_nonce", nonce)
 		issuerAPIClient.EXPECT().RequestAccessToken("urn:ietf:params:oauth:grant-type:pre-authorized_code", map[string]string{
 			"pre-authorized_code": "code",
 		}).Return(tokenResponse, nil)


### PR DESCRIPTION
closes #3314 

depends on #3333 

The access token request now also returns a kid that is used as path param.