### PR TITLE
change system requirements for V6

### DIFF
--- a/docs/pages/deployment/recommended-deployment.rst
+++ b/docs/pages/deployment/recommended-deployment.rst
@@ -197,11 +197,17 @@ Resource Requirements
 
 The Nuts node is built to be lightweight in terms of CPU and memory usage.
 
-For a production environment you should be able to easily run it on a small cloud VM, which typically start at;
+The minimum system for **development** and **test** are:
 
 - 1 CPU
 - 512 MB RAM
 - 25 GB storage
+
+Recommended system requirements for production depends on the expected load and use cases.
+It's recommended to keep track of the system's performance and adjust the resources accordingly.
+CPU and memory usage, and the API response times are good indicators of the system's performance.
+Make sure the CPUs are of a decent speed, as some operations are CPU-bound.
+The exposes metrics for ``process_cpu_seconds_total``, ``go_gc_duration_seconds_sum`` and ``go_memstats_alloc_bytes`` are a good starting point for monitoring CPU and memory usage.
 
 SQL storage size is influenced by:
 


### PR DESCRIPTION
backport to V6 branch.

The v5 version will get an additional remark on CPU usage when using AuthCreds.