### PR TITLE
#3663: Prometheus metrics for SQL query execution duration

### DIFF
--- a/storage/gorm_logger_test.go
+++ b/storage/gorm_logger_test.go
@@ -19,6 +19,7 @@
 package storage
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -36,6 +37,9 @@ func Test_gormLogrusLogger_Trace(t *testing.T) {
 	logger := gormLogrusLogger{
 		underlying:    underlying.WithFields(nil),
 		slowThreshold: 10 * time.Second,
+		queryDurationMetric: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name: "test",
+		}),
 	}
 	now := time.Now()
 	nowFunc = func() time.Time {


### PR DESCRIPTION
Example:

```
# HELP sql_query_duration_seconds Duration of SQL queries in seconds (experimental, may be removed without notice)
# TYPE sql_query_duration_seconds histogram
sql_query_duration_seconds_bucket{le="0.005"} 310
sql_query_duration_seconds_bucket{le="0.01"} 310
sql_query_duration_seconds_bucket{le="0.025"} 310
sql_query_duration_seconds_bucket{le="0.05"} 310
sql_query_duration_seconds_bucket{le="0.1"} 310
sql_query_duration_seconds_bucket{le="0.25"} 310
sql_query_duration_seconds_bucket{le="0.5"} 310
sql_query_duration_seconds_bucket{le="1"} 310
sql_query_duration_seconds_bucket{le="2.5"} 310
sql_query_duration_seconds_bucket{le="5"} 310
sql_query_duration_seconds_bucket{le="10"} 310
sql_query_duration_seconds_bucket{le="+Inf"} 310
sql_query_duration_seconds_sum 0.018362627000000003
sql_query_duration_seconds_count 310
```