### PR TITLE
add DIDMethods config param to discovery service

### DIFF
--- a/discovery/api/server/api.go
+++ b/discovery/api/server/api.go
@@ -43,6 +43,8 @@ func (w *Wrapper) ResolveStatusCode(err error) int {
 	switch {
 	case errors.Is(err, discovery.ErrInvalidPresentation):
 		return http.StatusBadRequest
+	case errors.Is(err, discovery.ErrDIDMethodsNotSupported):
+		return http.StatusBadRequest
 	case errors.Is(err, discovery.ErrServiceNotFound):
 		return http.StatusNotFound
 	default:

--- a/discovery/client_test.go
+++ b/discovery/client_test.go
@@ -89,6 +89,16 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 		require.ErrorIs(t, err, ErrPresentationRegistrationFailed)
 		assert.ErrorContains(t, err, "invoker error")
 	})
+	t.Run("DID method not supported", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
+		manager := newRegistrationManager(testDefinitions(), nil, nil, nil, mockSubjectManager)
+
+		err := manager.activate(audit.TestContext(), unsupportedServiceID, aliceSubject, defaultRegistrationParams(aliceSubject))
+
+		assert.ErrorIs(t, err, ErrDIDMethodsNotSupported)
+	})
 	t.Run("no matching credentials", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		invoker := client.NewMockHTTPClient(ctrl)
@@ -239,6 +249,17 @@ func Test_defaultClientRegistrationManager_deactivate(t *testing.T) {
 
 		assert.NoError(t, err)
 	})
+	t.Run("DID method not supported", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
+		store := setupStore(t, storageEngine.GetSQLDatabase())
+		manager := newRegistrationManager(testDefinitions(), store, nil, nil, mockSubjectManager)
+
+		err := manager.deactivate(audit.TestContext(), unsupportedServiceID, aliceSubject)
+
+		assert.ErrorIs(t, err, ErrDIDMethodsNotSupported)
+	})
 	t.Run("deregistering from Discovery Service fails", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		invoker := client.NewMockHTTPClient(ctrl)
@@ -348,6 +369,25 @@ func Test_defaultClientRegistrationManager_refresh(t *testing.T) {
 		err := manager.refresh(audit.TestContext(), time.Now())
 
 		assert.EqualError(t, err, "removed unknown subject (service=usecase_v1, subject=alice)")
+	})
+
+	t.Run("deactivate unsupported DID method", func(t *testing.T) {
+		store := setupStore(t, storageEngine.GetSQLDatabase())
+		ctrl := gomock.NewController(t)
+		invoker := client.NewMockHTTPClient(ctrl)
+		mockVCR := vcr.NewMockVCR(ctrl)
+		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
+		mockSubjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
+		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
+		_ = store.updatePresentationRefreshTime(unsupportedServiceID, aliceSubject, defaultRegistrationParams(aliceSubject), &time.Time{})
+
+		err := manager.refresh(audit.TestContext(), time.Now())
+
+		// refresh clears the registration
+		require.NoError(t, err)
+		refreshTime, err := store.getPresentationRefreshTime(unsupportedServiceID, aliceSubject)
+		assert.NoError(t, err)
+		assert.Nil(t, refreshTime)
 	})
 }
 

--- a/discovery/client_test.go
+++ b/discovery/client_test.go
@@ -472,6 +472,7 @@ func Test_clientUpdater_update(t *testing.T) {
 		httpClient := client.NewMockHTTPClient(ctrl)
 		httpClient.EXPECT().Get(gomock.Any(), "http://example.com/usecase", gomock.Any()).Return(map[string]vc.VerifiablePresentation{}, 0, nil)
 		httpClient.EXPECT().Get(gomock.Any(), "http://example.com/other", gomock.Any()).Return(nil, 0, errors.New("test"))
+		httpClient.EXPECT().Get(gomock.Any(), "http://example.com/unsupported", gomock.Any()).Return(map[string]vc.VerifiablePresentation{}, 0, nil)
 		updater := newClientUpdater(testDefinitions(), store, alwaysOkVerifier, httpClient)
 
 		err := updater.update(context.Background())

--- a/discovery/definition.go
+++ b/discovery/definition.go
@@ -48,6 +48,9 @@ func init() {
 type ServiceDefinition struct {
 	// ID is the unique identifier of the use case.
 	ID string `json:"id"`
+	// DIDMethods is a list of DID methods that are supported by the use case.
+	// If empty, all methods are supported.
+	DIDMethods []string `json:"did_methods"`
 	// Endpoint is the endpoint where the use case list is served.
 	Endpoint string `json:"endpoint"`
 	// PresentationDefinition specifies the Presentation ServiceDefinition submissions to the list must conform to,

--- a/discovery/interface.go
+++ b/discovery/interface.go
@@ -34,6 +34,8 @@ var ErrPresentationAlreadyExists = errors.New("presentation already exists")
 // ErrPresentationRegistrationFailed indicates registration of a presentation on a remote Discovery Service failed.
 var ErrPresentationRegistrationFailed = errors.New("registration of Verifiable Presentation on remote Discovery Service failed")
 
+var ErrDIDMethodsNotSupported = errors.New("DID methods not supported")
+
 // authServerURLField is the field name for the authServerURL in the DiscoveryRegistrationCredential.
 // it is used to resolve authorization server metadata and thus the endpoints for a service entry.
 const authServerURLField = "authServerURL"

--- a/discovery/module_test.go
+++ b/discovery/module_test.go
@@ -153,8 +153,7 @@ func Test_Module_Register(t *testing.T) {
 		t.Run("not conform to Presentation Definition", func(t *testing.T) {
 			m, _ := setupModule(t, storageEngine)
 
-			// Presentation Definition only allows did:example DIDs
-			otherVP := createPresentationCustom(unsupportedDID, func(claims map[string]interface{}, vp *vc.VerifiablePresentation) {
+			otherVP := createPresentationCustom(aliceDID, func(claims map[string]interface{}, vp *vc.VerifiablePresentation) {
 				claims[jwt.AudienceKey] = []string{testServiceID}
 			}, createCredential(unsupportedDID, unsupportedDID, nil, nil))
 			err := m.Register(ctx, testServiceID, otherVP)

--- a/discovery/module_test.go
+++ b/discovery/module_test.go
@@ -163,6 +163,20 @@ func Test_Module_Register(t *testing.T) {
 			_, timestamp, _ := m.Get(ctx, testServiceID, 0)
 			assert.Equal(t, 0, timestamp)
 		})
+		t.Run("unsupported DID method", func(t *testing.T) {
+			m, _ := setupModule(t, storageEngine, func(module *Module) {
+				module.serverDefinitions[unsupportedServiceID] = ServiceDefinition{
+					ID:         unsupportedServiceID,
+					DIDMethods: []string{"unsupported"},
+				}
+			})
+			otherVP := createPresentationCustom(aliceDID, func(claims map[string]interface{}, vp *vc.VerifiablePresentation) {
+				claims[jwt.AudienceKey] = []string{unsupportedServiceID}
+			}, vcAlice, aliceDiscoveryCredential)
+
+			err := m.Register(ctx, unsupportedServiceID, otherVP)
+			assert.ErrorIs(t, err, ErrDIDMethodsNotSupported)
+		})
 		t.Run("cycle detected", func(t *testing.T) {
 			m, _ := setupModule(t, storageEngine, func(module *Module) {
 				module.allDefinitions["someother"] = ServiceDefinition{
@@ -312,6 +326,7 @@ func setupModule(t *testing.T, storageInstance storage.Engine, visitors ...func(
 	httpClient := client.NewMockHTTPClient(ctrl)
 	httpClient.EXPECT().Get(gomock.Any(), "http://example.com/other", gomock.Any()).Return(nil, 0, nil).AnyTimes()
 	httpClient.EXPECT().Get(gomock.Any(), "http://example.com/usecase", gomock.Any()).Return(nil, 0, nil).AnyTimes()
+	httpClient.EXPECT().Get(gomock.Any(), "http://example.com/unsupported", gomock.Any()).Return(nil, 0, nil).AnyTimes()
 	m.httpClient = httpClient
 	m.allDefinitions = testDefinitions()
 	m.serverDefinitions = map[string]ServiceDefinition{

--- a/discovery/module_test.go
+++ b/discovery/module_test.go
@@ -557,7 +557,7 @@ func TestModule_Services(t *testing.T) {
 		services := (&Module{
 			allDefinitions: testDefinitions(),
 		}).Services()
-		assert.Len(t, services, 2)
+		assert.Len(t, services, 3)
 	})
 }
 

--- a/discovery/test.go
+++ b/discovery/test.go
@@ -54,6 +54,7 @@ var vpBob vc.VerifiablePresentation
 var unsupportedDID did.DID
 
 var testServiceID = "usecase_v1"
+var unsupportedServiceID = "unsupported"
 
 func testDefinitions() map[string]ServiceDefinition {
 	return map[string]ServiceDefinition{
@@ -144,6 +145,12 @@ func testDefinitions() map[string]ServiceDefinition {
 					},
 				},
 			},
+			PresentationMaxValidity: int((24 * time.Hour).Seconds()),
+		},
+		unsupportedServiceID: {
+			ID:                      "unsupported",
+			DIDMethods:              []string{"unsupported"},
+			Endpoint:                "http://example.com/unsupported",
 			PresentationMaxValidity: int((24 * time.Hour).Seconds()),
 		},
 	}

--- a/discovery/test.go
+++ b/discovery/test.go
@@ -59,8 +59,9 @@ var unsupportedServiceID = "unsupported"
 func testDefinitions() map[string]ServiceDefinition {
 	return map[string]ServiceDefinition{
 		testServiceID: {
-			ID:       testServiceID,
-			Endpoint: "http://example.com/usecase",
+			ID:         testServiceID,
+			DIDMethods: []string{"example"},
+			Endpoint:   "http://example.com/usecase",
 			PresentationDefinition: pe.PresentationDefinition{
 				Format: &pe.PresentationDefinitionClaimFormatDesignations{
 					"ldp_vc": {

--- a/docs/pages/deployment/discovery.rst
+++ b/docs/pages/deployment/discovery.rst
@@ -12,6 +12,7 @@ The parties implementing that use case then configure their Nuts nodes with the 
 The service definition is a JSON document agreed upon (and loaded) by all parties that specifies:
 
 - which Verifiable Credentials are required for the service,
+- which DID methods are allowed (blank for all),
 - where the Discovery Service is hosted, and
 - how often the Verifiable Presentations must be updated.
 


### PR DESCRIPTION
closes #3383

known under JSON as `did_methods`. Direct activation and deactivation fails with `ErrDIDMethodsNotSupported`. If this error occurs in a refresh, the registration is removed.