### PR TITLE
e2e tests: remove client_id from RFC021 (is derived from subject in URL)

### DIFF
--- a/e2e-tests/clustering/memcached/run-test.sh
+++ b/e2e-tests/clustering/memcached/run-test.sh
@@ -69,7 +69,6 @@ REQUEST=$(
 cat << EOF
 {
   "authorization_server": "https://nodeA/oauth2/vendorA",
-  "client_id": "https://nodeB/oauth2/vendorB",
   "scope": "test",
   "credentials": [
       {

--- a/e2e-tests/clustering/redis/run-test.sh
+++ b/e2e-tests/clustering/redis/run-test.sh
@@ -69,7 +69,6 @@ REQUEST=$(
 cat << EOF
 {
   "authorization_server": "https://nodeA/oauth2/vendorA",
-  "client_id": "https://nodeB/oauth2/vendorB",
   "scope": "test",
   "credentials": [
       {

--- a/e2e-tests/oauth-flow/rfc021/do-test.sh
+++ b/e2e-tests/oauth-flow/rfc021/do-test.sh
@@ -121,7 +121,6 @@ REQUEST=$(
 cat << EOF
 {
   "authorization_server": "https://nodeA/oauth2/vendorA",
-  "client_id": "https://nodeB/oauth2/vendorB",
   "scope": "test",
   "credentials": [
       {


### PR DESCRIPTION
The parameter doesn't exist any more.