### PR TITLE
pass matcher details from PEX in error for non-matches

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -31,7 +31,6 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/nuts-foundation/nuts-node/http/cache"
 	"github.com/nuts-foundation/nuts-node/http/user"
-	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"github.com/nuts-foundation/nuts-node/vdr/didsubject"
 	"html/template"
 	"net/http"
@@ -202,7 +201,7 @@ func (r Wrapper) ResolveStatusCode(err error) int {
 	return core.ResolveStatusCode(err, map[error]int{
 		vcrTypes.ErrNotFound:                http.StatusNotFound,
 		resolver.ErrDIDNotManagedByThisNode: http.StatusBadRequest,
-		holder.ErrNoCredentials:             http.StatusPreconditionFailed,
+		pe.ErrNoCredentials:                 http.StatusPreconditionFailed,
 		didsubject.ErrSubjectNotFound:       http.StatusNotFound,
 	})
 }

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -871,12 +871,12 @@ func TestWrapper_RequestServiceAccessToken(t *testing.T) {
 	})
 	t.Run("error - no matching credentials", func(t *testing.T) {
 		ctx := newTestClient(t)
-		ctx.iamClient.EXPECT().RequestRFC021AccessToken(nil, holderClientID, holderSubjectID, verifierURL.String(), "first second", true, nil).Return(nil, holder.ErrNoCredentials)
+		ctx.iamClient.EXPECT().RequestRFC021AccessToken(nil, holderClientID, holderSubjectID, verifierURL.String(), "first second", true, nil).Return(nil, pe.ErrNoCredentials)
 
 		_, err := ctx.client.RequestServiceAccessToken(nil, RequestServiceAccessTokenRequestObject{SubjectID: holderSubjectID, Body: body})
 
 		require.Error(t, err)
-		assert.Equal(t, err, holder.ErrNoCredentials)
+		assert.Equal(t, err, pe.ErrNoCredentials)
 		assert.Equal(t, http.StatusPreconditionFailed, statusCodeFrom(err))
 	})
 }

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -316,8 +316,8 @@ func (r Wrapper) handleAuthorizeRequestFromVerifier(ctx context.Context, subject
 	}
 	vp, submission, err := targetWallet.BuildSubmission(ctx, []did.DID{walletDID}, nil, *presentationDefinition, metadata.VPFormats, buildParams)
 	if err != nil {
-		if errors.Is(err, holder.ErrNoCredentials) {
-			return r.sendAndHandleDirectPostError(ctx, oauth.OAuth2Error{Code: oauth.InvalidRequest, Description: fmt.Sprintf("wallet does not contain the required credentials (PD ID: %s, wallet: %s)", presentationDefinition.Id, walletDID)}, responseURI, state)
+		if errors.Is(err, pe.ErrNoCredentials) {
+			return r.sendAndHandleDirectPostError(ctx, oauth.OAuth2Error{Code: oauth.InvalidRequest, Description: fmt.Sprintf("wallet could not fulfill requirements (PD ID: %s, wallet: %s): %s", presentationDefinition.Id, walletDID, err.Error())}, responseURI, state)
 		}
 		return r.sendAndHandleDirectPostError(ctx, oauth.OAuth2Error{Code: oauth.ServerError, Description: err.Error()}, responseURI, state)
 	}

--- a/auth/api/iam/openid4vp_test.go
+++ b/auth/api/iam/openid4vp_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/policy"
 	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/nuts-foundation/nuts-node/test"
-	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -354,8 +353,8 @@ func TestWrapper_handleAuthorizeRequestFromVerifier(t *testing.T) {
 		putState(ctx, "state", authzCodeSession)
 		ctx.iamClient.EXPECT().ClientMetadata(gomock.Any(), "https://example.com/.well-known/authorization-server/iam/verifier").Return(&clientMetadata, nil)
 		ctx.iamClient.EXPECT().PresentationDefinition(gomock.Any(), pdEndpoint).Return(&pe.PresentationDefinition{}, nil)
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{holderDID}, nil, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(nil, nil, holder.ErrNoCredentials)
-		expectPostError(t, ctx, oauth.InvalidRequest, "wallet does not contain the required credentials (PD ID: , wallet: did:web:example.com:iam:holder)", responseURI, "state")
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{holderDID}, nil, pe.PresentationDefinition{}, clientMetadata.VPFormats, gomock.Any()).Return(nil, nil, pe.ErrNoCredentials)
+		expectPostError(t, ctx, oauth.InvalidRequest, "wallet could not fulfill requirements (PD ID: , wallet: did:web:example.com:iam:holder): missing credentials", responseURI, "state")
 
 		_, err := ctx.client.handleAuthorizeRequestFromVerifier(httpRequestCtx, holderSubjectID, params, pe.WalletOwnerOrganization)
 

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -269,10 +269,6 @@ func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, clientID
 	if err != nil {
 		return nil, err
 	}
-	if vp == nil {
-		// No DID has the right credentials to present
-		return nil, holder.ErrNoCredentials
-	}
 	subjectDID, err := did.ParseDID(vp.Holder.String())
 	if err != nil {
 		return nil, err

--- a/auth/client/iam/openid4vp_test.go
+++ b/auth/client/iam/openid4vp_test.go
@@ -261,11 +261,11 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 	t.Run("no DID fulfills the Presentation Definition", func(t *testing.T) {
 		ctx := createClientServerTestContext(t)
 		ctx.subjectManager.EXPECT().ListDIDs(gomock.Any(), subjectID).Return([]did.DID{primaryWalletDID, secondaryWalletDID}, nil)
-		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{primaryWalletDID, secondaryWalletDID}, gomock.Any(), gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(nil, nil, holder.ErrNoCredentials)
+		ctx.wallet.EXPECT().BuildSubmission(gomock.Any(), []did.DID{primaryWalletDID, secondaryWalletDID}, gomock.Any(), gomock.Any(), oauth.DefaultOpenIDSupportedFormats(), gomock.Any()).Return(nil, nil, pe.ErrNoCredentials)
 
 		response, err := ctx.client.RequestRFC021AccessToken(context.Background(), subjectClientID, subjectID, ctx.verifierURL.String(), scopes, false, nil)
 
-		assert.ErrorIs(t, err, holder.ErrNoCredentials)
+		assert.ErrorIs(t, err, pe.ErrNoCredentials)
 		assert.Nil(t, response)
 	})
 	t.Run("with additional credentials", func(t *testing.T) {

--- a/discovery/client_test.go
+++ b/discovery/client_test.go
@@ -104,7 +104,7 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 		err := manager.activate(audit.TestContext(), testServiceID, aliceSubject, nil)
 
 		require.ErrorIs(t, err, ErrPresentationRegistrationFailed)
-		require.ErrorIs(t, err, errMissingCredential)
+		require.ErrorIs(t, err, pe.ErrNoCredentials)
 	})
 	t.Run("subject with 2 DIDs, one registers and other fails", func(t *testing.T) {
 		subjectDIDs := []did.DID{aliceDID, bobDID}

--- a/discovery/interface.go
+++ b/discovery/interface.go
@@ -34,9 +34,6 @@ var ErrPresentationAlreadyExists = errors.New("presentation already exists")
 // ErrPresentationRegistrationFailed indicates registration of a presentation on a remote Discovery Service failed.
 var ErrPresentationRegistrationFailed = errors.New("registration of Verifiable Presentation on remote Discovery Service failed")
 
-// errMissingCredential indicates that a VP does not have the credentials required to fulfill the Presentation Definition of a Discovery Service.
-var errMissingCredential = errors.New("missing credential")
-
 // authServerURLField is the field name for the authServerURL in the DiscoveryRegistrationCredential.
 // it is used to resolve authorization server metadata and thus the endpoints for a service entry.
 const authServerURLField = "authServerURL"

--- a/discovery/module.go
+++ b/discovery/module.go
@@ -257,7 +257,7 @@ func (m *Module) validateRegistration(definition ServiceDefinition, presentation
 	// We don't have a PresentationSubmission, so we can't use Validate().
 	creds, _, err := definition.PresentationDefinition.Match(presentation.VerifiableCredential)
 	if err != nil {
-		return err
+		return fmt.Errorf("verifiable presentation doesn't match required presentation definition: %w", err)
 	}
 	if len(creds) != len(presentation.VerifiableCredential) {
 		return errPresentationDoesNotFulfillDefinition

--- a/discovery/module_test.go
+++ b/discovery/module_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/nuts-foundation/nuts-node/vcr"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/holder"
+	"github.com/nuts-foundation/nuts-node/vcr/pe"
 	"github.com/nuts-foundation/nuts-node/vcr/verifier"
 	"github.com/nuts-foundation/nuts-node/vdr/didsubject"
 	"github.com/stretchr/testify/assert"
@@ -157,7 +158,7 @@ func Test_Module_Register(t *testing.T) {
 				claims[jwt.AudienceKey] = []string{testServiceID}
 			}, createCredential(unsupportedDID, unsupportedDID, nil, nil))
 			err := m.Register(ctx, testServiceID, otherVP)
-			require.ErrorContains(t, err, "presentation does not fulfill Presentation ServiceDefinition")
+			assert.ErrorIs(t, err, pe.ErrNoCredentials)
 
 			_, timestamp, _ := m.Get(ctx, testServiceID, 0)
 			assert.Equal(t, 0, timestamp)

--- a/vcr/holder/presenter.go
+++ b/vcr/holder/presenter.go
@@ -77,10 +77,6 @@ func (p presenter) buildSubmission(ctx context.Context, credentials map[did.DID]
 		return nil, nil, fmt.Errorf("failed to build presentation submission: %w", err)
 	}
 	if signInstructions.Empty() {
-		// we'll allow empty if no credentials are required
-		if presentationDefinition.CredentialsRequired() {
-			return nil, nil, ErrNoCredentials
-		}
 		// add empty sign instruction
 		// TODO: If the verifier doesn't require any credentials, it also can't signal which DID methods it supports/requires?
 		var holderDID did.DID

--- a/vcr/holder/presenter_test.go
+++ b/vcr/holder/presenter_test.go
@@ -328,7 +328,7 @@ func TestPresenter_buildSubmission(t *testing.T) {
 
 		vp, submission, err := w.BuildSubmission(ctx, []did.DID{nutsWalletDID}, nil, presentationDefinition, vpFormats, BuildParams{Audience: verifierDID.String(), Expires: time.Now().Add(time.Second), Nonce: ""})
 
-		assert.Equal(t, ErrNoCredentials, err)
+		assert.ErrorIs(t, err, pe.ErrNoCredentials)
 		assert.Nil(t, vp)
 		assert.Nil(t, submission)
 	})

--- a/vcr/holder/sql_wallet.go
+++ b/vcr/holder/sql_wallet.go
@@ -41,9 +41,6 @@ import (
 	"time"
 )
 
-// ErrNoCredentials is returned when no matching credentials are found in the wallet based on a PresentationDefinition
-var ErrNoCredentials = errors.New("no matching credentials")
-
 type sqlWallet struct {
 	keyResolver   resolver.KeyResolver
 	keyStore      crypto.KeyStore

--- a/vcr/pe/presentation_definition_test.go
+++ b/vcr/pe/presentation_definition_test.go
@@ -226,7 +226,7 @@ func TestMatch(t *testing.T) {
 
 				vcs, mappingObjects, err := definitions().JWT.Match([]vc.VerifiableCredential{*jwtCredential})
 
-				assert.NoError(t, err)
+				assert.EqualError(t, err, "missing credentials\nconstraints not matched: no VC for InputDescriptor (as_jwt)")
 				assert.Empty(t, vcs)
 				assert.Empty(t, mappingObjects)
 			})
@@ -256,7 +256,7 @@ func TestMatch(t *testing.T) {
 
 			vcs, mappingObjects, err := presentationDefinition.Match([]vc.VerifiableCredential{jsonldVC})
 
-			require.NoError(t, err)
+			require.EqualError(t, err, "missing credentials\nconstraints not matched: no VC for InputDescriptor (organization_credential)")
 			assert.Len(t, vcs, 0)
 			assert.Len(t, mappingObjects, 0)
 		})
@@ -317,7 +317,7 @@ func TestMatch(t *testing.T) {
 				_, _, err := presentationDefinition.Match([]vc.VerifiableCredential{})
 
 				require.Error(t, err)
-				assert.EqualError(t, err, "submission requirement (Pick 1 matcher) has less credentials (0) than required (1)")
+				assert.EqualError(t, err, "missing credentials\nsubmission requirement (Pick 1 matcher) has less credentials (0) than required (1)")
 			})
 		})
 		t.Run("Pick min max", func(t *testing.T) {
@@ -338,7 +338,7 @@ func TestMatch(t *testing.T) {
 				_, _, err := presentationDefinition.Match([]vc.VerifiableCredential{})
 
 				require.Error(t, err)
-				assert.EqualError(t, err, "submission requirement (Pick 1 matcher) has less matches (0) than minimal required (1)")
+				assert.EqualError(t, err, "missing credentials\nsubmission requirement (Pick 1 matcher) has less matches (0) than minimal required (1)")
 			})
 		})
 		t.Run("Pick 1 per group", func(t *testing.T) {
@@ -394,7 +394,7 @@ func TestMatch(t *testing.T) {
 				t.Run("no match", func(t *testing.T) {
 					vcs, _, err := presentationDefinition.Match([]vc.VerifiableCredential{vc1, vc3})
 
-					require.Error(t, err)
+					assert.EqualError(t, err, "missing credentials\nsubmission requirement (Pick 1 matcher) has less credentials (0) than required (1)")
 					assert.Len(t, vcs, 0)
 				})
 			})
@@ -417,7 +417,7 @@ func TestMatch(t *testing.T) {
 				_, _, err := presentationDefinition.Match([]vc.VerifiableCredential{})
 
 				require.Error(t, err)
-				assert.EqualError(t, err, "submission requirement (All from nested) does not have all credentials from the group")
+				assert.EqualError(t, err, "missing credentials\nsubmission requirement (All from nested) does not have all credentials from the group")
 			})
 		})
 		t.Run("Pick min max from nested", func(t *testing.T) {
@@ -438,7 +438,7 @@ func TestMatch(t *testing.T) {
 				_, _, err := presentationDefinition.Match([]vc.VerifiableCredential{})
 
 				require.Error(t, err)
-				assert.EqualError(t, err, "submission requirement (Pick 1 matcher) has less matches (0) than minimal required (1)")
+				assert.EqualError(t, err, "missing credentials\nsubmission requirement (Pick 1 matcher) has less matches (0) than minimal required (1)")
 			})
 		})
 	})

--- a/vcr/pe/presentation_submission.go
+++ b/vcr/pe/presentation_submission.go
@@ -114,7 +114,7 @@ func (b *PresentationSubmissionBuilder) Build(format string) (PresentationSubmis
 
 	selectedVCs, inputDescriptorMappingObjects, err := b.presentationDefinition.Match(allVCs)
 	if err != nil {
-		return presentationSubmission, nil, err
+		return presentationSubmission, nil, fmt.Errorf("failed to match presentation definition: %w", err)
 	}
 
 	// next we need to map the selected VCs to the correct wallet

--- a/vcr/pe/presentation_submission_test.go
+++ b/vcr/pe/presentation_submission_test.go
@@ -590,7 +590,7 @@ func TestPresentationSubmission_Validate(t *testing.T) {
 
 		credentials, err := PresentationSubmission{}.Validate(toEnvelope(t, []vc.VerifiablePresentation{vp}), definition)
 
-		assert.EqualError(t, err, "presentation submission doesn't match presentation definition")
+		assert.EqualError(t, err, "failed to match presentation definition: missing credentials\nconstraints not matched: no VC for InputDescriptor (1)")
 		assert.Empty(t, credentials)
 	})
 	t.Run("credentials match wrong input descriptors", func(t *testing.T) {

--- a/vcr/pe/submission_requirement.go
+++ b/vcr/pe/submission_requirement.go
@@ -19,6 +19,7 @@
 package pe
 
 import (
+	"errors"
 	"fmt"
 	"github.com/nuts-foundation/go-did/vc"
 	"slices"
@@ -134,7 +135,7 @@ func apply[S ~[]E, E selectable](list S, submissionRequirement SubmissionRequire
 	if submissionRequirement.Rule == "all" {
 		// no empty members allowed
 		if selectableCount != len(list) {
-			return nil, fmt.Errorf("submission requirement (%s) does not have all credentials from the group", submissionRequirement.Name)
+			return nil, errors.Join(ErrNoCredentials, fmt.Errorf("submission requirement (%s) does not have all credentials from the group", submissionRequirement.Name))
 		}
 		for _, member := range list {
 			// shouldn't happen, but prevents a panic
@@ -149,7 +150,7 @@ func apply[S ~[]E, E selectable](list S, submissionRequirement SubmissionRequire
 	if submissionRequirement.Count != nil {
 		// not enough matching constraints
 		if selectableCount < *submissionRequirement.Count {
-			return nil, fmt.Errorf("submission requirement (%s) has less credentials (%d) than required (%d)", submissionRequirement.Name, selectableCount, *submissionRequirement.Count)
+			return nil, errors.Join(ErrNoCredentials, fmt.Errorf("submission requirement (%s) has less credentials (%d) than required (%d)", submissionRequirement.Name, selectableCount, *submissionRequirement.Count))
 		}
 		i := 0
 		for _, member := range list {
@@ -167,7 +168,7 @@ func apply[S ~[]E, E selectable](list S, submissionRequirement SubmissionRequire
 	// check min and max rules
 	// only check if min requirement is met, max just determines the upper bound for the return
 	if submissionRequirement.Min != nil && selectableCount < *submissionRequirement.Min {
-		return nil, fmt.Errorf("submission requirement (%s) has less matches (%d) than minimal required (%d)", submissionRequirement.Name, selectableCount, *submissionRequirement.Min)
+		return nil, errors.Join(ErrNoCredentials, fmt.Errorf("submission requirement (%s) has less matches (%d) than minimal required (%d)", submissionRequirement.Name, selectableCount, *submissionRequirement.Min))
 	}
 	// take max if both min and max are set
 	index := 0

--- a/vcr/pe/test/pd_jsonld.json
+++ b/vcr/pe/test/pd_jsonld.json
@@ -3,6 +3,7 @@
   "input_descriptors": [
     {
       "id": "as_jsonld",
+      "name": "as_jsonld",
       "constraints": {
         "fields": [
           {

--- a/vcr/pe/test/pd_jsonld_jwt.json
+++ b/vcr/pe/test/pd_jsonld_jwt.json
@@ -3,6 +3,7 @@
   "input_descriptors": [
     {
       "id": "organization_credential",
+      "name": "organization_credential",
       "constraints": {
         "fields": [
           {

--- a/vcr/pe/test/pd_jsonld_jwt_pick.json
+++ b/vcr/pe/test/pd_jsonld_jwt_pick.json
@@ -10,6 +10,7 @@
   "input_descriptors": [
     {
       "id": "as_jsonld",
+      "name": "as_jsonld",
       "group": [
         "vc"
       ],
@@ -47,6 +48,7 @@
     },
     {
       "id": "as_jwt",
+      "name": "as_jwt",
       "group": [
         "vc"
       ],

--- a/vcr/pe/test/pd_jwt.json
+++ b/vcr/pe/test/pd_jwt.json
@@ -3,6 +3,7 @@
   "input_descriptors": [
     {
       "id": "as_jwt",
+      "name": "as_jwt",
       "constraints": {
         "fields": [
           {

--- a/vcr/pe/types.go
+++ b/vcr/pe/types.go
@@ -19,6 +19,10 @@
 // Package pe stands for Presentation Exchange which includes Presentation Definition and Presentation Submission
 package pe
 
+import "errors"
+
+var ErrNoCredentials = errors.New("missing credentials")
+
 // PresentationDefinitionClaimFormatDesignations (replaces generated one)
 type PresentationDefinitionClaimFormatDesignations map[string]map[string][]string
 


### PR DESCRIPTION
closes #3007 
closes #3025 

I changed the PEX implementation so it always returns a `errors.Join(pe.ErrNoCredentials, reason)` when there's no match. For RFC021 this is returned as is. For the discovery service this is placed in trace logging to get details when needed.