### PR TITLE
Auth: RFC021 additional credentials + multiple DID methods enabled = failure

### DIFF
--- a/e2e-tests/oauth-flow/rfc021/node-A/nuts.yaml
+++ b/e2e-tests/oauth-flow/rfc021/node-A/nuts.yaml
@@ -22,7 +22,7 @@ discovery:
     directory: /nuts/discovery
   server:
     ids: e2e-test
-vdr:
-  didmethods:
-    - web
+#vdr:
+#  didmethods:
+#    - web
 

--- a/e2e-tests/oauth-flow/rfc021/node-B/nuts.yaml
+++ b/e2e-tests/oauth-flow/rfc021/node-B/nuts.yaml
@@ -19,6 +19,6 @@ tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem
   certkeyfile: /opt/nuts/certificate-and-key.pem
-vdr:
-  didmethods:
-    - web
+#vdr:
+#  didmethods:
+#    - web


### PR DESCRIPTION
Fixes https://github.com/nuts-foundation/nuts-node/issues/3423

Made the RFC021 test fail by enabling `did:nuts`.