### PR TITLE
#4030: Fix Jaeger e2e test by upgrading to v2

### DIFF
--- a/e2e-tests/oauth-flow/rfc021/docker-compose.yml
+++ b/e2e-tests/oauth-flow/rfc021/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   jaeger:
-    image: jaegertracing/all-in-one:1.76.0
+    image: cr.jaegertracing.io/jaegertracing/jaeger:2.15.0
     ports:
       - "16686:16686"  # Jaeger API (used for trace verification)
     healthcheck:


### PR DESCRIPTION
Taken from https://www.jaegertracing.io/docs/2.15/getting-started/

Fixes #4030 