### PR TITLE
update minimal go version to 1.23.5 and cleanup dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,6 @@ ARG GIT_VERSION=undefined
 
 LABEL maintainer="wout.slakhorst@nuts.nl"
 
-RUN apk update \
- && apk add --no-cache \
-            gcc \
-            musl-dev \
- && update-ca-certificates
-
-ENV GO111MODULE=on
 ENV GOPATH=/
 
 RUN mkdir /opt/nuts && cd /opt/nuts

--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -3,6 +3,16 @@ Release notes
 #############
 
 ***************
+Peanut (v6.0.7)
+***************
+
+Release date: 2025-01-28
+
+- Update minimal GO version to 1.23.5 to fix vulnerabilities.
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v6.0.6...v6.0.7
+
+***************
 Peanut (v6.0.6)
 ***************
 
@@ -168,6 +178,16 @@ The following features have been deprecated:
 - DIDMan v1 API, to be removed
 - Network v1 API, to be removed
 - VDR v1 API, replaced by VDR v2
+
+*************************
+Hazelnut update (v5.4.14)
+*************************
+
+Release date: 2025-01-28
+
+- Update minimal GO version to 1.23.5 to fix vulnerabilities.
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v5.4.13...v5.4.14
 
 *************************
 Hazelnut update (v5.4.13)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nuts-foundation/nuts-node
 
 // This is the minimal version, the actual go version is determined by the images in the Dockerfile
 // This version is used in automated tests such as the 'Scheduled govulncheck' action
-go 1.23.4
+go 1.23.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0


### PR DESCRIPTION
backport to V6.0 and V5.4