### PR TITLE
have wallet.List() only return non-revoked/non-expired credentials

### DIFF
--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -91,7 +91,7 @@ func TestCrypto_New(t *testing.T) {
 	ctx := audit.TestContext()
 
 	t.Run("ok", func(t *testing.T) {
-		auditLogs := audit.CaptureLogs(t)
+		auditLogs := audit.CaptureAuditLogs(t)
 
 		ref, pubKey, err := client.New(ctx, StringNamingFunc("kid"))
 
@@ -122,7 +122,7 @@ func TestCrypto_New(t *testing.T) {
 
 func TestCrypto_Delete(t *testing.T) {
 	ctx := audit.TestContext()
-	auditLogs := audit.CaptureLogs(t)
+	auditLogs := audit.CaptureAuditLogs(t)
 
 	t.Run("ok", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/crypto/jwx_test.go
+++ b/crypto/jwx_test.go
@@ -207,7 +207,7 @@ func TestCrypto_SignJWT(t *testing.T) {
 		assert.Equal(t, kid, actualKID)
 	})
 	t.Run("writes audit logs", func(t *testing.T) {
-		auditLogs := audit.CaptureLogs(t)
+		auditLogs := audit.CaptureAuditLogs(t)
 
 		_, err := client.SignJWT(audit.TestContext(), map[string]interface{}{"iss": "nuts", "sub": "subject"}, nil, kid)
 
@@ -274,7 +274,7 @@ func TestCrypto_SignJWS(t *testing.T) {
 		assert.Equal(t, "nuts", body["iss"])
 	})
 	t.Run("writes audit log", func(t *testing.T) {
-		auditLogs := audit.CaptureLogs(t)
+		auditLogs := audit.CaptureAuditLogs(t)
 
 		_, err := client.SignJWS(audit.TestContext(), []byte{1, 2, 3}, map[string]interface{}{"typ": "JWT"}, kid, false)
 
@@ -380,7 +380,7 @@ func TestCrypto_EncryptJWE(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run("writes audit log", func(t *testing.T) {
-		auditLogs := audit.CaptureLogs(t)
+		auditLogs := audit.CaptureAuditLogs(t)
 
 		_, err := client.EncryptJWE(audit.TestContext(), []byte{1, 2, 3}, headers, pubKey)
 
@@ -446,7 +446,7 @@ func TestCrypto_DecryptJWE(t *testing.T) {
 		require.EqualError(t, err, "keys stored in 'test' do not support JWE decryption")
 	})
 	t.Run("writes audit log", func(t *testing.T) {
-		auditLogs := audit.CaptureLogs(t)
+		auditLogs := audit.CaptureAuditLogs(t)
 
 		tokenString, err := EncryptJWE([]byte{1, 2, 3}, map[string]interface{}{"typ": "JWT", "kid": kid}, pubKey)
 		require.NoError(t, err)

--- a/http/tokenV2/middleware_test.go
+++ b/http/tokenV2/middleware_test.go
@@ -172,7 +172,7 @@ func TestAuditLogAccessKeyRegistered(t *testing.T) {
 	_, _, authorizedKeys := generateEd25519TestKey(t)
 
 	// Setup audit log capturing
-	capturedAuditLog := audit.CaptureLogs(t)
+	capturedAuditLog := audit.CaptureAuditLogs(t)
 
 	// Create the middleware
 	_, err := New(nil, validHostname, []byte(authorizedKeys))
@@ -215,7 +215,7 @@ func TestAuditLogAccessDenied(t *testing.T) {
 	testCtx := echo.New().NewContext(request, recorder)
 
 	// Setup audit log capturing
-	capturedAuditLog := audit.CaptureLogs(t)
+	capturedAuditLog := audit.CaptureAuditLogs(t)
 
 	// Call the handler, ensuring the appropriate error is returned
 	httpErr := handler(testCtx).(*echo.HTTPError)
@@ -260,7 +260,7 @@ func TestAuditLogAccessGranted(t *testing.T) {
 	testCtx := echo.New().NewContext(request, recorder)
 
 	// Setup audit log capturing
-	capturedAuditLog := audit.CaptureLogs(t)
+	capturedAuditLog := audit.CaptureAuditLogs(t)
 
 	// Call the handler, ensuring no error is returned
 	err = handler(testCtx)

--- a/vcr/issuer/openid_test.go
+++ b/vcr/issuer/openid_test.go
@@ -167,7 +167,7 @@ func Test_memoryIssuer_HandleCredentialRequest(t *testing.T) {
 	validRequest := createRequest(createHeaders(), createClaims(cNonce))
 
 	t.Run("ok", func(t *testing.T) {
-		auditLogs := audit.CaptureLogs(t)
+		auditLogs := audit.CaptureAuditLogs(t)
 		response, err := service.HandleCredentialRequest(ctx, validRequest, accessToken)
 
 		require.NoError(t, err)

--- a/vcr/test/openid4vci_integration_test.go
+++ b/vcr/test/openid4vci_integration_test.go
@@ -50,7 +50,7 @@ import (
 
 // TestOpenID4VCIHappyFlow tests issuing a VC using OpenID4VCI.
 func TestOpenID4VCIHappyFlow(t *testing.T) {
-	auditLogs := audit.CaptureLogs(t)
+	auditLogs := audit.CaptureAuditLogs(t)
 	ctx := audit.TestContext()
 	_, baseURL, system := node.StartServer(t)
 	vcrService := system.FindEngineByName("vcr").(vcr.VCR)


### PR DESCRIPTION
fixes #3362 

`wallet.List()` now only returns non-revoked, non-expired credentials. Trust and signatures are not checked. Trust checking is done via PEX and signatures are checked at upload time.