### PR TITLE
#3663: add latency to HTTP access logging

### DIFF
--- a/http/requestlogger.go
+++ b/http/requestlogger.go
@@ -37,6 +37,7 @@ func requestLoggerMiddleware(skipper middleware.Skipper, logger *logrus.Entry) e
 		LogMethod:   true,
 		LogRemoteIP: true,
 		LogError:    true,
+		LogLatency:  true,
 		LogValuesFunc: func(c echo.Context, values middleware.RequestLoggerValues) error {
 			status := values.Status
 			if values.Error != nil {
@@ -47,6 +48,7 @@ func requestLoggerMiddleware(skipper middleware.Skipper, logger *logrus.Entry) e
 				"remote_ip": values.RemoteIP,
 				"method":    values.Method,
 				"uri":       values.URI,
+				"duration":  values.Latency,
 				"status":    status,
 			}
 			if logger.Level >= logrus.DebugLevel {

--- a/http/requestlogger.go
+++ b/http/requestlogger.go
@@ -45,11 +45,11 @@ func requestLoggerMiddleware(skipper middleware.Skipper, logger *logrus.Entry) e
 			}
 
 			fields := logrus.Fields{
-				"remote_ip": values.RemoteIP,
-				"method":    values.Method,
-				"uri":       values.URI,
-				"duration":  values.Latency,
-				"status":    status,
+				"remote_ip":   values.RemoteIP,
+				"method":      values.Method,
+				"uri":         values.URI,
+				"duration_ms": values.Latency.Milliseconds(),
+				"status":      status,
 			}
 			if logger.Level >= logrus.DebugLevel {
 				fields["headers"] = values.Headers

--- a/http/requestlogger_test.go
+++ b/http/requestlogger_test.go
@@ -32,6 +32,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func Test_requestLoggerMiddleware(t *testing.T) {
@@ -57,6 +58,7 @@ func Test_requestLoggerMiddleware(t *testing.T) {
 		assert.Equal(t, "::1", hook.LastEntry().Data["remote_ip"])
 		assert.Equal(t, http.StatusNoContent, hook.LastEntry().Data["status"])
 		assert.Equal(t, "/test", hook.LastEntry().Data["uri"])
+		assert.NotEmpty(t, hook.LastEntry().Data["duration"].(time.Duration))
 	})
 
 	t.Run("it handles echo.HTTPErrors", func(t *testing.T) {

--- a/http/requestlogger_test.go
+++ b/http/requestlogger_test.go
@@ -32,6 +32,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func Test_requestLoggerMiddleware(t *testing.T) {
@@ -49,6 +50,8 @@ func Test_requestLoggerMiddleware(t *testing.T) {
 			return false
 		}, logger.WithFields(logrus.Fields{}))
 		err := logFunc(func(context echo.Context) error {
+			// Simulate some processing time to cause latency to be > 0
+			time.Sleep(1 * time.Millisecond)
 			return context.NoContent(http.StatusNoContent)
 		})(echoMock)
 

--- a/http/requestlogger_test.go
+++ b/http/requestlogger_test.go
@@ -32,7 +32,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 )
 
 func Test_requestLoggerMiddleware(t *testing.T) {
@@ -58,7 +57,7 @@ func Test_requestLoggerMiddleware(t *testing.T) {
 		assert.Equal(t, "::1", hook.LastEntry().Data["remote_ip"])
 		assert.Equal(t, http.StatusNoContent, hook.LastEntry().Data["status"])
 		assert.Equal(t, "/test", hook.LastEntry().Data["uri"])
-		assert.NotEmpty(t, hook.LastEntry().Data["duration"].(time.Duration))
+		assert.NotEmpty(t, hook.LastEntry().Data["duration_ms"].(int64))
 	})
 
 	t.Run("it handles echo.HTTPErrors", func(t *testing.T) {


### PR DESCRIPTION
Example output:

```
INFO[0006] HTTP request   duration_ms=60 method=POST module=http remote_ip=127.0.0.1 status=200 uri=/internal/vdr/v2/subject
```

