### PR TITLE
Add sql to /health

### DIFF
--- a/storage/engine.go
+++ b/storage/engine.go
@@ -78,6 +78,28 @@ func (e *engine) Name() string {
 	return "Storage"
 }
 
+// CheckHealth performs health checks for the storage engine.
+func (e *engine) CheckHealth() map[string]core.Health {
+	results := make(map[string]core.Health)
+	if e.sqlDB != nil {
+		sqlHealth := core.Health{
+			Status: core.HealthStatusUp,
+		}
+		db, err := e.sqlDB.DB()
+		if err == nil {
+			err = db.Ping()
+		}
+		if err != nil {
+			sqlHealth = core.Health{
+				Status:  core.HealthStatusDown,
+				Details: err,
+			}
+		}
+		results["sql"] = sqlHealth
+	}
+	return results
+}
+
 func (e *engine) Start() error {
 	return nil
 }

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -92,7 +92,7 @@ func (e *engine) CheckHealth() map[string]core.Health {
 		if err != nil {
 			sqlHealth = core.Health{
 				Status:  core.HealthStatusDown,
-				Details: err,
+				Details: err.Error(),
 			}
 		}
 		results["sql"] = sqlHealth


### PR DESCRIPTION
closes #2987
`/health` of a health node:
```
{
    "status": "UP",
    "details": {
        "crypto.filesystem": {
            "status": "UP"
        },
        "network.auth_config": {
            "status": "UP"
        },
        "network.tls": {
            "status": "UP"
        },
        "pki.crl": {
            "status": "UP"
        },
        "storage.sql": {
            "status": "UP"
        }
    }
}
```