### PR TITLE
added checks to VCR.Load()

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -211,7 +211,7 @@ func CreateSystem(shutdownCallback context.CancelFunc) *core.System {
 	system.RegisterRoutes(&networkAPI.Wrapper{Service: networkInstance})
 	system.RegisterRoutes(&vdrAPI.Wrapper{VDR: vdrInstance, SubjectManager: vdrInstance})
 	system.RegisterRoutes(&vdrAPIv2.Wrapper{VDR: vdrInstance, SubjectManager: vdrInstance})
-	system.RegisterRoutes(&vcrAPI.Wrapper{VCR: credentialInstance, ContextManager: jsonld})
+	system.RegisterRoutes(&vcrAPI.Wrapper{VCR: credentialInstance, ContextManager: jsonld, SubjectManager: vdrInstance})
 	system.RegisterRoutes(&openid4vciAPI.Wrapper{
 		VCR: credentialInstance,
 		VDR: vdrInstance,

--- a/docs/_static/vcr/vcr_v2.yaml
+++ b/docs/_static/vcr/vcr_v2.yaml
@@ -479,17 +479,17 @@ paths:
                 $ref: "#/components/schemas/VerifiablePresentation"
         default:
           $ref: '../common/error_response.yaml'
-  /internal/vcr/v2/holder/{did}/vc:
+  /internal/vcr/v2/holder/{subjectID}/vc:
     parameters:
-      - name: did
+      - name: subjectID
         in: path
-        description: URL encoded DID.
+        description: Subject ID of the wallet owner at this node.
         required: true
         content:
           plain/text:
             schema:
               type: string
-              example: "did:web:example.com:iam:123"
+              example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
     get:
       summary: List all Verifiable Credentials in the holder's wallet.
       operationId: getCredentialsInWallet
@@ -510,8 +510,8 @@ paths:
       summary: Load a VerifiableCredential into the holders wallet.
       description: |
         If a VerifiableCredential is not directly issued to the wallet through e.g. OpenID4VCI, this API allows to add it to a wallet.
-        The DID of the holder has to be provided in the path.
-        It's assumed that the credentialSubject.id equals the holder DID.
+        The subject identifier of the holder has to be provided in the path.
+        The credentialSubject.id must equal to a DID of the holder, the signature must be valid and the credential must not be expired.
 
         error returns:
         * 400 - Invalid credential

--- a/docs/_static/vcr/vcr_v2.yaml
+++ b/docs/_static/vcr/vcr_v2.yaml
@@ -511,7 +511,7 @@ paths:
       description: |
         If a VerifiableCredential is not directly issued to the wallet through e.g. OpenID4VCI, this API allows to add it to a wallet.
         The subject identifier of the holder has to be provided in the path.
-        The credentialSubject.id must equal to a DID of the holder, the signature must be valid and the credential must not be expired.
+        The credentialSubject.id must equal to a DID of the holder, the signature must be valid and the credential must not be expired or revoked.
 
         error returns:
         * 400 - Invalid credential

--- a/e2e-tests/browser/openid4vp_employeecredential/main_test.go
+++ b/e2e-tests/browser/openid4vp_employeecredential/main_test.go
@@ -108,7 +108,7 @@ func Test_UserAccessToken_EmployeeCredential(t *testing.T) {
 func setupNode(t testing.TB, ctx context.Context, config core.ClientConfig) (string, did.DID, OpenID4VP) {
 	subject, didDoc, err := createDID(config)
 	require.NoError(t, err)
-	err = browser.IssueOrganizationCredential(didDoc, fmt.Sprintf("%s Organization", didDoc.ID.String()), "Testland", config)
+	err = browser.IssueOrganizationCredential(subject, didDoc, fmt.Sprintf("%s Organization", didDoc.ID.String()), "Testland", config)
 	require.NoError(t, err)
 
 	iamClientB, err := iamAPI.NewClient(config.GetAddress())

--- a/e2e-tests/browser/rfc019_selfsigned/main_test.go
+++ b/e2e-tests/browser/rfc019_selfsigned/main_test.go
@@ -52,14 +52,14 @@ func Test_LoginWithSelfSignedMeans(t *testing.T) {
 	require.NoError(t, err)
 	err = registerCompoundService(verifyingOrganization.ID, purposeOfUse)
 	require.NoError(t, err)
-	err = browser.IssueOrganizationCredential(verifyingOrganization, "Verifying Organization", "Testland", apps.NodeClientConfig)
+	err = browser.IssueOrganizationCredential("", verifyingOrganization, "Verifying Organization", "Testland", apps.NodeClientConfig)
 	require.NoError(t, err)
 
 	issuingOrganization, err := createDID()
 	require.NoError(t, err)
 	err = registerCompoundService(issuingOrganization.ID, purposeOfUse)
 	require.NoError(t, err)
-	err = browser.IssueOrganizationCredential(issuingOrganization, "Issuing Organization", "Testland", apps.NodeClientConfig)
+	err = browser.IssueOrganizationCredential("", issuingOrganization, "Issuing Organization", "Testland", apps.NodeClientConfig)
 	require.NoError(t, err)
 
 	selfSigned := apps.SelfSigned{

--- a/e2e-tests/browser/util.go
+++ b/e2e-tests/browser/util.go
@@ -26,7 +26,7 @@ import (
 	vcrAPI "github.com/nuts-foundation/nuts-node/vcr/api/vcr/v2"
 )
 
-func IssueOrganizationCredential(organization *did.Document, name, city string, clientConfig core.ClientConfig) error {
+func IssueOrganizationCredential(subject string, organization *did.Document, name, city string, clientConfig core.ClientConfig) error {
 	vcrClient := vcrAPI.HTTPClient{ClientConfig: clientConfig}
 	request := vcrAPI.IssueVCRequest{
 		Issuer: organization.ID.String(),
@@ -56,7 +56,7 @@ func IssueOrganizationCredential(organization *did.Document, name, city string, 
 	}
 	if organization.ID.Method == "web" {
 		// Need to load it into tbe wallet
-		return vcrClient.LoadVC(organization.ID, *issuedCredential)
+		return vcrClient.LoadVC(subject, *issuedCredential)
 	}
 	return nil
 }

--- a/e2e-tests/discovery/run-test.sh
+++ b/e2e-tests/discovery/run-test.sh
@@ -36,7 +36,7 @@ else
   exitWithDockerLogs 1
 fi
 
-RESPONSE=$(echo $RESPONSE | curl --insecure -s -X POST --data-binary @- http://localhost:28081/internal/vcr/v2/holder/${DID}/vc -H "Content-Type:application/json")
+RESPONSE=$(echo $RESPONSE | curl --insecure -s -X POST --data-binary @- http://localhost:28081/internal/vcr/v2/holder/${SUBJECT}/vc -H "Content-Type:application/json")
 if [[ $RESPONSE -eq "" ]]; then
   echo "VC stored in wallet"
 else

--- a/e2e-tests/oauth-flow/openid4vp/do-test.sh
+++ b/e2e-tests/oauth-flow/openid4vp/do-test.sh
@@ -33,7 +33,7 @@ else
   exitWithDockerLogs 1
 fi
 
-RESPONSE=$(echo $RESPONSE | curl -X POST --data-binary @- http://localhost:28081/internal/vcr/v2/holder/${PARTY_B_DID}/vc -H "Content-Type:application/json")
+RESPONSE=$(echo $RESPONSE | curl -X POST --data-binary @- http://localhost:28081/internal/vcr/v2/holder/subjectB/vc -H "Content-Type:application/json")
 if echo $RESPONSE == ""; then
   echo "VC stored in wallet"
 else

--- a/e2e-tests/oauth-flow/rfc021/do-test.sh
+++ b/e2e-tests/oauth-flow/rfc021/do-test.sh
@@ -54,7 +54,7 @@ else
   exitWithDockerLogs 1
 fi
 
-RESPONSE=$(echo $RESPONSE | curl -X POST --data-binary @- http://localhost:28081/internal/vcr/v2/holder/${VENDOR_B_DID}/vc -H "Content-Type:application/json")
+RESPONSE=$(echo $RESPONSE | curl -X POST --data-binary @- http://localhost:28081/internal/vcr/v2/holder/vendorB/vc -H "Content-Type:application/json")
 if echo $RESPONSE == ""; then
   echo "VC stored in wallet"
 else

--- a/vcr/api/vcr/v2/client.go
+++ b/vcr/api/vcr/v2/client.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/core"
 	"io"
@@ -93,10 +92,10 @@ func (hb HTTPClient) Untrusted(credentialType string) ([]string, error) {
 }
 
 // LoadVC loads the given Verifiable Credential into the holder's wallet.
-func (hb HTTPClient) LoadVC(holder did.DID, credential vc.VerifiableCredential) error {
+func (hb HTTPClient) LoadVC(holderSubjectID string, credential vc.VerifiableCredential) error {
 	ctx := context.Background()
 
-	httpResponse, err := hb.client().LoadVC(ctx, holder.String(), credential)
+	httpResponse, err := hb.client().LoadVC(ctx, holderSubjectID, credential)
 	if err != nil {
 		return err
 	} else if err := core.TestResponseCode(http.StatusNoContent, httpResponse); err != nil {

--- a/vcr/api/vcr/v2/generated.go
+++ b/vcr/api/vcr/v2/generated.go
@@ -482,16 +482,16 @@ type ClientInterface interface {
 
 	CreateVP(ctx context.Context, body CreateVPJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetCredentialsInWallet request
-	GetCredentialsInWallet(ctx context.Context, did string, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// LoadVCWithBody request with any body
-	LoadVCWithBody(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	LoadVC(ctx context.Context, did string, body LoadVCJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
-
 	// RemoveCredentialFromWallet request
 	RemoveCredentialFromWallet(ctx context.Context, did string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetCredentialsInWallet request
+	GetCredentialsInWallet(ctx context.Context, subjectID string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// LoadVCWithBody request with any body
+	LoadVCWithBody(ctx context.Context, subjectID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	LoadVC(ctx context.Context, subjectID string, body LoadVCJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// IssueVCWithBody request with any body
 	IssueVCWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -563,44 +563,44 @@ func (c *Client) CreateVP(ctx context.Context, body CreateVPJSONRequestBody, req
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetCredentialsInWallet(ctx context.Context, did string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetCredentialsInWalletRequest(c.Server, did)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) LoadVCWithBody(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewLoadVCRequestWithBody(c.Server, did, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) LoadVC(ctx context.Context, did string, body LoadVCJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewLoadVCRequest(c.Server, did, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
 func (c *Client) RemoveCredentialFromWallet(ctx context.Context, did string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRemoveCredentialFromWalletRequest(c.Server, did, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetCredentialsInWallet(ctx context.Context, subjectID string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetCredentialsInWalletRequest(c.Server, subjectID)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) LoadVCWithBody(ctx context.Context, subjectID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewLoadVCRequestWithBody(c.Server, subjectID, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) LoadVC(ctx context.Context, subjectID string, body LoadVCJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewLoadVCRequest(c.Server, subjectID, body)
 	if err != nil {
 		return nil, err
 	}
@@ -855,81 +855,6 @@ func NewCreateVPRequestWithBody(server string, contentType string, body io.Reade
 	return req, nil
 }
 
-// NewGetCredentialsInWalletRequest generates requests for GetCredentialsInWallet
-func NewGetCredentialsInWalletRequest(server string, did string) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0 = did
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/internal/vcr/v2/holder/%s/vc", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewLoadVCRequest calls the generic LoadVC builder with application/json body
-func NewLoadVCRequest(server string, did string, body LoadVCJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewLoadVCRequestWithBody(server, did, "application/json", bodyReader)
-}
-
-// NewLoadVCRequestWithBody generates requests for LoadVC with any type of body
-func NewLoadVCRequestWithBody(server string, did string, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0 = did
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/internal/vcr/v2/holder/%s/vc", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
 // NewRemoveCredentialFromWalletRequest generates requests for RemoveCredentialFromWallet
 func NewRemoveCredentialFromWalletRequest(server string, did string, id string) (*http.Request, error) {
 	var err error
@@ -964,6 +889,81 @@ func NewRemoveCredentialFromWalletRequest(server string, did string, id string) 
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewGetCredentialsInWalletRequest generates requests for GetCredentialsInWallet
+func NewGetCredentialsInWalletRequest(server string, subjectID string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0 = subjectID
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/internal/vcr/v2/holder/%s/vc", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewLoadVCRequest calls the generic LoadVC builder with application/json body
+func NewLoadVCRequest(server string, subjectID string, body LoadVCJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewLoadVCRequestWithBody(server, subjectID, "application/json", bodyReader)
+}
+
+// NewLoadVCRequestWithBody generates requests for LoadVC with any type of body
+func NewLoadVCRequestWithBody(server string, subjectID string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0 = subjectID
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/internal/vcr/v2/holder/%s/vc", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -1465,16 +1465,16 @@ type ClientWithResponsesInterface interface {
 
 	CreateVPWithResponse(ctx context.Context, body CreateVPJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateVPResponse, error)
 
-	// GetCredentialsInWalletWithResponse request
-	GetCredentialsInWalletWithResponse(ctx context.Context, did string, reqEditors ...RequestEditorFn) (*GetCredentialsInWalletResponse, error)
-
-	// LoadVCWithBodyWithResponse request with any body
-	LoadVCWithBodyWithResponse(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*LoadVCResponse, error)
-
-	LoadVCWithResponse(ctx context.Context, did string, body LoadVCJSONRequestBody, reqEditors ...RequestEditorFn) (*LoadVCResponse, error)
-
 	// RemoveCredentialFromWalletWithResponse request
 	RemoveCredentialFromWalletWithResponse(ctx context.Context, did string, id string, reqEditors ...RequestEditorFn) (*RemoveCredentialFromWalletResponse, error)
+
+	// GetCredentialsInWalletWithResponse request
+	GetCredentialsInWalletWithResponse(ctx context.Context, subjectID string, reqEditors ...RequestEditorFn) (*GetCredentialsInWalletResponse, error)
+
+	// LoadVCWithBodyWithResponse request with any body
+	LoadVCWithBodyWithResponse(ctx context.Context, subjectID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*LoadVCResponse, error)
+
+	LoadVCWithResponse(ctx context.Context, subjectID string, body LoadVCJSONRequestBody, reqEditors ...RequestEditorFn) (*LoadVCResponse, error)
 
 	// IssueVCWithBodyWithResponse request with any body
 	IssueVCWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IssueVCResponse, error)
@@ -1554,6 +1554,37 @@ func (r CreateVPResponse) StatusCode() int {
 	return 0
 }
 
+type RemoveCredentialFromWalletResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	ApplicationproblemJSONDefault *struct {
+		// Detail A human-readable explanation specific to this occurrence of the problem.
+		Detail string `json:"detail"`
+
+		// Status HTTP statuscode
+		Status float32 `json:"status"`
+
+		// Title A short, human-readable summary of the problem type.
+		Title string `json:"title"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r RemoveCredentialFromWalletResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RemoveCredentialFromWalletResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetCredentialsInWalletResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -1611,37 +1642,6 @@ func (r LoadVCResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r LoadVCResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type RemoveCredentialFromWalletResponse struct {
-	Body                          []byte
-	HTTPResponse                  *http.Response
-	ApplicationproblemJSONDefault *struct {
-		// Detail A human-readable explanation specific to this occurrence of the problem.
-		Detail string `json:"detail"`
-
-		// Status HTTP statuscode
-		Status float32 `json:"status"`
-
-		// Title A short, human-readable summary of the problem type.
-		Title string `json:"title"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r RemoveCredentialFromWalletResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r RemoveCredentialFromWalletResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -2015,32 +2015,6 @@ func (c *ClientWithResponses) CreateVPWithResponse(ctx context.Context, body Cre
 	return ParseCreateVPResponse(rsp)
 }
 
-// GetCredentialsInWalletWithResponse request returning *GetCredentialsInWalletResponse
-func (c *ClientWithResponses) GetCredentialsInWalletWithResponse(ctx context.Context, did string, reqEditors ...RequestEditorFn) (*GetCredentialsInWalletResponse, error) {
-	rsp, err := c.GetCredentialsInWallet(ctx, did, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetCredentialsInWalletResponse(rsp)
-}
-
-// LoadVCWithBodyWithResponse request with arbitrary body returning *LoadVCResponse
-func (c *ClientWithResponses) LoadVCWithBodyWithResponse(ctx context.Context, did string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*LoadVCResponse, error) {
-	rsp, err := c.LoadVCWithBody(ctx, did, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseLoadVCResponse(rsp)
-}
-
-func (c *ClientWithResponses) LoadVCWithResponse(ctx context.Context, did string, body LoadVCJSONRequestBody, reqEditors ...RequestEditorFn) (*LoadVCResponse, error) {
-	rsp, err := c.LoadVC(ctx, did, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseLoadVCResponse(rsp)
-}
-
 // RemoveCredentialFromWalletWithResponse request returning *RemoveCredentialFromWalletResponse
 func (c *ClientWithResponses) RemoveCredentialFromWalletWithResponse(ctx context.Context, did string, id string, reqEditors ...RequestEditorFn) (*RemoveCredentialFromWalletResponse, error) {
 	rsp, err := c.RemoveCredentialFromWallet(ctx, did, id, reqEditors...)
@@ -2048,6 +2022,32 @@ func (c *ClientWithResponses) RemoveCredentialFromWalletWithResponse(ctx context
 		return nil, err
 	}
 	return ParseRemoveCredentialFromWalletResponse(rsp)
+}
+
+// GetCredentialsInWalletWithResponse request returning *GetCredentialsInWalletResponse
+func (c *ClientWithResponses) GetCredentialsInWalletWithResponse(ctx context.Context, subjectID string, reqEditors ...RequestEditorFn) (*GetCredentialsInWalletResponse, error) {
+	rsp, err := c.GetCredentialsInWallet(ctx, subjectID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetCredentialsInWalletResponse(rsp)
+}
+
+// LoadVCWithBodyWithResponse request with arbitrary body returning *LoadVCResponse
+func (c *ClientWithResponses) LoadVCWithBodyWithResponse(ctx context.Context, subjectID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*LoadVCResponse, error) {
+	rsp, err := c.LoadVCWithBody(ctx, subjectID, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseLoadVCResponse(rsp)
+}
+
+func (c *ClientWithResponses) LoadVCWithResponse(ctx context.Context, subjectID string, body LoadVCJSONRequestBody, reqEditors ...RequestEditorFn) (*LoadVCResponse, error) {
+	rsp, err := c.LoadVC(ctx, subjectID, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseLoadVCResponse(rsp)
 }
 
 // IssueVCWithBodyWithResponse request with arbitrary body returning *IssueVCResponse
@@ -2239,6 +2239,41 @@ func ParseCreateVPResponse(rsp *http.Response) (*CreateVPResponse, error) {
 	return response, nil
 }
 
+// ParseRemoveCredentialFromWalletResponse parses an HTTP response from a RemoveCredentialFromWalletWithResponse call
+func ParseRemoveCredentialFromWalletResponse(rsp *http.Response) (*RemoveCredentialFromWalletResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RemoveCredentialFromWalletResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest struct {
+			// Detail A human-readable explanation specific to this occurrence of the problem.
+			Detail string `json:"detail"`
+
+			// Status HTTP statuscode
+			Status float32 `json:"status"`
+
+			// Title A short, human-readable summary of the problem type.
+			Title string `json:"title"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetCredentialsInWalletResponse parses an HTTP response from a GetCredentialsInWalletWithResponse call
 func ParseGetCredentialsInWalletResponse(rsp *http.Response) (*GetCredentialsInWalletResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -2290,41 +2325,6 @@ func ParseLoadVCResponse(rsp *http.Response) (*LoadVCResponse, error) {
 	}
 
 	response := &LoadVCResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest struct {
-			// Detail A human-readable explanation specific to this occurrence of the problem.
-			Detail string `json:"detail"`
-
-			// Status HTTP statuscode
-			Status float32 `json:"status"`
-
-			// Title A short, human-readable summary of the problem type.
-			Title string `json:"title"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.ApplicationproblemJSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseRemoveCredentialFromWalletResponse parses an HTTP response from a RemoveCredentialFromWalletWithResponse call
-func ParseRemoveCredentialFromWalletResponse(rsp *http.Response) (*RemoveCredentialFromWalletResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &RemoveCredentialFromWalletResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -2804,15 +2804,15 @@ type ServerInterface interface {
 	// Create a new Verifiable Presentation for a set of Verifiable Credentials.
 	// (POST /internal/vcr/v2/holder/vp)
 	CreateVP(ctx echo.Context) error
-	// List all Verifiable Credentials in the holder's wallet.
-	// (GET /internal/vcr/v2/holder/{did}/vc)
-	GetCredentialsInWallet(ctx echo.Context, did string) error
-	// Load a VerifiableCredential into the holders wallet.
-	// (POST /internal/vcr/v2/holder/{did}/vc)
-	LoadVC(ctx echo.Context, did string) error
 	// Remove a VerifiableCredential from the holders wallet.
 	// (DELETE /internal/vcr/v2/holder/{did}/vc/{id})
 	RemoveCredentialFromWallet(ctx echo.Context, did string, id string) error
+	// List all Verifiable Credentials in the holder's wallet.
+	// (GET /internal/vcr/v2/holder/{subjectID}/vc)
+	GetCredentialsInWallet(ctx echo.Context, subjectID string) error
+	// Load a VerifiableCredential into the holders wallet.
+	// (POST /internal/vcr/v2/holder/{subjectID}/vc)
+	LoadVC(ctx echo.Context, subjectID string) error
 	// Issues a new Verifiable Credential
 	// (POST /internal/vcr/v2/issuer/vc)
 	IssueVC(ctx echo.Context) error
@@ -2864,36 +2864,6 @@ func (w *ServerInterfaceWrapper) CreateVP(ctx echo.Context) error {
 	return err
 }
 
-// GetCredentialsInWallet converts echo context to params.
-func (w *ServerInterfaceWrapper) GetCredentialsInWallet(ctx echo.Context) error {
-	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
-
-	did = ctx.Param("did")
-
-	ctx.Set(JwtBearerAuthScopes, []string{})
-
-	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetCredentialsInWallet(ctx, did)
-	return err
-}
-
-// LoadVC converts echo context to params.
-func (w *ServerInterfaceWrapper) LoadVC(ctx echo.Context) error {
-	var err error
-	// ------------- Path parameter "did" -------------
-	var did string
-
-	did = ctx.Param("did")
-
-	ctx.Set(JwtBearerAuthScopes, []string{})
-
-	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.LoadVC(ctx, did)
-	return err
-}
-
 // RemoveCredentialFromWallet converts echo context to params.
 func (w *ServerInterfaceWrapper) RemoveCredentialFromWallet(ctx echo.Context) error {
 	var err error
@@ -2914,6 +2884,36 @@ func (w *ServerInterfaceWrapper) RemoveCredentialFromWallet(ctx echo.Context) er
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.RemoveCredentialFromWallet(ctx, did, id)
+	return err
+}
+
+// GetCredentialsInWallet converts echo context to params.
+func (w *ServerInterfaceWrapper) GetCredentialsInWallet(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "subjectID" -------------
+	var subjectID string
+
+	subjectID = ctx.Param("subjectID")
+
+	ctx.Set(JwtBearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetCredentialsInWallet(ctx, subjectID)
+	return err
+}
+
+// LoadVC converts echo context to params.
+func (w *ServerInterfaceWrapper) LoadVC(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "subjectID" -------------
+	var subjectID string
+
+	subjectID = ctx.Param("subjectID")
+
+	ctx.Set(JwtBearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.LoadVC(ctx, subjectID)
 	return err
 }
 
@@ -3118,9 +3118,9 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	}
 
 	router.POST(baseURL+"/internal/vcr/v2/holder/vp", wrapper.CreateVP)
-	router.GET(baseURL+"/internal/vcr/v2/holder/:did/vc", wrapper.GetCredentialsInWallet)
-	router.POST(baseURL+"/internal/vcr/v2/holder/:did/vc", wrapper.LoadVC)
 	router.DELETE(baseURL+"/internal/vcr/v2/holder/:did/vc/:id", wrapper.RemoveCredentialFromWallet)
+	router.GET(baseURL+"/internal/vcr/v2/holder/:subjectID/vc", wrapper.GetCredentialsInWallet)
+	router.POST(baseURL+"/internal/vcr/v2/holder/:subjectID/vc", wrapper.LoadVC)
 	router.POST(baseURL+"/internal/vcr/v2/issuer/vc", wrapper.IssueVC)
 	router.GET(baseURL+"/internal/vcr/v2/issuer/vc/search", wrapper.SearchIssuedVCs)
 	router.DELETE(baseURL+"/internal/vcr/v2/issuer/vc/:id", wrapper.RevokeVC)
@@ -3173,8 +3173,46 @@ func (response CreateVPdefaultApplicationProblemPlusJSONResponse) VisitCreateVPR
 	return json.NewEncoder(w).Encode(response.Body)
 }
 
-type GetCredentialsInWalletRequestObject struct {
+type RemoveCredentialFromWalletRequestObject struct {
 	Did string `json:"did"`
+	Id  string `json:"id"`
+}
+
+type RemoveCredentialFromWalletResponseObject interface {
+	VisitRemoveCredentialFromWalletResponse(w http.ResponseWriter) error
+}
+
+type RemoveCredentialFromWallet204Response struct {
+}
+
+func (response RemoveCredentialFromWallet204Response) VisitRemoveCredentialFromWalletResponse(w http.ResponseWriter) error {
+	w.WriteHeader(204)
+	return nil
+}
+
+type RemoveCredentialFromWalletdefaultApplicationProblemPlusJSONResponse struct {
+	Body struct {
+		// Detail A human-readable explanation specific to this occurrence of the problem.
+		Detail string `json:"detail"`
+
+		// Status HTTP statuscode
+		Status float32 `json:"status"`
+
+		// Title A short, human-readable summary of the problem type.
+		Title string `json:"title"`
+	}
+	StatusCode int
+}
+
+func (response RemoveCredentialFromWalletdefaultApplicationProblemPlusJSONResponse) VisitRemoveCredentialFromWalletResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(response.StatusCode)
+
+	return json.NewEncoder(w).Encode(response.Body)
+}
+
+type GetCredentialsInWalletRequestObject struct {
+	SubjectID string `json:"subjectID"`
 }
 
 type GetCredentialsInWalletResponseObject interface {
@@ -3212,8 +3250,8 @@ func (response GetCredentialsInWalletdefaultApplicationProblemPlusJSONResponse) 
 }
 
 type LoadVCRequestObject struct {
-	Did  string `json:"did"`
-	Body *LoadVCJSONRequestBody
+	SubjectID string `json:"subjectID"`
+	Body      *LoadVCJSONRequestBody
 }
 
 type LoadVCResponseObject interface {
@@ -3243,44 +3281,6 @@ type LoadVCdefaultApplicationProblemPlusJSONResponse struct {
 }
 
 func (response LoadVCdefaultApplicationProblemPlusJSONResponse) VisitLoadVCResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(response.StatusCode)
-
-	return json.NewEncoder(w).Encode(response.Body)
-}
-
-type RemoveCredentialFromWalletRequestObject struct {
-	Did string `json:"did"`
-	Id  string `json:"id"`
-}
-
-type RemoveCredentialFromWalletResponseObject interface {
-	VisitRemoveCredentialFromWalletResponse(w http.ResponseWriter) error
-}
-
-type RemoveCredentialFromWallet204Response struct {
-}
-
-func (response RemoveCredentialFromWallet204Response) VisitRemoveCredentialFromWalletResponse(w http.ResponseWriter) error {
-	w.WriteHeader(204)
-	return nil
-}
-
-type RemoveCredentialFromWalletdefaultApplicationProblemPlusJSONResponse struct {
-	Body struct {
-		// Detail A human-readable explanation specific to this occurrence of the problem.
-		Detail string `json:"detail"`
-
-		// Status HTTP statuscode
-		Status float32 `json:"status"`
-
-		// Title A short, human-readable summary of the problem type.
-		Title string `json:"title"`
-	}
-	StatusCode int
-}
-
-func (response RemoveCredentialFromWalletdefaultApplicationProblemPlusJSONResponse) VisitRemoveCredentialFromWalletResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(response.StatusCode)
 
@@ -3716,15 +3716,15 @@ type StrictServerInterface interface {
 	// Create a new Verifiable Presentation for a set of Verifiable Credentials.
 	// (POST /internal/vcr/v2/holder/vp)
 	CreateVP(ctx context.Context, request CreateVPRequestObject) (CreateVPResponseObject, error)
-	// List all Verifiable Credentials in the holder's wallet.
-	// (GET /internal/vcr/v2/holder/{did}/vc)
-	GetCredentialsInWallet(ctx context.Context, request GetCredentialsInWalletRequestObject) (GetCredentialsInWalletResponseObject, error)
-	// Load a VerifiableCredential into the holders wallet.
-	// (POST /internal/vcr/v2/holder/{did}/vc)
-	LoadVC(ctx context.Context, request LoadVCRequestObject) (LoadVCResponseObject, error)
 	// Remove a VerifiableCredential from the holders wallet.
 	// (DELETE /internal/vcr/v2/holder/{did}/vc/{id})
 	RemoveCredentialFromWallet(ctx context.Context, request RemoveCredentialFromWalletRequestObject) (RemoveCredentialFromWalletResponseObject, error)
+	// List all Verifiable Credentials in the holder's wallet.
+	// (GET /internal/vcr/v2/holder/{subjectID}/vc)
+	GetCredentialsInWallet(ctx context.Context, request GetCredentialsInWalletRequestObject) (GetCredentialsInWalletResponseObject, error)
+	// Load a VerifiableCredential into the holders wallet.
+	// (POST /internal/vcr/v2/holder/{subjectID}/vc)
+	LoadVC(ctx context.Context, request LoadVCRequestObject) (LoadVCResponseObject, error)
 	// Issues a new Verifiable Credential
 	// (POST /internal/vcr/v2/issuer/vc)
 	IssueVC(ctx context.Context, request IssueVCRequestObject) (IssueVCResponseObject, error)
@@ -3801,11 +3801,37 @@ func (sh *strictHandler) CreateVP(ctx echo.Context) error {
 	return nil
 }
 
-// GetCredentialsInWallet operation middleware
-func (sh *strictHandler) GetCredentialsInWallet(ctx echo.Context, did string) error {
-	var request GetCredentialsInWalletRequestObject
+// RemoveCredentialFromWallet operation middleware
+func (sh *strictHandler) RemoveCredentialFromWallet(ctx echo.Context, did string, id string) error {
+	var request RemoveCredentialFromWalletRequestObject
 
 	request.Did = did
+	request.Id = id
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.RemoveCredentialFromWallet(ctx.Request().Context(), request.(RemoveCredentialFromWalletRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "RemoveCredentialFromWallet")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(RemoveCredentialFromWalletResponseObject); ok {
+		return validResponse.VisitRemoveCredentialFromWalletResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// GetCredentialsInWallet operation middleware
+func (sh *strictHandler) GetCredentialsInWallet(ctx echo.Context, subjectID string) error {
+	var request GetCredentialsInWalletRequestObject
+
+	request.SubjectID = subjectID
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.GetCredentialsInWallet(ctx.Request().Context(), request.(GetCredentialsInWalletRequestObject))
@@ -3827,10 +3853,10 @@ func (sh *strictHandler) GetCredentialsInWallet(ctx echo.Context, did string) er
 }
 
 // LoadVC operation middleware
-func (sh *strictHandler) LoadVC(ctx echo.Context, did string) error {
+func (sh *strictHandler) LoadVC(ctx echo.Context, subjectID string) error {
 	var request LoadVCRequestObject
 
-	request.Did = did
+	request.SubjectID = subjectID
 
 	var body LoadVCJSONRequestBody
 	if err := ctx.Bind(&body); err != nil {
@@ -3851,32 +3877,6 @@ func (sh *strictHandler) LoadVC(ctx echo.Context, did string) error {
 		return err
 	} else if validResponse, ok := response.(LoadVCResponseObject); ok {
 		return validResponse.VisitLoadVCResponse(ctx.Response())
-	} else if response != nil {
-		return fmt.Errorf("unexpected response type: %T", response)
-	}
-	return nil
-}
-
-// RemoveCredentialFromWallet operation middleware
-func (sh *strictHandler) RemoveCredentialFromWallet(ctx echo.Context, did string, id string) error {
-	var request RemoveCredentialFromWalletRequestObject
-
-	request.Did = did
-	request.Id = id
-
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.RemoveCredentialFromWallet(ctx.Request().Context(), request.(RemoveCredentialFromWalletRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "RemoveCredentialFromWallet")
-	}
-
-	response, err := handler(ctx, request)
-
-	if err != nil {
-		return err
-	} else if validResponse, ok := response.(RemoveCredentialFromWalletResponseObject); ok {
-		return validResponse.VisitRemoveCredentialFromWalletResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}


### PR DESCRIPTION
closes #3413 

Changed API from using DID path to subject.

Added checks:
- subject in path must exist
- subject in path must own credentialSubject.ID
- credential must be valid (without trust): sig, not revoked, not expired.