### PR TITLE
feat: add extraEnv to helm chart values

### DIFF
--- a/charts/nuts-node/README.md
+++ b/charts/nuts-node/README.md
@@ -26,6 +26,7 @@ of. However, we do need to expose the `http` and `gRPC` ports. This is extracted
 | `http.external.address` (must align with `service.external.internalPort`) | :8080           |
 | `http.internal.address` (must align with `service.internal.internalPort`) | :8081           |
 | `network.grpcaddr`                                                        | :5555           | 
+| `extraEnv`                                                                | not set         |
 
 For the `nuts-node` port, the `service.internalPort` can simply be used. For gRPC, the Helm chart filters out all digits 
 after the last `:` character. If not set, defaults will be used.

--- a/charts/nuts-node/templates/deployment.yaml
+++ b/charts/nuts-node/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+          {{- with .Values.extraEnv }}
+            {{ toYaml . | nindent 12 }}
+          {{- end }}
             - name: NUTS_CONFIGFILE
               value: "/opt/nuts/nuts.yaml"
         {{- if .Values.storage}}


### PR DESCRIPTION
This PR adds an `extraEnv` Helm value which can be used to set arbitrary environment values on the nuts-node deployment. This is often used when values need to be injected dynamically. My use-case is setting the `NUTS_STORAGE_SQL_CONNECTION` environment variable automatically from an automatically generated secret (required for: https://github.com/nuts-foundation/nuts-knooppunt/issues/111).

Although it's not part of the default Helm chart starter template it's a common property that is available in many other Helm charts.