### PR TITLE
Prevent data dir from being created in cmd/

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -141,6 +141,8 @@ func Test_serverCmd(t *testing.T) {
 		assert.Error(t, err, "unable to start")
 	})
 	t.Run("migration fails", func(t *testing.T) {
+		testDirectory := io.TestDirectory(t)
+		t.Setenv("NUTS_DATADIR", testDirectory)
 		ctrl := gomock.NewController(t)
 		r := core.NewMockMigratable(ctrl)
 		system := core.NewSystem()


### PR DESCRIPTION
a test kept creating `./cmd/data`