### PR TITLE
Change UpdateService API to POST

### DIFF
--- a/codegen/configs/vdr_v2.yaml
+++ b/codegen/configs/vdr_v2.yaml
@@ -10,4 +10,5 @@ output-options:
   - DIDDocument
   - DIDDocumentMetadata
   - Service
+  - ServiceRequest
   - VerificationMethod

--- a/didman/didman.go
+++ b/didman/didman.go
@@ -624,7 +624,9 @@ func referencedService(doc *did.Document, serviceRef string) bool {
 }
 
 func generateIDForService(id did.DID, service did.Service) ssi.URI {
-	bytes, _ := json.Marshal(service)
+	serviceWithoutID := service
+	serviceWithoutID.ID = ssi.URI{}
+	bytes, _ := json.Marshal(serviceWithoutID)
 	// go-did earlier unmarshaled/marshaled the service endpoint to a map[string]interface{} ("NormalizeDocument()"), which changes the order of the keys.
 	// To retain the same hash given as before go-did v0.10.0, we need to mimic this behavior.
 	var raw map[string]interface{}

--- a/didman/didman_test.go
+++ b/didman/didman_test.go
@@ -963,11 +963,23 @@ func TestGenerateIDForService(t *testing.T) {
 	u, _ := url.Parse("https://api.example.com/v1")
 	expectedID := ssi.MustParseURI(fmt.Sprintf("%s#D4eNCVjdtGaeHYMdjsdYHpTQmiwXtQKJmE9QSwwsKKzy", vdr.TestDIDA.String()))
 
-	id := generateIDForService(testDIDA, did.Service{
-		Type:            "type",
-		ServiceEndpoint: u.String(),
+	t.Run("ok", func(t *testing.T) {
+		id := generateIDForService(testDIDA, did.Service{
+			Type:            "type",
+			ServiceEndpoint: u.String(),
+		})
+		assert.Equal(t, expectedID, id)
 	})
-	assert.Equal(t, expectedID, id)
+	t.Run("id is ignored", func(t *testing.T) {
+		service := did.Service{
+			ID:              ssi.MustParseURI("ID-is-ignored"),
+			Type:            "type",
+			ServiceEndpoint: u.String(),
+		}
+		id := generateIDForService(testDIDA, service)
+		assert.Equal(t, expectedID, id)
+		assert.Equal(t, "ID-is-ignored", service.ID.String(), "input service should not change")
+	})
 }
 
 type mockContext struct {

--- a/docs/_static/vdr/v2.yaml
+++ b/docs/_static/vdr/v2.yaml
@@ -54,7 +54,7 @@ paths:
       tags:
         - Subject
       requestBody:
-        description: Options for the DID creation. keys.assertionKey settings are ignored.
+        description: Options for the subject creation. keys.assertionKey settings are ignored.
         required: false
         content:
           application/json:
@@ -62,7 +62,7 @@ paths:
               $ref: '#/components/schemas/CreateSubjectOptions'
       responses:
         "200":
-          description: "New DID has been created successfully. Returns the DID document."
+          description: "New subject has been created successfully. Returns the DID documents and subject."
           content:
             application/json:
               schema:
@@ -129,15 +129,15 @@ paths:
       description: |
 
         error returns:
-          * 400 - the DID param was malformed
-          * 404 - Corresponding DID document could not be found
+          * 400 - the subject param was malformed
+          * 404 - Corresponding subject could not be found
           * 500 - An error occurred while processing the request
       operationId: "deactivate"
       tags:
         - Subject
       responses:
         "204":
-          description: DID document has been deactivated.
+          description: DID documents have been deactivated.
         default:
           $ref: '../common/error_response.yaml'
   /internal/vdr/v2/subject/{id}/service:
@@ -154,12 +154,12 @@ paths:
     post:
       summary: Adds a service to DID documents of a subject.
       description: |
-        It adds the given service to the DID Documents of a subject. The ID is always generated.
-        Duplicate services are ignored.
+        It adds the given service to the DID Documents of a subject after generating a Service ID.
+        Duplicate services registrations (same type and serviceEndpoint) are ignored.
 
         error returns:
         * 400 - Returned in case of malformed DID or service
-        * 404 - If the subject has no DIDs
+        * 404 - Subject could not be found
         * 500 - An error occurred while processing the request
       operationId: createService
       tags:
@@ -170,7 +170,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Service'
+              $ref: '#/components/schemas/ServiceRequest'
       responses:
         "200":
           description: "New service has been added successfully. Returns a service per DID Document."
@@ -183,7 +183,7 @@ paths:
         default:
           $ref: '../common/error_response.yaml'
     get:
-      summary: "Find services of a DID subject"
+      summary: "Find services of a subject"
       parameters:
         - name: type
           in: query
@@ -212,12 +212,12 @@ paths:
               - object
               - array
       description: |
-        Find services for a DID subject. All DID documents of the subject have the same services.
+        Find services for a subject. All DID documents of the subject have the same services.
         It returns the services that match specified filter parameters.
 
         error returns:
         * 400 - Returned in case of malformed DID.
-        * 404 - DID document could not be found
+        * 404 - Subject could not be found
         * 500 - An error occurred while processing the request
       operationId: "findServices"
       tags:
@@ -286,17 +286,22 @@ paths:
           plain/text:
             schema:
               type: string
-        example:
-          - "did:web:example.com:iam:013c6fda-73e8-45ee-9220-48652dba854b#3106f751-59e3-440f-b57b-39a96a2da6c6"
-          - "#3106f751-59e3-440f-b57b-39a96a2da6c6"
+        examples:
+          long-form:
+            value: "did:web:example.com:iam:013c6fda-73e8-45ee-9220-48652dba854b#3106f751-59e3-440f-b57b-39a96a2da6c6"
+            summary: Long form of a service.ID starting with a DID
+          short-form:
+            value: "#3106f751-59e3-440f-b57b-39a96a2da6c6"
+            summary: "Short form of a service.ID containing only the fragment. Must include the # prefix."
     delete:
-      summary: Delete a specific service
+      summary: Delete a specific service from the subject
       description: |
-        Removes the service from the DID Documents. Matching is done on the fragment of the id.
+        Removes the service from all DID Documents in the subject. Matching is done on the fragment of the id.
         No cascading will happen for references to the service. 
 
         error returns:
-        * 404 - Corresponding DID document or verification method could not be found
+        * 400 - Returned in case of malformed subject or service ID
+        * 404 - Corresponding subject or service could not be found
         * 500 - An error occurred while processing the request
       tags:
         - Subject
@@ -306,14 +311,14 @@ paths:
           description: The service was successfully deleted
         default:
           $ref: '../common/error_response.yaml'
-    put:
-      summary: Updates a service for DID documents.
+    post:
+      summary: Updates a service for the subject
       description: |
-        It updates the given service in DID Documents.
+        It replaces the given service in all DID Documents of the subject by deleting the current service and adding the provided service with a newly generated ID.
 
         error returns:
-        * 400 - Returned in case of malformed DID or service
-        * 404 - Corresponding DID document could not be found
+        * 400 - Returned in case of malformed subject or service ID
+        * 404 - Corresponding subject or service could not be found
         * 500 - An error occurred while processing the request
       tags:
         - Subject
@@ -324,7 +329,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Service'
+              $ref: '#/components/schemas/ServiceRequest'
       responses:
         "200":
           description: "Service has been updated successfully. Returns the service."
@@ -348,12 +353,12 @@ paths:
               type: string
               example: "90BC1AE9-752B-432F-ADC3-DD9F9C61843C"
     post:
-      summary: Creates and adds one or more verificationMethods to the DID document.
+      summary: Creates and adds one or more verificationMethods to each DID document in the subject.
       description: |
         Based on the keyCreationOptions, it will add an RSA key for encryption usage and an EC key for signing and authentication.
 
         error returns:
-        * 404 - Corresponding DID document could not be found
+        * 404 - Corresponding subject could not be found
         * 500 - An error occurred while processing the request
       operationId: addVerificationMethod
       tags:
@@ -463,13 +468,13 @@ components:
       properties:
         assertionKey:
           type: boolean
-          description: If true, an EC keypair is generated and added to the DID Document as a assertion, authentication, capability invocation and capability delegation method.
+          description: If true, an EC keypair is generated and added to the DID Documents as a assertion, authentication, capability invocation and capability delegation method.
         encryptionKey:
           type: boolean
-          description: If true, an RSA keypair is generated and added to the DID Document as a key agreement method.
+          description: If true, an RSA keypair is generated and added to the DID Documents as a key agreement method.
     CreateSubjectOptions:
       type: object
-      description: Options for the DID creation.
+      description: Options for the subject creation.
       properties:
         subject:
           type: string
@@ -484,6 +489,18 @@ components:
       $ref: '../common/ssi_types.yaml#/components/schemas/VerificationMethod'
     Service:
       $ref: '../common/ssi_types.yaml#/components/schemas/Service'
+    ServiceRequest: # copy of Service minus ID field
+      type: object
+      description: A service supported by a DID subject.
+      required:
+        - type
+        - serviceEndpoint
+      properties:
+        type:
+          description: The type of the endpoint.
+          type: string
+        serviceEndpoint:
+          description: Either a URI or a complex object.
     DIDResolutionResult:
       required:
         - document
@@ -495,7 +512,7 @@ components:
           $ref: '#/components/schemas/DIDDocumentMetadata'
     SubjectCreationResult:
       type: object
-      description: Result of a DID creation request. Contains the subject and any created DID Documents.
+      description: Result of a subject creation request. Contains the subject and any created DID Documents.
       required:
         - subject
         - documents

--- a/vdr/api/v2/generated.go
+++ b/vdr/api/v2/generated.go
@@ -29,7 +29,7 @@ const (
 	String FindServicesParamsEndpointType = "string"
 )
 
-// CreateSubjectOptions Options for the DID creation.
+// CreateSubjectOptions Options for the subject creation.
 type CreateSubjectOptions struct {
 	// Keys Options for the key creation.
 	Keys *KeyCreationOptions `json:"keys,omitempty"`
@@ -49,14 +49,14 @@ type DIDResolutionResult struct {
 
 // KeyCreationOptions Options for the key creation.
 type KeyCreationOptions struct {
-	// AssertionKey If true, an EC keypair is generated and added to the DID Document as a assertion, authentication, capability invocation and capability delegation method.
+	// AssertionKey If true, an EC keypair is generated and added to the DID Documents as a assertion, authentication, capability invocation and capability delegation method.
 	AssertionKey bool `json:"assertionKey"`
 
-	// EncryptionKey If true, an RSA keypair is generated and added to the DID Document as a key agreement method.
+	// EncryptionKey If true, an RSA keypair is generated and added to the DID Documents as a key agreement method.
 	EncryptionKey bool `json:"encryptionKey"`
 }
 
-// SubjectCreationResult Result of a DID creation request. Contains the subject and any created DID Documents.
+// SubjectCreationResult Result of a subject creation request. Contains the subject and any created DID Documents.
 type SubjectCreationResult struct {
 	Documents []DIDDocument `json:"documents"`
 
@@ -87,10 +87,10 @@ type FindServicesParamsEndpointType string
 type CreateSubjectJSONRequestBody = CreateSubjectOptions
 
 // CreateServiceJSONRequestBody defines body for CreateService for application/json ContentType.
-type CreateServiceJSONRequestBody = Service
+type CreateServiceJSONRequestBody = ServiceRequest
 
 // UpdateServiceJSONRequestBody defines body for UpdateService for application/json ContentType.
-type UpdateServiceJSONRequestBody = Service
+type UpdateServiceJSONRequestBody = ServiceRequest
 
 // AddVerificationMethodJSONRequestBody defines body for AddVerificationMethod for application/json ContentType.
 type AddVerificationMethodJSONRequestBody = KeyCreationOptions
@@ -812,7 +812,7 @@ func NewUpdateServiceRequestWithBody(server string, id string, serviceId string,
 		return nil, err
 	}
 
-	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	req, err := http.NewRequest("POST", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -1937,19 +1937,19 @@ type ServerInterface interface {
 	// Lists all DIDs for a subject
 	// (GET /internal/vdr/v2/subject/{id})
 	SubjectDIDs(ctx echo.Context, id string) error
-	// Find services of a DID subject
+	// Find services of a subject
 	// (GET /internal/vdr/v2/subject/{id}/service)
 	FindServices(ctx echo.Context, id string, params FindServicesParams) error
 	// Adds a service to DID documents of a subject.
 	// (POST /internal/vdr/v2/subject/{id}/service)
 	CreateService(ctx echo.Context, id string) error
-	// Delete a specific service
+	// Delete a specific service from the subject
 	// (DELETE /internal/vdr/v2/subject/{id}/service/{serviceId})
 	DeleteService(ctx echo.Context, id string, serviceId string) error
-	// Updates a service for DID documents.
-	// (PUT /internal/vdr/v2/subject/{id}/service/{serviceId})
+	// Updates a service for the subject
+	// (POST /internal/vdr/v2/subject/{id}/service/{serviceId})
 	UpdateService(ctx echo.Context, id string, serviceId string) error
-	// Creates and adds one or more verificationMethods to the DID document.
+	// Creates and adds one or more verificationMethods to each DID document in the subject.
 	// (POST /internal/vdr/v2/subject/{id}/verificationmethod)
 	AddVerificationMethod(ctx echo.Context, id string) error
 }
@@ -2194,7 +2194,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.GET(baseURL+"/internal/vdr/v2/subject/:id/service", wrapper.FindServices)
 	router.POST(baseURL+"/internal/vdr/v2/subject/:id/service", wrapper.CreateService)
 	router.DELETE(baseURL+"/internal/vdr/v2/subject/:id/service/:serviceId", wrapper.DeleteService)
-	router.PUT(baseURL+"/internal/vdr/v2/subject/:id/service/:serviceId", wrapper.UpdateService)
+	router.POST(baseURL+"/internal/vdr/v2/subject/:id/service/:serviceId", wrapper.UpdateService)
 	router.POST(baseURL+"/internal/vdr/v2/subject/:id/verificationmethod", wrapper.AddVerificationMethod)
 
 }
@@ -2654,19 +2654,19 @@ type StrictServerInterface interface {
 	// Lists all DIDs for a subject
 	// (GET /internal/vdr/v2/subject/{id})
 	SubjectDIDs(ctx context.Context, request SubjectDIDsRequestObject) (SubjectDIDsResponseObject, error)
-	// Find services of a DID subject
+	// Find services of a subject
 	// (GET /internal/vdr/v2/subject/{id}/service)
 	FindServices(ctx context.Context, request FindServicesRequestObject) (FindServicesResponseObject, error)
 	// Adds a service to DID documents of a subject.
 	// (POST /internal/vdr/v2/subject/{id}/service)
 	CreateService(ctx context.Context, request CreateServiceRequestObject) (CreateServiceResponseObject, error)
-	// Delete a specific service
+	// Delete a specific service from the subject
 	// (DELETE /internal/vdr/v2/subject/{id}/service/{serviceId})
 	DeleteService(ctx context.Context, request DeleteServiceRequestObject) (DeleteServiceResponseObject, error)
-	// Updates a service for DID documents.
-	// (PUT /internal/vdr/v2/subject/{id}/service/{serviceId})
+	// Updates a service for the subject
+	// (POST /internal/vdr/v2/subject/{id}/service/{serviceId})
 	UpdateService(ctx context.Context, request UpdateServiceRequestObject) (UpdateServiceResponseObject, error)
-	// Creates and adds one or more verificationMethods to the DID document.
+	// Creates and adds one or more verificationMethods to each DID document in the subject.
 	// (POST /internal/vdr/v2/subject/{id}/verificationmethod)
 	AddVerificationMethod(ctx context.Context, request AddVerificationMethodRequestObject) (AddVerificationMethodResponseObject, error)
 }

--- a/vdr/api/v2/types.go
+++ b/vdr/api/v2/types.go
@@ -33,3 +33,6 @@ type VerificationMethod = did.VerificationMethod
 
 // Service is an alias
 type Service = did.Service
+
+// ServiceRequest API definition does not contain an ID, but we alias did.Service here for simplicity
+type ServiceRequest = did.Service

--- a/vdr/didsubject/manager.go
+++ b/vdr/didsubject/manager.go
@@ -534,7 +534,9 @@ func (r *Manager) applyToDIDDocuments(ctx context.Context, subject string, opera
 // NewIDForService generates a unique ID for a service based on the service data.
 // This is compatible with all DID methods.
 func NewIDForService(service did.Service) string {
-	bytes, _ := json.Marshal(service)
+	serviceWithoutID := service
+	serviceWithoutID.ID = ssi.URI{}
+	bytes, _ := json.Marshal(serviceWithoutID)
 	// go-did earlier unmarshaled/marshaled the service endpoint to a map[string]interface{} ("NormalizeDocument()"), which changes the order of the keys.
 	// To retain the same hash given as before go-did v0.10.0, we need to mimic this behavior.
 	var raw map[string]interface{}

--- a/vdr/didsubject/manager_test.go
+++ b/vdr/didsubject/manager_test.go
@@ -21,6 +21,7 @@ package didsubject
 import (
 	"context"
 	"fmt"
+	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/nuts-node/storage/orm"
 	"net/url"
 	"strings"
@@ -430,11 +431,23 @@ func TestNewIDForService(t *testing.T) {
 	u, _ := url.Parse("https://api.example.com/v1")
 	expectedID := "D4eNCVjdtGaeHYMdjsdYHpTQmiwXtQKJmE9QSwwsKKzy"
 
-	id := NewIDForService(did.Service{
-		Type:            "type",
-		ServiceEndpoint: u.String(),
+	t.Run("ok", func(t *testing.T) {
+		id := NewIDForService(did.Service{
+			Type:            "type",
+			ServiceEndpoint: u.String(),
+		})
+		assert.Equal(t, expectedID, id)
 	})
-	assert.Equal(t, expectedID, id)
+	t.Run("id is ignored", func(t *testing.T) {
+		service := did.Service{
+			ID:              ssi.MustParseURI("ID-is-ignored"),
+			Type:            "type",
+			ServiceEndpoint: u.String(),
+		}
+		id := NewIDForService(service)
+		assert.Equal(t, expectedID, id)
+		assert.Equal(t, "ID-is-ignored", service.ID.String(), "input service should not change")
+	})
 }
 
 type testMethod struct {


### PR DESCRIPTION
PUT should idempotent, but calling this on an existing service is effectively a DELETE + POST to create a new service with a new ID. Hence first call would be 200, second call using same ID would be a 404 since the service no longer exists.

Also includes some documentation, cleanup, and a bugfix.