### PR TITLE
disable did:web root e2e-test

### DIFF
--- a/e2e-tests/oauth-flow/openid4vp/run-test.sh
+++ b/e2e-tests/oauth-flow/openid4vp/run-test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -e
 ./do-test.sh didweb-user
-./do-test.sh didweb-root
+# skip test, root did:web is not supported and test is broken
+# ./do-test.sh didweb-root

--- a/e2e-tests/oauth-flow/openid4vp/run-test.sh
+++ b/e2e-tests/oauth-flow/openid4vp/run-test.sh
@@ -2,4 +2,5 @@
 set -e
 ./do-test.sh didweb-user
 # skip test, root did:web is not supported and test is broken
+# see https://github.com/nuts-foundation/nuts-node/issues/3299
 # ./do-test.sh didweb-root


### PR DESCRIPTION
fixes #3299 

re-enabling root did:web DIDs will not be part of the 6.0 release. It can be added in a minor, then the test can be fixed properly.