### PR TITLE
dropped support for 6.0 and add support for 6.1

### DIFF
--- a/.github/workflows/codeql-analysis-cron-schedule.yml
+++ b/.github/workflows/codeql-analysis-cron-schedule.yml
@@ -25,7 +25,7 @@ jobs:
         branches:
           - 'master'
           - 'V5.4'
-          - 'V6.0'
+          - 'V6.1'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/govulncheck-cron-schedule.yaml
+++ b/.github/workflows/govulncheck-cron-schedule.yaml
@@ -23,7 +23,6 @@ jobs:
         branches:
           - 'master'
           - 'V5.4'
-          - 'V6.0'
           - 'V6.1'
 
     steps:


### PR DESCRIPTION
These checks run on a schedule. The 'master' schedule only needs to be updated on the main branch.

This disables vulnerability warnings in slack for branch 6.0