### PR TITLE
pass problem details when discovery service returns them

### DIFF
--- a/discovery/api/server/client/http.go
+++ b/discovery/api/server/client/http.go
@@ -109,5 +109,5 @@ func problemResponseToError(httpErr core.HttpError) string {
 	if err := json.Unmarshal(httpErr.ResponseBody, &problemDetails); err != nil {
 		return fmt.Sprintf("%s: %s", httpErr.Error(), httpErr.ResponseBody)
 	}
-	return fmt.Sprintf("server returned HTTP %d: %s: %s", problemDetails.Status, problemDetails.Title, problemDetails.Description)
+	return fmt.Sprintf("server returned HTTP status code %d: %s: %s", problemDetails.Status, problemDetails.Title, problemDetails.Description)
 }

--- a/discovery/api/server/client/http.go
+++ b/discovery/api/server/client/http.go
@@ -65,7 +65,8 @@ func (h DefaultHTTPClient) Register(ctx context.Context, serviceEndpointURL stri
 	}
 	defer httpResponse.Body.Close()
 	if err := core.TestResponseCodeWithLog(201, httpResponse, log.Logger()); err != nil {
-		return fmt.Errorf("non-OK response from remote Discovery Service (url=%s): %w", serviceEndpointURL, err)
+		httpErr := err.(core.HttpError) // TestResponseCodeWithLog always returns an HttpError
+		return fmt.Errorf("non-OK response from remote Discovery Service (url=%s): %s", serviceEndpointURL, problemResponseToError(httpErr))
 	}
 	return nil
 }
@@ -83,7 +84,8 @@ func (h DefaultHTTPClient) Get(ctx context.Context, serviceEndpointURL string, t
 	}
 	defer httpResponse.Body.Close()
 	if err := core.TestResponseCode(200, httpResponse); err != nil {
-		return nil, 0, fmt.Errorf("non-OK response from remote Discovery Service (url=%s): %w", serviceEndpointURL, err)
+		httpErr := err.(core.HttpError) // TestResponseCodeWithLog always returns an HttpError
+		return nil, 0, fmt.Errorf("non-OK response from remote Discovery Service (url=%s): %s", serviceEndpointURL, problemResponseToError(httpErr))
 	}
 	responseData, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
@@ -94,4 +96,18 @@ func (h DefaultHTTPClient) Get(ctx context.Context, serviceEndpointURL string, t
 		return nil, 0, fmt.Errorf("failed to unmarshal response from remote Discovery Service (url=%s): %w", serviceEndpointURL, err)
 	}
 	return result.Entries, result.Timestamp, nil
+}
+
+// problemResponseToError converts a Problem Details response to an error.
+// It creates an error with the given string concatenated with the title and detail fields of the problem details.
+func problemResponseToError(httpErr core.HttpError) string {
+	var problemDetails struct {
+		Title       string `json:"title"`
+		Description string `json:"detail"`
+		Status      int    `json:"status"`
+	}
+	if err := json.Unmarshal(httpErr.ResponseBody, &problemDetails); err != nil {
+		return fmt.Sprintf("%s: %s", httpErr.Error(), httpErr.ResponseBody)
+	}
+	return fmt.Sprintf("server returned HTTP %d: %s: %s", problemDetails.Status, problemDetails.Title, problemDetails.Description)
 }

--- a/discovery/api/server/client/http_test.go
+++ b/discovery/api/server/client/http_test.go
@@ -56,7 +56,7 @@ func TestHTTPInvoker_Register(t *testing.T) {
 		err := client.Register(context.Background(), server.URL, vp)
 
 		assert.ErrorContains(t, err, "non-OK response from remote Discovery Service")
-		assert.ErrorContains(t, err, "server returned HTTP 400")
+		assert.ErrorContains(t, err, "server returned HTTP status code 400")
 		assert.ErrorContains(t, err, "missing credentials: could not resolve DID")
 	})
 	t.Run("non-ok other", func(t *testing.T) {
@@ -132,7 +132,7 @@ func TestHTTPInvoker_Get(t *testing.T) {
 		_, _, err := client.Get(context.Background(), server.URL, 0)
 
 		assert.ErrorContains(t, err, "non-OK response from remote Discovery Service")
-		assert.ErrorContains(t, err, "server returned HTTP 500")
+		assert.ErrorContains(t, err, "server returned HTTP status code 500")
 		assert.ErrorContains(t, err, "internal server error: db not found")
 	})
 	t.Run("server does not return JSON", func(t *testing.T) {

--- a/discovery/api/server/client/http_test.go
+++ b/discovery/api/server/client/http_test.go
@@ -49,13 +49,25 @@ func TestHTTPInvoker_Register(t *testing.T) {
 		assert.Equal(t, "application/json", handler.Request.Header.Get("Content-Type"))
 		assert.Equal(t, vpData, handler.RequestData)
 	})
-	t.Run("non-ok", func(t *testing.T) {
-		server := httptest.NewServer(&testHTTP.Handler{StatusCode: http.StatusInternalServerError})
+	t.Run("non-ok with problem details", func(t *testing.T) {
+		server := httptest.NewServer(&testHTTP.Handler{StatusCode: http.StatusBadRequest, ResponseData: `{"title":"missing credentials", "status":400, "detail":"could not resolve DID"}`})
 		client := New(false, time.Minute, server.TLS)
 
 		err := client.Register(context.Background(), server.URL, vp)
 
 		assert.ErrorContains(t, err, "non-OK response from remote Discovery Service")
+		assert.ErrorContains(t, err, "server returned HTTP 400")
+		assert.ErrorContains(t, err, "missing credentials: could not resolve DID")
+	})
+	t.Run("non-ok other", func(t *testing.T) {
+		server := httptest.NewServer(&testHTTP.Handler{StatusCode: http.StatusNotFound, ResponseData: `not found`})
+		client := New(false, time.Minute, server.TLS)
+
+		err := client.Register(context.Background(), server.URL, vp)
+
+		assert.ErrorContains(t, err, "non-OK response from remote Discovery Service")
+		assert.ErrorContains(t, err, "server returned HTTP 404")
+		assert.ErrorContains(t, err, "not found")
 	})
 }
 
@@ -113,13 +125,15 @@ func TestHTTPInvoker_Get(t *testing.T) {
 		assert.True(t, strings.HasPrefix(capturedRequest.Header.Get("X-Forwarded-Host"), "127.0.0.1"))
 	})
 	t.Run("server returns invalid status code", func(t *testing.T) {
-		handler := &testHTTP.Handler{StatusCode: http.StatusInternalServerError}
+		handler := &testHTTP.Handler{StatusCode: http.StatusInternalServerError, ResponseData: `{"title":"internal server error", "status":500, "detail":"db not found"}`}
 		server := httptest.NewServer(handler)
 		client := New(false, time.Minute, server.TLS)
 
 		_, _, err := client.Get(context.Background(), server.URL, 0)
 
 		assert.ErrorContains(t, err, "non-OK response from remote Discovery Service")
+		assert.ErrorContains(t, err, "server returned HTTP 500")
+		assert.ErrorContains(t, err, "internal server error: db not found")
 	})
 	t.Run("server does not return JSON", func(t *testing.T) {
 		handler := &testHTTP.Handler{StatusCode: http.StatusOK}


### PR DESCRIPTION
fixes #3471 

when the discovery server returns problem details, the client will try to parse. If successful, it'll pass on the error.