### PR TITLE
require DiscoveryRegistrationCredential in PEX

### DIFF
--- a/discovery/client.go
+++ b/discovery/client.go
@@ -256,18 +256,6 @@ func (r *defaultClientRegistrationManager) findCredentialsAndBuildPresentation(c
 		return nil, fmt.Errorf(errStr, service.ID, subjectDID, err)
 	}
 
-	// add registration params as credential if not already done so by the Presentation Definition
-	var found bool
-	for _, cred := range matchingCredentials {
-		if cred.ID == registrationCredential.ID {
-			found = true
-			break
-		}
-	}
-	if !found {
-		matchingCredentials = append(matchingCredentials, credential.AutoCorrectSelfAttestedCredential(registrationCredential, subjectDID))
-	}
-
 	return r.buildPresentation(ctx, subjectDID, service, matchingCredentials, nil)
 }
 

--- a/discovery/client_test.go
+++ b/discovery/client_test.go
@@ -176,8 +176,7 @@ func Test_defaultClientRegistrationManager_activate(t *testing.T) {
 		ctx.didResolver.EXPECT().Resolve(aliceDID, gomock.Any()).Return(nil, nil, nil)
 		ctx.wallet.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil)
 		ctx.wallet.EXPECT().BuildPresentation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), false).DoAndReturn(func(_ interface{}, credentials []vc.VerifiableCredential, _ interface{}, _ interface{}, _ interface{}) (*vc.VerifiablePresentation, error) {
-			// expect registration credential
-			assert.Len(t, credentials, 1)
+			assert.Len(t, credentials, 0)
 			return &vpAlice, nil
 		})
 		ctx.subjectManager.EXPECT().ListDIDs(gomock.Any(), aliceSubject).Return([]did.DID{aliceDID}, nil)

--- a/discovery/module.go
+++ b/discovery/module.go
@@ -276,26 +276,6 @@ func (m *Module) validateRegistration(definition ServiceDefinition, presentation
 		return fmt.Errorf("verifiable presentation doesn't match required presentation definition: %w", err)
 	}
 	if len(creds) != len(presentation.VerifiableCredential) {
-		// it could be the case that the VP contains a registration credential and the matching credentials do not.
-		// only return errPresentationDoesNotFulfillDefinition if both contain the registration credential or neither do.
-		vpContainsRegistrationCredential := false
-		for _, cred := range presentation.VerifiableCredential {
-			if slices.Contains(cred.Type, credential.DiscoveryRegistrationCredentialTypeV1URI()) {
-				vpContainsRegistrationCredential = true
-				break
-			}
-		}
-		matchingContainsRegistrationCredential := false
-		for _, cred := range creds {
-			if slices.Contains(cred.Type, credential.DiscoveryRegistrationCredentialTypeV1URI()) {
-				matchingContainsRegistrationCredential = true
-				break
-			}
-		}
-		if vpContainsRegistrationCredential && !matchingContainsRegistrationCredential && len(presentation.VerifiableCredential)-len(creds) == 1 {
-			return nil
-		}
-
 		return errPresentationDoesNotFulfillDefinition
 	}
 	return nil

--- a/discovery/module_test.go
+++ b/discovery/module_test.go
@@ -453,6 +453,7 @@ func TestModule_Search(t *testing.T) {
 			{
 				Presentation: vpAlice,
 				Fields: map[string]interface{}{
+					"auth_server_url":"https://example.com/oauth2/alice",
 					"issuer_field": authorityDID,
 				},
 				Parameters: defaultRegistrationParams(aliceSubject),

--- a/discovery/test.go
+++ b/discovery/test.go
@@ -102,6 +102,16 @@ func testDefinitions() map[string]ServiceDefinition {
 								},
 							},
 						},
+					}, {
+						Id: "2",
+						Constraints: &pe.Constraints{
+							Fields: []pe.Field{
+								{
+									Id:   to.Ptr("auth_server_url"),
+									Path: []string{"$.credentialSubject.authServerURL"},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/docs/pages/deployment/discovery.rst
+++ b/docs/pages/deployment/discovery.rst
@@ -60,6 +60,7 @@ Optionally, a POST body can be provided with registration parameters, e.g.:
 
 This can be used to provide additional information. All registration parameters are returned by the search API.
 The ``authServerURL`` is added automatically by the Nuts node. It's constructed as ``https://<config.url>/oauth2/<subject_id>``.
+Registration parameters can only be used if the specific parameters and/or ``DiscoveryRegistrationCredential`` are required by the Presentation Definition.
 
 Once registered, future refreshes will be done automatically by the Nuts node. These refreshes could fail because of various reasons.
 You can check the status of the refreshes by querying the service, e.g.:
@@ -153,6 +154,18 @@ Service definitions
                   "filter": {
                     "type": "string"
                   }
+                }
+              ]
+            }
+          }, {
+            "id": "DiscoveryRegistrationCredential",
+            "constraints": {
+              "fields": [
+                {
+                  "id":   "auth_server_url",
+                  "path": [
+                    "$.credentialSubject.authServerURL"
+                  ]
                 }
               ]
             }

--- a/e2e-tests/discovery/definitions/definition.json
+++ b/e2e-tests/discovery/definitions/definition.json
@@ -46,6 +46,18 @@
             }
           ]
         }
+      },{
+        "id": "DiscoveryRegistrationCredential",
+        "constraints": {
+          "fields": [
+            {
+              "id":   "auth_server_url",
+              "path": [
+                "$.credentialSubject.authServerURL"
+              ]
+            }
+          ]
+        }
       }
     ]
   }


### PR DESCRIPTION
closes #3298 

`DiscoveryRegistrationCredential` is now required in PEX to do anything useful. Other remarks are pushed to RFC branch