### PR TITLE
OAPI update introspection example

### DIFF
--- a/docs/_static/auth/v2.yaml
+++ b/docs/_static/auth/v2.yaml
@@ -578,7 +578,7 @@ components:
       properties:
         token:
           type: string
-          example: spnhVHZ4IFVvuNrpflVaB1A7P3A2xZ7G_a8gF_SHMynYSA
+      example: token=spnhVHZ4IFVvuNrpflVaB1A7P3A2xZ7G_a8gF_SHMynYSA
     TokenIntrospectionResponse:
       description: Token introspection response as described in RFC7662 section 2.2
       required:


### PR DESCRIPTION
examples on the properties are shown as json:
```
{
  "token": "spnhVHZ4IFVvuNrpflVaB1A7P3A2xZ7G_a8gF_SHMynYSA"
}
```
which is confusing when using `Content-Type: application/x-www-form-urlencoded`

Moving the example to the schema becomes:
```
token=spnhVHZ4IFVvuNrpflVaB1A7P3A2xZ7G_a8gF_SHMynYSA
```
