### PR TITLE
Rename EmployeeCredential to NutsEmployeeCredential

### DIFF
--- a/auth/api/iam/user.go
+++ b/auth/api/iam/user.go
@@ -76,7 +76,7 @@ func (r Wrapper) handleUserLanding(echoCtx echo.Context) error {
 	accessTokenRequest := redirectSession.AccessTokenRequest
 	authServerURL := accessTokenRequest.Body.AuthorizationServer
 
-	// Make sure there's a user session, loaded with EmployeeCredential
+	// Make sure there's a user session, loaded with NutsEmployeeCredential
 	userSession, err := user.GetSession(echoCtx.Request().Context())
 	if err != nil {
 		return err
@@ -176,7 +176,7 @@ func (r Wrapper) issueEmployeeCredential(ctx context.Context, session user.Sessi
 	expirationDate := session.ExpiresAt
 	template := vc.VerifiableCredential{
 		Context:        []ssi.URI{credential.NutsV1ContextURI},
-		Type:           []ssi.URI{ssi.MustParseURI("EmployeeCredential")},
+		Type:           []ssi.URI{ssi.MustParseURI("NutsEmployeeCredential")},
 		Issuer:         issuerDID,
 		IssuanceDate:   issuanceDate,
 		ExpirationDate: &expirationDate,
@@ -196,7 +196,7 @@ func (r Wrapper) issueEmployeeCredential(ctx context.Context, session user.Sessi
 		WithStatusListRevocation: false,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("issue EmployeeCredential: %w", err)
+		return nil, fmt.Errorf("issue NutsEmployeeCredential: %w", err)
 	}
 	return employeeCredential, nil
 }

--- a/auth/api/iam/user_test.go
+++ b/auth/api/iam/user_test.go
@@ -120,7 +120,7 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 
 		err = ctx.client.handleUserLanding(echoCtx)
 		require.NoError(t, err)
-		// check for issued EmployeeCredential in session wallet
+		// check for issued NutsEmployeeCredential in session wallet
 		require.NoError(t, err)
 		require.Equal(t, holderSubjectID, userSession.SubjectID)
 		require.Len(t, userSession.Wallet.Credentials, 1)
@@ -129,8 +129,8 @@ func TestWrapper_handleUserLanding(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, sessionKey.KeyID)
 		assert.Equal(t, jwa.EC, sessionKey.KeyType())
-		// check for details of issued EmployeeCredential
-		assert.Equal(t, "EmployeeCredential", employeeCredentialTemplate.Type[0].String())
+		// check for details of issued NutsEmployeeCredential
+		assert.Equal(t, "NutsEmployeeCredential", employeeCredentialTemplate.Type[0].String())
 		employeeCredentialSubject := employeeCredentialTemplate.CredentialSubject[0].(map[string]string)
 		assert.True(t, strings.HasPrefix(employeeCredentialSubject["id"], "did:jwk:"))
 		assert.Equal(t, userDetails.Id, employeeCredentialSubject["identifier"])

--- a/auth/client/iam/openid4vp_test.go
+++ b/auth/client/iam/openid4vp_test.go
@@ -291,7 +291,7 @@ func TestRelyingParty_RequestRFC021AccessToken(t *testing.T) {
 					holder.VerifiableCredentialLDContextV1,
 					credential.NutsV1ContextURI,
 				},
-				Type: []ssi.URI{vc.VerifiableCredentialTypeV1URI(), ssi.MustParseURI("EmployeeCredential")},
+				Type: []ssi.URI{vc.VerifiableCredentialTypeV1URI(), ssi.MustParseURI("NutsEmployeeCredential")},
 				CredentialSubject: []interface{}{
 					map[string]interface{}{
 						"roleName":   "employee",

--- a/docs/_static/auth/v2.yaml
+++ b/docs/_static/auth/v2.yaml
@@ -418,7 +418,7 @@ components:
                 "https://www.w3.org/2018/credentials/v1",
                 "https://nuts.nl/credentials/v1"
               ],
-              "type": ["VerifiableCredential", "EmployeeCredential"],
+              "type": ["VerifiableCredential", "NutsEmployeeCredential"],
               "credentialSubject": {
                 "name": "John Doe",
                 "roleName": "Janitor",

--- a/e2e-tests/browser/openid4vp_employeecredential/config/policy/zorgtoepassing.json
+++ b/e2e-tests/browser/openid4vp_employeecredential/config/policy/zorgtoepassing.json
@@ -102,7 +102,7 @@
                 ],
                 "filter": {
                   "type": "string",
-                  "const": "EmployeeCredential"
+                  "const": "NutsEmployeeCredential"
                 }
               },
               {

--- a/e2e-tests/clustering/memcached/run-test.sh
+++ b/e2e-tests/clustering/memcached/run-test.sh
@@ -76,7 +76,7 @@ cat << EOF
           "https://www.w3.org/2018/credentials/v1",
           "https://nuts.nl/credentials/v1"
         ],
-        "type": ["VerifiableCredential", "EmployeeCredential"],
+        "type": ["VerifiableCredential", "NutsEmployeeCredential"],
         "credentialSubject": {
           "name": "John Doe",
           "roleName": "Janitor",

--- a/e2e-tests/clustering/redis/run-test.sh
+++ b/e2e-tests/clustering/redis/run-test.sh
@@ -76,7 +76,7 @@ cat << EOF
           "https://www.w3.org/2018/credentials/v1",
           "https://nuts.nl/credentials/v1"
         ],
-        "type": ["VerifiableCredential", "EmployeeCredential"],
+        "type": ["VerifiableCredential", "NutsEmployeeCredential"],
         "credentialSubject": {
           "name": "John Doe",
           "roleName": "Janitor",

--- a/e2e-tests/clustering/shared/presentationexchangemapping.json
+++ b/e2e-tests/clustering/shared/presentationexchangemapping.json
@@ -59,7 +59,7 @@
                 ],
                 "filter": {
                   "type": "string",
-                  "const": "EmployeeCredential"
+                  "const": "NutsEmployeeCredential"
                 }
               },
               {

--- a/e2e-tests/oauth-flow/rfc021/do-test.sh
+++ b/e2e-tests/oauth-flow/rfc021/do-test.sh
@@ -128,7 +128,7 @@ cat << EOF
           "https://www.w3.org/2018/credentials/v1",
           "https://nuts.nl/credentials/v1"
         ],
-        "type": ["VerifiableCredential", "EmployeeCredential"],
+        "type": ["VerifiableCredential", "NutsEmployeeCredential"],
         "credentialSubject": {
           "name": "John Doe",
           "roleName": "Janitor",

--- a/e2e-tests/oauth-flow/rfc021/node-A/presentationexchangemapping.json
+++ b/e2e-tests/oauth-flow/rfc021/node-A/presentationexchangemapping.json
@@ -59,7 +59,7 @@
                 ],
                 "filter": {
                   "type": "string",
-                  "const": "EmployeeCredential"
+                  "const": "NutsEmployeeCredential"
                 }
               },
               {

--- a/http/user/session.go
+++ b/http/user/session.go
@@ -205,7 +205,7 @@ type Session struct {
 	Save func() error `json:"-"`
 	// SubjectID identifies the requesting subject when the user session was created.
 	// A session needs to be scoped to the subject, since the session gives access to the subject's wallets,
-	// and the user session might contain session-bound credentials (e.g. EmployeeCredential) that were issued by the subject.
+	// and the user session might contain session-bound credentials (e.g. NutsEmployeeCredential) that were issued by the subject.
 	SubjectID string    `json:"subjectID"`
 	Wallet    Wallet    `json:"wallet"`
 	ExpiresAt time.Time `json:"expiresAt"`
@@ -213,7 +213,7 @@ type Session struct {
 
 // Wallet is a session-bound Verifiable Credential wallet.
 // It's an in-memory wallet which contains the user's private key in plain text.
-// This is OK, since the associated credentials are intended for protocol compatibility (OpenID4VP with a low-assurance EmployeeCredential),
+// This is OK, since the associated credentials are intended for protocol compatibility (OpenID4VP with a low-assurance NutsEmployeeCredential),
 // when an actual user wallet is involved, this wallet isn't used.
 type Wallet struct {
 	Credentials []vc.VerifiableCredential

--- a/vcr/pe/presentation_definition_test.go
+++ b/vcr/pe/presentation_definition_test.go
@@ -140,7 +140,7 @@ func TestEmployeeCredential(t *testing.T) {
                 ],
                 "filter": {
                   "type": "string",
-                  "const": "EmployeeCredential"
+                  "const": "NutsEmployeeCredential"
                 }
               },
               {
@@ -179,7 +179,8 @@ func TestEmployeeCredential(t *testing.T) {
       ]
     }`))
 	require.NoError(t, err)
-	cred, err := vc.ParseVerifiableCredential(`eyJhbGciOiJFUzI1NiIsImtpZCI6ImRpZDp3ZWI6bm9kZUE6aWFtOnJlcXVlc3RlciMwIiwidHlwIjoiSldUIn0.eyJleHAiOjE3MTI1NzI2MTIsImlzcyI6ImRpZDp3ZWI6bm9kZUE6aWFtOnJlcXVlc3RlciIsImp0aSI6ImRpZDp3ZWI6bm9kZUE6aWFtOnJlcXVlc3RlciM4ZjNkMWI0OS1iODYzLTQxZjYtYmY4Ny05ZTVhODY2YWMyMzEiLCJuYmYiOjE3MTI1NjkwMTIsInN1YiI6ImRpZDpqd2s6ZXlKamNuWWlPaUpRTFRJMU5pSXNJbXQwZVNJNklrVkRJaXdpZUNJNklsOVFVVk5TVkY5UmRFWmpOMFpvU0VwUGFGVXRibEJ2TVVaNGRFZDRTRmRqUzJ0b2FqUTVhRE5hT1VVaUxDSjVJam9pTmpoek16TTFOVkJIYm5CcVVVSkVNamRKTjE4NVpFUnpkRzU2TVVwZlZtZzNZVlprUlVOVlNHOXpRU0o5IiwidmMiOnsiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL251dHMubmwvY3JlZGVudGlhbHMvdjEiXSwiY3JlZGVudGlhbFN1YmplY3QiOlt7ImlkIjoiZGlkOmp3azpleUpqY25ZaU9pSlFMVEkxTmlJc0ltdDBlU0k2SWtWRElpd2llQ0k2SWw5UVVWTlNWRjlSZEVaak4wWm9TRXBQYUZVdGJsQnZNVVo0ZEVkNFNGZGpTMnRvYWpRNWFETmFPVVVpTENKNUlqb2lOamh6TXpNMU5WQkhibkJxVVVKRU1qZEpOMTg1WkVSemRHNTZNVXBmVm1nM1lWWmtSVU5WU0c5elFTSjkiLCJpZGVudGlmaWVyIjoiamRvZUBleGFtcGxlLmNvbSIsIm5hbWUiOiJKb2huIERvZSIsInJvbGVOYW1lIjoiQWNjb3VudGFudCJ9XSwidHlwZSI6WyJFbXBsb3llZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlQ3JlZGVudGlhbCJdfX0.6VeGDsTEy2BpQW3RKCiczIVoAAdlfl_EP4KioE9lavWIuXTASTAPkcY9oOlfG_HFLZvu82Nnt6L-ntK8XzR7Ew`)
+	cred, err := vc.ParseVerifiableCredential(`eyJhbGciOiJFUzI1NiIsImtpZCI6ImRpZDp3ZWI6bm9kZUE6aWFtOnJlcXVlc3RlciMwIiwidHlwIjoiSldUIn0.eyJleHAiOiAxNzEyNTcyNjEyLCJpc3MiOiAiZGlkOndlYjpub2RlQTppYW06cmVxdWVzdGVyIiwianRpIjogImRpZDp3ZWI6bm9kZUE6aWFtOnJlcXVlc3RlciM4ZjNkMWI0OS1iODYzLTQxZjYtYmY4Ny05ZTVhODY2YWMyMzEiLCJuYmYiOiAxNzEyNTY5MDEyLCJzdWIiOiAiZGlkOmp3azpleUpqY25ZaU9pSlFMVEkxTmlJc0ltdDBlU0k2SWtWRElpd2llQ0k2SWw5UVVWTlNWRjlSZEVaak4wWm9TRXBQYUZVdGJsQnZNVVo0ZEVkNFNGZGpTMnRvYWpRNWFETmFPVVVpTENKNUlqb2lOamh6TXpNMU5WQkhibkJxVVVKRU1qZEpOMTg1WkVSemRHNTZNVXBmVm1nM1lWWmtSVU5WU0c5elFTSjkiLCJ2YyI6IHsiQGNvbnRleHQiOiBbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIiwiaHR0cHM6Ly9udXRzLm5sL2NyZWRlbnRpYWxzL3YxIl0sICJjcmVkZW50aWFsU3ViamVjdCI6IFt7ImlkIjogImRpZDpqd2s6ZXlKamNuWWlPaUpRTFRJMU5pSXNJbXQwZVNJNklrVkRJaXdpZUNJNklsOVFVVk5TVkY5UmRFWmpOMFpvU0VwUGFGVXRibEJ2TVVaNGRFZDRTRmRqUzJ0b2FqUTVhRE5hT1VVaUxDSjVJam9pTmpoek16TTFOVkJIYm5CcVVVSkVNamRKTjE4NVpFUnpkRzU2TVVwZlZtZzNZVlprUlVOVlNHOXpRU0o5IiwiaWRlbnRpZmllciI6ICJqZG9lQGV4YW1wbGUuY29tIiwibmFtZSI6ICJKb2huIERvZSIsICJyb2xlTmFtZSI6ICJBY2NvdW50YW50In1dLCJ0eXBlIjogWyJOdXRzRW1wbG95ZWVDcmVkZW50aWFsIiwiVmVyaWZpYWJsZUNyZWRlbnRpYWwiXX19.BAD_C0DE`)
+	require.NoError(t, err)
 
 	credentials, _, err := pd.Match([]vc.VerifiableCredential{*cred})
 


### PR DESCRIPTION
We used an `EmployeeCredential` and `NutsEmployeeCredential`. Both use the `https://nuts.nl/credentials/v1` context that only contains the `NutsEmployeeCredential`. 
My understanding is that there was a proposal to add the `EmployeeCredential`, but the idea was abandoned because the same could be achieved with the `NutsEmployeeCredential`.

I've tested this against v6.0.8 and there are no breaking changes except possibly for the browser/openid4vp_employeecredential e2e test. This uses the /request-user-access-token flow that is under a feature flag, so a breaking change is allowed.

backport to V6.0 to fix the documentation examples