### PR TITLE
VCR: fix MS SQL Server status list refresh

### DIFF
--- a/vcr/revocation/statuslist2021_issuer.go
+++ b/vcr/revocation/statuslist2021_issuer.go
@@ -170,7 +170,7 @@ func (cs *StatusList2021) Credential(ctx context.Context, issuerDID did.DID, pag
 		// Microsoft SQL server does not support the locking clause, so we have to use a raw query instead.
 		// See https://github.com/nuts-foundation/nuts-node/issues/3393
 		if tx.Dialector.Name() == "sqlserver" {
-			err = tx.Raw("SELECT * FROM status_list_entry WITH (UPDLOCK, ROWLOCK) WHERE subject_id = ?", statusListCredentialURL).
+			err = tx.Raw("SELECT * FROM status_list_credential WITH (UPDLOCK, ROWLOCK) WHERE subject_id = ?", statusListCredentialURL).
 				Scan(new(credentialRecord)).
 				Error
 		} else {
@@ -423,10 +423,9 @@ func (cs *StatusList2021) Revoke(ctx context.Context, credentialID ssi.URI, entr
 		// lock relevant credentialRecord. It was created when the first entry was issued for this StatusList2021Credential.
 		err = tx.Model(new(credentialRecord)).
 			Clauses(clause.Locking{Strength: clause.LockingStrengthUpdate}).
-			Select("count(*) > 0").
-			Group("subject_id").
+			Select("subject_id").
 			Where("subject_id = ?", entry.StatusListCredential).
-			Find(new([]bool)).
+			Find(new([]string)).
 			Error
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes:

```
{"detail":"mssql: Invalid column name 'subject_id'.","status":500,"title":"StatusList failed"}
```

Caused by:
```
SELECT * FROM status_list_entry WITH (UPDLOCK, ROWLOCK) WHERE subject_id =
```

Also fixes a `count(*) > 0` leftover, which isn't supported by all databases (at least not by MS SQL Server).

There isn't really a good way to test this, since it only triggers when the StatusList credential expires (after 24h).