### PR TITLE
Ignore errRetractionReferencesUnknownPresentation when validating as client

### DIFF
--- a/discovery/module.go
+++ b/discovery/module.go
@@ -317,7 +317,10 @@ func (m *Module) validateRetraction(serviceID string, presentation vc.Verifiable
 		return err
 	}
 	if !exists {
-		return errRetractionReferencesUnknownPresentation
+		if _, ok = m.serverDefinitions[serviceID]; !ok { // clients do not need to check that the retraction refers to a VP
+			return errRetractionReferencesUnknownPresentation
+		}
+		log.Logger().Warnf("Ignored retraction (ID=%s) signed by (did=%s) for (service=%s) that references a VP (retractedJTI=%s) that does not exist (anymore).", presentation.ID, signerDID.String(), serviceID, retractJTI)
 	}
 	return nil
 }

--- a/discovery/module.go
+++ b/discovery/module.go
@@ -317,7 +317,7 @@ func (m *Module) validateRetraction(serviceID string, presentation vc.Verifiable
 		return err
 	}
 	if !exists {
-		if _, ok = m.serverDefinitions[serviceID]; !ok { // clients do not need to check that the retraction refers to a VP
+		if _, ok = m.serverDefinitions[serviceID]; ok { // only throw an error if acting as server for this service, see https://github.com/nuts-foundation/nuts-node/issues/3691
 			return errRetractionReferencesUnknownPresentation
 		}
 		log.Logger().Warnf("Ignored retraction (ID=%s) signed by (did=%s) for (service=%s) that references a VP (retractedJTI=%s) that does not exist (anymore).", presentation.ID, signerDID.String(), serviceID, retractJTI)

--- a/discovery/module_test.go
+++ b/discovery/module_test.go
@@ -214,7 +214,18 @@ func Test_Module_Register(t *testing.T) {
 			err = m.Register(ctx, testServiceID, vpAliceRetract)
 			assert.NoError(t, err)
 		})
-		t.Run("non-existent presentation", func(t *testing.T) {
+		t.Run("non-existent presentation as client", func(t *testing.T) {
+			m, testContext := setupModule(t, storageEngine, func(module *Module) {
+				// disable updater
+				module.config.Client.RefreshInterval = 0
+			})
+			testContext.verifier.EXPECT().VerifyVP(gomock.Any(), true, true, nil)
+			definition := m.serverDefinitions[testServiceID]
+			delete(m.serverDefinitions, testServiceID)
+			err := m.verifyRegistration(definition, vpAliceRetract)
+			assert.NoError(t, err)
+		})
+		t.Run("non-existent presentation as server", func(t *testing.T) {
 			m, _ := setupModule(t, storageEngine)
 			err := m.Register(ctx, testServiceID, vpAliceRetract)
 			assert.ErrorIs(t, err, errRetractionReferencesUnknownPresentation)


### PR DESCRIPTION
fixes #3691

