### PR TITLE
Have s2s flow take verifier supported DID methods into account

### DIFF
--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -353,7 +353,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 		ctx.iamClient.EXPECT().ClientMetadata(gomock.Any(), "https://example.com/.well-known/authorization-server/oauth2/verifier").Return(&clientMetadata, nil)
 		pdEndpoint := "https://example.com/oauth2/verifier/presentation_definition?scope=test"
 		ctx.iamClient.EXPECT().PresentationDefinition(gomock.Any(), pdEndpoint).Return(&pe.PresentationDefinition{}, nil)
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{holderDID}, nil, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{holderDID}, nil, pe.PresentationDefinition{}, gomock.Any()).Return(&vc.VerifiablePresentation{}, &pe.PresentationSubmission{}, nil)
 		ctx.iamClient.EXPECT().PostAuthorizationResponse(gomock.Any(), vc.VerifiablePresentation{}, pe.PresentationSubmission{}, "https://example.com/oauth2/verifier/response", "state").Return("https://example.com/iam/holder/redirect", nil)
 
 		res, err := ctx.client.HandleAuthorizeRequest(callCtx, HandleAuthorizeRequestRequestObject{

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -285,10 +285,10 @@ func (r Wrapper) handleAuthorizeRequestFromVerifier(ctx context.Context, subject
 	// at this point in the flow it would be possible to ask the user to confirm the credentials to use
 
 	// all params checked, delegate responsibility to the holder
-	// todo expiration
 	buildParams := holder.BuildParams{
 		Audience: params.get(oauth.ClientIDParam),
 		Expires:  time.Now().Add(15 * time.Minute),
+		Format:   metadata.VPFormats,
 		Nonce:    nonce,
 	}
 
@@ -314,7 +314,7 @@ func (r Wrapper) handleAuthorizeRequestFromVerifier(ctx context.Context, subject
 			map[did.DID][]vc.VerifiableCredential{userSession.Wallet.DID: userSession.Wallet.Credentials},
 		)
 	}
-	vp, submission, err := targetWallet.BuildSubmission(ctx, []did.DID{walletDID}, nil, *presentationDefinition, metadata.VPFormats, buildParams)
+	vp, submission, err := targetWallet.BuildSubmission(ctx, []did.DID{walletDID}, nil, *presentationDefinition, buildParams)
 	if err != nil {
 		if errors.Is(err, pe.ErrNoCredentials) {
 			return r.sendAndHandleDirectPostError(ctx, oauth.OAuth2Error{Code: oauth.InvalidRequest, Description: fmt.Sprintf("wallet could not fulfill requirements (PD ID: %s, wallet: %s): %s", presentationDefinition.Id, walletDID, err.Error())}, responseURI, state)

--- a/auth/api/iam/openid4vp_test.go
+++ b/auth/api/iam/openid4vp_test.go
@@ -340,7 +340,7 @@ func TestWrapper_handleAuthorizeRequestFromVerifier(t *testing.T) {
 		putState(ctx, "state", authzCodeSession)
 		ctx.iamClient.EXPECT().ClientMetadata(gomock.Any(), "https://example.com/.well-known/authorization-server/iam/verifier").Return(&clientMetadata, nil)
 		ctx.iamClient.EXPECT().PresentationDefinition(gomock.Any(), pdEndpoint).Return(&pe.PresentationDefinition{}, nil)
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{holderDID}, nil, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(nil, nil, assert.AnError)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{holderDID}, nil, pe.PresentationDefinition{}, gomock.Any()).Return(nil, nil, assert.AnError)
 		expectPostError(t, ctx, oauth.ServerError, assert.AnError.Error(), responseURI, "state")
 
 		_, err := ctx.client.handleAuthorizeRequestFromVerifier(httpRequestCtx, holderSubjectID, params, pe.WalletOwnerOrganization)
@@ -353,7 +353,7 @@ func TestWrapper_handleAuthorizeRequestFromVerifier(t *testing.T) {
 		putState(ctx, "state", authzCodeSession)
 		ctx.iamClient.EXPECT().ClientMetadata(gomock.Any(), "https://example.com/.well-known/authorization-server/iam/verifier").Return(&clientMetadata, nil)
 		ctx.iamClient.EXPECT().PresentationDefinition(gomock.Any(), pdEndpoint).Return(&pe.PresentationDefinition{}, nil)
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{holderDID}, nil, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(nil, nil, pe.ErrNoCredentials)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{holderDID}, nil, pe.PresentationDefinition{}, gomock.Any()).Return(nil, nil, pe.ErrNoCredentials)
 		expectPostError(t, ctx, oauth.InvalidRequest, "wallet could not fulfill requirements (PD ID: , wallet: did:web:example.com:iam:holder): missing credentials", responseURI, "state")
 
 		_, err := ctx.client.handleAuthorizeRequestFromVerifier(httpRequestCtx, holderSubjectID, params, pe.WalletOwnerOrganization)

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -252,10 +252,11 @@ func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, clientID
 	}
 
 	params := holder.BuildParams{
-		Audience: authServerURL,
-		Expires:  time.Now().Add(time.Second * 5),
-		Format:   metadata.VPFormatsSupported,
-		Nonce:    nutsCrypto.GenerateNonce(),
+		Audience:   authServerURL,
+		DIDMethods: metadata.DIDMethodsSupported,
+		Expires:    time.Now().Add(time.Second * 5),
+		Format:     metadata.VPFormatsSupported,
+		Nonce:      nutsCrypto.GenerateNonce(),
 	}
 
 	subjectDIDs, err := c.subjectManager.ListDIDs(ctx, subjectID)

--- a/go.mod
+++ b/go.mod
@@ -199,3 +199,5 @@ require (
 	modernc.org/sqlite v1.32.0 // indirect
 	rsc.io/qr v0.2.0 // indirect
 )
+
+require golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8

--- a/vcr/credential/util.go
+++ b/vcr/credential/util.go
@@ -145,6 +145,10 @@ func AutoCorrectSelfAttestedCredential(credential vc.VerifiableCredential, reque
 // FilterOnDIDMethod filters the credentials based on the DID method of the issuer and credentialSubject.
 // credentials are only removed if there's a false match. Nil fields are ignored.
 func FilterOnDIDMethod(credentials []vc.VerifiableCredential, didMethods []string) []vc.VerifiableCredential {
+	// todo: for OpenID4vp there's currently no metadata that passes DID methods to the wallet.
+	if len(didMethods) == 0 {
+		return credentials
+	}
 	var result []vc.VerifiableCredential
 outer:
 	for _, credential := range credentials {

--- a/vcr/credential/util.go
+++ b/vcr/credential/util.go
@@ -24,6 +24,7 @@ import (
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
+	"slices"
 	"time"
 )
 
@@ -139,4 +140,38 @@ func AutoCorrectSelfAttestedCredential(credential vc.VerifiableCredential, reque
 		}
 	}
 	return credential
+}
+
+// FilterOnDIDMethod filters the credentials based on the DID method of the issuer and credentialSubject.
+// credentials are only removed if there's a false match. Nil fields are ignored.
+func FilterOnDIDMethod(credentials []vc.VerifiableCredential, didMethods []string) []vc.VerifiableCredential {
+	var result []vc.VerifiableCredential
+outer:
+	for _, credential := range credentials {
+		// check issuer
+		issuerDID, err := did.ParseDID(credential.Issuer.String())
+		if err == nil {
+			if !slices.Contains(didMethods, issuerDID.Method) {
+				continue
+			}
+		}
+		bl := make([]BaseCredentialSubject, 0)
+		err = credential.UnmarshalCredentialSubject(&bl)
+		if err != nil {
+			continue
+		}
+		for _, b := range bl {
+			if b.ID != "" {
+				// check credentialSubject
+				subjectDID, err := did.ParseDID(b.ID)
+				if err == nil {
+					if !slices.Contains(didMethods, subjectDID.Method) {
+						continue outer
+					}
+				}
+			}
+		}
+		result = append(result, credential)
+	}
+	return result
 }

--- a/vcr/credential/util_test.go
+++ b/vcr/credential/util_test.go
@@ -363,4 +363,43 @@ func TestFilterOnDIDMethod(t *testing.T) {
 
 		assert.Len(t, result, 1)
 	})
+	bug := `
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://nuts.nl/credentials/v1",
+    "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json"
+  ],
+  "credentialSubject": {
+    "id": "did:web:nodeB:iam:f17d021a-f0e6-4ed9-a22a-e4447f1720ba",
+    "organization": {
+      "city": "Caretown",
+      "name": "Caresoft B.V."
+    }
+  },
+  "id": "did:web:nodeB:iam:f17d021a-f0e6-4ed9-a22a-e4447f1720ba#36b83620-13b2-4fbf-a57a-618731839a6f",
+  "issuanceDate": "2024-09-17T06:44:57.97676521Z",
+  "issuer": "did:web:nodeB:iam:f17d021a-f0e6-4ed9-a22a-e4447f1720ba",
+  "proof": {
+    "created": "2024-09-17T06:44:57.97676521Z",
+    "jws": "eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il0sImtpZCI6ImRpZDp3ZWI6bm9kZUI6aWFtOmYxN2QwMjFhLWYwZTYtNGVkOS1hMjJhLWU0NDQ3ZjE3MjBiYSM3YTExZTIxZi05ZWYwLTQ5NTctOTM4Zi0xZTUyZTE5NTc1M2QifQ..4t6XiCFkvl3swZkpN63xvRUcTwMj5uUP2wVpkAmQXg33Jaou6JEgi_gwnygTK1C_bfwaqa6X7cMvT5Fm0cwTEA",
+    "proofPurpose": "assertionMethod",
+    "type": "JsonWebSignature2020",
+    "verificationMethod": "did:web:nodeB:iam:f17d021a-f0e6-4ed9-a22a-e4447f1720ba#7a11e21f-9ef0-4957-938f-1e52e195753d"
+  },
+  "type": [
+    "NutsOrganizationCredential",
+    "VerifiableCredential"
+  ]
+}
+`
+	t.Run("foo", func(t *testing.T) {
+		c := vc.VerifiableCredential{}
+		_ = c.UnmarshalJSON([]byte(bug))
+		credentials := []vc.VerifiableCredential{c}
+
+		result := FilterOnDIDMethod(credentials, []string{"web"})
+
+		assert.Len(t, result, 1)
+	})
 }

--- a/vcr/holder/interface.go
+++ b/vcr/holder/interface.go
@@ -50,7 +50,7 @@ type Wallet interface {
 
 	// BuildSubmission builds a Verifiable Presentation based on the given presentation definition.
 	// additionalCredentials can be given to have the submission consider extra credentials that are not in the wallet.
-	BuildSubmission(ctx context.Context, walletDIDs []did.DID, additionalCredentials map[did.DID][]vc.VerifiableCredential, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error)
+	BuildSubmission(ctx context.Context, walletDIDs []did.DID, additionalCredentials map[did.DID][]vc.VerifiableCredential, presentationDefinition pe.PresentationDefinition, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error)
 
 	// List returns all credentials in the wallet for the given holder.
 	// If the wallet does not contain any credentials for the given holder, it returns an empty list.

--- a/vcr/holder/memory_wallet.go
+++ b/vcr/holder/memory_wallet.go
@@ -58,7 +58,7 @@ func (m memoryWallet) BuildPresentation(ctx context.Context, credentials []vc.Ve
 	}.buildPresentation(ctx, signerDID, credentials, options)
 }
 
-func (m memoryWallet) BuildSubmission(ctx context.Context, walletDIDs []did.DID, additionalCredentials map[did.DID][]vc.VerifiableCredential, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
+func (m memoryWallet) BuildSubmission(ctx context.Context, walletDIDs []did.DID, additionalCredentials map[did.DID][]vc.VerifiableCredential, presentationDefinition pe.PresentationDefinition, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
 	wallets := make(map[did.DID][]vc.VerifiableCredential)
 	for _, walletDID := range walletDIDs {
 		wallets[walletDID] = m.credentials[walletDID]
@@ -70,7 +70,7 @@ func (m memoryWallet) BuildSubmission(ctx context.Context, walletDIDs []did.DID,
 		documentLoader: m.documentLoader,
 		signer:         m.signer,
 		keyResolver:    m.keyResolver,
-	}.buildSubmission(ctx, wallets, presentationDefinition, acceptedFormats, params)
+	}.buildSubmission(ctx, wallets, presentationDefinition, params)
 }
 
 func (m memoryWallet) List(_ context.Context, holderDID did.DID) ([]vc.VerifiableCredential, error) {

--- a/vcr/holder/mock.go
+++ b/vcr/holder/mock.go
@@ -60,9 +60,9 @@ func (mr *MockWalletMockRecorder) BuildPresentation(ctx, credentials, options, s
 }
 
 // BuildSubmission mocks base method.
-func (m *MockWallet) BuildSubmission(ctx context.Context, walletDIDs []did.DID, additionalCredentials map[did.DID][]vc.VerifiableCredential, presentationDefinition pe.PresentationDefinition, acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
+func (m *MockWallet) BuildSubmission(ctx context.Context, walletDIDs []did.DID, additionalCredentials map[did.DID][]vc.VerifiableCredential, presentationDefinition pe.PresentationDefinition, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildSubmission", ctx, walletDIDs, additionalCredentials, presentationDefinition, acceptedFormats, params)
+	ret := m.ctrl.Call(m, "BuildSubmission", ctx, walletDIDs, additionalCredentials, presentationDefinition, params)
 	ret0, _ := ret[0].(*vc.VerifiablePresentation)
 	ret1, _ := ret[1].(*pe.PresentationSubmission)
 	ret2, _ := ret[2].(error)
@@ -70,9 +70,9 @@ func (m *MockWallet) BuildSubmission(ctx context.Context, walletDIDs []did.DID, 
 }
 
 // BuildSubmission indicates an expected call of BuildSubmission.
-func (mr *MockWalletMockRecorder) BuildSubmission(ctx, walletDIDs, additionalCredentials, presentationDefinition, acceptedFormats, params any) *gomock.Call {
+func (mr *MockWalletMockRecorder) BuildSubmission(ctx, walletDIDs, additionalCredentials, presentationDefinition, params any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildSubmission", reflect.TypeOf((*MockWallet)(nil).BuildSubmission), ctx, walletDIDs, additionalCredentials, presentationDefinition, acceptedFormats, params)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildSubmission", reflect.TypeOf((*MockWallet)(nil).BuildSubmission), ctx, walletDIDs, additionalCredentials, presentationDefinition, params)
 }
 
 // Diagnostics mocks base method.

--- a/vcr/holder/presenter.go
+++ b/vcr/holder/presenter.go
@@ -48,7 +48,7 @@ type presenter struct {
 }
 
 func (p presenter) buildSubmission(ctx context.Context, credentials map[did.DID][]vc.VerifiableCredential, presentationDefinition pe.PresentationDefinition,
-	acceptedFormats map[string]map[string][]string, params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
+	params BuildParams) (*vc.VerifiablePresentation, *pe.PresentationSubmission, error) {
 	// match against the wallet's credentials
 	// if there's a match, create a VP and call the token endpoint
 	// If the token endpoint succeeds, return the access token
@@ -63,7 +63,7 @@ func (p presenter) buildSubmission(ctx context.Context, credentials map[did.DID]
 	// - the presentation definition "claimed format designation" (optional)
 	// - the verifier's metadata (optional)
 	formatCandidates := credential.OpenIDSupportedFormats(oauth.DefaultOpenIDSupportedFormats())
-	formatCandidates = formatCandidates.Match(credential.OpenIDSupportedFormats(acceptedFormats))
+	formatCandidates = formatCandidates.Match(credential.OpenIDSupportedFormats(params.Format))
 	if presentationDefinition.Format != nil {
 		formatCandidates = formatCandidates.Match(credential.DIFClaimFormats(*presentationDefinition.Format))
 	}

--- a/vcr/holder/presenter_test.go
+++ b/vcr/holder/presenter_test.go
@@ -336,12 +336,12 @@ func TestPresenter_buildSubmission(t *testing.T) {
 	t.Run("error - no matching credentials due to DID method mismatch", func(t *testing.T) {
 		resetStore(t, storageEngine.GetSQLDatabase())
 
-		w := NewSQLWallet(nil, keyStore, nil, jsonldManager, storageEngine)
+		w := NewSQLWallet(nil, keyStore, testVerifier{}, jsonldManager, storageEngine)
 		_ = w.Put(context.Background(), credentials[nutsWalletDID]...)
 
 		_, _, err := w.BuildSubmission(ctx, []did.DID{nutsWalletDID}, nil, presentationDefinition, BuildParams{Audience: verifierDID.String(), DIDMethods: []string{"test"}, Expires: time.Now().Add(time.Second), Format: vpFormats, Nonce: ""})
 
-		assert.Equal(t, ErrNoCredentials, err)
+		assert.ErrorIs(t, err, pe.ErrNoCredentials)
 	})
 	t.Run("ok - empty presentation", func(t *testing.T) {
 		resetStore(t, storageEngine.GetSQLDatabase())


### PR DESCRIPTION
Closes #3337

This PR only makes sure the holder uses a DID method in the RFC021 flow that is supported by the other side. All VCs used must also have a compliant issuer/credentialSubject.id. 