### PR TITLE
Auth: allow client-side access token cache to be bypassed

### DIFF
--- a/docs/_static/auth/v2.yaml
+++ b/docs/_static/auth/v2.yaml
@@ -34,6 +34,13 @@ paths:
           description: |
             Access tokens are cached by the Nuts node, specify Cache-Control: no-cache to bypass the cache.
             This forces the Nuts node to request a new access token from the authorizer.
+            
+            A valid use case for this is when the Resource Server rejects the access token with 401 Unauthorized.
+            In that case it could be suspected that the Authorization Server lost the access token due to a server restart,
+            in combination with (non-recommended) usage of in-memory session storage.
+            The local Nuts node then still considers the token valid, while the Authorization Server does not.
+            
+            Note that this should not be used under normal circumstances, as it will increase round trip time and load on both the requester and authorizer.
           schema:
             type: string
             example: no-cache

--- a/docs/_static/auth/v2.yaml
+++ b/docs/_static/auth/v2.yaml
@@ -28,6 +28,15 @@ paths:
           schema:
             type: string
             example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
+        - name: Cache-Control
+          in: header
+          required: false
+          description: |
+            Access tokens are cached by the Nuts node, specify Cache-Control: no-cache to bypass the cache.
+            This forces the Nuts node to request a new access token from the authorizer.
+          schema:
+            type: string
+            example: no-cache
       requestBody:
         required: true
         content:

--- a/docs/_static/auth/v2.yaml
+++ b/docs/_static/auth/v2.yaml
@@ -36,7 +36,7 @@ paths:
             This forces the Nuts node to request a new access token from the authorizer.
             
             A valid use case for this is when the Resource Server rejects the access token with 401 Unauthorized.
-            In that case it could be suspected that the Authorization Server lost the access token due to a server restart,
+            It could be that the Authorization Server lost the access token due to a server restart,
             in combination with (non-recommended) usage of in-memory session storage.
             The local Nuts node then still considers the token valid, while the Authorization Server does not.
             


### PR DESCRIPTION
Fixes https://github.com/nuts-foundation/nuts-node/issues/3719