### PR TITLE
Support did:x509 in Authorization Server metadata

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -179,7 +179,7 @@ func (auth *Auth) Configure(config core.ServerConfig) error {
 }
 
 func (auth *Auth) SupportedDIDMethods() []string {
-	return auth.supportedDIDMethods
+	return append(auth.supportedDIDMethods, "x509")
 }
 
 // Start starts the Auth engine (Noop)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -189,9 +189,12 @@ func (auth *Auth) Configure(config core.ServerConfig) error {
 func (auth *Auth) SupportedDIDMethods() []string {
 	// DID methods that don't require additional resources/configuration in the Nuts node are always supported.
 	// Other DID methods (did:nuts), are only supported if explicitly enabled.
-	result := []string{didweb.MethodName, didjwk.MethodName, didkey.MethodName, didx509.MethodName}
+	result := []string{didjwk.MethodName, didkey.MethodName, didx509.MethodName}
 	if slices.Contains(auth.configuredDIDMethods, didnuts.MethodName) {
 		result = append(result, didnuts.MethodName)
+	}
+	if slices.Contains(auth.configuredDIDMethods, didweb.MethodName) {
+		result = append(result, didweb.MethodName)
 	}
 	return result
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -125,3 +125,22 @@ func TestAuth_IAMClient(t *testing.T) {
 	})
 
 }
+
+func TestAuth_SupportedDIDMethods(t *testing.T) {
+	t.Run("supports did:web", func(t *testing.T) {
+		assert.Contains(t, (&Auth{}).SupportedDIDMethods(), "web")
+	})
+	t.Run("supports did:key", func(t *testing.T) {
+		assert.Contains(t, (&Auth{}).SupportedDIDMethods(), "key")
+	})
+	t.Run("supports did:x509", func(t *testing.T) {
+		assert.Contains(t, (&Auth{}).SupportedDIDMethods(), "x509")
+	})
+	t.Run("supports did:jwk", func(t *testing.T) {
+		assert.Contains(t, (&Auth{}).SupportedDIDMethods(), "jwk")
+	})
+	t.Run("supports did:nuts if configured", func(t *testing.T) {
+		assert.NotContains(t, (&Auth{}).SupportedDIDMethods(), "nuts")
+		assert.Contains(t, (&Auth{configuredDIDMethods: []string{"nuts"}}).SupportedDIDMethods(), "nuts")
+	})
+}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -127,9 +127,6 @@ func TestAuth_IAMClient(t *testing.T) {
 }
 
 func TestAuth_SupportedDIDMethods(t *testing.T) {
-	t.Run("supports did:web", func(t *testing.T) {
-		assert.Contains(t, (&Auth{}).SupportedDIDMethods(), "web")
-	})
 	t.Run("supports did:key", func(t *testing.T) {
 		assert.Contains(t, (&Auth{}).SupportedDIDMethods(), "key")
 	})
@@ -142,5 +139,9 @@ func TestAuth_SupportedDIDMethods(t *testing.T) {
 	t.Run("supports did:nuts if configured", func(t *testing.T) {
 		assert.NotContains(t, (&Auth{}).SupportedDIDMethods(), "nuts")
 		assert.Contains(t, (&Auth{configuredDIDMethods: []string{"nuts"}}).SupportedDIDMethods(), "nuts")
+	})
+	t.Run("supports did:web if configured", func(t *testing.T) {
+		assert.NotContains(t, (&Auth{}).SupportedDIDMethods(), "web")
+		assert.Contains(t, (&Auth{configuredDIDMethods: []string{"web"}}).SupportedDIDMethods(), "web")
 	})
 }

--- a/auth/interface.go
+++ b/auth/interface.go
@@ -42,6 +42,6 @@ type AuthenticationServices interface {
 	PublicURL() *url.URL
 	// AuthorizationEndpointEnabled returns whether the v2 API's OAuth2 Authorization Endpoint is enabled.
 	AuthorizationEndpointEnabled() bool
-	// SupportedDIDMethods list the DID methods configured for the nuts node in preferred order.
+	// SupportedDIDMethods lists the DID methods the Nuts node can resolve.
 	SupportedDIDMethods() []string
 }


### PR DESCRIPTION
Allowing credentials to be issued from it.

This is probably not the right solution, since the actual issue is that `didmethods` indicates 2 things:
- DIDs the Nuts node creates for its subjects
- DID methods it accepts when other parties present credentials

These should probably be 2 lists. The 2nd list could actually be all supported DID methods (nuts, web, x509, jwk, key) minus those we can't resolve if not configured properly (nuts).
@woutslakhorst ?



