### PR TITLE
backport - write DAG XOR tree consistency fixes to disk

### DIFF
--- a/network/dag/consistency.go
+++ b/network/dag/consistency.go
@@ -120,6 +120,10 @@ func (f *xorTreeRepair) checkPage() {
 			if err != nil {
 				return err
 			}
+			err = f.state.xorTree.writeWithoutLock(txn)
+			if err != nil {
+				return err
+			}
 			log.Logger().Warnf("detected XOR tree mismatch for page %d, fixed using recalculated values", f.currentPage)
 		}
 


### PR DESCRIPTION
does this need a patch release, or should we just leave it in this branch to be released together with some other fix?