### PR TITLE
allow for registration credential if not defined in PD

### DIFF
--- a/discovery/client_test.go
+++ b/discovery/client_test.go
@@ -156,7 +156,11 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 		mockVCR := vcr.NewMockVCR(ctrl)
 		wallet := holder.NewMockWallet(ctrl)
 		wallet.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil)
-		wallet.EXPECT().BuildPresentation(gomock.Any(), []vc.VerifiableCredential{}, gomock.Any(), gomock.Any(), false).Return(&vpAlice, nil)
+		wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), false).DoAndReturn(func(_ interface{}, credentials []vc.VerifiableCredential, _ interface{}, _ interface{}, _ interface{}) (*vc.VerifiablePresentation, error) {
+			// expect registration credential
+			assert.Len(t, credentials, 1)
+			return &vpAlice, nil
+		})
 		mockVCR.EXPECT().Wallet().Return(wallet).AnyTimes()
 		mockSubjectManager := didsubject.NewMockSubjectManager(ctrl)
 		mockSubjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)

--- a/discovery/module_test.go
+++ b/discovery/module_test.go
@@ -423,9 +423,7 @@ func TestModule_Search(t *testing.T) {
 			{
 				Presentation: vpAlice,
 				Fields: map[string]interface{}{
-					"auth_server_url_field": "https://example.com/oauth2/alice",
-					"issuer_field":          authorityDID,
-					"type_field":            []string{vc.VerifiableCredentialType, credential.DiscoveryRegistrationCredentialType},
+					"issuer_field": authorityDID,
 				},
 				Parameters: defaultRegistrationParams(aliceSubject),
 			},

--- a/discovery/test.go
+++ b/discovery/test.go
@@ -101,28 +101,6 @@ func testDefinitions() map[string]ServiceDefinition {
 							},
 						},
 					},
-					{
-						Id: "2",
-						Constraints: &pe.Constraints{
-							Fields: []pe.Field{
-								{
-									Id:   to.Ptr("auth_server_url_field"),
-									Path: []string{"$.credentialSubject.authServerURL", "$.credentialSubject[0].authServerURL"},
-									Filter: &pe.Filter{
-										Type: "string",
-									},
-								},
-								{
-									Id:   to.Ptr("type_field"),
-									Path: []string{"$.type"},
-									Filter: &pe.Filter{
-										Type:  "string",
-										Const: to.Ptr(credential.DiscoveryRegistrationCredentialType),
-									},
-								},
-							},
-						},
-					},
 				},
 			},
 			PresentationMaxValidity: int((24 * time.Hour).Seconds()),

--- a/e2e-tests/discovery/run-test.sh
+++ b/e2e-tests/discovery/run-test.sh
@@ -80,6 +80,14 @@ else
   exitWithDockerLogs 1
 fi
 
+if echo $RESPONSE | grep -q "authServerURL"; then
+  echo "Authorization server URL found"
+else
+  echo "FAILED: Could not find authServerURL" 1>&2
+  echo $RESPONSE
+  exitWithDockerLogs 1
+fi
+
 echo "------------------------------------"
 echo "Stopping Docker containers..."
 echo "------------------------------------"


### PR DESCRIPTION
fixes #3405 

tests and logic required DiscoveryRegistrationCredential to be defined in Presentation Definition of discovery service. This was not the idea, it should always be present. Now it's allowed to not be in the PD, if it's in the PD that's fine as well. That way you can require certain services to be included.