### PR TITLE
allow for additional parameters when activating discovery service

### DIFF
--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -708,10 +708,7 @@ func (w *ServerInterfaceWrapper) CreateDPoPProof(ctx echo.Context) error {
 	// ------------- Path parameter "kid" -------------
 	var kid string
 
-	err = runtime.BindStyledParameterWithOptions("simple", "kid", ctx.Param("kid"), &kid, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter kid: %s", err))
-	}
+	kid = ctx.Param("kid")
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 

--- a/discovery/api/v1/api.go
+++ b/discovery/api/v1/api.go
@@ -87,9 +87,10 @@ func (w *Wrapper) SearchPresentations(ctx context.Context, request SearchPresent
 	results := make([]SearchResult, 0)
 	for _, searchResult := range searchResults {
 		result := SearchResult{
-			Vp:     searchResult.Presentation,
-			Id:     searchResult.Presentation.ID.String(),
-			Fields: searchResult.Fields,
+			Vp:                     searchResult.Presentation,
+			Id:                     searchResult.Presentation.ID.String(),
+			Fields:                 searchResult.Fields,
+			RegistrationParameters: searchResult.Parameters,
 		}
 		subjectDID, _ := credential.PresentationSigner(searchResult.Presentation)
 		if subjectDID != nil {
@@ -101,7 +102,12 @@ func (w *Wrapper) SearchPresentations(ctx context.Context, request SearchPresent
 }
 
 func (w *Wrapper) ActivateServiceForSubject(ctx context.Context, request ActivateServiceForSubjectRequestObject) (ActivateServiceForSubjectResponseObject, error) {
-	err := w.Client.ActivateServiceForSubject(ctx, request.ServiceID, request.SubjectID)
+	var parameters map[string]interface{}
+	if request.Body != nil && request.Body.RegistrationParameters != nil {
+		parameters = *request.Body.RegistrationParameters
+	}
+
+	err := w.Client.ActivateServiceForSubject(ctx, request.ServiceID, request.SubjectID, parameters)
 	if errors.Is(err, discovery.ErrPresentationRegistrationFailed) {
 		// registration failed, but will be retried
 		return ActivateServiceForSubject202JSONResponse{

--- a/discovery/api/v1/api_test.go
+++ b/discovery/api/v1/api_test.go
@@ -53,6 +53,24 @@ func TestWrapper_ActivateServiceForSubject(t *testing.T) {
 		assert.NoError(t, err)
 		assert.IsType(t, ActivateServiceForSubject200Response{}, response)
 	})
+	t.Run("ok with params", func(t *testing.T) {
+		test := newMockContext(t)
+		parameters := map[string]interface{}{
+			"foo": "bar",
+		}
+		test.client.EXPECT().ActivateServiceForSubject(gomock.Any(), serviceID, subjectID, parameters).Return(nil)
+
+		response, err := test.wrapper.ActivateServiceForSubject(nil, ActivateServiceForSubjectRequestObject{
+			ServiceID: serviceID,
+			SubjectID: subjectID,
+			Body: &ActivateServiceForSubjectJSONRequestBody{
+				RegistrationParameters: &parameters,
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.IsType(t, ActivateServiceForSubject200Response{}, response)
+	})
 	t.Run("ok, but registration failed", func(t *testing.T) {
 		test := newMockContext(t)
 		test.client.EXPECT().ActivateServiceForSubject(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(discovery.ErrPresentationRegistrationFailed)
@@ -125,6 +143,7 @@ func TestWrapper_SearchPresentations(t *testing.T) {
 			{
 				Presentation: vp,
 				Fields:       nil,
+				Parameters:   map[string]interface{}{"test": "value"},
 			},
 		}
 		test.client.EXPECT().Search(serviceID, expectedQuery).Return(results, nil)
@@ -140,6 +159,7 @@ func TestWrapper_SearchPresentations(t *testing.T) {
 		assert.Equal(t, vp, actual[0].Vp)
 		assert.Equal(t, vp.ID.String(), actual[0].Id)
 		assert.Equal(t, "did:nuts:foo", actual[0].CredentialSubjectId)
+		assert.Equal(t, "value", actual[0].RegistrationParameters["test"])
 	})
 	t.Run("no results", func(t *testing.T) {
 		test := newMockContext(t)

--- a/discovery/api/v1/api_test.go
+++ b/discovery/api/v1/api_test.go
@@ -43,7 +43,7 @@ const (
 func TestWrapper_ActivateServiceForSubject(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		test := newMockContext(t)
-		test.client.EXPECT().ActivateServiceForSubject(gomock.Any(), serviceID, subjectID).Return(nil)
+		test.client.EXPECT().ActivateServiceForSubject(gomock.Any(), serviceID, subjectID, nil).Return(nil)
 
 		response, err := test.wrapper.ActivateServiceForSubject(nil, ActivateServiceForSubjectRequestObject{
 			ServiceID: serviceID,
@@ -55,7 +55,7 @@ func TestWrapper_ActivateServiceForSubject(t *testing.T) {
 	})
 	t.Run("ok, but registration failed", func(t *testing.T) {
 		test := newMockContext(t)
-		test.client.EXPECT().ActivateServiceForSubject(gomock.Any(), gomock.Any(), gomock.Any()).Return(discovery.ErrPresentationRegistrationFailed)
+		test.client.EXPECT().ActivateServiceForSubject(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(discovery.ErrPresentationRegistrationFailed)
 
 		response, err := test.wrapper.ActivateServiceForSubject(nil, ActivateServiceForSubjectRequestObject{
 			ServiceID: serviceID,
@@ -67,7 +67,7 @@ func TestWrapper_ActivateServiceForSubject(t *testing.T) {
 	})
 	t.Run("other error", func(t *testing.T) {
 		test := newMockContext(t)
-		test.client.EXPECT().ActivateServiceForSubject(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("foo"))
+		test.client.EXPECT().ActivateServiceForSubject(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("foo"))
 
 		_, err := test.wrapper.ActivateServiceForSubject(nil, ActivateServiceForSubjectRequestObject{
 			ServiceID: serviceID,

--- a/discovery/api/v1/types.go
+++ b/discovery/api/v1/types.go
@@ -28,3 +28,6 @@ type VerifiablePresentation = vc.VerifiablePresentation
 
 // ServiceDefinition is a type alias
 type ServiceDefinition = discovery.ServiceDefinition
+
+// VerifiableCredential is a type alias for the VerifiableCredential from the go-did library.
+type VerifiableCredential = vc.VerifiableCredential

--- a/discovery/client.go
+++ b/discovery/client.go
@@ -207,6 +207,7 @@ func (r *defaultClientRegistrationManager) buildPresentation(ctx context.Context
 	nonce := nutsCrypto.GenerateNonce()
 	// Make sure the presentation is not valid for longer than the max validity as defined by the Service Definitio.
 	expires := time.Now().Add(time.Duration(service.PresentationMaxValidity-1) * time.Second).Truncate(time.Second)
+	holderURI := subjectDID.URI()
 	return r.vcr.Wallet().BuildPresentation(ctx, credentials, holder.PresentationOptions{
 		ProofOptions: proof.ProofOptions{
 			Created:              time.Now(),
@@ -216,6 +217,7 @@ func (r *defaultClientRegistrationManager) buildPresentation(ctx context.Context
 			AdditionalProperties: additionalProperties,
 		},
 		Format: vc.JWTPresentationProofFormat,
+		Holder: &holderURI,
 	}, &subjectDID, false)
 }
 

--- a/discovery/client.go
+++ b/discovery/client.go
@@ -22,12 +22,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
 	nutsCrypto "github.com/nuts-foundation/nuts-node/crypto"
 	"github.com/nuts-foundation/nuts-node/discovery/api/server/client"
 	"github.com/nuts-foundation/nuts-node/discovery/log"
 	"github.com/nuts-foundation/nuts-node/vcr"
+	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"github.com/nuts-foundation/nuts-node/vcr/signature/proof"
 	"github.com/nuts-foundation/nuts-node/vdr/didsubject"
@@ -38,7 +40,7 @@ import (
 // clientRegistrationManager is a client component, responsible for managing registrations on a Discovery Service.
 // It can refresh registered Verifiable Presentations when they are about to expire.
 type clientRegistrationManager interface {
-	activate(ctx context.Context, serviceID, subjectID string) error
+	activate(ctx context.Context, serviceID, subjectID string, parameters map[string]interface{}) error
 	deactivate(ctx context.Context, serviceID, subjectID string) error
 	// refresh checks which Verifiable Presentations that are about to expire, and should be refreshed on the Discovery Service.
 	refresh(ctx context.Context, now time.Time) error
@@ -64,7 +66,7 @@ func newRegistrationManager(services map[string]ServiceDefinition, store *sqlSto
 	}
 }
 
-func (r *defaultClientRegistrationManager) activate(ctx context.Context, serviceID, subjectID string) error {
+func (r *defaultClientRegistrationManager) activate(ctx context.Context, serviceID, subjectID string, parameters map[string]interface{}) error {
 	service, serviceExists := r.services[serviceID]
 	if !serviceExists {
 		return ErrServiceNotFound
@@ -74,7 +76,7 @@ func (r *defaultClientRegistrationManager) activate(ctx context.Context, service
 		return err
 	}
 	var asSoonAsPossible time.Time
-	if err := r.store.updatePresentationRefreshTime(serviceID, subjectID, &asSoonAsPossible); err != nil {
+	if err := r.store.updatePresentationRefreshTime(serviceID, subjectID, parameters, &asSoonAsPossible); err != nil {
 		return err
 	}
 	log.Logger().Debugf("Registering Verifiable Presentation on Discovery Service (service=%s, subject=%s)", service.ID, subjectID)
@@ -82,7 +84,7 @@ func (r *defaultClientRegistrationManager) activate(ctx context.Context, service
 	var registeredDIDs []string
 	var loopErrs []error
 	for _, subjectDID := range subjectDIDs {
-		err := r.registerPresentation(ctx, subjectDID, service)
+		err := r.registerPresentation(ctx, subjectDID, service, parameters)
 		if err != nil {
 			if !errors.Is(err, errMissingCredential) { // ignore missing credentials
 				loopErrs = append(loopErrs, fmt.Errorf("%s: %w", subjectDID.String(), err))
@@ -107,7 +109,7 @@ func (r *defaultClientRegistrationManager) activate(ctx context.Context, service
 	// Set presentation to be refreshed before it expires
 	// TODO: When to refresh? For now, we refresh when the registration is about at 45% of max age. This means a refresh can fail once without consequence.
 	refreshVPAfter := time.Now().Add(time.Duration(float64(service.PresentationMaxValidity)*0.45) * time.Second)
-	if err := r.store.updatePresentationRefreshTime(serviceID, subjectID, &refreshVPAfter); err != nil {
+	if err := r.store.updatePresentationRefreshTime(serviceID, subjectID, parameters, &refreshVPAfter); err != nil {
 		return fmt.Errorf("unable to update Verifiable Presentation refresh time: %w", err)
 	}
 	return nil
@@ -115,7 +117,7 @@ func (r *defaultClientRegistrationManager) activate(ctx context.Context, service
 
 func (r *defaultClientRegistrationManager) deactivate(ctx context.Context, serviceID, subjectID string) error {
 	// delete DID/service combination from DB, so it won't be registered again
-	err := r.store.updatePresentationRefreshTime(serviceID, subjectID, nil)
+	err := r.store.updatePresentationRefreshTime(serviceID, subjectID, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -166,19 +168,29 @@ func (r *defaultClientRegistrationManager) deregisterPresentation(ctx context.Co
 	return r.client.Register(ctx, service.Endpoint, *presentation)
 }
 
-func (r *defaultClientRegistrationManager) registerPresentation(ctx context.Context, subjectDID did.DID, service ServiceDefinition) error {
-	presentation, err := r.findCredentialsAndBuildPresentation(ctx, subjectDID, service)
+func (r *defaultClientRegistrationManager) registerPresentation(ctx context.Context, subjectDID did.DID, service ServiceDefinition, parameters map[string]interface{}) error {
+	presentation, err := r.findCredentialsAndBuildPresentation(ctx, subjectDID, service, parameters)
 	if err != nil {
 		return err
 	}
 	return r.client.Register(ctx, service.Endpoint, *presentation)
 }
 
-func (r *defaultClientRegistrationManager) findCredentialsAndBuildPresentation(ctx context.Context, subjectDID did.DID, service ServiceDefinition) (*vc.VerifiablePresentation, error) {
+func (r *defaultClientRegistrationManager) findCredentialsAndBuildPresentation(ctx context.Context, subjectDID did.DID, service ServiceDefinition, parameters map[string]interface{}) (*vc.VerifiablePresentation, error) {
 	credentials, err := r.vcr.Wallet().List(ctx, subjectDID)
 	if err != nil {
 		return nil, err
 	}
+	// add registration params as credential
+	if len(parameters) > 0 {
+		registrationCredential := vc.VerifiableCredential{
+			Context:           []ssi.URI{vc.VCContextV1URI(), credential.NutsV1ContextURI},
+			Type:              []ssi.URI{vc.VerifiableCredentialTypeV1URI(), credential.DiscoveryRegistrationCredentialTypeV1URI()},
+			CredentialSubject: []interface{}{parameters},
+		}
+		credentials = append(credentials, credential.AutoCorrectSelfAttestedCredential(registrationCredential, subjectDID))
+	}
+
 	matchingCredentials, _, err := service.PresentationDefinition.Match(credentials)
 	const errStr = "failed to match Discovery Service's Presentation Definition (service=%s, did=%s): %w"
 	if err != nil {
@@ -215,11 +227,11 @@ func (r *defaultClientRegistrationManager) refresh(ctx context.Context, now time
 	}
 	var loopErrs []error
 	for _, candidate := range refreshCandidates {
-		if err = r.activate(ctx, candidate.ServiceID, candidate.SubjectID); err != nil {
+		if err = r.activate(ctx, candidate.ServiceID, candidate.SubjectID, candidate.Parameters); err != nil {
 			var loopErr error
 			if errors.Is(err, didsubject.ErrSubjectNotFound) {
 				// Subject has probably been deactivated. Remove from service or registration will be retried every refresh interval.
-				err = r.store.updatePresentationRefreshTime(candidate.ServiceID, candidate.SubjectID, nil)
+				err = r.store.updatePresentationRefreshTime(candidate.ServiceID, candidate.SubjectID, candidate.Parameters, nil)
 				if err != nil {
 					loopErr = fmt.Errorf("failed to remove unknown subject (service=%s, subject=%s): %w", candidate.ServiceID, candidate.SubjectID, err)
 				} else {

--- a/discovery/client_test.go
+++ b/discovery/client_test.go
@@ -49,13 +49,14 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 		invoker.EXPECT().Register(gomock.Any(), "http://example.com/usecase", vpAlice)
 		wallet := holder.NewMockWallet(ctrl)
 		wallet.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vc.VerifiableCredential{vcAlice}, nil)
-		wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), false).DoAndReturn(func(_ interface{}, credentials []vc.VerifiableCredential, _ interface{}, _ interface{}, _ interface{}) (*vc.VerifiablePresentation, error) {
+		wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), false).DoAndReturn(func(_ interface{}, credentials []vc.VerifiableCredential, options holder.PresentationOptions, _ interface{}, _ interface{}) (*vc.VerifiablePresentation, error) {
 			// check if two credentials are given
 			// check if the DiscoveryRegistrationCredential is added with an authServerURL
 			assert.Len(t, credentials, 2)
 			subject := make([]credential.DiscoveryRegistrationCredentialSubject, 0)
 			_ = credentials[1].UnmarshalCredentialSubject(&subject)
 			assert.Equal(t, "https://example.com/oauth2/alice", subject[0][authServerURLField])
+			assert.Equal(t, aliceDID.String(), options.Holder.String())
 			return &vpAlice, nil
 		})
 		mockVCR := vcr.NewMockVCR(ctrl)

--- a/discovery/client_test.go
+++ b/discovery/client_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/discovery/api/server/client"
 	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/nuts-foundation/nuts-node/vcr"
+	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
 	"github.com/nuts-foundation/nuts-node/vdr/didsubject"
@@ -48,7 +49,15 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 		invoker.EXPECT().Register(gomock.Any(), "http://example.com/usecase", vpAlice)
 		wallet := holder.NewMockWallet(ctrl)
 		wallet.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vc.VerifiableCredential{vcAlice}, nil)
-		wallet.EXPECT().BuildPresentation(gomock.Any(), []vc.VerifiableCredential{vcAlice}, gomock.Any(), gomock.Any(), false).Return(&vpAlice, nil)
+		wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), false).DoAndReturn(func(_ interface{}, credentials []vc.VerifiableCredential, _ interface{}, _ interface{}, _ interface{}) (*vc.VerifiablePresentation, error) {
+			// check if two credentials are given
+			// check if the DiscoveryRegistrationCredential is added with an authServerURL
+			assert.Len(t, credentials, 2)
+			subject := make([]credential.DiscoveryRegistrationCredentialSubject, 0)
+			_ = credentials[1].UnmarshalCredentialSubject(&subject)
+			assert.Equal(t, "https://example.com/oauth2/alice", subject[0][authServerURLField])
+			return &vpAlice, nil
+		})
 		mockVCR := vcr.NewMockVCR(ctrl)
 		mockVCR.EXPECT().Wallet().Return(wallet).AnyTimes()
 		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
@@ -56,7 +65,7 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 		store := setupStore(t, storageEngine.GetSQLDatabase())
 		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
 
-		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject)
+		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject, defaultRegistrationParams(aliceSubject))
 
 		assert.NoError(t, err)
 	})
@@ -74,7 +83,7 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 		store := setupStore(t, storageEngine.GetSQLDatabase())
 		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
 
-		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject)
+		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject, defaultRegistrationParams(aliceSubject))
 
 		require.ErrorIs(t, err, ErrPresentationRegistrationFailed)
 		assert.ErrorContains(t, err, "invoker error")
@@ -91,7 +100,7 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 		store := setupStore(t, storageEngine.GetSQLDatabase())
 		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
 
-		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject)
+		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject, nil)
 
 		require.ErrorIs(t, err, ErrPresentationRegistrationFailed)
 		require.ErrorIs(t, err, errMissingCredential)
@@ -111,11 +120,11 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 
 		// aliceDID registers
 		wallet.EXPECT().List(gomock.Any(), aliceDID).Return([]vc.VerifiableCredential{vcAlice}, nil)
-		wallet.EXPECT().BuildPresentation(gomock.Any(), []vc.VerifiableCredential{vcAlice}, gomock.Any(), &aliceDID, false).Return(&vpAlice, nil)
+		wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), &aliceDID, false).Return(&vpAlice, nil)
 		// bobDID has no credentials, so builds no presentation
 		wallet.EXPECT().List(gomock.Any(), bobDID).Return(nil, nil)
 
-		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject)
+		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject, defaultRegistrationParams(aliceSubject))
 
 		assert.NoError(t, err)
 	})
@@ -143,7 +152,7 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 		store := setupStore(t, storageEngine.GetSQLDatabase())
 		manager := newRegistrationManager(emptyDefinition, store, invoker, mockVCR, mockSubjectManager)
 
-		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject)
+		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject, nil)
 
 		assert.NoError(t, err)
 	})
@@ -154,7 +163,7 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 		store := setupStore(t, storageEngine.GetSQLDatabase())
 		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, nil)
 
-		err := manager.activate(audit.TestContext(), "unknown", aliceSubject)
+		err := manager.activate(audit.TestContext(), "unknown", aliceSubject, nil)
 
 		assert.EqualError(t, err, "discovery service not found")
 	})
@@ -167,7 +176,7 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 		mockSubjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return([]did.DID{}, didsubject.ErrSubjectNotFound)
 		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
 
-		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject)
+		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject, nil)
 
 		assert.ErrorIs(t, err, didsubject.ErrSubjectNotFound)
 	})
@@ -301,8 +310,8 @@ func Test_defaultClientRegistrationManager_refresh(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		invoker := client.NewMockHTTPClient(ctrl)
 		gomock.InOrder(
-			invoker.EXPECT().Register(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("remote error")),
 			invoker.EXPECT().Register(gomock.Any(), gomock.Any(), gomock.Any()),
+			invoker.EXPECT().Register(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("remote error")),
 		)
 		wallet := holder.NewMockWallet(ctrl)
 		mockVCR := vcr.NewMockVCR(ctrl)
@@ -311,19 +320,19 @@ func Test_defaultClientRegistrationManager_refresh(t *testing.T) {
 		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
 
 		// Alice
-		_ = store.updatePresentationRefreshTime(testServiceID, aliceSubject, &time.Time{})
+		_ = store.updatePresentationRefreshTime(testServiceID, aliceSubject, defaultRegistrationParams(aliceSubject), &time.Time{})
 		mockSubjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
 		wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), &aliceDID, false).Return(&vpAlice, nil)
 		wallet.EXPECT().List(gomock.Any(), aliceDID).Return([]vc.VerifiableCredential{vcAlice}, nil)
 		// Bob
-		_ = store.updatePresentationRefreshTime(testServiceID, bobSubject, &time.Time{})
+		_ = store.updatePresentationRefreshTime(testServiceID, bobSubject, defaultRegistrationParams(aliceSubject), &time.Time{})
 		mockSubjectManager.EXPECT().ListDIDs(gomock.Any(), bobSubject).Return([]did.DID{bobDID}, nil)
 		wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), &bobDID, false).Return(&vpBob, nil)
 		wallet.EXPECT().List(gomock.Any(), bobDID).Return([]vc.VerifiableCredential{vcBob}, nil)
 
 		err := manager.refresh(audit.TestContext(), time.Now())
 
-		assert.EqualError(t, err, "failed to refresh Verifiable Presentation (service=usecase_v1, subject=alice): registration of Verifiable Presentation on remote Discovery Service failed: did:example:alice: remote error")
+		assert.EqualError(t, err, "failed to refresh Verifiable Presentation (service=usecase_v1, subject=bob): registration of Verifiable Presentation on remote Discovery Service failed: did:example:bob: remote error")
 	})
 	t.Run("deactivate unknown subject", func(t *testing.T) {
 		store := setupStore(t, storageEngine.GetSQLDatabase())
@@ -333,7 +342,7 @@ func Test_defaultClientRegistrationManager_refresh(t *testing.T) {
 		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
 		mockSubjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return(nil, didsubject.ErrSubjectNotFound)
 		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
-		_ = store.updatePresentationRefreshTime(testServiceID, aliceSubject, &time.Time{})
+		_ = store.updatePresentationRefreshTime(testServiceID, aliceSubject, nil, &time.Time{})
 
 		err := manager.refresh(audit.TestContext(), time.Now())
 

--- a/discovery/interface.go
+++ b/discovery/interface.go
@@ -38,6 +38,7 @@ var ErrPresentationRegistrationFailed = errors.New("registration of Verifiable P
 var errMissingCredential = errors.New("missing credential")
 
 // authServerURLField is the field name for the authServerURL in the DiscoveryRegistrationCredential.
+// it is used to resolve authorization server metadata and thus the endpoints for a service entry.
 const authServerURLField = "authServerURL"
 
 // Server defines the API for Discovery Servers.

--- a/discovery/interface.go
+++ b/discovery/interface.go
@@ -37,6 +37,9 @@ var ErrPresentationRegistrationFailed = errors.New("registration of Verifiable P
 // errMissingCredential indicates that a VP does not have the credentials required to fulfill the Presentation Definition of a Discovery Service.
 var errMissingCredential = errors.New("missing credential")
 
+// authServerURLField is the field name for the authServerURL in the DiscoveryRegistrationCredential.
+const authServerURLField = "authServerURL"
+
 // Server defines the API for Discovery Servers.
 type Server interface {
 	// Register registers a presentation on the given Discovery Service.
@@ -58,8 +61,9 @@ type Client interface {
 	// Registration of all DIDs of the subject will be attempted immediately, and automatically refreshed.
 	// If the initial registration for all DIDs fails with ErrPresentationRegistrationFailed, registration will be retried.
 	// If the function is called again for the same service/DID combination, it will try to refresh the registration.
+	// parameters are added as credentialSubject to a DiscoveryRegistrationCredential holder credential.
 	// It returns an error if the service or subject is invalid/unknown.
-	ActivateServiceForSubject(ctx context.Context, serviceID, subjectID string) error
+	ActivateServiceForSubject(ctx context.Context, serviceID, subjectID string, parameters map[string]interface{}) error
 
 	// DeactivateServiceForSubject stops registration of a subject on a Discovery Service.
 	// It also tries to remove all active registrations of the subject from the Discovery Service.
@@ -84,6 +88,8 @@ type SearchResult struct {
 	// The keys are the Input Descriptor IDs mapped to the values from the credential(s) inside the Presentation.
 	// It only includes constraint fields that have an ID.
 	Fields map[string]interface{} `json:"fields"`
+	// Parameters is a map of parameters that were used during registration.
+	Parameters map[string]interface{} `json:"registrationParameters"`
 }
 
 type presentationVerifier func(definition ServiceDefinition, presentation vc.VerifiablePresentation) error

--- a/discovery/mock.go
+++ b/discovery/mock.go
@@ -94,17 +94,17 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // ActivateServiceForSubject mocks base method.
-func (m *MockClient) ActivateServiceForSubject(ctx context.Context, serviceID, subjectID string) error {
+func (m *MockClient) ActivateServiceForSubject(ctx context.Context, serviceID, subjectID string, parameters map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ActivateServiceForSubject", ctx, serviceID, subjectID)
+	ret := m.ctrl.Call(m, "ActivateServiceForSubject", ctx, serviceID, subjectID, parameters)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ActivateServiceForSubject indicates an expected call of ActivateServiceForSubject.
-func (mr *MockClientMockRecorder) ActivateServiceForSubject(ctx, serviceID, subjectID any) *gomock.Call {
+func (mr *MockClientMockRecorder) ActivateServiceForSubject(ctx, serviceID, subjectID, parameters any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActivateServiceForSubject", reflect.TypeOf((*MockClient)(nil).ActivateServiceForSubject), ctx, serviceID, subjectID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActivateServiceForSubject", reflect.TypeOf((*MockClient)(nil).ActivateServiceForSubject), ctx, serviceID, subjectID, parameters)
 }
 
 // DeactivateServiceForSubject mocks base method.

--- a/discovery/module.go
+++ b/discovery/module.go
@@ -347,7 +347,7 @@ func (m *Module) ActivateServiceForSubject(ctx context.Context, serviceID, subje
 	if parameters == nil {
 		parameters = make(map[string]interface{})
 	}
-	parameters[authServerURLField] = m.publicURL.JoinPath("/oauth2/subjectID").String()
+	parameters[authServerURLField] = m.publicURL.JoinPath("/oauth2/", subjectID).String()
 
 	err := m.registrationManager.activate(ctx, serviceID, subjectID, parameters)
 	if err != nil {

--- a/discovery/module_test.go
+++ b/discovery/module_test.go
@@ -500,6 +500,7 @@ func TestModule_ActivateServiceForSubject(t *testing.T) {
 			subject := make([]credential.DiscoveryRegistrationCredentialSubject, 0)
 			_ = credentials[1].UnmarshalCredentialSubject(&subject)
 			assert.Equal(t, "value", subject[0]["test"])
+			assert.Equal(t, "https://example.com/oauth2/alice", subject[0]["authServerURL"])
 			return &vpAlice, nil
 		})
 		testContext.subjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)

--- a/discovery/module_test.go
+++ b/discovery/module_test.go
@@ -410,6 +410,7 @@ func TestModule_Search(t *testing.T) {
 				Fields: map[string]interface{}{
 					"auth_server_url_field": "https://example.com/oauth2/alice",
 					"issuer_field":          authorityDID,
+					"type_field":            []string{vc.VerifiableCredentialType, credential.DiscoveryRegistrationCredentialType},
 				},
 				Parameters: defaultRegistrationParams(aliceSubject),
 			},

--- a/discovery/store.go
+++ b/discovery/store.go
@@ -307,8 +307,12 @@ func (s *sqlStore) updatePresentationRefreshTime(serviceID string, subjectID str
 		}
 		// Create or update it
 		var bytes []byte
+		var err error
 		if parameters != nil {
-			bytes, _ = json.Marshal(parameters)
+			bytes, err = json.Marshal(parameters)
+			if err != nil {
+				return err
+			}
 		}
 		return tx.Save(presentationRefreshRecord{SubjectID: subjectID, ServiceID: serviceID, NextRefresh: nextRefresh.Unix(), Parameters: bytes}).Error
 	})

--- a/discovery/store.go
+++ b/discovery/store.go
@@ -19,6 +19,7 @@
 package discovery
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/go-did/did"
@@ -85,6 +86,8 @@ type presentationRefreshRecord struct {
 	SubjectID string `gorm:"primaryKey"`
 	// NextRefresh is the Timestamp (seconds since Unix epoch) when the registration on the Discovery Service should be refreshed.
 	NextRefresh int64
+	// Parameters is a serialized JSON object containing parameters that should be used when registering the subject on the service.
+	Parameters []byte
 }
 
 // TableName returns the table name for this DTO.
@@ -296,14 +299,18 @@ func (s *sqlStore) removeExpired() (int, error) {
 
 // updatePresentationRefreshTime creates/updates the next refresh time for a Verifiable Presentation on a Discovery Service.
 // If nextRegistration is nil, the entry will be removed from the database.
-func (s *sqlStore) updatePresentationRefreshTime(serviceID string, subjectID string, nextRefresh *time.Time) error {
+func (s *sqlStore) updatePresentationRefreshTime(serviceID string, subjectID string, parameters map[string]interface{}, nextRefresh *time.Time) error {
 	return s.db.Transaction(func(tx *gorm.DB) error {
 		if nextRefresh == nil {
 			// Delete registration
 			return tx.Delete(&presentationRefreshRecord{}, "service_id = ? AND subject_id = ?", serviceID, subjectID).Error
 		}
 		// Create or update it
-		return tx.Save(presentationRefreshRecord{SubjectID: subjectID, ServiceID: serviceID, NextRefresh: nextRefresh.Unix()}).Error
+		var bytes []byte
+		if parameters != nil {
+			bytes, _ = json.Marshal(parameters)
+		}
+		return tx.Save(presentationRefreshRecord{SubjectID: subjectID, ServiceID: serviceID, NextRefresh: nextRefresh.Unix(), Parameters: bytes}).Error
 	})
 }
 
@@ -321,11 +328,24 @@ func (s *sqlStore) getPresentationRefreshTime(serviceID string, subjectID string
 
 // getSubjectsToBeRefreshed returns all registered subject-service combinations that are due for refreshing.
 func (s *sqlStore) getSubjectsToBeRefreshed(now time.Time) ([]refreshCandidate, error) {
-	var candidates []refreshCandidate
+	var candidates []presentationRefreshRecord
 	if err := s.db.Model(&presentationRefreshRecord{}).Find(&candidates, "next_refresh < ?", now.Unix()).Error; err != nil {
 		return nil, err
 	}
-	return candidates, nil
+	result := make([]refreshCandidate, len(candidates))
+	for i, candidate := range candidates {
+		c := refreshCandidate{
+			ServiceID: candidate.ServiceID,
+			SubjectID: candidate.SubjectID,
+		}
+		if len(candidate.Parameters) > 0 {
+			if err := json.Unmarshal(candidate.Parameters, &c.Parameters); err != nil {
+				return nil, err
+			}
+		}
+		result[i] = c
+	}
+	return result, nil
 }
 
 // refreshCandidate is a subset of presentationRefreshRecord
@@ -334,6 +354,8 @@ type refreshCandidate struct {
 	ServiceID string
 	// SubjectID is the presentationRefreshRecord.SubjectID
 	SubjectID string
+	// Parameters is the presentationRefreshRecord.Parameters
+	Parameters map[string]interface{}
 }
 
 func (s *sqlStore) getTimestamp(serviceID string) (int, error) {

--- a/discovery/test.go
+++ b/discovery/test.go
@@ -45,8 +45,7 @@ var aliceSubject string
 var aliceDID did.DID
 var vcAlice vc.VerifiableCredential
 var vpAlice vc.VerifiablePresentation
-var aliceAuthCredential vc.VerifiableCredential
-var bobAuthCredential vc.VerifiableCredential
+var aliceDiscoveryCredential vc.VerifiableCredential
 var bobSubject string
 var bobDID did.DID
 var vcBob vc.VerifiableCredential
@@ -135,8 +134,7 @@ func init() {
 	unsupportedDID = did.MustParseDID("did:web:example.com")
 	keyPairs[unsupportedDID.String()], _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 
-	aliceAuthCredential = createHolderCredential(aliceDID, defaultRegistrationParams(aliceSubject))
-	bobAuthCredential = createHolderCredential(bobDID, defaultRegistrationParams(bobSubject))
+	aliceDiscoveryCredential = createHolderCredential(aliceDID, defaultRegistrationParams(aliceSubject))
 	vcAlice = createCredential(authorityDID, aliceDID, map[string]interface{}{
 		"person": map[string]interface{}{
 			"givenName":  "Alice",
@@ -145,7 +143,7 @@ func init() {
 	}, nil)
 	vpAlice = createPresentationCustom(aliceDID, func(claims map[string]interface{}, vp *vc.VerifiablePresentation) {
 		claims[jwt.AudienceKey] = []string{testServiceID}
-	}, vcAlice, aliceAuthCredential)
+	}, vcAlice, aliceDiscoveryCredential)
 	vcBob = createCredential(authorityDID, bobDID, map[string]interface{}{
 		"person": map[string]interface{}{
 			"givenName":  "Bob",

--- a/discovery/test.go
+++ b/discovery/test.go
@@ -33,6 +33,7 @@ import (
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
+	"github.com/nuts-foundation/nuts-node/core/to"
 	"github.com/nuts-foundation/nuts-node/test"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
@@ -55,25 +56,44 @@ var unsupportedDID did.DID
 var testServiceID = "usecase_v1"
 
 func testDefinitions() map[string]ServiceDefinition {
-	issuerPattern := "did:example:authority"
-	issuerFieldID := "issuer_field"
-	authServerURLFieldID := "auth_server_url_field"
 	return map[string]ServiceDefinition{
 		testServiceID: {
 			ID:       testServiceID,
 			Endpoint: "http://example.com/usecase",
 			PresentationDefinition: pe.PresentationDefinition{
+				Format: &pe.PresentationDefinitionClaimFormatDesignations{
+					"ldp_vc": {
+						"proof_type": []string{
+							"JsonWebSignature2020",
+						},
+					},
+					"ldp_vp": {
+						"proof_type": []string{
+							"JsonWebSignature2020",
+						},
+					},
+					"jwt_vc": {
+						"alg": []string{
+							"ES256",
+						},
+					},
+					"jwt_vp": {
+						"alg": []string{
+							"ES256",
+						},
+					},
+				},
 				InputDescriptors: []*pe.InputDescriptor{
 					{
 						Id: "1",
 						Constraints: &pe.Constraints{
 							Fields: []pe.Field{
 								{
-									Id:   &issuerFieldID,
+									Id:   to.Ptr("issuer_field"),
 									Path: []string{"$.issuer"},
 									Filter: &pe.Filter{
 										Type:    "string",
-										Pattern: &issuerPattern,
+										Pattern: to.Ptr("did:example:authority"),
 									},
 								},
 							},
@@ -84,10 +104,18 @@ func testDefinitions() map[string]ServiceDefinition {
 						Constraints: &pe.Constraints{
 							Fields: []pe.Field{
 								{
-									Id:   &authServerURLFieldID,
+									Id:   to.Ptr("auth_server_url_field"),
 									Path: []string{"$.credentialSubject.authServerURL", "$.credentialSubject[0].authServerURL"},
 									Filter: &pe.Filter{
 										Type: "string",
+									},
+								},
+								{
+									Id:   to.Ptr("type_field"),
+									Path: []string{"$.type"},
+									Filter: &pe.Filter{
+										Type:  "string",
+										Const: to.Ptr(credential.DiscoveryRegistrationCredentialType),
 									},
 								},
 							},

--- a/discovery/test.go
+++ b/discovery/test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/lestrrat-go/jwx/v2/jwa"
@@ -32,6 +33,8 @@ import (
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
+	"github.com/nuts-foundation/nuts-node/test"
+	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
 	"time"
 )
@@ -42,6 +45,8 @@ var aliceSubject string
 var aliceDID did.DID
 var vcAlice vc.VerifiableCredential
 var vpAlice vc.VerifiablePresentation
+var aliceAuthCredential vc.VerifiableCredential
+var bobAuthCredential vc.VerifiableCredential
 var bobSubject string
 var bobDID did.DID
 var vcBob vc.VerifiableCredential
@@ -51,8 +56,9 @@ var unsupportedDID did.DID
 var testServiceID = "usecase_v1"
 
 func testDefinitions() map[string]ServiceDefinition {
-	issuerPattern := "did:example:*"
+	issuerPattern := "did:example:authority"
 	issuerFieldID := "issuer_field"
+	authServerURLFieldID := "auth_server_url_field"
 	return map[string]ServiceDefinition{
 		testServiceID: {
 			ID:       testServiceID,
@@ -69,6 +75,20 @@ func testDefinitions() map[string]ServiceDefinition {
 									Filter: &pe.Filter{
 										Type:    "string",
 										Pattern: &issuerPattern,
+									},
+								},
+							},
+						},
+					},
+					{
+						Id: "2",
+						Constraints: &pe.Constraints{
+							Fields: []pe.Field{
+								{
+									Id:   &authServerURLFieldID,
+									Path: []string{"$.credentialSubject.authServerURL", "$.credentialSubject[0].authServerURL"},
+									Filter: &pe.Filter{
+										Type: "string",
 									},
 								},
 							},
@@ -115,6 +135,8 @@ func init() {
 	unsupportedDID = did.MustParseDID("did:web:example.com")
 	keyPairs[unsupportedDID.String()], _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 
+	aliceAuthCredential = createHolderCredential(aliceDID, defaultRegistrationParams(aliceSubject))
+	bobAuthCredential = createHolderCredential(bobDID, defaultRegistrationParams(bobSubject))
 	vcAlice = createCredential(authorityDID, aliceDID, map[string]interface{}{
 		"person": map[string]interface{}{
 			"givenName":  "Alice",
@@ -123,7 +145,7 @@ func init() {
 	}, nil)
 	vpAlice = createPresentationCustom(aliceDID, func(claims map[string]interface{}, vp *vc.VerifiablePresentation) {
 		claims[jwt.AudienceKey] = []string{testServiceID}
-	}, vcAlice)
+	}, vcAlice, aliceAuthCredential)
 	vcBob = createCredential(authorityDID, bobDID, map[string]interface{}{
 		"person": map[string]interface{}{
 			"givenName":  "Bob",
@@ -162,6 +184,20 @@ func createCredential(issuerDID did.DID, subjectDID did.DID, credentialSubject m
 		panic(err)
 	}
 	return *result
+}
+
+func createHolderCredential(subjectDID did.DID, credentialSubject map[string]interface{}) vc.VerifiableCredential {
+	c := vc.VerifiableCredential{
+		Context:           []ssi.URI{vc.VCContextV1URI(), credential.NutsV1ContextURI},
+		Type:              []ssi.URI{vc.VerifiableCredentialTypeV1URI(), credential.DiscoveryRegistrationCredentialTypeV1URI()},
+		CredentialSubject: []interface{}{credentialSubject},
+	}
+	c = credential.AutoCorrectSelfAttestedCredential(c, subjectDID)
+	// serialize/deserialize
+	bytes, _ := json.Marshal(c)
+	result := vc.VerifiableCredential{}
+	_ = json.Unmarshal(bytes, &result)
+	return result
 }
 
 func createPresentation(subjectDID did.DID, credentials ...vc.VerifiableCredential) vc.VerifiablePresentation {
@@ -232,4 +268,10 @@ func signJWT(subjectDID did.DID, claims map[string]interface{}, headers map[stri
 	}
 	bytes, err := jwt.Sign(token, jwt.WithKey(subjectKeyJWK.Algorithm(), subjectKeyJWK, jws.WithProtectedHeaders(hdr)))
 	return string(bytes), err
+}
+
+func defaultRegistrationParams(subject string) map[string]interface{} {
+	return map[string]interface{}{
+		"authServerURL": test.MustParseURL("https://example.com/oauth2/").JoinPath(subject).String(),
+	}
 }

--- a/docs/_static/discovery/v1.yaml
+++ b/docs/_static/discovery/v1.yaml
@@ -151,6 +151,12 @@ paths:
       operationId: activateServiceForSubject
       tags:
         - discovery
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ServiceActivationRequest'
       responses:
         "200":
           description: Activation was successful.
@@ -215,6 +221,7 @@ components:
         - credential_subject_id
         - vp
         - fields
+        - registrationParameters
       properties:
         id:
           type: string
@@ -222,11 +229,33 @@ components:
         credential_subject_id:
           type: string
           description: The ID of the Verifiable Credential subject (holder), typically a DID.
+        registrationParameters:
+          type: object
+          description: |
+            Additional parameters used when activating the service.
+            The authServerURL parameter is always present.
         vp:
           $ref: "#/components/schemas/VerifiablePresentation"
         fields:
           type: object
           description: Input descriptor IDs and their mapped values that from the Verifiable Credential.
+    ServiceActivationRequest:
+      type: object
+      description: Request for service activation.
+      properties:
+        registrationParameters:
+          type: object
+          description: |
+            Additional parameters to use when activating a service. The contents of the object will be placed in the credentialSubject field of a DiscoveryRegistrationCredential.
+            
+            This, for example, allows use cases to require and clients to register specific endpoints.
+            
+            The authServerURL parameter is added automatically.
+          example: [
+            {
+              "some-endpoint-type": "https://example.com/some-endpoint"
+            }
+          ]
     ServiceDefinition:
       type: object
       required:

--- a/e2e-tests/browser/client/iam/generated.go
+++ b/e2e-tests/browser/client/iam/generated.go
@@ -930,10 +930,7 @@ func NewCreateDPoPProofRequestWithBody(server string, kid string, contentType st
 
 	var pathParam0 string
 
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "kid", runtime.ParamLocationPath, kid)
-	if err != nil {
-		return nil, err
-	}
+	pathParam0 = kid
 
 	serverURL, err := url.Parse(server)
 	if err != nil {

--- a/storage/sql_migrations/004_discoveryservice_client_registration.sql
+++ b/storage/sql_migrations/004_discoveryservice_client_registration.sql
@@ -9,6 +9,7 @@ create table discovery_presentation_refresh
     -- subject_id is the subject that should be registered on the Discovery Service.
     subject_id   varchar(370) not null,
     -- parameters contains the registration parameters passed at activation.
+    -- It is a JSON object that maps to map[string]interface{}
     parameters $TEXT_TYPE,
     -- next_refresh is the timestamp (seconds since Unix epoch) when the registration on the
     -- Discovery Service should be refreshed.

--- a/storage/sql_migrations/004_discoveryservice_client_registration.sql
+++ b/storage/sql_migrations/004_discoveryservice_client_registration.sql
@@ -1,3 +1,4 @@
+-- +goose ENVSUB ON
 -- +goose Up
 -- discovery_did_registration contains the DIDs that should be registered on the specified Discovery Service(s).
 create table discovery_presentation_refresh
@@ -7,6 +8,8 @@ create table discovery_presentation_refresh
     service_id   varchar(200) not null,
     -- subject_id is the subject that should be registered on the Discovery Service.
     subject_id   varchar(370) not null,
+    -- parameters contains the registration parameters passed at activation.
+    parameters $TEXT_TYPE,
     -- next_refresh is the timestamp (seconds since Unix epoch) when the registration on the
     -- Discovery Service should be refreshed.
     next_refresh integer      not null,

--- a/vcr/assets/assets/contexts/nuts.ldjson
+++ b/vcr/assets/assets/contexts/nuts.ldjson
@@ -83,6 +83,15 @@
         "@vocab": "schema"
       }
     },
+    "DiscoveryRegistrationCredential": {
+      "@id": "nuts:DiscoveryRegistrationCredential",
+      "@context": {
+        "@version": 1.1,
+        "@propagate": true,
+        "@protected": true,
+        "@vocab": "nuts"
+      }
+    },
     "NutsSelfSignedPresentation": "nuts:NutsSelfSignedPresentation"
   }
 }

--- a/vcr/credential/types.go
+++ b/vcr/credential/types.go
@@ -54,6 +54,16 @@ type NutsOrganizationCredentialSubject struct {
 	Organization map[string]string `json:"organization"`
 }
 
+// DiscoveryRegistrationCredentialSubject defines the CredentialSubject struct for the DiscoveryRegistrationCredential
+type DiscoveryRegistrationCredentialSubject map[string]interface{}
+
+// DiscoveryRegistrationCredentialType is the type for a Discovery Registration Credential
+const DiscoveryRegistrationCredentialType = "DiscoveryRegistrationCredential"
+
+func DiscoveryRegistrationCredentialTypeV1URI() ssi.URI {
+	return ssi.MustParseURI(DiscoveryRegistrationCredentialType)
+}
+
 // NutsAuthorizationCredentialSubject defines the CredentialSubject struct for the NutsAuthorizationCredential
 type NutsAuthorizationCredentialSubject struct {
 	// ID contains the DID of the subject

--- a/vcr/credential/util.go
+++ b/vcr/credential/util.go
@@ -130,6 +130,9 @@ func AutoCorrectSelfAttestedCredential(credential vc.VerifiableCredential, reque
 	var credentialSubject []map[string]interface{}
 	_ = credential.UnmarshalCredentialSubject(&credentialSubject)
 	if len(credentialSubject) == 1 {
+		if credentialSubject[0] == nil {
+			credentialSubject[0] = make(map[string]interface{})
+		}
 		if _, ok := credentialSubject[0]["id"]; !ok {
 			credentialSubject[0]["id"] = requester.String()
 			credential.CredentialSubject[0] = credentialSubject[0]

--- a/vcr/credential/util.go
+++ b/vcr/credential/util.go
@@ -20,6 +20,8 @@ package credential
 
 import (
 	"errors"
+	"github.com/google/uuid"
+	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
 	"time"
@@ -107,4 +109,31 @@ func PresentationExpirationDate(presentation vc.VerifiablePresentation) *time.Ti
 		return nil
 	}
 	return &result
+}
+
+// AutoCorrectSelfAttestedCredential sets the required fields for a self-attested credential.
+// These are provided through the API, and for convenience we set the required fields, if not already set.
+// It only does this for unsigned credentials.
+func AutoCorrectSelfAttestedCredential(credential vc.VerifiableCredential, requester did.DID) vc.VerifiableCredential {
+	if len(credential.Proof) > 0 {
+		return credential
+	}
+	if credential.ID == nil {
+		credential.ID, _ = ssi.ParseURI(uuid.NewString())
+	}
+	if credential.Issuer.String() == "" {
+		credential.Issuer = requester.URI()
+	}
+	if credential.IssuanceDate.IsZero() {
+		credential.IssuanceDate = time.Now().Truncate(time.Second)
+	}
+	var credentialSubject []map[string]interface{}
+	_ = credential.UnmarshalCredentialSubject(&credentialSubject)
+	if len(credentialSubject) == 1 {
+		if _, ok := credentialSubject[0]["id"]; !ok {
+			credentialSubject[0]["id"] = requester.String()
+			credential.CredentialSubject[0] = credentialSubject[0]
+		}
+	}
+	return credential
 }

--- a/vcr/credential/util_test.go
+++ b/vcr/credential/util_test.go
@@ -287,3 +287,15 @@ func TestPresentationExpirationDate(t *testing.T) {
 		assert.Nil(t, actual)
 	})
 }
+
+func TestAutoCorrectSelfAttestedCredential(t *testing.T) {
+	requestor := did.MustParseDID("did:test:123")
+	credential := vc.VerifiableCredential{
+		CredentialSubject: make([]interface{}, 1),
+	}
+	result := AutoCorrectSelfAttestedCredential(credential, requestor)
+	assert.Equal(t, requestor.URI(), result.Issuer)
+	assert.NotEqual(t, time.Time{}, result.IssuanceDate)
+	assert.NotEqual(t, "", result.ID.String())
+	assert.Equal(t, requestor.String(), result.CredentialSubject[0].(map[string]interface{})["id"])
+}

--- a/vcr/pe/presentation_definition.go
+++ b/vcr/pe/presentation_definition.go
@@ -368,8 +368,11 @@ func matchConstraint(constraint *Constraints, credential vc.VerifiableCredential
 		type Alias vc.VerifiableCredential
 		credentialAsMap, err = remarshalToMap(Alias(credential))
 	case vc.JSONLDCredentialProofFormat:
+		fallthrough
+	case "": // holder credential
 		credentialAsMap, err = remarshalToMap(credential)
 	}
+
 	if err != nil {
 		return false, nil, err
 	}

--- a/vcr/pe/presentation_definition.go
+++ b/vcr/pe/presentation_definition.go
@@ -294,6 +294,11 @@ func matchFormat(format *PresentationDefinitionClaimFormatDesignations, credenti
 		return true
 	}
 
+	if credential.Format() == "" {
+		// holder credential
+		return true
+	}
+
 	asMap := map[string]map[string][]string(*format)
 	switch credential.Format() {
 	case vc.JSONLDCredentialProofFormat:

--- a/vcr/verifier/verifier.go
+++ b/vcr/verifier/verifier.go
@@ -256,7 +256,7 @@ func (v verifier) doVerifyVP(vcVerifier Verifier, presentation vc.VerifiablePres
 
 	// we only support presenter = holder = credential subject.
 	// Check optional holder property (required for self-attesting VCs)
-	if presentation.Holder != nil && presentation.Holder.String() != subjectDID.String() {
+	if subjectDID != nil && presentation.Holder != nil && presentation.Holder.String() != subjectDID.String() {
 		return nil, newVerificationError("presentation holder must equal credential subject")
 	}
 


### PR DESCRIPTION
closes #3353 
closes #3352 

also returns the params with a search.