### PR TITLE
Discovery: fix 'as soon as possible' refresh timestamp

### DIFF
--- a/discovery/client.go
+++ b/discovery/client.go
@@ -92,7 +92,7 @@ func (r *defaultClientRegistrationManager) activate(ctx context.Context, service
 		return fmt.Errorf("%w: %w for %s", ErrPresentationRegistrationFailed, ErrDIDMethodsNotSupported, subjectID)
 	}
 
-	var asSoonAsPossible time.Time
+	asSoonAsPossible := time.Now().Add(-10 * time.Second) // could be whatever, as long as it's a bit in the past to avoid issues with some weird clock skew scenarios when running a cluster
 	if err := r.store.updatePresentationRefreshTime(serviceID, subjectID, parameters, &asSoonAsPossible); err != nil {
 		return err
 	}

--- a/discovery/client_test.go
+++ b/discovery/client_test.go
@@ -39,6 +39,8 @@ import (
 	"time"
 )
 
+var nextRefresh = time.Now().Add(-1 * time.Hour)
+
 func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 	storageEngine := storage.NewTestStorageEngine(t)
 	require.NoError(t, storageEngine.Start())
@@ -346,12 +348,12 @@ func Test_defaultClientRegistrationManager_refresh(t *testing.T) {
 		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
 
 		// Alice
-		_ = store.updatePresentationRefreshTime(testServiceID, aliceSubject, defaultRegistrationParams(aliceSubject), &time.Time{})
+		_ = store.updatePresentationRefreshTime(testServiceID, aliceSubject, defaultRegistrationParams(aliceSubject), &nextRefresh)
 		mockSubjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
 		wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), &aliceDID, false).Return(&vpAlice, nil)
 		wallet.EXPECT().List(gomock.Any(), aliceDID).Return([]vc.VerifiableCredential{vcAlice}, nil)
 		// Bob
-		_ = store.updatePresentationRefreshTime(testServiceID, bobSubject, defaultRegistrationParams(aliceSubject), &time.Time{})
+		_ = store.updatePresentationRefreshTime(testServiceID, bobSubject, defaultRegistrationParams(aliceSubject), &nextRefresh)
 		mockSubjectManager.EXPECT().ListDIDs(gomock.Any(), bobSubject).Return([]did.DID{bobDID}, nil)
 		wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), &bobDID, false).Return(&vpBob, nil)
 		wallet.EXPECT().List(gomock.Any(), bobDID).Return([]vc.VerifiableCredential{vcBob}, nil)
@@ -368,7 +370,7 @@ func Test_defaultClientRegistrationManager_refresh(t *testing.T) {
 		mockSubjectManager := didsubject.NewMockManager(ctrl)
 		mockSubjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return(nil, didsubject.ErrSubjectNotFound)
 		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
-		_ = store.updatePresentationRefreshTime(testServiceID, aliceSubject, nil, &time.Time{})
+		_ = store.updatePresentationRefreshTime(testServiceID, aliceSubject, nil, &nextRefresh)
 
 		err := manager.refresh(audit.TestContext(), time.Now())
 
@@ -383,7 +385,7 @@ func Test_defaultClientRegistrationManager_refresh(t *testing.T) {
 		mockSubjectManager := didsubject.NewMockManager(ctrl)
 		mockSubjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
 		manager := newRegistrationManager(testDefinitions(), store, invoker, mockVCR, mockSubjectManager)
-		_ = store.updatePresentationRefreshTime(unsupportedServiceID, aliceSubject, defaultRegistrationParams(aliceSubject), &time.Time{})
+		_ = store.updatePresentationRefreshTime(unsupportedServiceID, aliceSubject, defaultRegistrationParams(aliceSubject), &nextRefresh)
 
 		err := manager.refresh(audit.TestContext(), time.Now())
 

--- a/discovery/store.go
+++ b/discovery/store.go
@@ -85,7 +85,7 @@ type presentationRefreshRecord struct {
 	// SubjectID is the ID of the subject that should be registered on the service.
 	SubjectID string `gorm:"primaryKey"`
 	// NextRefresh is the Timestamp (seconds since Unix epoch) when the registration on the Discovery Service should be refreshed.
-	NextRefresh int64
+	NextRefresh int
 	// Parameters is a serialized JSON object containing parameters that should be used when registering the subject on the service.
 	Parameters []byte
 }
@@ -328,7 +328,7 @@ func (s *sqlStore) updatePresentationRefreshTime(serviceID string, subjectID str
 				return err
 			}
 		}
-		return tx.Save(presentationRefreshRecord{SubjectID: subjectID, ServiceID: serviceID, NextRefresh: nextRefresh.Unix(), Parameters: bytes}).Error
+		return tx.Save(presentationRefreshRecord{SubjectID: subjectID, ServiceID: serviceID, NextRefresh: int(nextRefresh.Unix()), Parameters: bytes}).Error
 	})
 }
 
@@ -340,7 +340,7 @@ func (s *sqlStore) getPresentationRefreshTime(serviceID string, subjectID string
 	if row.NextRefresh == 0 {
 		return nil, nil
 	}
-	result := time.Unix(row.NextRefresh, 0)
+	result := time.Unix(int64(row.NextRefresh), 0)
 	return &result, nil
 }
 

--- a/e2e-tests/oauth-flow/rfc021/do-test.sh
+++ b/e2e-tests/oauth-flow/rfc021/do-test.sh
@@ -67,7 +67,7 @@ fi
 echo "Registering vendor B on Discovery Service..."
 REQUEST="{\"registrationParameters\":{\"key\":\"value\"}}"
 RESPONSE=$(echo $REQUEST | curl -s -o /dev/null -w "%{http_code}" -X POST --data-binary @- http://localhost:28081/internal/discovery/v1/e2e-test/vendorB)
-if echo $RESPONSE == "200"; then
+if [ $RESPONSE -eq 200 ]; then
   echo "Vendor B registered on Discovery Service"
 else
   echo "FAILED: Could not register vendor B on Discovery Service" 1>&2


### PR DESCRIPTION
Was a "zero" `time.Time` (0000-00-00 00:00:00), which lead to a (very) large negative int, which didn't fit in the INT (4 bytes) type of MS SQL Server. Didn't find it earlier, since the check in the e2e test was incorrect.

```
{"error":"mssql: Arithmetic overflow error converting expression to data type int.","level":"warning","module":"Storage","msg":"Query failed (took 8.809369ms): UPDATE \"discovery_presentation_refresh\" SET \"service_id\"='test:SharedCarePlanning2024',\"subject_id\"='zbj-tst',\"next_refresh\"=-62135596800,\"parameters\"='{\"authServerURL\":\"...\"}' WHERE \"service_id\" = 'test:SharedCarePlanning2024' AND \"subject_id\" = 'zbj-tst'","time":"2024-09-26T17:02:51Z"}
```