### PR TITLE
lock redis to 7 to fix e2e tests

### DIFF
--- a/e2e-tests/clustering/redis/docker-compose.yml
+++ b/e2e-tests/clustering/redis/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redisA:
-    image: &image redis:latest
+    image: &image redis:7
     command: redis-server /redis/conf/redis.conf
     volumes:
       - "./master:/redis/conf:ro"


### PR DESCRIPTION
backport