### PR TITLE
did:x509 implementation touch-ups

### DIFF
--- a/test/pki/test.go
+++ b/test/pki/test.go
@@ -189,6 +189,8 @@ func BuildRootCert() (*rsa.PrivateKey, *x509.Certificate, error) {
 		return nil, nil, err
 	}
 	rootCertTmpl, err := certTemplate("Root CA")
+	// Set a fixed validity period for the root certificate, so expiration can be tested deterministically.
+	// Also, set expiration in the far future, so we don't have failing tests due to expiration of the root cert in 10 years or so.
 	rootCertTmpl.NotBefore = time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC)
 	rootCertTmpl.NotAfter = time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)
 	if err != nil {

--- a/vcr/credential/validator.go
+++ b/vcr/credential/validator.go
@@ -270,6 +270,9 @@ func (d x509CredentialValidator) Validate(credential vc.VerifiableCredential) er
 	if err != nil {
 		return errors.Join(errValidation, err)
 	}
+	if didX509Issuer.Method != didx509.MethodName {
+		return fmt.Errorf("%w: issuer of X509Credential MUST be did:%s DID", errValidation, didx509.MethodName)
+	}
 	x509resolver := didx509.NewResolver()
 	resolveMetadata := resolver.ResolveMetadata{}
 	if credential.Format() == vc.JWTCredentialProofFormat {

--- a/vcr/credential/validator.go
+++ b/vcr/credential/validator.go
@@ -266,11 +266,11 @@ type x509CredentialValidator struct {
 }
 
 func (d x509CredentialValidator) Validate(credential vc.VerifiableCredential) error {
-	didX509Issuer, err := did.ParseDID(credential.Issuer.String())
+	issuerDID, err := did.ParseDID(credential.Issuer.String())
 	if err != nil {
 		return errors.Join(errValidation, err)
 	}
-	if didX509Issuer.Method != didx509.MethodName {
+	if issuerDID.Method != didx509.MethodName {
 		return fmt.Errorf("%w: issuer of X509Credential MUST be did:%s DID", errValidation, didx509.MethodName)
 	}
 	x509resolver := didx509.NewResolver()
@@ -286,12 +286,12 @@ func (d x509CredentialValidator) Validate(credential vc.VerifiableCredential) er
 		// unsupported format
 		return fmt.Errorf("%w: unsupported credential format: %s", errValidation, credential.Format())
 	}
-	_, _, err = x509resolver.Resolve(*didX509Issuer, &resolveMetadata)
+	_, _, err = x509resolver.Resolve(*issuerDID, &resolveMetadata)
 	if err != nil {
 		return fmt.Errorf("%w: invalid issuer: %w", errValidation, err)
 	}
 
-	if err = validatePolicyAssertions(*didX509Issuer, credential); err != nil {
+	if err = validatePolicyAssertions(*issuerDID, credential); err != nil {
 		return fmt.Errorf("%w: %w", errValidation, err)
 	}
 
@@ -305,6 +305,19 @@ func (d x509CredentialValidator) Validate(credential vc.VerifiableCredential) er
 		cert, _ := x509.ParseCertificate(der)
 		chain[i] = cert
 	}
+
+	// Check credential's time validity v.s. certificate's time validity
+	if credential.ExpirationDate == nil || credential.ExpirationDate.IsZero() {
+		return fmt.Errorf("%w: 'expirationDate' is required", errValidation)
+	}
+	leafCert := chain[0]
+	if credential.ExpirationDate.After(leafCert.NotAfter) {
+		return fmt.Errorf("%w: credential expiration date is after certificate's notAfter", errValidation)
+	}
+	if credential.IssuanceDate.Before(leafCert.NotBefore) {
+		return fmt.Errorf("%w: credential issuance date is before certificate's notBefore", errValidation)
+	}
+
 	if err = d.pkiValidator.CheckCRL(chain); err != nil {
 		return fmt.Errorf("%w: %w", errValidation, err)
 	}

--- a/vcr/credential/validator_test.go
+++ b/vcr/credential/validator_test.go
@@ -529,6 +529,16 @@ func TestX509CredentialValidator_Validate(t *testing.T) {
 		assert.ErrorIs(t, err, errValidation)
 		assert.ErrorIs(t, err, did.ErrInvalidDID)
 	})
+	t.Run("issuer is not did:x509", func(t *testing.T) {
+		x509credential := test.ValidX509Credential(t)
+		x509credential.Issuer = ssi.MustParseURI("did:web:example.com")
+		ctx := createTestContext(t)
+
+		err := ctx.validator.Validate(x509credential)
+
+		assert.ErrorIs(t, err, errValidation)
+		assert.ErrorContains(t, err, "issuer of X509Credential MUST be did:x509 DID")
+	})
 	t.Run("invalid format", func(t *testing.T) {
 		x509credential := vc.VerifiableCredential{Issuer: ssi.MustParseURI("did:example:123")}
 

--- a/vcr/test/credentials.go
+++ b/vcr/test/credentials.go
@@ -137,7 +137,7 @@ type credentialOption func(*jwt.Builder) *jwt.Builder
 
 func ValidX509Credential(t *testing.T, options ...credentialOption) vc.VerifiableCredential {
 	otherNameValue := "A_BIG_STRING"
-	certs, keys, err := pki.BuildCertChain([]string{otherNameValue}, "123")
+	certs, keys, err := pki.BuildCertChain([]string{otherNameValue}, "123", nil)
 	require.NoError(t, err)
 	rootCertificate := certs[len(certs)-1]
 	rootKey := keys[len(keys)-1]
@@ -157,6 +157,7 @@ func ValidX509Credential(t *testing.T, options ...credentialOption) vc.Verifiabl
 		JwtID(fmt.Sprintf("%s#1", rootDID)).
 		Issuer(rootDID.String()).
 		NotBefore(time.Now()).
+		Expiration(time.Now().Add(time.Hour)).
 		Subject("did:example:1").
 		Claim("vc", map[string]interface{}{
 			"@context": []string{"https://www.w3.org/2018/credentials/v1"},

--- a/vcr/verifier/signature_verifier_test.go
+++ b/vcr/verifier/signature_verifier_test.go
@@ -87,7 +87,7 @@ func TestSignatureVerifier_VerifySignature(t *testing.T) {
 	t.Run("JWT - X509", func(t *testing.T) {
 
 		ura := "312312312"
-		certs, keys, err := testpki.BuildCertChain(nil, ura)
+		certs, keys, err := testpki.BuildCertChain(nil, ura, nil)
 		chain := testpki.CertsToChain(certs)
 		signingCert := certs[0]
 		signingKey := keys[0]

--- a/vcr/verifier/verifier_test.go
+++ b/vcr/verifier/verifier_test.go
@@ -307,7 +307,7 @@ func TestVerifier_Verify(t *testing.T) {
 
 	t.Run("verify x509", func(t *testing.T) {
 		ura := "312312312"
-		certs, keys, err := pki.BuildCertChain(nil, ura)
+		certs, keys, err := pki.BuildCertChain(nil, ura, nil)
 		chain := pki.CertsToChain(certs)
 		signingCert := certs[0]
 		signingKey := keys[0]

--- a/vdr/didx509/x509_utils_test.go
+++ b/vdr/didx509/x509_utils_test.go
@@ -37,7 +37,7 @@ import (
 func TestFindOtherNameValue(t *testing.T) {
 	key, certificate, err := pki.BuildRootCert()
 	require.NoError(t, err)
-	_, signingCert, err := pki.BuildSigningCert([]string{"123", "321"}, certificate, key, "4567")
+	_, signingCert, err := pki.BuildSigningCert([]string{"123", "321"}, certificate, key, "4567", nil)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -88,7 +88,7 @@ func TestFindCertificateByHash(t *testing.T) {
 		}
 		return base64.RawURLEncoding.EncodeToString(h)
 	}
-	chainCerts, _, err := pki.BuildCertChain([]string{"123"}, "")
+	chainCerts, _, err := pki.BuildCertChain([]string{"123"}, "", nil)
 	require.NoError(t, err)
 	type testCase struct {
 		name      string
@@ -186,7 +186,7 @@ func TestParseChain(t *testing.T) {
 		}
 		return &chain
 	}
-	certs, _, _ := pki.BuildCertChain([]string{"123"}, "")
+	certs, _, _ := pki.BuildCertChain([]string{"123"}, "", nil)
 
 	invalidCert := `Y29ycnVwdCBjZXJ0aWZpY2F0ZQo=`
 	invalidBase64 := `Hello, world!`


### PR DESCRIPTION
Checking the implementation v.s. the spec (https://nuts-foundation.gitbook.io/drafts/rfc/rfc023-x509credential), some touch-ups.

Changes to align to the did:x509 specification:
- Explicitly refer to steps from resolution spec
- Removed the usage of x5t, and just use the first certificate of x5c. 
- Set verification method relationships (key usage) according to certificate key usage
- Error out of certificate key usage is invalid for did:x509 DID usage.
- Added some sanity checks for x5c header (no extra certs, order is correct)