### PR TITLE
Check RW permissions in datadir

### DIFF
--- a/storage/engine.go
+++ b/storage/engine.go
@@ -378,7 +378,7 @@ func (p *provider) getStore(moduleName string, name string, adapter database) (s
 
 func confirmWriteAccess(datadir string) error {
 	// Make sure the data directory exists
-	err := os.MkdirAll(path.Dir(datadir+string(os.PathSeparator)), 0644)
+	err := os.MkdirAll(path.Dir(datadir+string(os.PathSeparator)), os.ModePerm)
 	if err != nil {
 		// log error: "unable to create datadir (dir=./data): mkdir ./data: read-only file system"
 		return err

--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -119,7 +119,8 @@ func Test_engine_sqlDatabase(t *testing.T) {
 		dataDir := io.TestDirectory(t)
 		require.NoError(t, os.Remove(dataDir))
 		e := New()
-		err := e.Configure(core.ServerConfig{Datadir: dataDir})
+		e.(*engine).datadir = dataDir
+		err := e.(*engine).initSQLDatabase()
 		assert.ErrorContains(t, err, "unable to open database file")
 	})
 	t.Run("sqlite is restricted to 1 connection", func(t *testing.T) {


### PR DESCRIPTION
closes #3470 

I'm not convinced this is actually an improvement. The 2 most likely errors are
```
level=fatal msg="Could not start the server" error="unable to create datadir (dir=./data): mkdir ./data: read-only file system"
```
and
```
level=fatal msg="Could not start the server" error="unable to configure Storage: open data/rw-access-test-file: read-only file system"
```
Both are pointing to read-only file system issue, but the real issue is an unprivileged user.
The unprivileged user is what also caused `"failed to initialize database, got error unable to open database file: out of memory (14)"` that resulted in this issue. This check does prevent the OOM error from ever occurring again though.

I don't see how to clarify the error without adding a very long error description since we can't differentiate between unprivileged users and an actual read-only file systems.