### PR TITLE
disable e2e tests for PRs from forks

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   e2e-test:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       packages: write
 


### PR DESCRIPTION
This is needed to accept PRs from forks. Consequences might be that we have to ask for a PR to a new branch if a PR is significant.