### PR TITLE
add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @woutslakhorst @reinkrul @gerardsn @stevenvegt


### PR DESCRIPTION
to restrict acking PRs