### PR TITLE
remove AlsoKnownAs from ORM

### DIFF
--- a/storage/orm/did.go
+++ b/storage/orm/did.go
@@ -26,7 +26,6 @@ import (
 type DID struct {
 	ID      string `gorm:"primaryKey"`
 	Subject string `gorm:"column:subject"`
-	Aka     []DID  `gorm:"foreignKey:Subject;references:Subject"`
 }
 
 func (d DID) TableName() string {

--- a/storage/orm/did_document.go
+++ b/storage/orm/did_document.go
@@ -20,7 +20,6 @@ package orm
 
 import (
 	"encoding/json"
-	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/nuts-node/jsonld"
 	"gorm.io/gorm/schema"
@@ -62,18 +61,7 @@ func (sqlDoc DidDocument) ToDIDDocument() (did.Document, error) {
 
 func (sqlDoc DidDocument) GenerateDIDDocument() (did.Document, error) {
 	id, _ := did.ParseDID(sqlDoc.DID.ID)
-	others := make([]ssi.URI, 0)
-	for _, alias := range sqlDoc.DID.Aka {
-		uri, err := ssi.ParseURI(alias.ID)
-		if err != nil {
-			return did.Document{}, err
-		}
-		if id.String() != uri.String() {
-			others = append(others, *uri)
-		}
-	}
 	document := did.Document{
-		AlsoKnownAs: others,
 		Context: []interface{}{
 			did.DIDContextV1URI(),
 			jsonld.JWS2020ContextV1URI(),

--- a/storage/orm/did_document_test.go
+++ b/storage/orm/did_document_test.go
@@ -28,7 +28,7 @@ func TestDIDDocument_ToDIDDocument(t *testing.T) {
 	}
 	document := DidDocument{
 		ID:                  "id",
-		DID:                 DID{ID: alice.String(), Aka: []DID{{ID: bob.String()}}},
+		DID:                 DID{ID: alice.String()},
 		Version:             1,
 		VerificationMethods: []VerificationMethod{vm},
 		Services:            []Service{service},
@@ -43,5 +43,4 @@ func TestDIDDocument_ToDIDDocument(t *testing.T) {
 	require.Len(t, didDoc.Service, 1)
 	assert.Equal(t, "#1", didDoc.VerificationMethod[0].ID.String())
 	assert.Equal(t, "#2", didDoc.Service[0].ID.String())
-	assert.Len(t, didDoc.AlsoKnownAs, 1)
 }

--- a/vdr/didsubject/did.go
+++ b/vdr/didsubject/did.go
@@ -61,7 +61,7 @@ func (s SqlDIDManager) Add(subject string, did did.DID) (*orm.DID, error) {
 
 func (s SqlDIDManager) All() ([]orm.DID, error) {
 	dids := make([]orm.DID, 0)
-	return dids, s.tx.Preload("Aka").Find(&dids).Error
+	return dids, s.tx.Find(&dids).Error
 }
 
 func (s SqlDIDManager) Delete(did did.DID) error {
@@ -74,7 +74,7 @@ func (s SqlDIDManager) DeleteAll(subject string) error {
 
 func (s SqlDIDManager) Find(id did.DID) (*orm.DID, error) {
 	var did orm.DID
-	err := s.tx.Preload("Aka").First(&did, "id = ?", id.String()).Error
+	err := s.tx.First(&did, "id = ?", id.String()).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -86,7 +86,7 @@ func (s SqlDIDManager) Find(id did.DID) (*orm.DID, error) {
 
 func (s SqlDIDManager) FindBySubject(subject string) ([]orm.DID, error) {
 	dids := make([]orm.DID, 0)
-	err := s.tx.Preload("Aka").Find(&dids, "subject = ?", subject).Error
+	err := s.tx.Find(&dids, "subject = ?", subject).Error
 	if err != nil {
 		return nil, err
 	}

--- a/vdr/didsubject/did_document.go
+++ b/vdr/didsubject/did_document.go
@@ -35,7 +35,7 @@ var _ DIDDocumentManager = (*SqlDIDDocumentManager)(nil)
 type DIDDocumentManager interface {
 	// CreateOrUpdate adds a new version of a DID document, starts at 1
 	// If the DID does not exist yet, it will be created
-	// It adds all verification methods, services, alsoKnownAs to the DID document
+	// It adds all verification methods and services to the DID document
 	// Not passing any verification methods will create an empty DID document, deactivation checking should be done by the caller
 	CreateOrUpdate(did orm.DID, verificationMethods []orm.VerificationMethod, services []orm.Service) (*orm.DidDocument, error)
 	// Latest returns the latest version of a DID document

--- a/vdr/didsubject/did_document.go
+++ b/vdr/didsubject/did_document.go
@@ -84,7 +84,7 @@ func (s *SqlDIDDocumentManager) Latest(did did.DID, resolveTime *time.Time) (*or
 	if resolveTime != nil {
 		notAfter = resolveTime.Unix()
 	}
-	err := s.tx.Preload("DID").Preload("DID.Aka").Preload("Services").Preload("VerificationMethods").Where("did = ? AND updated_at <= ?", did.String(), notAfter).Order("version desc").First(&doc).Error
+	err := s.tx.Preload("DID").Preload("Services").Preload("VerificationMethods").Where("did = ? AND updated_at <= ?", did.String(), notAfter).Order("version desc").First(&doc).Error
 	if err != nil {
 		return nil, err
 	}

--- a/vdr/didsubject/did_document_test.go
+++ b/vdr/didsubject/did_document_test.go
@@ -152,20 +152,4 @@ func TestSqlDIDDocumentManager_Latest(t *testing.T) {
 		assert.Equal(t, gorm.ErrRecordNotFound, err)
 		assert.Nil(t, latest)
 	})
-	t.Run("contains alsoKnownAs", func(t *testing.T) {
-		sqlDidBob := orm.DID{ID: bob.String(), Subject: "bob", Aka: []orm.DID{sqlDidAlice}}
-		_, err := docManager.CreateOrUpdate(sqlDidBob, nil, nil)
-		require.NoError(t, err)
-
-		latest, err := docManager.Latest(bob, nil)
-		require.NoError(t, err)
-
-		// in DID
-		assert.Len(t, latest.DID.Aka, 2)
-
-		// in did document (from Raw)
-		didDoc, err := latest.ToDIDDocument()
-		require.NoError(t, err)
-		assert.Len(t, didDoc.AlsoKnownAs, 1)
-	})
 }

--- a/vdr/didsubject/did_test.go
+++ b/vdr/didsubject/did_test.go
@@ -93,16 +93,6 @@ func TestSqlDIDManager_Find(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, did)
 	})
-	t.Run("loads aliases", func(t *testing.T) {
-		_, err := manager.Add("alice", bob)
-		require.NoError(t, err)
-
-		did, err := manager.Find(alice)
-		require.NoError(t, err)
-
-		require.Len(t, did.Aka, 2)
-
-	})
 }
 
 func TestSqlDIDManager_FindBySubject(t *testing.T) {
@@ -125,8 +115,6 @@ func TestSqlDIDManager_FindBySubject(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, dids, 2)
-		a := dids[0]
-		require.Len(t, a.Aka, 2)
 	})
 }
 

--- a/vdr/didsubject/manager.go
+++ b/vdr/didsubject/manager.go
@@ -156,11 +156,6 @@ func (r *Manager) Create(ctx context.Context, options CreationOptions) ([]did.Do
 			sqlDocs[method] = *sqlDoc
 		}
 
-		alsoKnownAs := make([]orm.DID, 0)
-		for _, sqlDoc := range sqlDocs {
-			alsoKnownAs = append(alsoKnownAs, sqlDoc.DID)
-		}
-
 		// then store all docs in the sql db with matching events
 		changes := make(map[string]orm.DIDChangeLog)
 		sqlDIDDocumentManager := NewDIDDocumentManager(tx)
@@ -170,7 +165,6 @@ func (r *Manager) Create(ctx context.Context, options CreationOptions) ([]did.Do
 			sqlDID := orm.DID{
 				ID:      sqlDoc.DID.ID,
 				Subject: subject,
-				Aka:     alsoKnownAs,
 			}
 			createdDoc, err := sqlDIDDocumentManager.CreateOrUpdate(sqlDID, sqlDoc.VerificationMethods, nil)
 			if err != nil {

--- a/vdr/didsubject/manager.go
+++ b/vdr/didsubject/manager.go
@@ -161,7 +161,7 @@ func (r *Manager) Create(ctx context.Context, options CreationOptions) ([]did.Do
 		sqlDIDDocumentManager := NewDIDDocumentManager(tx)
 		transactionId := uuid.New().String()
 		for method, sqlDoc := range sqlDocs {
-			// overwrite sql.DID from returned document because we have the subject and alsoKnownAs here
+			// overwrite sql.DID from returned document because we have the subject here
 			sqlDID := orm.DID{
 				ID:      sqlDoc.DID.ID,
 				Subject: subject,

--- a/vdr/didsubject/manager_test.go
+++ b/vdr/didsubject/manager_test.go
@@ -133,10 +133,6 @@ func TestManager_Create(t *testing.T) {
 		}
 		assert.True(t, strings.HasPrefix(IDs[0], "did:test:"))
 		assert.True(t, strings.HasPrefix(IDs[1], "did:example:"))
-
-		// test alsoKnownAs requirements
-		document := documents[0]
-		assert.Len(t, document.AlsoKnownAs, 1)
 	})
 	t.Run("with unknown option", func(t *testing.T) {
 		db := testDB(t)
@@ -254,23 +250,12 @@ func TestManager_AddVerificationMethod(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, documents, 2)
-	document := documents[0]
 
 	t.Run("ok", func(t *testing.T) {
 		vms, err := m.AddVerificationMethod(audit.TestContext(), subject, orm.AssertionKeyUsage())
 
 		require.NoError(t, err)
 		require.Len(t, vms, 2)
-		t.Run("update keeps alsoKnownAs", func(t *testing.T) {
-			sqlDocumentManager := NewDIDDocumentManager(db)
-
-			latest, err := sqlDocumentManager.Latest(did.MustParseDID(document.ID.String()), nil)
-			require.NoError(t, err)
-			didDocument, err := latest.ToDIDDocument()
-
-			require.NoError(t, err)
-			assert.Len(t, didDocument.AlsoKnownAs, 1)
-		})
 	})
 }
 


### PR DESCRIPTION
Closes #3381

For now we'll just allow VCs to be embedded in a VP by the credentialSubject.id. No cross-did possibilities using AlsoKnownAs