### PR TITLE
move discovery VP validation to background process to prevent errors

### DIFF
--- a/discovery/client.go
+++ b/discovery/client.go
@@ -167,7 +167,7 @@ func (r *defaultClientRegistrationManager) deactivate(ctx context.Context, servi
 	if !serviceExists {
 		return ErrServiceNotFound
 	}
-	// deletePresentationRecord DID/service combination from DB, so it won't be registered again
+	// delete DID/service combination from DB, so it won't be registered again
 	err := r.store.updatePresentationRefreshTime(serviceID, subjectID, nil, nil)
 	if err != nil {
 		return err

--- a/discovery/client.go
+++ b/discovery/client.go
@@ -385,7 +385,7 @@ func (r *defaultClientRegistrationManager) removeRevoked() error {
 			continue
 		}
 		_, err = r.vcr.Verifier().VerifyVP(*verifiablePresentation, true, true, nil)
-		if !errors.Is(err, types.ErrRevoked) {
+		if err != nil && !errors.Is(err, types.ErrRevoked) {
 			log.Logger().WithError(err).Warnf(errMsg, presentation.ID)
 			continue
 		}

--- a/discovery/client_test.go
+++ b/discovery/client_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
+	"github.com/nuts-foundation/nuts-node/vcr/types"
+	"github.com/nuts-foundation/nuts-node/vcr/verifier"
 	"github.com/nuts-foundation/nuts-node/vdr/didsubject"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 	"github.com/stretchr/testify/assert"
@@ -64,7 +66,7 @@ func newTestContext(t *testing.T) testContext {
 	wallet := holder.NewMockWallet(ctrl)
 	subjectManager := didsubject.NewMockManager(ctrl)
 	store := setupStore(t, storageEngine.GetSQLDatabase())
-	manager := newRegistrationManager(testDefinitions(), store, invoker, vcr, subjectManager, didResolver)
+	manager := newRegistrationManager(testDefinitions(), store, invoker, vcr, subjectManager, didResolver, alwaysOkVerifier)
 	vcr.EXPECT().Wallet().Return(wallet).AnyTimes()
 
 	return testContext{
@@ -181,7 +183,7 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 			return &vpAlice, nil
 		})
 		ctx.subjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)
-		ctx.manager = newRegistrationManager(emptyDefinition, ctx.store, ctx.invoker, ctx.vcr, ctx.subjectManager, ctx.didResolver)
+		ctx.manager = newRegistrationManager(emptyDefinition, ctx.store, ctx.invoker, ctx.vcr, ctx.subjectManager, ctx.didResolver, alwaysOkVerifier)
 
 		err := ctx.manager.activate(audit.TestContext(), testServiceID, aliceSubject, nil)
 
@@ -380,6 +382,102 @@ func Test_defaultClientRegistrationManager_refresh(t *testing.T) {
 	})
 }
 
+func Test_defaultClientRegistrationManager_validate(t *testing.T) {
+	storageEngine := storage.NewTestStorageEngine(t)
+	require.NoError(t, storageEngine.Start())
+
+	tests := []struct {
+		name         string
+		setupManager func(ctx testContext) *defaultClientRegistrationManager
+		expectedLen  int
+	}{
+		{
+			name: "ok",
+			setupManager: func(ctx testContext) *defaultClientRegistrationManager {
+				return ctx.manager
+			},
+			expectedLen: 1,
+		},
+		{
+			name: "verification failed",
+			setupManager: func(ctx testContext) *defaultClientRegistrationManager {
+				return newRegistrationManager(testDefinitions(), ctx.store, ctx.invoker, ctx.vcr, ctx.subjectManager, ctx.didResolver, func(service ServiceDefinition, vp vc.VerifiablePresentation) error {
+					return errors.New("verification failed")
+				})
+			},
+			expectedLen: 0,
+		},
+		{
+			name: "registration for unknown service",
+			setupManager: func(ctx testContext) *defaultClientRegistrationManager {
+				return newRegistrationManager(map[string]ServiceDefinition{}, ctx.store, ctx.invoker, ctx.vcr, ctx.subjectManager, ctx.didResolver, alwaysOkVerifier)
+			},
+			expectedLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newTestContext(t)
+			require.NoError(t, ctx.store.add(testServiceID, vpAlice, testSeed, 0))
+			manager := tt.setupManager(ctx)
+
+			err := manager.validate()
+			require.NoError(t, err)
+
+			presentations, err := ctx.store.allPresentations(true)
+			require.NoError(t, err)
+			assert.Len(t, presentations, tt.expectedLen)
+		})
+	}
+}
+
+func Test_defaultClientRegistrationManager_removeRevoked(t *testing.T) {
+	storageEngine := storage.NewTestStorageEngine(t)
+	require.NoError(t, storageEngine.Start())
+
+	tests := []struct {
+		name          string
+		verifyVPError error
+		expectedLen   int
+	}{
+		{
+			name:          "ok - not revoked",
+			verifyVPError: nil,
+			expectedLen:   1,
+		},
+		{
+			name:          "ok - revoked",
+			verifyVPError: types.ErrRevoked,
+			expectedLen:   0,
+		},
+		{
+			name:          "error",
+			verifyVPError: assert.AnError,
+			expectedLen:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newTestContext(t)
+			require.NoError(t, ctx.store.add(testServiceID, vpAlice, testSeed, 0))
+			require.NoError(t, ctx.manager.validate())
+
+			mockVerifier := verifier.NewMockVerifier(ctx.ctrl)
+			ctx.vcr.EXPECT().Verifier().Return(mockVerifier).AnyTimes()
+			mockVerifier.EXPECT().VerifyVP(gomock.Any(), true, true, nil).Return(nil, tt.verifyVPError)
+
+			err := ctx.manager.removeRevoked()
+			require.NoError(t, err)
+
+			presentations, err := ctx.store.allPresentations(true)
+			require.NoError(t, err)
+			assert.Len(t, presentations, tt.expectedLen)
+		})
+	}
+}
+
 func Test_clientUpdater_updateService(t *testing.T) {
 	storageEngine := storage.NewTestStorageEngine(t)
 	require.NoError(t, storageEngine.Start())
@@ -408,11 +506,21 @@ func Test_clientUpdater_updateService(t *testing.T) {
 
 		httpClient.EXPECT().Get(ctx, serviceDefinition.Endpoint, 0).Return(map[string]vc.VerifiablePresentation{"1": vpAlice}, testSeed, 1, nil)
 
-		err := updater.updateService(ctx, testDefinitions()[testServiceID])
+		require.NoError(t, updater.updateService(ctx, testDefinitions()[testServiceID]))
 
-		require.NoError(t, err)
+		t.Run("ignores duplicates", func(t *testing.T) {
+			httpClient.EXPECT().Get(ctx, serviceDefinition.Endpoint, 1).Return(map[string]vc.VerifiablePresentation{"1": vpAlice}, testSeed, 1, nil)
+
+			require.NoError(t, updater.updateService(ctx, testDefinitions()[testServiceID]))
+
+			// check count
+			presentation, err := updater.store.allPresentations(false)
+
+			require.NoError(t, err)
+			assert.Len(t, presentation, 1)
+		})
 	})
-	t.Run("ignores invalid presentations", func(t *testing.T) {
+	t.Run("allows invalid presentations", func(t *testing.T) {
 		resetStore(t, storageEngine.GetSQLDatabase())
 		ctrl := gomock.NewController(t)
 		httpClient := client.NewMockHTTPClient(ctrl)
@@ -434,7 +542,7 @@ func Test_clientUpdater_updateService(t *testing.T) {
 		require.True(t, exists)
 		exists, err = store.exists(testServiceID, aliceDID.String(), vpAlice.ID.String())
 		require.NoError(t, err)
-		require.False(t, exists)
+		require.True(t, exists)
 	})
 	t.Run("pass timestamp", func(t *testing.T) {
 		resetStore(t, storageEngine.GetSQLDatabase())

--- a/discovery/module.go
+++ b/discovery/module.go
@@ -215,8 +215,16 @@ func (m *Module) Register(context context.Context, serviceID string, presentatio
 	if exists {
 		return errors.Join(ErrInvalidPresentation, ErrPresentationAlreadyExists)
 	}
-	_, err = m.store.add(serviceID, presentation, "", 0)
-	return err
+	record, err := m.store.add(serviceID, presentation, "", 0)
+	if err != nil {
+		return err
+	}
+	// also update validated flag since validation is already done
+	if err = m.store.updateValidated([]presentationRecord{*record}); err != nil {
+		log.Logger().WithError(err).Errorf("failed to update validated flag for presentation (id: %s)", record.ID)
+	}
+
+	return nil
 }
 
 func (m *Module) verifyRegistration(definition ServiceDefinition, presentation vc.VerifiablePresentation) error {

--- a/discovery/module.go
+++ b/discovery/module.go
@@ -215,7 +215,8 @@ func (m *Module) Register(context context.Context, serviceID string, presentatio
 	if exists {
 		return errors.Join(ErrInvalidPresentation, ErrPresentationAlreadyExists)
 	}
-	return m.store.add(serviceID, presentation, "", 0)
+	_, err = m.store.add(serviceID, presentation, "", 0)
+	return err
 }
 
 func (m *Module) verifyRegistration(definition ServiceDefinition, presentation vc.VerifiablePresentation) error {

--- a/discovery/module.go
+++ b/discovery/module.go
@@ -152,7 +152,7 @@ func (m *Module) Start() error {
 		return err
 	}
 	m.clientUpdater = newClientUpdater(m.allDefinitions, m.store, m.verifyRegistration, m.httpClient)
-	m.registrationManager = newRegistrationManager(m.allDefinitions, m.store, m.httpClient, m.vcrInstance, m.subjectManager, m.didResolver)
+	m.registrationManager = newRegistrationManager(m.allDefinitions, m.store, m.httpClient, m.vcrInstance, m.subjectManager, m.didResolver, m.verifyRegistration)
 	if m.config.Client.RefreshInterval > 0 {
 		m.routines.Add(1)
 		go func() {
@@ -203,6 +203,18 @@ func (m *Module) Register(context context.Context, serviceID string, presentatio
 		return err
 	}
 
+	// Check if the presentation already exists
+	credentialSubjectID, err := credential.PresentationSigner(presentation)
+	if err != nil {
+		return err
+	}
+	exists, err := m.store.exists(definition.ID, credentialSubjectID.String(), presentation.ID.String())
+	if err != nil {
+		return err
+	}
+	if exists {
+		return errors.Join(ErrInvalidPresentation, ErrPresentationAlreadyExists)
+	}
 	return m.store.add(serviceID, presentation, "", 0)
 }
 
@@ -235,15 +247,7 @@ func (m *Module) verifyRegistration(definition ServiceDefinition, presentation v
 		return errors.Join(ErrInvalidPresentation, ErrDIDMethodsNotSupported)
 	}
 
-	// Check if the presentation already exists
-	exists, err := m.store.exists(definition.ID, credentialSubjectID.String(), presentation.ID.String())
-	if err != nil {
-		return err
-	}
-	if exists {
-		return errors.Join(ErrInvalidPresentation, ErrPresentationAlreadyExists)
-	}
-	// Depending on the presentation type, we need to validate different properties before storing it.
+	// Depending on the presentation type, we need to updateValidated different properties before storing it.
 	if presentation.IsType(retractionPresentationType) {
 		err = m.validateRetraction(definition.ID, presentation)
 	} else {
@@ -484,7 +488,7 @@ func (m *Module) Search(serviceID string, query map[string]string) ([]SearchResu
 	if !exists {
 		return nil, ErrServiceNotFound
 	}
-	matchingVPs, err := m.store.search(serviceID, query)
+	matchingVPs, err := m.store.search(serviceID, query, false)
 	if err != nil {
 		return nil, err
 	}
@@ -556,6 +560,16 @@ func (m *Module) update() {
 		err = m.clientUpdater.update(m.ctx)
 		if err != nil {
 			log.Logger().WithError(err).Errorf("Failed to load latest Verifiable Presentations from Discovery Service")
+		}
+		// updateValidated all presentations not yet validated
+		err = m.registrationManager.validate()
+		if err != nil {
+			log.Logger().WithError(err).Errorf("Failed to validate presentations")
+		}
+		// purge list
+		err = m.registrationManager.removeRevoked()
+		if err != nil {
+			log.Logger().WithError(err).Errorf("Failed to remove revoked presentations")
 		}
 	}
 	do()

--- a/discovery/module_test.go
+++ b/discovery/module_test.go
@@ -267,7 +267,8 @@ func Test_Module_Get(t *testing.T) {
 		m, _ := setupModule(t, storageEngine, func(module *Module) {
 			module.config.Client.RefreshInterval = 0
 		})
-		require.NoError(t, m.store.add(testServiceID, vpAlice, testSeed, 0))
+		_, err := m.store.add(testServiceID, vpAlice, testSeed, 1)
+		require.NoError(t, err)
 		presentations, seed, timestamp, err := m.Get(ctx, testServiceID, 0)
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]vc.VerifiablePresentation{"1": vpAlice}, presentations)
@@ -449,7 +450,8 @@ func TestModule_Search(t *testing.T) {
 			module.config.Client.RefreshInterval = 0
 		})
 		ctx.verifier.EXPECT().VerifyVP(gomock.Any(), true, true, nil)
-		require.NoError(t, m.store.add(testServiceID, vpAlice, testSeed, 0))
+		_, err := m.store.add(testServiceID, vpAlice, testSeed, 1)
+		require.NoError(t, err)
 		require.NoError(t, m.registrationManager.validate())
 
 		results, err := m.Search(testServiceID, map[string]string{
@@ -518,7 +520,8 @@ func TestModule_update(t *testing.T) {
 			m.httpClient = httpClient
 			m.store, _ = newSQLStore(m.storageInstance.GetSQLDatabase(), m.allDefinitions)
 			mockVerifier.EXPECT().VerifyVP(gomock.Any(), true, true, nil).MinTimes(tt.expectedVerifyVPCalls)
-			require.NoError(t, m.store.add(testServiceID, vpAlice, testSeed, 0))
+			_, err := m.store.add(testServiceID, vpAlice, testSeed, 1)
+			require.NoError(t, err)
 
 			require.NoError(t, m.Start())
 			time.Sleep(10 * time.Millisecond)
@@ -667,7 +670,8 @@ func TestModule_GetServiceActivation(t *testing.T) {
 		testContext.subjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil).AnyTimes()
 		next := time.Now()
 		_ = m.store.updatePresentationRefreshTime(testServiceID, aliceSubject, nil, &next)
-		_ = m.store.add(testServiceID, vpAlice, testSeed, 0)
+		_, err := m.store.add(testServiceID, vpAlice, testSeed, 1)
+		require.NoError(t, err)
 
 		activated, presentation, err := m.GetServiceActivation(context.Background(), testServiceID, aliceSubject)
 

--- a/discovery/store.go
+++ b/discovery/store.go
@@ -479,7 +479,7 @@ func (s *sqlStore) setPresentationRefreshError(serviceID string, subjectID strin
 		}
 
 		if refreshErr == nil {
-			// a deletePresentationRecord
+			// a delete
 			return nil
 		}
 

--- a/discovery/store.go
+++ b/discovery/store.go
@@ -19,6 +19,7 @@
 package discovery
 
 import (
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -48,6 +49,8 @@ func (s serviceRecord) TableName() string {
 
 var _ schema.Tabler = (*presentationRecord)(nil)
 
+type SQLBool bool
+
 type presentationRecord struct {
 	ID                     string `gorm:"primaryKey"`
 	ServiceID              string
@@ -56,11 +59,36 @@ type presentationRecord struct {
 	PresentationID         string
 	PresentationRaw        string
 	PresentationExpiration int64
+	Validated              SQLBool
 	Credentials            []credentialRecord `gorm:"foreignKey:PresentationID;references:ID"`
 }
 
 func (s presentationRecord) TableName() string {
 	return "discovery_presentation"
+}
+
+func (b *SQLBool) Scan(value interface{}) error {
+	*b = false
+	if value != nil {
+		switch v := value.(type) {
+		case int64:
+			if v != 0 {
+				*b = true
+			}
+		}
+	}
+	return nil
+}
+
+func (b SQLBool) Value() (driver.Value, error) {
+	if b {
+		return int64(1), nil
+	}
+	return int64(0), nil
+}
+
+func (b SQLBool) Bool() bool {
+	return bool(b)
 }
 
 // credentialRecord is a Verifiable Credential, part of a presentation (entry) on a use case list.
@@ -232,11 +260,14 @@ func (s *sqlStore) get(serviceID string, startAfter int) (map[string]vc.Verifiab
 // The query is a map of JSON paths and expected string values, matched against the presentation's credentials.
 // Wildcard matching is supported by prefixing or suffixing the value with an asterisk (*).
 // It returns the presentations which contain credentials that match the given query.
-func (s *sqlStore) search(serviceID string, query map[string]string) ([]vc.VerifiablePresentation, error) {
+func (s *sqlStore) search(serviceID string, query map[string]string, allowUnvalidated bool) ([]vc.VerifiablePresentation, error) {
 	// first only select columns also used in group by clause
 	// if the query is empty, there's no need to do a join
 	stmt := s.db.Model(&presentationRecord{}).
 		Where("service_id = ?", serviceID)
+	if !allowUnvalidated {
+		stmt = stmt.Where("validated != 0")
+	}
 	if len(query) > 0 {
 		stmt = stmt.Joins("inner join discovery_credential ON discovery_credential.presentation_id = discovery_presentation.id")
 		stmt = store.CredentialStore{}.BuildSearchStatement(stmt, "discovery_credential.credential_id", query)
@@ -344,6 +375,41 @@ func (s *sqlStore) removeExpired() (int, error) {
 	return int(result.RowsAffected), nil
 }
 
+// allPresentations returns all presentations, the validated param can be used to select validated or unvalidated presentations
+func (s *sqlStore) allPresentations(validated bool) ([]presentationRecord, error) {
+	result := make([]presentationRecord, 0)
+	stmt := s.db
+	if validated {
+		stmt = stmt.Where("validated != 0")
+	} else {
+		stmt = stmt.Where("validated = 0")
+	}
+	err := stmt.Find(&result).Error
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// updateValidated sets the validated flag for the given presentations
+func (s *sqlStore) updateValidated(records []presentationRecord) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		for _, record := range records {
+			if err := tx.Model(&presentationRecord{}).Where("id = ?", record.ID).Update("validated", true).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// deletePresentationRecord removes a presentationRecord from the store based on its ID
+func (s *sqlStore) deletePresentationRecord(id string) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		return tx.Delete(&presentationRecord{}, "id = ?", id).Error
+	})
+}
+
 // updatePresentationRefreshTime creates/updates the next refresh time for a Verifiable Presentation on a Discovery Service.
 // If nextRegistration is nil, the entry will be removed from the database.
 func (s *sqlStore) updatePresentationRefreshTime(serviceID string, subjectID string, parameters map[string]interface{}, nextRefresh *time.Time) error {
@@ -410,7 +476,7 @@ func (s *sqlStore) setPresentationRefreshError(serviceID string, subjectID strin
 		}
 
 		if refreshErr == nil {
-			// a delete
+			// a deletePresentationRecord
 			return nil
 		}
 
@@ -466,7 +532,7 @@ func (s *sqlStore) getSubjectVPsOnService(serviceID string, subjectDIDs []did.DI
 	for _, subjectDID := range subjectDIDs {
 		loopVPs, err := s.search(serviceID, map[string]string{
 			"credentialSubject.id": subjectDID.String(),
-		})
+		}, true)
 		if err != nil {
 			return nil, err
 		}

--- a/discovery/store_test.go
+++ b/discovery/store_test.go
@@ -45,21 +45,24 @@ func Test_sqlStore_exists(t *testing.T) {
 	})
 	t.Run("non-empty list, no match (other subject and ID)", func(t *testing.T) {
 		m := setupStore(t, storageEngine.GetSQLDatabase())
-		require.NoError(t, m.add(testServiceID, vpBob, testSeed, 0))
+		_, err := m.add(testServiceID, vpBob, testSeed, 0)
+		require.NoError(t, err)
 		exists, err := m.exists(testServiceID, aliceDID.String(), vpAlice.ID.String())
 		assert.NoError(t, err)
 		assert.False(t, exists)
 	})
 	t.Run("non-empty list, no match (other list)", func(t *testing.T) {
 		m := setupStore(t, storageEngine.GetSQLDatabase())
-		require.NoError(t, m.add(testServiceID, vpAlice, testSeed, 0))
+		_, err := m.add(testServiceID, vpAlice, testSeed, 0)
+		require.NoError(t, err)
 		exists, err := m.exists("other", aliceDID.String(), vpAlice.ID.String())
 		assert.NoError(t, err)
 		assert.False(t, exists)
 	})
 	t.Run("non-empty list, match", func(t *testing.T) {
 		m := setupStore(t, storageEngine.GetSQLDatabase())
-		require.NoError(t, m.add(testServiceID, vpAlice, testSeed, 0))
+		_, err := m.add(testServiceID, vpAlice, testSeed, 0)
+		require.NoError(t, err)
 		exists, err := m.exists(testServiceID, aliceDID.String(), vpAlice.ID.String())
 		assert.NoError(t, err)
 		assert.True(t, exists)
@@ -72,14 +75,15 @@ func Test_sqlStore_add(t *testing.T) {
 
 	t.Run("no credentials in presentation", func(t *testing.T) {
 		m := setupStore(t, storageEngine.GetSQLDatabase())
-		err := m.add(testServiceID, createPresentation(aliceDID), testSeed, 0)
+		_, err := m.add(testServiceID, createPresentation(aliceDID), testSeed, 0)
 		assert.NoError(t, err)
 	})
 
 	t.Run("seed", func(t *testing.T) {
 		t.Run("passing seed updates last_seed", func(t *testing.T) {
 			m := setupStore(t, storageEngine.GetSQLDatabase())
-			require.NoError(t, m.add(testServiceID, createPresentation(aliceDID), testSeed, 0))
+			_, err := m.add(testServiceID, createPresentation(aliceDID), testSeed, 0)
+			require.NoError(t, err)
 
 			_, seed, _, err := m.get(testServiceID, 0)
 
@@ -88,7 +92,8 @@ func Test_sqlStore_add(t *testing.T) {
 		})
 		t.Run("generated seed", func(t *testing.T) {
 			m := setupStore(t, storageEngine.GetSQLDatabase())
-			require.NoError(t, m.add(testServiceID, createPresentation(aliceDID), "", 0))
+			_, err := m.add(testServiceID, createPresentation(aliceDID), "", 0)
+			require.NoError(t, err)
 
 			_, seed, _, err := m.get(testServiceID, 0)
 
@@ -99,7 +104,7 @@ func Test_sqlStore_add(t *testing.T) {
 
 	t.Run("passing timestamp updates last_timestamp", func(t *testing.T) {
 		m := setupStore(t, storageEngine.GetSQLDatabase())
-		err := m.add(testServiceID, createPresentation(aliceDID), testSeed, 1)
+		_, err := m.add(testServiceID, createPresentation(aliceDID), testSeed, 1)
 		require.NoError(t, err)
 
 		timestamp, err := m.getTimestamp(testServiceID)
@@ -112,8 +117,10 @@ func Test_sqlStore_add(t *testing.T) {
 		m := setupStore(t, storageEngine.GetSQLDatabase())
 
 		secondVP := createPresentation(aliceDID, vcAlice)
-		require.NoError(t, m.add(testServiceID, vpAlice, testSeed, 0))
-		require.NoError(t, m.add(testServiceID, secondVP, testSeed, 0))
+		_, err := m.add(testServiceID, vpAlice, testSeed, 0)
+		require.NoError(t, err)
+		_, err = m.add(testServiceID, secondVP, testSeed, 0)
+		require.NoError(t, err)
 
 		// First VP should not exist
 		exists, err := m.exists(testServiceID, aliceDID.String(), vpAlice.ID.String())
@@ -141,7 +148,8 @@ func Test_sqlStore_get(t *testing.T) {
 	})
 	t.Run("1 entry, 0 timestamp", func(t *testing.T) {
 		m := setupStore(t, storageEngine.GetSQLDatabase())
-		require.NoError(t, m.add(testServiceID, vpAlice, testSeed, 0))
+		_, err := m.add(testServiceID, vpAlice, testSeed, 0)
+		require.NoError(t, err)
 		presentations, seed, timestamp, err := m.get(testServiceID, 0)
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]vc.VerifiablePresentation{"1": vpAlice}, presentations)
@@ -150,8 +158,10 @@ func Test_sqlStore_get(t *testing.T) {
 	})
 	t.Run("2 entries, 0 timestamp", func(t *testing.T) {
 		m := setupStore(t, storageEngine.GetSQLDatabase())
-		require.NoError(t, m.add(testServiceID, vpAlice, testSeed, 0))
-		require.NoError(t, m.add(testServiceID, vpBob, testSeed, 0))
+		_, err := m.add(testServiceID, vpAlice, testSeed, 0)
+		require.NoError(t, err)
+		_, err = m.add(testServiceID, vpBob, testSeed, 0)
+		require.NoError(t, err)
 		presentations, _, timestamp, err := m.get(testServiceID, 0)
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]vc.VerifiablePresentation{"1": vpAlice, "2": vpBob}, presentations)
@@ -159,8 +169,10 @@ func Test_sqlStore_get(t *testing.T) {
 	})
 	t.Run("2 entries, start after first", func(t *testing.T) {
 		m := setupStore(t, storageEngine.GetSQLDatabase())
-		require.NoError(t, m.add(testServiceID, vpAlice, testSeed, 0))
-		require.NoError(t, m.add(testServiceID, vpBob, testSeed, 0))
+		_, err := m.add(testServiceID, vpAlice, testSeed, 0)
+		require.NoError(t, err)
+		_, err = m.add(testServiceID, vpBob, testSeed, 0)
+		require.NoError(t, err)
 		presentations, _, timestamp, err := m.get(testServiceID, 1)
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]vc.VerifiablePresentation{"2": vpBob}, presentations)
@@ -168,8 +180,9 @@ func Test_sqlStore_get(t *testing.T) {
 	})
 	t.Run("2 entries, start at end", func(t *testing.T) {
 		m := setupStore(t, storageEngine.GetSQLDatabase())
-		require.NoError(t, m.add(testServiceID, vpAlice, testSeed, 0))
-		require.NoError(t, m.add(testServiceID, vpBob, testSeed, 0))
+		_, err := m.add(testServiceID, vpAlice, testSeed, 0)
+		require.NoError(t, err)
+		_, err = m.add(testServiceID, vpBob, testSeed, 0)
 		presentations, _, timestamp, err := m.get(testServiceID, 2)
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]vc.VerifiablePresentation{}, presentations)
@@ -182,7 +195,7 @@ func Test_sqlStore_get(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				err := c.add(testServiceID, createPresentation(aliceDID, vcAlice), testSeed, 0)
+				_, err := c.add(testServiceID, createPresentation(aliceDID, vcAlice), testSeed, 0)
 				require.NoError(t, err)
 			}()
 		}
@@ -208,7 +221,7 @@ func Test_sqlStore_search(t *testing.T) {
 		vps := []vc.VerifiablePresentation{vpAlice}
 		c := setupStore(t, storageEngine.GetSQLDatabase())
 		for _, vp := range vps {
-			err := c.add(testServiceID, vp, testSeed, 0)
+			_, err := c.add(testServiceID, vp, testSeed, 0)
 			require.NoError(t, err)
 		}
 
@@ -223,7 +236,7 @@ func Test_sqlStore_search(t *testing.T) {
 		vps := []vc.VerifiablePresentation{vpAlice, vpBob}
 		c := setupStore(t, storageEngine.GetSQLDatabase())
 		for _, vp := range vps {
-			err := c.add(testServiceID, vp, testSeed, 0)
+			_, err := c.add(testServiceID, vp, testSeed, 0)
 			require.NoError(t, err)
 		}
 
@@ -241,7 +254,7 @@ func Test_sqlStore_search(t *testing.T) {
 		vps := []vc.VerifiablePresentation{vpAlice, vpBob}
 		c := setupStore(t, storageEngine.GetSQLDatabase())
 		for _, vp := range vps {
-			err := c.add(testServiceID, vp, testSeed, 0)
+			_, err := c.add(testServiceID, vp, testSeed, 0)
 			require.NoError(t, err)
 		}
 		actualVPs, err := c.search(testServiceID, map[string]string{
@@ -379,8 +392,10 @@ func Test_sqlStore_getSubjectVPsOnService(t *testing.T) {
 		_ = storageEngine.Shutdown()
 	})
 	c := setupStore(t, storageEngine.GetSQLDatabase())
-	require.NoError(t, c.add(testServiceID, vpAlice2, testSeed, 0))
-	require.NoError(t, c.add(testServiceID, vpBob2, testSeed, 0))
+	_, err := c.add(testServiceID, vpAlice2, testSeed, 0)
+	require.NoError(t, err)
+	_, err = c.add(testServiceID, vpBob2, testSeed, 0)
+	require.NoError(t, err)
 
 	t.Run("ok - single", func(t *testing.T) {
 		vps, err := c.getSubjectVPsOnService(testServiceID, []did.DID{aliceDID})
@@ -409,10 +424,12 @@ func Test_sqlStore_wipeOnSeedChange(t *testing.T) {
 	})
 	t.Run("1 entry wiped, 1 remains", func(t *testing.T) {
 		c := setupStore(t, storageEngine.GetSQLDatabase())
-		require.NoError(t, c.add(testServiceID, vpAlice, testSeed, 0))
-		require.NoError(t, c.add("other", vpAlice, testSeed, 0))
+		_, err := c.add(testServiceID, vpAlice, testSeed, 0)
+		require.NoError(t, err)
+		_, err = c.add("other", vpAlice, testSeed, 0)
+		require.NoError(t, err)
 
-		err := c.wipeOnSeedChange(testServiceID, "other")
+		err = c.wipeOnSeedChange(testServiceID, "other")
 		require.NoError(t, err)
 
 		vps, err := c.search(testServiceID, map[string]string{}, true)
@@ -432,7 +449,8 @@ func Test_sqlStore_updateValidated(t *testing.T) {
 	})
 
 	c := setupStore(t, storageEngine.GetSQLDatabase())
-	require.NoError(t, c.add(testServiceID, vpAlice, testSeed, 0))
+	_, err := c.add(testServiceID, vpAlice, testSeed, 0)
+	require.NoError(t, err)
 
 	result, err := c.allPresentations(true)
 	require.NoError(t, err)
@@ -462,11 +480,12 @@ func Test_sqlStore_delete(t *testing.T) {
 	})
 
 	c := setupStore(t, storageEngine.GetSQLDatabase())
-	require.NoError(t, c.add(testServiceID, vpAlice, testSeed, 0))
+	_, err := c.add(testServiceID, vpAlice, testSeed, 0)
+	require.NoError(t, err)
 	presentations, _ := c.allPresentations(false)
 	require.Len(t, presentations, 1)
 
-	err := c.deletePresentationRecord(presentations[0].ID)
+	err = c.deletePresentationRecord(presentations[0].ID)
 
 	require.NoError(t, err)
 

--- a/storage/sql_migrations/010_discoverypresentation_validation.sql
+++ b/storage/sql_migrations/010_discoverypresentation_validation.sql
@@ -1,0 +1,6 @@
+-- +goose Up
+-- discovery_presentation: add validated column
+alter table discovery_presentation add validated SMALLINT NOT NULL DEFAULT 0;
+
+-- +goose Down
+alter table discovery_presentation drop column validated;


### PR DESCRIPTION
fixes #3468 

any did:web or revocation downtime will not block discovery entries. Entries are invalid until VerifyVP succeeds at least once. After that a revocation checker will remove entries when a VC is revoked.

Only downside is a full table scan on presentation records every 10 minutes. If this becomes a problem (eg > 100k results) then `Search` has to verify the VPs and delete entries as a side effect.... (or some elaborate eventing thing from revocationList to discovery service.)