### PR TITLE
Proof of Concept: user authentication through OpenID Connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ data
 
 # Editors
 .idea
+.run
 
 # MacOS
 .DS_Store

--- a/auth/api/iam/access_token.go
+++ b/auth/api/iam/access_token.go
@@ -118,7 +118,18 @@ func (r Wrapper) createAccessToken(ctx context.Context, subject string, issuerUR
 }
 
 func (r Wrapper) createIDToken(ctx context.Context, subject string, issuer string, audience string, issueTime time.Time, token []VerifiablePresentation, definitions pe.WalletOwnerMapping) (string, error) {
-	claims := map[string]any{}
+	claims := map[string]any{
+		"iss":   issuer,
+		"aud":   audience,
+		"iat":   issueTime.Unix(),
+		"exp":   issueTime.Add(accessTokenValidity).Unix(),
+		"nonce": crypto.GenerateNonce(),
+		// TODO: Derive these from the authenticated user
+		"sub":   "1.2.3.4.5 (remote user identifier)",
+		"name":  "Dokter Jansen",
+		"email": "doctor@hospital.nl",
+		"roles": []string{"Verpleegkundige niveau 4"},
+	}
 
 	// TODO: use OpenID Configuration instead
 	dids, err := r.subjectManager.ListDIDs(ctx, subject)

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -680,7 +680,7 @@ func (r Wrapper) handleAccessTokenRequest(ctx context.Context, request HandleTok
 		// a failing request could indicate a stolen authorization code. always burn a code once presented.
 		_ = r.oauthCodeStore().Delete(*request.Code)
 	}()
-	// check if code_verifier is present
+	// PKCE: check if code_verifier is present
 	if request.CodeVerifier == nil {
 		return nil, oauthError(oauth.InvalidRequest, "missing code_verifier parameter")
 	}
@@ -713,7 +713,7 @@ func (r Wrapper) handleAccessTokenRequest(ctx context.Context, request HandleTok
 
 	// All done, issue access token
 	issuerURL := r.subjectToBaseURL(*oauthSession.OwnSubject)
-	response, err := r.createAccessToken(issuerURL.String(), oauthSession.ClientID, time.Now(), oauthSession.Scope, *oauthSession.OpenID4VPVerifier, dpopProof)
+	response, err := r.createAccessToken(ctx, *oauthSession.OwnSubject, issuerURL.String(), oauthSession.ClientID, time.Now(), oauthSession.Scope, *oauthSession.OpenID4VPVerifier, dpopProof)
 	if err != nil {
 		return nil, oauthError(oauth.ServerError, fmt.Sprintf("failed to create access token: %s", err.Error()))
 	}

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/nuts-foundation/nuts-node/core/to"
 	"github.com/nuts-foundation/nuts-node/http/user"
 	"net/http"
 	"net/url"
@@ -92,7 +93,8 @@ func (r Wrapper) handleAuthorizeRequestFromHolder(ctx context.Context, subject s
 
 	// additional JAR checks
 	// check if the audience is the verifier
-	if params.get(jwt.AudienceKey) != clientID.String() {
+	// TODO: Make this check required if JAR is used
+	if params.get(jwt.AudienceKey) != "" && params.get(jwt.AudienceKey) != clientID.String() {
 		return nil, withCallbackURI(oauthError(oauth.InvalidRequest, fmt.Sprintf("invalid audience, expected: %s, was: %s", clientID.String(), params.get(jwt.AudienceKey))), redirectURL)
 	}
 	// we require PKCE (RFC7636) for authorization code flows
@@ -123,6 +125,9 @@ func (r Wrapper) handleAuthorizeRequestFromHolder(ctx context.Context, subject s
 			Challenge:       params.get(oauth.CodeChallengeParam),
 			ChallengeMethod: params.get(oauth.CodeChallengeMethodParam),
 		},
+	}
+	if params.get(oauth.LoginHintParam) != "" {
+		session.LoginHint = to.Ptr(params.get(oauth.LoginHintParam))
 	}
 	// create a client state for the verifier
 	state := crypto.GenerateNonce()
@@ -192,8 +197,20 @@ func (r Wrapper) nextOpenID4VPFlow(ctx context.Context, state string, session OA
 		// User wallet, make an openid4vp: request URL
 		redirectURL, err = r.createAuthorizationRequest(ctx, *session.OwnSubject, staticAuthorizationServerMetadata(), modifier)
 	} else {
+		// When determining the credential wallet (remote Authorization Server) to query, there's 2 possibilities:
+		// - The flow was initiated by the verifier, which is the case for OpenID Connect (acquire an id_token to authenticate a user from a remote organization).
+		//   We assume this is the case when there's a login_hint parameter that looks like a URL.
+		// - The flow was initiated by the wallet owner, which is the case for the "user access token flow" (acquire an access token for a user local to the organization, to consume a remote API).
+		var remoteAuthServerURL string
+		if session.LoginHint != nil &&
+			(strings.HasPrefix(strings.ToLower(*session.LoginHint), "https://") || strings.HasPrefix(strings.ToLower(*session.LoginHint), "http://")) {
+			remoteAuthServerURL = *session.LoginHint
+		} else {
+			remoteAuthServerURL = session.ClientID
+		}
+
 		// fetch openId configuration
-		configuration, innerErr := r.auth.IAMClient().OpenIDConfiguration(ctx, session.ClientID)
+		configuration, innerErr := r.auth.IAMClient().OpenIDConfiguration(ctx, remoteAuthServerURL)
 		if innerErr != nil {
 			return nil, oauth.OAuth2Error{
 				Code:          oauth.ServerError,

--- a/auth/api/iam/s2s_vptoken.go
+++ b/auth/api/iam/s2s_vptoken.go
@@ -109,7 +109,7 @@ func (r Wrapper) handleS2SAccessTokenRequest(ctx context.Context, clientID strin
 
 	// All OK, allow access
 	issuerURL := r.subjectToBaseURL(subject)
-	response, err := r.createAccessToken(issuerURL.String(), clientID, time.Now(), scope, *pexConsumer, dpopProof)
+	response, err := r.createAccessToken(ctx, subject, issuerURL.String(), clientID, time.Now(), scope, *pexConsumer, dpopProof)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/api/iam/s2s_vptoken_test.go
+++ b/auth/api/iam/s2s_vptoken_test.go
@@ -25,6 +25,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+	"github.com/nuts-foundation/nuts-node/audit"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	"github.com/nuts-foundation/nuts-node/policy"
 	"go.uber.org/mock/gomock"
@@ -447,7 +448,7 @@ func TestWrapper_createAccessToken(t *testing.T) {
 		ctx := newTestClient(t)
 
 		require.NoError(t, err)
-		accessToken, err := ctx.client.createAccessToken(issuerURL.String(), credentialSubjectID.String(), time.Now(), "everything", pexConsumer, dpopToken)
+		accessToken, err := ctx.client.createAccessToken(audit.TestContext(), "subject", issuerURL.String(), credentialSubjectID.String(), time.Now(), "everything", pexConsumer, dpopToken)
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, accessToken.AccessToken)
@@ -470,7 +471,7 @@ func TestWrapper_createAccessToken(t *testing.T) {
 	})
 	t.Run("ok - bearer token", func(t *testing.T) {
 		ctx := newTestClient(t)
-		accessToken, err := ctx.client.createAccessToken(issuerURL.String(), credentialSubjectID.String(), time.Now(), "everything", pexConsumer, nil)
+		accessToken, err := ctx.client.createAccessToken(audit.TestContext(), "subject", issuerURL.String(), credentialSubjectID.String(), time.Now(), "everything", pexConsumer, nil)
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, accessToken.AccessToken)

--- a/auth/api/iam/session.go
+++ b/auth/api/iam/session.go
@@ -46,6 +46,8 @@ type OAuthSession struct {
 	Scope                       string                             `json:"scope,omitempty"`
 	SessionID                   string                             `json:"session_id,omitempty"`
 	TokenEndpoint               string                             `json:"token_endpoint,omitempty"`
+	// LoginHint is the OpenID Connect login_hint parameter that is passed to the authorization server.
+	LoginHint *string `json:"login_hint,omitempty"`
 	// IssuerURL is the URL that identifies the OAuth2 Authorization Server according to RFC 8414 (Authorization Server Metadata).
 	IssuerURL string `json:"issuer_url,omitempty"`
 	UseDPoP   bool   `json:"use_dpop,omitempty"`

--- a/auth/api/iam/types.go
+++ b/auth/api/iam/types.go
@@ -24,6 +24,8 @@ import (
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
+	"slices"
+	"strings"
 )
 
 // DIDDocument is an alias
@@ -85,3 +87,13 @@ const (
 	AccessTokenTypeBearer = "Bearer"
 	AccessTokenTypeDPoP   = "DPoP"
 )
+
+type Scope string
+
+func (s Scope) Contains(scope string) bool {
+	if s == "" {
+		return false
+	}
+	scopes := strings.Split(scope, " ")
+	return slices.Contains(scopes, string(s))
+}

--- a/auth/oauth/types.go
+++ b/auth/oauth/types.go
@@ -164,6 +164,8 @@ const (
 	CodeVerifierParam = "code_verifier"
 	// GrantTypeParam is the parameter name for the grant_type parameter. (RFC6749)
 	GrantTypeParam = "grant_type"
+	// LoginHintParam is the parameter name for the login_hint parameter. (OpenID Connect)
+	LoginHintParam = "login_hint"
 	// NonceParam is the parameter name for the nonce parameter
 	NonceParam = "nonce"
 	// PresentationDefParam is the parameter name for the OpenID4VP presentation_definition parameter. (OpenID4VP)

--- a/auth/oauth/types.go
+++ b/auth/oauth/types.go
@@ -32,6 +32,7 @@ import (
 // Through With() and Get() additional parameters (for OpenID4VCI, for instance) can be set and retrieved.
 type TokenResponse struct {
 	AccessToken string  `json:"access_token"`
+	IDToken     *string `json:"id_token,omitempty"`
 	DPoPKid     *string `json:"dpop_kid,omitempty"`
 	ExpiresAt   *int    `json:"expires_at,omitempty"`
 	ExpiresIn   *int    `json:"expires_in,omitempty"`


### PR DESCRIPTION
This PoC verifies the feasibility of using the Nuts Node as OpenID Connect Provider to authenticate users from other care organizations. This can be used to log remote users into the organization's applications using generic OpenID Connect client libraries.

PoC setup can be found here: https://github.com/Zorgbijjou/nuts-openid-poc