### PR TITLE
E2E: action doesn't fail when the container cleanup step fails

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Login to ghcr.io
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -81,6 +81,7 @@ jobs:
 
       - name: package cleanup
         uses: dataaxiom/ghcr-cleanup-action@v1
+        continue-on-error: true # action doesn't fail when this step fails
         if: ${{ github.actor != 'dependabot' }}
         with:
           owner: nuts-foundation
@@ -91,6 +92,7 @@ jobs:
 
       - name: package cleanup dependabot
         uses: dataaxiom/ghcr-cleanup-action@v1
+        continue-on-error: true # action doesn't fail when this step fails
         if: ${{ github.actor == 'dependabot' }}
         with:
           owner: nuts-foundation


### PR DESCRIPTION
the e2e tests occasionally fail because the cleanup step that removes the container fails. This addition should make the action succeed even if the cleanup action fails. cleanup will be performed on the next run