### PR TITLE
Cache access tokens client side

### DIFF
--- a/storage/engine.go
+++ b/storage/engine.go
@@ -147,7 +147,7 @@ func (e *engine) Shutdown() error {
 	}
 
 	// Close session database
-	e.sessionDatabase.close()
+	e.sessionDatabase.Close()
 	// Close SQL db
 	if e.sqlDB != nil {
 		underlyingDB, err := e.sqlDB.DB()

--- a/storage/mock.go
+++ b/storage/mock.go
@@ -255,6 +255,18 @@ func (m *MockSessionDatabase) EXPECT() *MockSessionDatabaseMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockSessionDatabase) Close() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Close")
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockSessionDatabaseMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockSessionDatabase)(nil).Close))
+}
+
 // GetStore mocks base method.
 func (m *MockSessionDatabase) GetStore(ttl time.Duration, keys ...string) SessionStore {
 	m.ctrl.T.Helper()
@@ -272,18 +284,6 @@ func (mr *MockSessionDatabaseMockRecorder) GetStore(ttl any, keys ...any) *gomoc
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ttl}, keys...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStore", reflect.TypeOf((*MockSessionDatabase)(nil).GetStore), varargs...)
-}
-
-// close mocks base method.
-func (m *MockSessionDatabase) close() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "close")
-}
-
-// close indicates an expected call of close.
-func (mr *MockSessionDatabaseMockRecorder) close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "close", reflect.TypeOf((*MockSessionDatabase)(nil).close))
 }
 
 // MockSessionStore is a mock of SessionStore interface.
@@ -367,15 +367,20 @@ func (mr *MockSessionStoreMockRecorder) GetAndDelete(key, target any) *gomock.Ca
 }
 
 // Put mocks base method.
-func (m *MockSessionStore) Put(key string, value any) error {
+func (m *MockSessionStore) Put(key string, value any, options ...SessionOption) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Put", key, value)
+	varargs := []any{key, value}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Put", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockSessionStoreMockRecorder) Put(key, value any) *gomock.Call {
+func (mr *MockSessionStoreMockRecorder) Put(key, value any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockSessionStore)(nil).Put), key, value)
+	varargs := append([]any{key, value}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockSessionStore)(nil).Put), varargs...)
 }

--- a/storage/session.go
+++ b/storage/session.go
@@ -91,9 +91,9 @@ func (s SessionStoreImpl[T]) Put(key string, value interface{}, options ...Sessi
 		opt(&opts)
 	}
 	// TTL can't go below 0 because that is translated to "no expiration" by the library
-	// in that case it should be 1 nanosecond
-	if opts.ttl < 0 {
-		opts.ttl = 1
+	// so just don't cache
+	if opts.ttl <= 0 {
+		return nil
 	}
 	bytes, err := json.Marshal(value)
 	if err != nil {

--- a/storage/session.go
+++ b/storage/session.go
@@ -85,16 +85,31 @@ func (s SessionStoreImpl[T]) Get(key string, target interface{}) error {
 	return json.Unmarshal([]byte(val), target)
 }
 
-func (s SessionStoreImpl[T]) Put(key string, value interface{}) error {
+func (s SessionStoreImpl[T]) Put(key string, value interface{}, options ...SessionOption) error {
+	opts := s.defaultOptions()
+	for _, opt := range options {
+		opt(&opts)
+	}
+	// TTL can't go below 0 because that is translated to "no expiration" by the library
+	// in that case it should be 1 nanosecond
+	if opts.ttl < 0 {
+		opts.ttl = 1
+	}
 	bytes, err := json.Marshal(value)
 	if err != nil {
 		return err
 	}
-	return s.underlying.Set(context.Background(), s.db.getFullKey(s.prefixes, key), T(bytes), store.WithExpiration(s.ttl))
+	return s.underlying.Set(context.Background(), s.db.getFullKey(s.prefixes, key), T(bytes), store.WithExpiration(opts.ttl))
 }
 func (s SessionStoreImpl[T]) GetAndDelete(key string, target interface{}) error {
 	if err := s.Get(key, target); err != nil {
 		return err
 	}
 	return s.underlying.Delete(context.Background(), s.db.getFullKey(s.prefixes, key))
+}
+
+func (s SessionStoreImpl[T]) defaultOptions() sessionOptions {
+	return sessionOptions{
+		ttl: s.ttl,
+	}
 }

--- a/storage/session_inmemory.go
+++ b/storage/session_inmemory.go
@@ -56,7 +56,7 @@ func (s *InMemorySessionDatabase) GetStore(ttl time.Duration, keys ...string) Se
 	}
 }
 
-func (s *InMemorySessionDatabase) close() {
+func (s *InMemorySessionDatabase) Close() {
 	// NOP
 }
 

--- a/storage/session_memcached.go
+++ b/storage/session_memcached.go
@@ -40,6 +40,7 @@ func NewMemcachedSessionDatabase(client *memcache.Client) *MemcachedSessionDatab
 	memcachedStore := memcachestore.NewMemcache(client, store.WithExpiration(defaultSessionDataTTL))
 	return &MemcachedSessionDatabase{
 		underlying: cache.New[[]byte](memcachedStore),
+		client:     client,
 	}
 }
 
@@ -52,8 +53,7 @@ func (s MemcachedSessionDatabase) GetStore(ttl time.Duration, keys ...string) Se
 	}
 }
 
-func (s MemcachedSessionDatabase) close() {
-	// noop
+func (s MemcachedSessionDatabase) Close() {
 	if s.client != nil {
 		_ = s.client.Close()
 	}

--- a/storage/session_redis.go
+++ b/storage/session_redis.go
@@ -30,6 +30,7 @@ import (
 type redisSessionDatabase struct {
 	underlying *cache.Cache[string]
 	prefix     string
+	client     *redis.Client
 }
 
 func NewRedisSessionDatabase(client *redis.Client, prefix string) SessionDatabase {
@@ -37,6 +38,7 @@ func NewRedisSessionDatabase(client *redis.Client, prefix string) SessionDatabas
 	return redisSessionDatabase{
 		underlying: cache.New[string](redisStore),
 		prefix:     prefix,
+		client:     client,
 	}
 }
 
@@ -54,8 +56,10 @@ func (s redisSessionDatabase) GetStore(ttl time.Duration, keys ...string) Sessio
 	}
 }
 
-func (s redisSessionDatabase) close() {
-	// nop
+func (s redisSessionDatabase) Close() {
+	if s.client != nil {
+		_ = s.client.Close()
+	}
 }
 
 func (s redisSessionDatabase) getFullKey(prefixes []string, key string) string {

--- a/storage/session_redis_test.go
+++ b/storage/session_redis_test.go
@@ -45,7 +45,7 @@ func TestRedisSessionStore(t *testing.T) {
 	store, _ := NewTestStorageEngineRedis(t)
 	require.NoError(t, store.Start())
 	sessions := store.GetSessionDatabase()
-	defer sessions.close()
+	defer sessions.Close()
 
 	t.Run("lifecycle", func(t *testing.T) {
 		store := sessions.GetStore(time.Second, "unit")
@@ -66,7 +66,7 @@ func TestRedisSessionStore_Get(t *testing.T) {
 	storageEngine, miniRedis := NewTestStorageEngineRedis(t)
 	require.NoError(t, storageEngine.Start())
 	sessions := storageEngine.GetSessionDatabase()
-	defer sessions.close()
+	defer sessions.Close()
 
 	var actual testType
 	t.Run("non-existing key", func(t *testing.T) {
@@ -90,7 +90,7 @@ func TestRedisSessionStore_Delete(t *testing.T) {
 	store, _ := NewTestStorageEngineRedis(t)
 	require.NoError(t, store.Start())
 	sessions := store.GetSessionDatabase()
-	defer sessions.close()
+	defer sessions.Close()
 	// We make sure the value exists in another store,
 	// to test partitioning
 	otherStore := sessions.GetStore(time.Second, "unit_other")
@@ -111,7 +111,7 @@ func TestRedisSessionStore_GetAndDelete(t *testing.T) {
 	storageEngine, miniRedis := NewTestStorageEngineRedis(t)
 	require.NoError(t, storageEngine.Start())
 	sessions := storageEngine.GetSessionDatabase()
-	defer sessions.close()
+	defer sessions.Close()
 
 	t.Run("ok", func(t *testing.T) {
 		var actual testType
@@ -152,7 +152,7 @@ func TestRedisSessionStore_Exists(t *testing.T) {
 	store, miniRedis := NewTestStorageEngineRedis(t)
 	require.NoError(t, store.Start())
 	sessions := store.GetSessionDatabase()
-	defer sessions.close()
+	defer sessions.Close()
 	// We make sure the value exists in another store,
 	// to test partitioning
 	otherStore := sessions.GetStore(time.Second, "unit_other")
@@ -177,7 +177,7 @@ func TestRedisSessionStore_Put(t *testing.T) {
 	store, _ := NewTestStorageEngineRedis(t)
 	require.NoError(t, store.Start())
 	sessions := store.GetSessionDatabase()
-	defer sessions.close()
+	defer sessions.Close()
 	// We make sure the value exists in another store,
 	// to test partitioning
 	otherStore := sessions.GetStore(time.Second, "unit_other")
@@ -209,7 +209,7 @@ func TestRedisSessionStore_Pruning(t *testing.T) {
 	store, miniRedis := NewTestStorageEngineRedis(t)
 	require.NoError(t, store.Start())
 	sessions := store.GetSessionDatabase()
-	defer sessions.close()
+	defer sessions.Close()
 	// We make sure the value exists in another store,
 	// to test partitioning
 	otherStore := sessions.GetStore(time.Second*1, "unit_other")

--- a/storage/test.go
+++ b/storage/test.go
@@ -122,7 +122,7 @@ func (p *StaticKVStoreProvider) GetKVStore(_ string, _ Class) (stoabs.KVStore, e
 func NewTestInMemorySessionDatabase(t *testing.T) *InMemorySessionDatabase {
 	db := NewInMemorySessionDatabase()
 	t.Cleanup(func() {
-		db.close()
+		db.Close()
 	})
 	return db
 }
@@ -164,7 +164,7 @@ func (e errorSessionDatabase) getFullKey(prefixes []string, key string) string {
 	return ""
 }
 
-func (e errorSessionDatabase) close() {
+func (e errorSessionDatabase) Close() {
 	// nop
 }
 
@@ -180,7 +180,7 @@ func (e errorSessionStore) Get(key string, target interface{}) error {
 	return e.err
 }
 
-func (e errorSessionStore) Put(key string, value interface{}) error {
+func (e errorSessionStore) Put(key string, value interface{}, options ...SessionOption) error {
 	return e.err
 }
 


### PR DESCRIPTION
Cache access tokens per request. Subsequent requests are fulfilled from cache.
Added SessionOption to allow for custom `ttl` on session store.
Only implemented for `auth.iam`, not for `auth/v1`

closes #3552 