### PR TITLE
VCR: Fix deleting credential from wallet with encoded characters in ID/DID fails

### DIFF
--- a/docs/_static/vcr/vcr_v2.yaml
+++ b/docs/_static/vcr/vcr_v2.yaml
@@ -545,8 +545,11 @@ paths:
         in: path
         description: URL encoded VC ID.
         required: true
-        schema:
-          type: string
+        content:
+          plain/text:
+            schema:
+              type: string
+              example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
     delete:
       summary: Remove a VerifiableCredential from the holders wallet.
       description: |

--- a/vcr/api/vcr/v2/generated.go
+++ b/vcr/api/vcr/v2/generated.go
@@ -940,10 +940,7 @@ func NewRemoveCredentialFromWalletRequest(server string, subjectID string, id st
 
 	var pathParam1 string
 
-	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
-	if err != nil {
-		return nil, err
-	}
+	pathParam1 = id
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
@@ -2905,10 +2902,7 @@ func (w *ServerInterfaceWrapper) RemoveCredentialFromWallet(ctx echo.Context) er
 	// ------------- Path parameter "id" -------------
 	var id string
 
-	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
-	}
+	id = ctx.Param("id")
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 


### PR DESCRIPTION
This currently leads to a "credential not found" error.

Test case was for a certificate with an é, which lead to a did:x509 DID containing this character, which got double-decoded in the credential ID (because the ID is in format `<issuer DID>#<guid>`).