### PR TITLE
Add state.Configure to load state/trees before migrations are run

### DIFF
--- a/network/dag/interface.go
+++ b/network/dag/interface.go
@@ -41,6 +41,7 @@ var ErrPayloadNotFound = errors.New("payload not found")
 type State interface {
 	core.Diagnosable
 	core.Migratable
+	core.Configurable
 
 	// WritePayload writes contents for the specified payload, identified by the given hash.
 	// It also calls observers and therefore requires the transaction.

--- a/network/dag/mock.go
+++ b/network/dag/mock.go
@@ -57,6 +57,20 @@ func (mr *MockStateMockRecorder) Add(ctx, transactions, payload any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockState)(nil).Add), ctx, transactions, payload)
 }
 
+// Configure mocks base method.
+func (m *MockState) Configure(config core.ServerConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Configure", config)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Configure indicates an expected call of Configure.
+func (mr *MockStateMockRecorder) Configure(config any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Configure", reflect.TypeOf((*MockState)(nil).Configure), config)
+}
+
 // CorrectStateDetected mocks base method.
 func (m *MockState) CorrectStateDetected() {
 	m.ctrl.T.Helper()

--- a/network/network.go
+++ b/network/network.go
@@ -176,6 +176,11 @@ func (n *Network) Configure(config core.ServerConfig) error {
 	if n.state, err = dag.NewState(dagStore, dag.NewPrevTransactionsVerifier(), dag.NewTransactionSignatureVerifier(nutsKeyResolver)); err != nil {
 		return fmt.Errorf("failed to configure state: %w", err)
 	}
+	// load state
+	err = n.state.Configure(core.ServerConfig{})
+	if err != nil {
+		return err
+	}
 
 	n.strictMode = config.Strictmode
 	n.peerID = transport.PeerID(uuid.New().String())

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -357,7 +357,9 @@ func TestNetwork_Configure(t *testing.T) {
 		prov := storage.NewMockProvider(ctrl)
 		ctx.network.storeProvider = prov
 		ctx.network.connectionManager = nil
-		prov.EXPECT().GetKVStore(gomock.Any(), gomock.Any())
+		store := stoabs.NewMockKVStore(ctrl)
+		store.EXPECT().Read(gomock.Any(), gomock.Any())
+		prov.EXPECT().GetKVStore(gomock.Any(), gomock.Any()).Return(store, nil)
 		prov.EXPECT().GetKVStore(gomock.Any(), gomock.Any()).Return(nil, errors.New("failed"))
 
 		err := ctx.network.Configure(core.TestServerConfig(func(config *core.ServerConfig) {


### PR DESCRIPTION
fixes #3355 

from logs:
```
level=debug msg="Received 0 new transaction references via Gossip from peer" 
level=debug msg="XOR is different from peer but Gossip contained no new transactions"
level=debug msg="Requesting state from peer" 
```

The migration happens while the network is offline, so the changes aren't gossiped to peers. Should be fine though