### PR TITLE
Alter discovery activation

### DIFF
--- a/discovery/api/v1/api_test.go
+++ b/discovery/api/v1/api_test.go
@@ -71,17 +71,16 @@ func TestWrapper_ActivateServiceForSubject(t *testing.T) {
 		assert.NoError(t, err)
 		assert.IsType(t, ActivateServiceForSubject200Response{}, response)
 	})
-	t.Run("ok, but registration failed", func(t *testing.T) {
+	t.Run("but registration failed", func(t *testing.T) {
 		test := newMockContext(t)
 		test.client.EXPECT().ActivateServiceForSubject(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(discovery.ErrPresentationRegistrationFailed)
 
-		response, err := test.wrapper.ActivateServiceForSubject(nil, ActivateServiceForSubjectRequestObject{
+		_, err := test.wrapper.ActivateServiceForSubject(nil, ActivateServiceForSubjectRequestObject{
 			ServiceID: serviceID,
 			SubjectID: subjectID,
 		})
 
-		assert.NoError(t, err)
-		assert.IsType(t, ActivateServiceForSubject202JSONResponse{}, response)
+		assert.ErrorIs(t, err, discovery.ErrPresentationRegistrationFailed)
 	})
 	t.Run("other error", func(t *testing.T) {
 		test := newMockContext(t)

--- a/discovery/api/v1/api_test.go
+++ b/discovery/api/v1/api_test.go
@@ -190,7 +190,6 @@ func TestWrapper_GetServiceActivation(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		test := newMockContext(t)
 		test.client.EXPECT().GetServiceActivation(gomock.Any(), serviceID, subjectID).Return(true, nil, nil)
-		test.client.EXPECT().GetServiceRefreshError(gomock.Any(), serviceID, subjectID).Return(nil)
 
 		response, err := test.wrapper.GetServiceActivation(nil, GetServiceActivationRequestObject{
 			SubjectID: subjectID,
@@ -206,8 +205,7 @@ func TestWrapper_GetServiceActivation(t *testing.T) {
 	})
 	t.Run("refresh failed", func(t *testing.T) {
 		test := newMockContext(t)
-		test.client.EXPECT().GetServiceActivation(gomock.Any(), serviceID, subjectID).Return(true, nil, nil)
-		test.client.EXPECT().GetServiceRefreshError(gomock.Any(), serviceID, subjectID).Return(discovery.RegistrationRefreshError{assert.AnError})
+		test.client.EXPECT().GetServiceActivation(gomock.Any(), serviceID, subjectID).Return(true, nil, discovery.RegistrationRefreshError{Underlying: assert.AnError})
 
 		response, err := test.wrapper.GetServiceActivation(nil, GetServiceActivationRequestObject{
 			SubjectID: subjectID,

--- a/discovery/api/v1/generated.go
+++ b/discovery/api/v1/generated.go
@@ -428,18 +428,6 @@ func (response ActivateServiceForSubject200Response) VisitActivateServiceForSubj
 	return nil
 }
 
-type ActivateServiceForSubject202JSONResponse struct {
-	// Reason Description of why registration failed.
-	Reason string `json:"reason"`
-}
-
-func (response ActivateServiceForSubject202JSONResponse) VisitActivateServiceForSubjectResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(202)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
 type ActivateServiceForSubject400ApplicationProblemPlusJSONResponse struct {
 	// Detail A human-readable explanation specific to this occurrence of the problem.
 	Detail string `json:"detail"`
@@ -454,6 +442,24 @@ type ActivateServiceForSubject400ApplicationProblemPlusJSONResponse struct {
 func (response ActivateServiceForSubject400ApplicationProblemPlusJSONResponse) VisitActivateServiceForSubjectResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ActivateServiceForSubject412ApplicationProblemPlusJSONResponse struct {
+	// Detail A human-readable explanation specific to this occurrence of the problem.
+	Detail string `json:"detail"`
+
+	// Status HTTP statuscode
+	Status float32 `json:"status"`
+
+	// Title A short, human-readable summary of the problem type.
+	Title string `json:"title"`
+}
+
+func (response ActivateServiceForSubject412ApplicationProblemPlusJSONResponse) VisitActivateServiceForSubjectResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(412)
 
 	return json.NewEncoder(w).Encode(response)
 }

--- a/discovery/api/v1/generated.go
+++ b/discovery/api/v1/generated.go
@@ -377,6 +377,12 @@ type GetServiceActivation200JSONResponse struct {
 	// Activated Whether the Discovery Service is activated for the given subject
 	Activated bool `json:"activated"`
 
+	// Error Error message if status is "error".
+	Error *string `json:"error,omitempty"`
+
+	// Status Status of the activation. "active" or "error".
+	Status GetServiceActivation200JSONResponseStatus `json:"status"`
+
 	// Vp List of VPs on the Discovery Service for the subject. One per DID method registered on the Service.
 	// The list can be empty even if activated==true if none of the DIDs of a subject is actually registered on the Discovery Service.
 	Vp *[]VerifiablePresentation `json:"vp,omitempty"`

--- a/discovery/api/v1/types.go
+++ b/discovery/api/v1/types.go
@@ -31,3 +31,13 @@ type ServiceDefinition = discovery.ServiceDefinition
 
 // VerifiableCredential is a type alias for the VerifiableCredential from the go-did library.
 type VerifiableCredential = vc.VerifiableCredential
+
+// GetServiceActivation200JSONResponseStatus is a type alias for string, generated from an enum.
+type GetServiceActivation200JSONResponseStatus string
+
+const (
+	// ServiceStatusActive is the status for an active service.
+	ServiceStatusActive = "active"
+	// ServiceStatusError is the status for an inactive service.
+	ServiceStatusError = "error"
+)

--- a/discovery/client_test.go
+++ b/discovery/client_test.go
@@ -92,10 +92,10 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 		assert.ErrorContains(t, err, "invoker error")
 
 		// check no refresh records are added
-		refreshTime, err := store.getPresentationRefreshTime(testServiceID, aliceSubject)
+		record, err := store.getPresentationRefreshRecord(testServiceID, aliceSubject)
 
 		require.NoError(t, err)
-		assert.Nil(t, refreshTime)
+		assert.Nil(t, record)
 	})
 	t.Run("DID method not supported", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -402,9 +402,9 @@ func Test_defaultClientRegistrationManager_refresh(t *testing.T) {
 
 		// refresh clears the registration
 		require.NoError(t, err)
-		refreshTime, err := store.getPresentationRefreshTime(unsupportedServiceID, aliceSubject)
+		record, err := store.getPresentationRefreshRecord(unsupportedServiceID, aliceSubject)
 		assert.NoError(t, err)
-		assert.Nil(t, refreshTime)
+		assert.Nil(t, record)
 	})
 	t.Run("remove presentationRefreshError on success", func(t *testing.T) {
 		store := setupStore(t, storageEngine.GetSQLDatabase())

--- a/discovery/client_test.go
+++ b/discovery/client_test.go
@@ -90,6 +90,12 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 
 		require.ErrorIs(t, err, ErrPresentationRegistrationFailed)
 		assert.ErrorContains(t, err, "invoker error")
+
+		// check no refresh records are added
+		refreshTime, err := store.getPresentationRefreshTime(testServiceID, aliceSubject)
+
+		require.NoError(t, err)
+		assert.Nil(t, refreshTime)
 	})
 	t.Run("DID method not supported", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/discovery/interface.go
+++ b/discovery/interface.go
@@ -77,6 +77,10 @@ type Client interface {
 	// The boolean indicates whether the subject is activated on the Discovery Service (ActivateServiceForSubject() has been called).
 	// It also returns the Verifiable Presentations for all DIDs of the subject that are registered on the Discovery Service, if any.
 	GetServiceActivation(ctx context.Context, serviceID, subjectID string) (bool, []vc.VerifiablePresentation, error)
+
+	// GetServiceRefreshError returns the error that occurred during the last refresh of the service.
+	// The time of the last refresh is added in the error message.
+	GetServiceRefreshError(ctx context.Context, serviceID, subjectID string) error
 }
 
 // SearchResult is a single result of a search operation.
@@ -95,3 +99,12 @@ type presentationVerifier func(definition ServiceDefinition, presentation vc.Ver
 
 // XForwardedHostContextKey is the context key for the X-Forwarded-Host header.
 type XForwardedHostContextKey struct{}
+
+// RegistrationRefreshError is returned from GetServiceRefreshError.
+type RegistrationRefreshError struct {
+	Underlying error
+}
+
+func (r RegistrationRefreshError) Error() string {
+	return r.Underlying.Error()
+}

--- a/discovery/interface.go
+++ b/discovery/interface.go
@@ -76,11 +76,9 @@ type Client interface {
 	// GetServiceActivation returns the activation status of a subject on a Discovery Service.
 	// The boolean indicates whether the subject is activated on the Discovery Service (ActivateServiceForSubject() has been called).
 	// It also returns the Verifiable Presentations for all DIDs of the subject that are registered on the Discovery Service, if any.
+	// It returns a refreshRecordError if the last refresh of the service failed (activation status and VPs are still returned).
+	// The time of the last error is added in the error message.
 	GetServiceActivation(ctx context.Context, serviceID, subjectID string) (bool, []vc.VerifiablePresentation, error)
-
-	// GetServiceRefreshError returns the error that occurred during the last refresh of the service.
-	// The time of the last refresh is added in the error message.
-	GetServiceRefreshError(ctx context.Context, serviceID, subjectID string) error
 }
 
 // SearchResult is a single result of a search operation.

--- a/discovery/interface.go
+++ b/discovery/interface.go
@@ -59,7 +59,6 @@ type Client interface {
 
 	// ActivateServiceForSubject causes a subject to be registered for a Discovery Service.
 	// Registration of all DIDs of the subject will be attempted immediately, and automatically refreshed.
-	// If the initial registration for all DIDs fails with ErrPresentationRegistrationFailed, registration will be retried.
 	// If the function is called again for the same service/DID combination, it will try to refresh the registration.
 	// parameters are added as credentialSubject to a DiscoveryRegistrationCredential holder credential.
 	// It returns an error if the service or subject is invalid/unknown.

--- a/discovery/mock.go
+++ b/discovery/mock.go
@@ -137,6 +137,20 @@ func (mr *MockClientMockRecorder) GetServiceActivation(ctx, serviceID, subjectID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceActivation", reflect.TypeOf((*MockClient)(nil).GetServiceActivation), ctx, serviceID, subjectID)
 }
 
+// GetServiceRefreshError mocks base method.
+func (m *MockClient) GetServiceRefreshError(ctx context.Context, serviceID, subjectID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetServiceRefreshError", ctx, serviceID, subjectID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetServiceRefreshError indicates an expected call of GetServiceRefreshError.
+func (mr *MockClientMockRecorder) GetServiceRefreshError(ctx, serviceID, subjectID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceRefreshError", reflect.TypeOf((*MockClient)(nil).GetServiceRefreshError), ctx, serviceID, subjectID)
+}
+
 // Search mocks base method.
 func (m *MockClient) Search(serviceID string, query map[string]string) ([]SearchResult, error) {
 	m.ctrl.T.Helper()

--- a/discovery/mock.go
+++ b/discovery/mock.go
@@ -137,20 +137,6 @@ func (mr *MockClientMockRecorder) GetServiceActivation(ctx, serviceID, subjectID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceActivation", reflect.TypeOf((*MockClient)(nil).GetServiceActivation), ctx, serviceID, subjectID)
 }
 
-// GetServiceRefreshError mocks base method.
-func (m *MockClient) GetServiceRefreshError(ctx context.Context, serviceID, subjectID string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServiceRefreshError", ctx, serviceID, subjectID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// GetServiceRefreshError indicates an expected call of GetServiceRefreshError.
-func (mr *MockClientMockRecorder) GetServiceRefreshError(ctx, serviceID, subjectID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceRefreshError", reflect.TypeOf((*MockClient)(nil).GetServiceRefreshError), ctx, serviceID, subjectID)
-}
-
 // Search mocks base method.
 func (m *MockClient) Search(serviceID string, query map[string]string) ([]SearchResult, error) {
 	m.ctrl.T.Helper()

--- a/discovery/module.go
+++ b/discovery/module.go
@@ -379,9 +379,6 @@ func (m *Module) ActivateServiceForSubject(ctx context.Context, serviceID, subje
 
 	err := m.registrationManager.activate(ctx, serviceID, subjectID, parameters)
 	if err != nil {
-		if errors.Is(err, ErrPresentationRegistrationFailed) {
-			log.Logger().WithError(err).Warnf("Presentation registration failed, will be retried later (subject=%s,service=%s)", subjectID, serviceID)
-		}
 		return err
 	}
 

--- a/discovery/module.go
+++ b/discovery/module.go
@@ -431,6 +431,21 @@ func (m *Module) GetServiceActivation(ctx context.Context, serviceID, subjectID 
 	return true, results, nil
 }
 
+func (m *Module) GetServiceRefreshError(_ context.Context, serviceID, subjectID string) error {
+	refreshError, err := m.store.getPresentationRefreshError(serviceID, subjectID)
+	if err != nil {
+		// db error
+		return err
+	}
+	if refreshError == nil {
+		return nil
+	}
+	// format a readable time using RFC3339
+	lastOccurrence := time.Unix(refreshError.LastOccurrence, 0)
+	readableTime := lastOccurrence.Format(time.RFC3339)
+	return RegistrationRefreshError{fmt.Errorf("[%s] %s", readableTime, refreshError.Error)}
+}
+
 func loadDefinitions(directory string) (map[string]ServiceDefinition, error) {
 	entries, err := os.ReadDir(directory)
 	if err != nil {

--- a/discovery/module_test.go
+++ b/discovery/module_test.go
@@ -539,7 +539,7 @@ func TestModule_ActivateServiceForSubject(t *testing.T) {
 		wallet := holder.NewMockWallet(gomock.NewController(t))
 		m.vcrInstance.(*vcr.MockVCR).EXPECT().Wallet().Return(wallet).MinTimes(1)
 		wallet.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, errors.New("failed")).MinTimes(1)
-		testContext.subjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil).Times(2)
+		testContext.subjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
 
 		err := m.ActivateServiceForSubject(context.Background(), testServiceID, aliceSubject, nil)
 

--- a/discovery/module_test.go
+++ b/discovery/module_test.go
@@ -596,3 +596,23 @@ func TestModule_GetServiceActivation(t *testing.T) {
 		assert.NotNil(t, presentation)
 	})
 }
+
+func TestModule_GetServiceRefreshError(t *testing.T) {
+	storageEngine := storage.NewTestStorageEngine(t)
+	require.NoError(t, storageEngine.Start())
+	t.Run("no error", func(t *testing.T) {
+		m, _ := setupModule(t, storageEngine)
+
+		err := m.GetServiceRefreshError(context.Background(), testServiceID, aliceSubject)
+
+		assert.NoError(t, err)
+	})
+	t.Run("error", func(t *testing.T) {
+		m, _ := setupModule(t, storageEngine)
+		_ = m.store.setPresentationRefreshError(testServiceID, aliceSubject, assert.AnError)
+
+		err := m.GetServiceRefreshError(context.Background(), testServiceID, aliceSubject)
+
+		assert.ErrorContains(t, err, assert.AnError.Error())
+	})
+}

--- a/discovery/store_test.go
+++ b/discovery/store_test.go
@@ -282,6 +282,34 @@ func Test_sqlStore_getPresentationRefreshTime(t *testing.T) {
 	})
 }
 
+func Test_sqlStore_setPresentationRefreshError(t *testing.T) {
+	storageEngine := storage.NewTestStorageEngine(t)
+	require.NoError(t, storageEngine.Start())
+
+	t.Run("store", func(t *testing.T) {
+		c := setupStore(t, storageEngine.GetSQLDatabase())
+
+		require.NoError(t, c.setPresentationRefreshError(testServiceID, aliceSubject, assert.AnError))
+
+		// Check if the error is stored
+		refreshError, err := c.getPresentationRefreshError(testServiceID, aliceSubject)
+
+		require.NoError(t, err)
+		assert.Equal(t, refreshError.Error, assert.AnError.Error())
+		assert.True(t, refreshError.LastOccurrence > time.Now().Add(-1*time.Second).Unix())
+	})
+	t.Run("delete", func(t *testing.T) {
+		c := setupStore(t, storageEngine.GetSQLDatabase())
+		require.NoError(t, c.setPresentationRefreshError(testServiceID, aliceSubject, assert.AnError))
+		require.NoError(t, c.setPresentationRefreshError(testServiceID, aliceSubject, nil))
+
+		refreshError, err := c.getPresentationRefreshError(testServiceID, aliceSubject)
+
+		require.NoError(t, err)
+		assert.Nil(t, refreshError)
+	})
+}
+
 func Test_sqlStore_getSubjectVPsOnService(t *testing.T) {
 	// create VPs that have credentials for both Alice and Bob
 	visitor := func(claims map[string]interface{}, vp *vc.VerifiablePresentation) {

--- a/discovery/store_test.go
+++ b/discovery/store_test.go
@@ -280,7 +280,7 @@ func Test_sqlStore_getPresentationRefreshTime(t *testing.T) {
 		ts, err := c.getPresentationRefreshRecord(testServiceID, aliceSubject)
 		require.NoError(t, err)
 		require.NotNil(t, ts)
-		assert.Equal(t, now.Unix(), ts.NextRefresh)
+		assert.Equal(t, int(now.Unix()), ts.NextRefresh)
 
 		t.Run("error is preloaded", func(t *testing.T) {
 			require.NoError(t, c.setPresentationRefreshError(testServiceID, aliceSubject, assert.AnError))

--- a/docs/_static/discovery/v1.yaml
+++ b/docs/_static/discovery/v1.yaml
@@ -148,6 +148,7 @@ paths:
         
         error returns:
         * 400 - incorrect input: invalid/unknown service or subject.
+        * 412 - precondition failed: subject doesn't have the required certificates.
       operationId: activateServiceForSubject
       tags:
         - discovery
@@ -160,19 +161,10 @@ paths:
       responses:
         "200":
           description: Activation was successful.
-        "202":
-          description: Activation was successful, but registration of the Verifiable Presentation failed (but will be automatically re-attempted later).
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - reason
-                properties:
-                  reason:
-                    type: string
-                    description: Description of why registration failed.
+
         "400":
+          $ref: "../common/error_response.yaml"
+        "412":
           $ref: "../common/error_response.yaml"
         default:
           $ref: "../common/error_response.yaml"

--- a/docs/_static/discovery/v1.yaml
+++ b/docs/_static/discovery/v1.yaml
@@ -159,7 +159,7 @@ paths:
         
         error returns:
         * 400 - incorrect input: invalid/unknown service or subject.
-        * 412 - precondition failed: subject doesn't have the required certificates.
+        * 412 - precondition failed: subject doesn't have the required credentials.
       operationId: activateServiceForSubject
       tags:
         - discovery

--- a/docs/_static/discovery/v1.yaml
+++ b/docs/_static/discovery/v1.yaml
@@ -107,7 +107,8 @@ paths:
       summary: Retrieves the activation status of a subject on a Discovery Service.
       description: |
         An API provided by the Discovery Client,
-        used to check whether the client is managing the given subject on the specified Discovery Service (service has been activated for the subject).
+        used to check whether the client is managing the given subject on the specified Discovery Service (service has been activated for the subject)
+        and the status of the activation. A refresh could have failed.
         It will return true after successfully calling the activateServiceForSubject API, and false after calling the deactivateServiceForSubject API.
         It also returns the active Verifiable Presentations, if any.
       operationId: getServiceActivation
@@ -122,10 +123,20 @@ paths:
                 type: object
                 required:
                   - activated
+                  - status
                 properties:
                   activated:
                     type: boolean
                     description: Whether the Discovery Service is activated for the given subject
+                  status:
+                    type: string
+                    description: Status of the activation. "active" or "error".
+                    enum:
+                      - active
+                      - error
+                  error:
+                    type: string
+                    description: Error message if status is "error".
                   vp:
                     description: |
                       List of VPs on the Discovery Service for the subject. One per DID method registered on the Service.

--- a/docs/pages/deployment/discovery.rst
+++ b/docs/pages/deployment/discovery.rst
@@ -44,9 +44,8 @@ E.g., for service ``coffeecorner`` and subject ``example``:
 
     POST /internal/discovery/v1/coffeecorner/example
 
-The DID's wallet must contain the Verifiable Credential(s) that are required by the service definition,
-otherwise registration will fail. If the wallet does not contain the credentials,
-the Nuts node will retry registration periodically for all DIDs of a subject.
+The wallet must contain the Verifiable Credential(s) that are required by the service definition,
+otherwise registration will fail immediately.
 
 Optionally, a POST body can be provided with registration parameters, e.g.:
 
@@ -61,6 +60,24 @@ Optionally, a POST body can be provided with registration parameters, e.g.:
 
 This can be used to provide additional information. All registration parameters are returned by the search API.
 The ``authServerURL`` is added automatically by the Nuts node. It's constructed as ``https://<config.url>/oauth2/<subject_id>``.
+
+Once registered, future refreshes will be done automatically by the Nuts node. These refreshes could fail because of various reasons.
+You can check the status of the refreshes by querying the service, e.g.:
+
+.. code-block:: text
+
+    GET /internal/discovery/v1/coffeecorner/example
+
+The result contains a ``status`` field that indicates the status of the registration (``active`` or ``error``) . If the refresh fails, the ``error`` field contains the error message.
+
+.. code-block:: json
+
+    {
+      "activated": true,
+      "status": "error",
+      "error": "error message",
+      "vp": [...]
+    }
 
 Servers
 *******

--- a/e2e-tests/discovery/run-test.sh
+++ b/e2e-tests/discovery/run-test.sh
@@ -15,6 +15,7 @@ docker compose down
 echo "------------------------------------"
 echo "Starting Docker containers..."
 echo "------------------------------------"
+docker compose up --wait nodeA-backend nodeA
 docker compose up --wait nodeB-backend nodeB
 
 echo "------------------------------------"
@@ -49,8 +50,7 @@ echo "---------------------------------------"
 echo "Registering care organization on Discovery Service..."
 echo "---------------------------------------"
 curl --insecure -s -X POST http://localhost:28081/internal/discovery/v1/dev:eOverdracht2023/${SUBJECT}
-# Start Discovery Server
-docker compose up --wait nodeA-backend nodeA
+
 # Registration refresh interval is 500ms, wait some to make sure the registration is refreshed
 sleep 2
 

--- a/e2e-tests/discovery/run-test.sh
+++ b/e2e-tests/discovery/run-test.sh
@@ -15,8 +15,7 @@ docker compose down
 echo "------------------------------------"
 echo "Starting Docker containers..."
 echo "------------------------------------"
-docker compose up --wait nodeA-backend nodeA
-docker compose up --wait nodeB-backend nodeB
+docker compose up --wait nodeA-backend nodeA nodeB-backend nodeB
 
 echo "------------------------------------"
 echo "Registering care organization..."

--- a/storage/sql_migrations/008_discoveryservice_client_error.sql
+++ b/storage/sql_migrations/008_discoveryservice_client_error.sql
@@ -13,7 +13,7 @@ create table discovery_presentation_error
     -- last_occurrence is the timestamp (seconds since Unix epoch) when the registration last failed.
     last_occurrence integer      not null,
     primary key (service_id, subject_id),
-    constraint fk_discovery_presentation_error_service foreign key (service_id) references discovery_service (id) on delete cascade
+    constraint fk_discovery_presentation_error_service foreign key (service_id, subject_id) references discovery_presentation_refresh (service_id, subject_id) on delete cascade
 );
 
 -- +goose Down

--- a/storage/sql_migrations/008_discoveryservice_client_error.sql
+++ b/storage/sql_migrations/008_discoveryservice_client_error.sql
@@ -13,7 +13,7 @@ create table discovery_presentation_error
     -- last_occurrence is the timestamp (seconds since Unix epoch) when the registration last failed.
     last_occurrence integer      not null,
     primary key (service_id, subject_id),
-    constraint fk_discovery_presentation_refresh_service foreign key (service_id) references discovery_service (id) on delete cascade
+    constraint fk_discovery_presentation_error_service foreign key (service_id) references discovery_service (id) on delete cascade
 );
 
 -- +goose Down

--- a/storage/sql_migrations/008_discoveryservice_client_error.sql
+++ b/storage/sql_migrations/008_discoveryservice_client_error.sql
@@ -1,0 +1,20 @@
+-- +goose ENVSUB ON
+-- +goose Up
+-- discovery_presentation_error contains errors for activated registrations that once succeeded but fail to refresh.
+create table discovery_presentation_error
+(
+    -- service_id is the ID of the Discover Service that the DID should be registered on.
+    -- It comes from the service definition.
+    service_id   varchar(200) not null,
+    -- subject_id is the subject that should be registered on the Discovery Service.
+    subject_id   varchar(370) not null,
+    -- reason contains the error message that caused the registration to fail.
+    error $TEXT_TYPE,
+    -- last_occurrence is the timestamp (seconds since Unix epoch) when the registration last failed.
+    last_occurrence integer      not null,
+    primary key (service_id, subject_id),
+    constraint fk_discovery_presentation_refresh_service foreign key (service_id) references discovery_service (id) on delete cascade
+);
+
+-- +goose Down
+drop table discovery_presentation_error;


### PR DESCRIPTION
closes #3408 

- activation through the API is now a fail/success API, no magic is done at a later point if it fails.
- the refresh adds `presentationRefreshError` records if it fails for a candidate.
- refresh success or activation through the API clears the `presentationRefreshError` records.
- The `getServiceActivation` API returns an additional `status` and `error` field.