### PR TITLE
Don't use RC versions of golang

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "golang"
+        versions: ["*.*rc*"]
 
   # Python (PRs disabled)
   - package-ecosystem: "pip"


### PR DESCRIPTION
Dependabot recently started proposing release candidate build images. This should prevent that.

see #3988 and #3970