### PR TITLE
Use root user in performance analyzer

### DIFF
--- a/development/performance_analyzer/Dockerfile
+++ b/development/performance_analyzer/Dockerfile
@@ -1,5 +1,8 @@
 FROM nutsfoundation/nuts-node:master
 
+# set UID to root user
+USER 0:0
+
 # install and configure node-exporter
 RUN apk update && apk add --no-cache prometheus-node-exporter openrc
 RUN rc-update add node-exporter default \


### PR DESCRIPTION
needs a privileged user to run `apk`. No harm in using root here since it is for dev purposes only