### PR TITLE
adapt X509Credential validation, use nested JSON structure

### DIFF
--- a/vcr/credential/validator_test.go
+++ b/vcr/credential/validator_test.go
@@ -559,28 +559,28 @@ func TestX509CredentialValidator_Validate(t *testing.T) {
 			{
 				name: "invalid assertion value",
 				claim: map[string]interface{}{
-					"san:otherName": "A_BIG_STRIN",
+					"san": map[string]interface{}{"otherName": "A_BIG_STRIN"},
 				},
 				expectedError: "invalid assertion value 'A_BIG_STRIN' for 'san:otherName' did:x509 policy",
 			},
 			{
-				name: "invalid assertion name",
+				name: "invalid assertion type",
 				claim: map[string]interface{}{
 					"san": "A_BIG_STRING",
 				},
-				expectedError: "invalid credentialSubject assertion name 'san'",
+				expectedError: "invalid assertion value type for 'credentialSubject.san'",
 			},
 			{
 				name: "unknown assertion",
 				claim: map[string]interface{}{
-					"san:ip": "10.0.0.1",
+					"san": map[string]interface{}{"ip": "10.0.0.1"},
 				},
-				expectedError: "assertion 'san:ip' not found in did:x509 policy",
+				expectedError: "assertion 'credentialSubject.san.ip' not found in did:x509 policy",
 			},
 			{
 				name: "unknown policy",
 				claim: map[string]interface{}{
-					"stan:ip": "10.0.0.1",
+					"stan": map[string]interface{}{"ip": "10.0.0.1"},
 				},
 				expectedError: "policy 'stan' not found in did:x509 policy",
 			},

--- a/vcr/test/credentials.go
+++ b/vcr/test/credentials.go
@@ -162,12 +162,16 @@ func ValidX509Credential(t *testing.T, options ...credentialOption) vc.Verifiabl
 			"@context": []string{"https://www.w3.org/2018/credentials/v1"},
 			"type":     []string{vc.VerifiableCredentialType, "X509Credential"},
 			"credentialSubject": map[string]interface{}{
-				"id":            rootDID.String(),
-				"subject:C":     "NL",
-				"subject:O":     "NUTS Foundation",
-				"subject:L":     "Amsterdam",
-				"subject:CN":    "www.example.com",
-				"san:otherName": otherNameValue,
+				"id": rootDID.String(),
+				"subject": map[string]interface{}{
+					"C":  "NL",
+					"O":  "NUTS Foundation",
+					"L":  "Amsterdam",
+					"CN": "www.example.com",
+				},
+				"san": map[string]interface{}{
+					"otherName": otherNameValue,
+				},
 			},
 		})
 	for _, option := range options {


### PR DESCRIPTION
closes #3639 

validates:
```
"credentialSubject": {
  "san": {
    "otherName":"example.com"
  }
}
```