### PR TITLE
write DAG XOR tree consistency fixes to disk

### DIFF
--- a/network/dag/consistency.go
+++ b/network/dag/consistency.go
@@ -119,6 +119,10 @@ func (f *xorTreeRepair) checkPage() {
 			if err != nil {
 				return err
 			}
+			err = f.state.xorTree.writeWithoutLock(txn)
+			if err != nil {
+				return err
+			}
 			log.Logger().Warnf("detected XOR tree mismatch for page %d, fixed using recalculated values", f.currentPage)
 		}
 


### PR DESCRIPTION
part of #3355 

the `xorTreeRepair` fixes the `state.xorTree` issues in memory, but they are not written to disk. The next network transaction will result in the fix being stored, but this might take a while if transaction volume is low. (Such as during testing)

backport to v5