### PR TITLE
Add CAs/CRLs to the PKI engine at runtime

### DIFF
--- a/auth/test.go
+++ b/auth/test.go
@@ -40,7 +40,6 @@ func testInstance(t *testing.T, cfg Config) *Auth {
 	vcrInstance := vcr.NewTestVCRInstance(t)
 	ctrl := gomock.NewController(t)
 	pkiMock := pki.NewMockProvider(ctrl)
-	pkiMock.EXPECT().AddTruststore(gomock.Any()).AnyTimes()
 	pkiMock.EXPECT().CreateTLSConfig(gomock.Any()).AnyTimes()
 	vdrInstance := vdr.NewMockVDR(ctrl)
 	vdrInstance.EXPECT().Resolver().AnyTimes()

--- a/docs/pages/deployment/certificates.rst
+++ b/docs/pages/deployment/certificates.rst
@@ -24,6 +24,6 @@ In ``did:x509`` the certificates are also used in the cryptographic proofs to ob
 This means the certificate chain now provides the root of trust and has stricter requirements than connection certificates.
 
 Trust in specific certificate CAs is configured per use-case in a :ref:`Discovery <discovery>` and :ref:`Policy <policy>` definition file.
-All CA certificates from chains trusted per the above definition files are automatically added to the CRL checker at runtime.
+CRLs from trusted chains (per the above definition files) are consulted when evaluating ``did:x509`` Verifiable Credentials.
 For certificate chains used in ``did:x509`` the Nuts-node always uses a hard-fail strategy, i.e., the ``pki.softfail`` config value is ignored during certificate validation for ``did:x509``.
 This means that the Nuts-node will not be able to verify a ``did:x509`` DID or Verifiable Credential signed by this DID Method if the CRL cannot be downloaded and the CRL in the cache is older than ``pki.maxupdatefailhours``.

--- a/docs/pages/deployment/certificates.rst
+++ b/docs/pages/deployment/certificates.rst
@@ -24,11 +24,6 @@ In ``did:x509`` the certificates are also used in the cryptographic proofs to ob
 This means the certificate chain now provides the root of trust and has stricter requirements than connection certificates.
 
 Trust in specific certificate CAs is configured per use-case in a :ref:`Discovery <discovery>` and :ref:`Policy <policy>` definition file.
-In addition, all trusted CA chains must also be added to the ``tls.truststorefile``.
+All CA certificates from chains trusted per the above definition files are automatically added to the CRL checker at runtime.
 For certificate chains used in ``did:x509`` the Nuts-node always uses a hard-fail strategy, i.e., the ``pki.softfail`` config value is ignored during certificate validation for ``did:x509``.
 This means that the Nuts-node will not be able to verify a ``did:x509`` DID or Verifiable Credential signed by this DID Method if the CRL cannot be downloaded and the CRL in the cache is older than ``pki.maxupdatefailhours``.
-
-.. note::
-
-    Since the configured truststore file is now used for multiple purposes, it is no longer possible for the Nuts-node to determine what certificate chain is accepted/trusted for what purpose.
-    This means that all incoming TLS connections (including gRPC) must be offloaded in a proxy and validated against the expected certificate chain.

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -217,7 +217,6 @@ func TestNetwork_Configure(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		ctx := createNetwork(t, ctrl)
 		ctx.protocol.EXPECT().Configure(gomock.Any())
-		ctx.pkiValidator.EXPECT().AddTruststore(gomock.Any())
 		ctx.pkiValidator.EXPECT().SetVerifyPeerCertificateFunc(gomock.Any()).Times(2) // tls.Configs: client, selfTestDialer
 		ctx.pkiValidator.EXPECT().SubscribeDenied(gomock.Any())
 		ctx.network.connectionManager = nil
@@ -277,7 +276,6 @@ func TestNetwork_Configure(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		ctx := createNetwork(t, ctrl)
 		ctx.protocol.EXPECT().Configure(gomock.Any())
-		ctx.pkiValidator.EXPECT().AddTruststore(gomock.Any())
 		ctx.pkiValidator.EXPECT().SetVerifyPeerCertificateFunc(gomock.Any()) // selftestDialer tls.Config
 		ctx.network.connectionManager = nil
 

--- a/network/transport/grpc/config.go
+++ b/network/transport/grpc/config.go
@@ -65,9 +65,6 @@ func WithTLS(clientCertificate tls.Certificate, trustStore *core.TrustStore, pki
 		config.clientCert = &clientCertificate
 		config.trustStore = trustStore.CertPool
 		config.pkiValidator = pkiValidator
-		if err := pkiValidator.AddTruststore(trustStore.Certificates()); err != nil {
-			return err
-		}
 		// Load TLS server certificate if the gRPC server should be started.
 		if config.listenAddress != "" {
 			config.serverCert = config.clientCert

--- a/network/transport/grpc/config_test.go
+++ b/network/transport/grpc/config_test.go
@@ -53,7 +53,6 @@ func TestNewConfig(t *testing.T) {
 		ts := &core.TrustStore{
 			CertPool: x509.NewCertPool(),
 		}
-		pkiMock.EXPECT().AddTruststore(gomock.Any())
 		cfg, err := NewConfig(":1234", "foo", WithTLS(tlsCert, ts, pkiMock))
 		require.NoError(t, err)
 		assert.Equal(t, &tlsCert, cfg.clientCert)
@@ -64,7 +63,6 @@ func TestNewConfig(t *testing.T) {
 		ts := &core.TrustStore{
 			CertPool: core.NewCertPool(x509Cert),
 		}
-		pkiMock.EXPECT().AddTruststore(gomock.Any())
 		cfg, err := NewConfig(":1234", "foo", WithTLS(tlsCert, ts, pkiMock))
 		require.NoError(t, err)
 		assert.Equal(t, &tlsCert, cfg.clientCert)

--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -137,7 +137,6 @@ func Test_grpcConnectionManager_Connect(t *testing.T) {
 		clientCert := testPKI.Certificate()
 		ctrl := gomock.NewController(t)
 		pkiMock := pki.NewMockValidator(ctrl)
-		pkiMock.EXPECT().AddTruststore(ts.Certificates())
 		pkiMock.EXPECT().SetVerifyPeerCertificateFunc(gomock.Any())
 		pkiMock.EXPECT().SubscribeDenied(gomock.Any())
 
@@ -557,7 +556,6 @@ func Test_grpcConnectionManager_Start(t *testing.T) {
 	serverCert := testPKI.Certificate()
 	ctrl := gomock.NewController(t)
 	pkiMock := pki.NewMockValidator(ctrl)
-	pkiMock.EXPECT().AddTruststore(gomock.Any()).AnyTimes()
 
 	t.Run("ok - gRPC server not bound", func(t *testing.T) {
 		cm, err := NewGRPCConnectionManager(Config{}, nil, *nodeDID, nil)

--- a/pki/interface.go
+++ b/pki/interface.go
@@ -79,10 +79,6 @@ type Validator interface {
 	// SetVerifyPeerCertificateFunc sets config.ValidatePeerCertificate to use CheckCRL.
 	SetVerifyPeerCertificateFunc(config *tls.Config) error
 
-	// addCAs adds all CAs to the list of CAs for validation of CRL signatures. It also adds all CRL Distribution Endpoints found in the chain.
-	// The certificate chain MUST be sorted leaf to root.
-	addCAs(chain []*x509.Certificate) error
-
 	// SubscribeDenied registers a callback that is triggered everytime the denylist is updated.
 	// This can be used to revalidate all certificates on long-lasting connections by calling CheckCRL on them again.
 	SubscribeDenied(f func())

--- a/pki/interface.go
+++ b/pki/interface.go
@@ -31,7 +31,7 @@ var (
 	ErrCRLMissing    = errors.New("crl is missing")
 	ErrCRLExpired    = errors.New("crl has expired")
 	ErrCertRevoked   = errors.New("certificate is revoked")
-	ErrCertUntrusted = errors.New("certificate's issuer is not trusted")
+	ErrUnknownIssuer = errors.New("unknown certificate issuer")
 	// ErrDenylistMissing occurs when the denylist cannot be downloaded
 	ErrDenylistMissing = errors.New("denylist cannot be retrieved")
 
@@ -57,14 +57,20 @@ type Denylist interface {
 	Subscribe(f func())
 }
 
+// Validator is used to check the revocation status of certificates on the issuer controlled CRL and the user controlled Denylist.
+// It does NOT manage trust and assumes all presented certificates belong to a trusted certificate tree.
 type Validator interface {
 	// CheckCRL returns an error if any of the certificates in the chain has been revoked, or if the request cannot be processed.
-	// ErrCertRevoked and ErrCertUntrusted indicate that at least one of the certificates is revoked, or signed by a CA that is not in the truststore.
+	// All certificates in the chain are considered trusted, which means that the caller has verified the integrity of the chain and appropriateness for the use-case.
+	// Any new CA / CRL in the chain will be added to the internal watchlist and updated periodically, so it MUST NOT be called on untrusted/invalid chains.
+	// The certificate chain MUST be sorted leaf to root.
+	//
+	// ErrCertRevoked and ErrUnknownIssuer indicate that at least one of the certificates is revoked, or signed by an unknown CA (so we have no key to verify the CRL).
 	// ErrCRLMissing and ErrCRLExpired signal that at least one of the certificates cannot be validated reliably.
 	// If the certificate was revoked on an expired CRL, it wil return ErrCertRevoked.
+	//
 	// CheckCRL uses the configured soft-/hard-fail strategy
 	// If set to soft-fail it ignores ErrCRLMissing and ErrCRLExpired errors.
-	// The certificate chain is expected to be sorted leaf to root.
 	CheckCRL(chain []*x509.Certificate) error
 
 	// CheckCRLStrict does the same as CheckCRL, except it always uses the hard-fail strategy.
@@ -73,10 +79,9 @@ type Validator interface {
 	// SetVerifyPeerCertificateFunc sets config.ValidatePeerCertificate to use CheckCRL.
 	SetVerifyPeerCertificateFunc(config *tls.Config) error
 
-	// AddTruststore adds all CAs to the truststore for validation of CRL signatures. It also adds all CRL Distribution Endpoints found in the chain.
-	// CRL Distribution Points encountered at runtime, such as on end user certificates when calling CheckCRL, are only added to the monitored CRLs if their issuer is in the truststore.
-	// This fails if any of the issuers mentioned in the chain is not also in the chain or already in the truststore
-	AddTruststore(chain []*x509.Certificate) error
+	// addCAs adds all CAs to the list of CAs for validation of CRL signatures. It also adds all CRL Distribution Endpoints found in the chain.
+	// The certificate chain MUST be sorted leaf to root.
+	addCAs(chain []*x509.Certificate) error
 
 	// SubscribeDenied registers a callback that is triggered everytime the denylist is updated.
 	// This can be used to revalidate all certificates on long-lasting connections by calling CheckCRL on them again.
@@ -86,6 +91,7 @@ type Validator interface {
 // Provider is an interface for providing PKI services (e.g. TLS configuration, certificate validation).
 type Provider interface {
 	Validator
-	// CreateTLSConfig creates a tls.Config for outbound connections. It returns nil (and no error) if TLS is disabled.
+	// CreateTLSConfig creates a tls.Config from the core.TLSConfig for outbound connections.
+	// It returns (nil, nil)  if core.TLSConfig.Enabled() == false.
 	CreateTLSConfig(cfg core.TLSConfig) (*tls.Config, error)
 }

--- a/pki/mock.go
+++ b/pki/mock.go
@@ -189,20 +189,6 @@ func (mr *MockValidatorMockRecorder) SubscribeDenied(f any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeDenied", reflect.TypeOf((*MockValidator)(nil).SubscribeDenied), f)
 }
 
-// addCAs mocks base method.
-func (m *MockValidator) addCAs(chain []*x509.Certificate) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "addCAs", chain)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// addCAs indicates an expected call of addCAs.
-func (mr *MockValidatorMockRecorder) addCAs(chain any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "addCAs", reflect.TypeOf((*MockValidator)(nil).addCAs), chain)
-}
-
 // MockProvider is a mock of Provider interface.
 type MockProvider struct {
 	ctrl     *gomock.Controller
@@ -294,18 +280,4 @@ func (m *MockProvider) SubscribeDenied(f func()) {
 func (mr *MockProviderMockRecorder) SubscribeDenied(f any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeDenied", reflect.TypeOf((*MockProvider)(nil).SubscribeDenied), f)
-}
-
-// addCAs mocks base method.
-func (m *MockProvider) addCAs(chain []*x509.Certificate) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "addCAs", chain)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// addCAs indicates an expected call of addCAs.
-func (mr *MockProviderMockRecorder) addCAs(chain any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "addCAs", reflect.TypeOf((*MockProvider)(nil).addCAs), chain)
 }

--- a/pki/mock.go
+++ b/pki/mock.go
@@ -135,20 +135,6 @@ func (m *MockValidator) EXPECT() *MockValidatorMockRecorder {
 	return m.recorder
 }
 
-// AddTruststore mocks base method.
-func (m *MockValidator) AddTruststore(chain []*x509.Certificate) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddTruststore", chain)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AddTruststore indicates an expected call of AddTruststore.
-func (mr *MockValidatorMockRecorder) AddTruststore(chain any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTruststore", reflect.TypeOf((*MockValidator)(nil).AddTruststore), chain)
-}
-
 // CheckCRL mocks base method.
 func (m *MockValidator) CheckCRL(chain []*x509.Certificate) error {
 	m.ctrl.T.Helper()
@@ -203,6 +189,20 @@ func (mr *MockValidatorMockRecorder) SubscribeDenied(f any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeDenied", reflect.TypeOf((*MockValidator)(nil).SubscribeDenied), f)
 }
 
+// addCAs mocks base method.
+func (m *MockValidator) addCAs(chain []*x509.Certificate) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "addCAs", chain)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// addCAs indicates an expected call of addCAs.
+func (mr *MockValidatorMockRecorder) addCAs(chain any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "addCAs", reflect.TypeOf((*MockValidator)(nil).addCAs), chain)
+}
+
 // MockProvider is a mock of Provider interface.
 type MockProvider struct {
 	ctrl     *gomock.Controller
@@ -225,20 +225,6 @@ func NewMockProvider(ctrl *gomock.Controller) *MockProvider {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 	return m.recorder
-}
-
-// AddTruststore mocks base method.
-func (m *MockProvider) AddTruststore(chain []*x509.Certificate) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddTruststore", chain)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AddTruststore indicates an expected call of AddTruststore.
-func (mr *MockProviderMockRecorder) AddTruststore(chain any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTruststore", reflect.TypeOf((*MockProvider)(nil).AddTruststore), chain)
 }
 
 // CheckCRL mocks base method.
@@ -308,4 +294,18 @@ func (m *MockProvider) SubscribeDenied(f func()) {
 func (mr *MockProviderMockRecorder) SubscribeDenied(f any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeDenied", reflect.TypeOf((*MockProvider)(nil).SubscribeDenied), f)
+}
+
+// addCAs mocks base method.
+func (m *MockProvider) addCAs(chain []*x509.Certificate) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "addCAs", chain)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// addCAs indicates an expected call of addCAs.
+func (mr *MockProviderMockRecorder) addCAs(chain any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "addCAs", reflect.TypeOf((*MockProvider)(nil).addCAs), chain)
 }

--- a/vdr/didx509/resolver.go
+++ b/vdr/didx509/resolver.go
@@ -145,6 +145,10 @@ func (r Resolver) Resolve(id did.DID, metadata *resolver.ResolveMetadata) (*did.
 		return nil, nil, err
 	}
 
+	// Check CRLs on the verifiedChain, but
+	// 		only after the integrity of the chain has been verified, and
+	// 		only after we have established it is appropriate to use this chain.
+	// Any CAs/CRLs in the verifiedChain will from hereon exist in the CRL checker and will be periodically updated
 	err = r.pkiValidator.CheckCRLStrict(verifiedChains[0])
 	if err != nil {
 		return nil, nil, err

--- a/vdr/vdr.go
+++ b/vdr/vdr.go
@@ -163,7 +163,7 @@ func (r *Module) Configure(config core.ServerConfig) error {
 
 	r.didResolver.(*resolver.DIDResolverRouter).Register(didjwk.MethodName, didjwk.NewResolver())
 	r.didResolver.(*resolver.DIDResolverRouter).Register(didkey.MethodName, didkey.NewResolver())
-	r.didResolver.(*resolver.DIDResolverRouter).Register(didx509.MethodName, didx509.NewResolver(r.pkiValidator))
+	r.didResolver.(*resolver.DIDResolverRouter).Register(didx509.MethodName, didx509.NewResolver())
 	// Register DID resolver and DID methods we can resolve
 	r.ownedDIDResolver = didsubject.Resolver{DB: db}
 


### PR DESCRIPTION
I've updated some go docs and comments to clarify that the pki engine is only a CRL checker, not a trust manager.

Since trust in the certificate chain must be validated externally (prior to checking the CRLs), we can assume that all presented certificates are part of trusted certificates chains and can be added to the CRL/CA lists at runtime. This simplifies the usage of the PKI engine a bit and closes #3583.

`PKI.CreateTLSConfig()` returns a `tls.Config` that contains the truststore that is in the nuts.yaml config. Added clarification that this must not be replaced the internal truststore of the engine. This method only exists here to set the CRL checker on the `tls.Config.VerifyPeerCertificate`.


**Currently the CRLs are checked by the did:x509 resolver that, I think, does not know if the chain should be trusted or not?**
This means that the CRLvalidator / PKI engine will be filled based on data/certs presented by external parties -> enables certain attacks on the node.


TODO:
- [x] update documentation