### PR TITLE
Nuts chart seems outdated: update chart version to 0.0.4

### DIFF
--- a/charts/nuts-node/Chart.yaml
+++ b/charts/nuts-node/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
The latest changes are not available when pulling the `https://nuts-foundation.github.io/nuts-node/` repo. The version listed seems from a commit way before (16-6-'23) the latest changes:

```bash
$ helm search repo nuts-repo
NAME                     	CHART VERSION	APP VERSION	DESCRIPTION                          
nuts-repo/nuts-node-chart	0.0.3        	0.0.1      	A NUTS node Helm chart for Kubernetes
```

This PR bumps the version.