### PR TITLE
fix: nil pointer dereference DoS via invalid DPoP htu URL

### DIFF
--- a/crypto/dpop/dpop.go
+++ b/crypto/dpop/dpop.go
@@ -251,7 +251,9 @@ func strip(raw string) (string, error) {
 		return "", err
 	}
 	u.Scheme = "https"
-	u.Host = strings.Split(u.Host, ":")[0]
+	if host := u.Hostname(); host != "" {
+		u.Host = host
+	}
 	u.RawQuery = ""
 	u.Fragment = ""
 	return u.String(), nil

--- a/crypto/dpop/dpop.go
+++ b/crypto/dpop/dpop.go
@@ -156,12 +156,16 @@ func Parse(s string) (*DPoP, error) {
 	if token.IssuedAt().IsZero() {
 		return nil, fmt.Errorf("%w: missing iat claim", ErrInvalidDPoP)
 	}
-	if v, ok := token.Get(HTUKey); !ok || v == "" {
+	if v, ok := token.Get(HTUKey); !ok {
 		return nil, fmt.Errorf("%w: missing htu claim", ErrInvalidDPoP)
-	} else if _, err := url.Parse(v.(string)); err != nil {
+	} else if s, ok := v.(string); !ok || s == "" {
+		return nil, fmt.Errorf("%w: missing htu claim", ErrInvalidDPoP)
+	} else if _, err := url.Parse(s); err != nil {
 		return nil, fmt.Errorf("%w: invalid htu claim: %w", ErrInvalidDPoP, err)
 	}
-	if v, ok := token.Get(HTMKey); !ok || v == "" {
+	if v, ok := token.Get(HTMKey); !ok {
+		return nil, fmt.Errorf("%w: missing htm claim", ErrInvalidDPoP)
+	} else if s, ok := v.(string); !ok || s == "" {
 		return nil, fmt.Errorf("%w: missing htm claim", ErrInvalidDPoP)
 	}
 	if token.JwtID() == "" {

--- a/crypto/dpop/dpop.go
+++ b/crypto/dpop/dpop.go
@@ -158,6 +158,8 @@ func Parse(s string) (*DPoP, error) {
 	}
 	if v, ok := token.Get(HTUKey); !ok || v == "" {
 		return nil, fmt.Errorf("%w: missing htu claim", ErrInvalidDPoP)
+	} else if _, err := url.Parse(v.(string)); err != nil {
+		return nil, fmt.Errorf("%w: invalid htu claim: %w", ErrInvalidDPoP, err)
 	}
 	if v, ok := token.Get(HTMKey); !ok || v == "" {
 		return nil, fmt.Errorf("%w: missing htm claim", ErrInvalidDPoP)
@@ -220,8 +222,14 @@ func (t DPoP) Match(jkt string, method string, url string) (bool, error) {
 	if method != t.HTM() {
 		return false, fmt.Errorf("method mismatch, token: %s, given: %s", t.HTM(), method)
 	}
-	urlLeft := strip(t.HTU())
-	urlRight := strip(url)
+	urlLeft, err := strip(t.HTU())
+	if err != nil {
+		return false, fmt.Errorf("invalid htu claim: %w", err)
+	}
+	urlRight, err := strip(url)
+	if err != nil {
+		return false, fmt.Errorf("invalid url: %w", err)
+	}
 	if urlLeft != urlRight {
 		return false, fmt.Errorf("url mismatch, token: %s, given: %s", urlLeft, urlRight)
 	}
@@ -229,13 +237,16 @@ func (t DPoP) Match(jkt string, method string, url string) (bool, error) {
 	return true, nil
 }
 
-func strip(raw string) string {
-	url, _ := url.Parse(raw)
-	url.Scheme = "https"
-	url.Host = strings.Split(url.Host, ":")[0]
-	url.RawQuery = ""
-	url.Fragment = ""
-	return url.String()
+func strip(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	u.Scheme = "https"
+	u.Host = strings.Split(u.Host, ":")[0]
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
 }
 
 func (t DPoP) MarshalJSON() ([]byte, error) {

--- a/crypto/dpop/dpop.go
+++ b/crypto/dpop/dpop.go
@@ -30,7 +30,6 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
@@ -158,18 +157,18 @@ func Parse(s string) (*DPoP, error) {
 	}
 	if v, ok := token.Get(HTUKey); !ok {
 		return nil, fmt.Errorf("%w: missing htu claim", ErrInvalidDPoP)
-	} else if s, ok := v.(string); !ok {
+	} else if htu, ok := v.(string); !ok {
 		return nil, fmt.Errorf("%w: invalid htu claim", ErrInvalidDPoP)
-	} else if s == "" {
+	} else if htu == "" {
 		return nil, fmt.Errorf("%w: missing htu claim", ErrInvalidDPoP)
-	} else if _, err := url.Parse(s); err != nil {
+	} else if _, err := url.Parse(htu); err != nil {
 		return nil, fmt.Errorf("%w: invalid htu claim: %w", ErrInvalidDPoP, err)
 	}
 	if v, ok := token.Get(HTMKey); !ok {
 		return nil, fmt.Errorf("%w: missing htm claim", ErrInvalidDPoP)
-	} else if s, ok := v.(string); !ok {
+	} else if htm, ok := v.(string); !ok {
 		return nil, fmt.Errorf("%w: invalid htm claim", ErrInvalidDPoP)
-	} else if s == "" {
+	} else if htm == "" {
 		return nil, fmt.Errorf("%w: missing htm claim", ErrInvalidDPoP)
 	}
 	if token.JwtID() == "" {

--- a/crypto/dpop/dpop.go
+++ b/crypto/dpop/dpop.go
@@ -158,14 +158,18 @@ func Parse(s string) (*DPoP, error) {
 	}
 	if v, ok := token.Get(HTUKey); !ok {
 		return nil, fmt.Errorf("%w: missing htu claim", ErrInvalidDPoP)
-	} else if s, ok := v.(string); !ok || s == "" {
+	} else if s, ok := v.(string); !ok {
+		return nil, fmt.Errorf("%w: invalid htu claim", ErrInvalidDPoP)
+	} else if s == "" {
 		return nil, fmt.Errorf("%w: missing htu claim", ErrInvalidDPoP)
 	} else if _, err := url.Parse(s); err != nil {
 		return nil, fmt.Errorf("%w: invalid htu claim: %w", ErrInvalidDPoP, err)
 	}
 	if v, ok := token.Get(HTMKey); !ok {
 		return nil, fmt.Errorf("%w: missing htm claim", ErrInvalidDPoP)
-	} else if s, ok := v.(string); !ok || s == "" {
+	} else if s, ok := v.(string); !ok {
+		return nil, fmt.Errorf("%w: invalid htm claim", ErrInvalidDPoP)
+	} else if s == "" {
 		return nil, fmt.Errorf("%w: missing htm claim", ErrInvalidDPoP)
 	}
 	if token.JwtID() == "" {

--- a/crypto/dpop/dpop_test.go
+++ b/crypto/dpop/dpop_test.go
@@ -251,7 +251,7 @@ func TestParseDPoP(t *testing.T) {
 		_, err := Parse(dpopString)
 
 		require.Error(t, err)
-		assert.EqualError(t, err, "invalid DPoP token: missing htu claim")
+		assert.EqualError(t, err, "invalid DPoP token: invalid htu claim")
 	})
 	t.Run("non-string htm claim", func(t *testing.T) {
 		dpopToken := New(*request)
@@ -261,7 +261,7 @@ func TestParseDPoP(t *testing.T) {
 		_, err := Parse(dpopString)
 
 		require.Error(t, err)
-		assert.EqualError(t, err, "invalid DPoP token: missing htm claim")
+		assert.EqualError(t, err, "invalid DPoP token: invalid htm claim")
 	})
 }
 

--- a/crypto/dpop/dpop_test.go
+++ b/crypto/dpop/dpop_test.go
@@ -229,6 +229,20 @@ func TestParseDPoP(t *testing.T) {
 		require.Error(t, err)
 		assert.EqualError(t, err, "invalid DPoP token: jti claim too long")
 	})
+	t.Run("invalid htu claim URL", func(t *testing.T) {
+		// Regression test: url.Parse returns (nil, error) for invalid percent-encoded
+		// sequences. Without the fix, strip() dereferenced the nil pointer, panicking
+		// the server when Match() was called on a token with htu="%zz".
+		dpopToken := New(*request)
+		_ = dpopToken.Token.Set(HTUKey, "%zz")
+		dpopString, _ := dpopToken.Sign("kid", keyPair, alg)
+
+		_, err := Parse(dpopString)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidDPoP)
+		assert.Contains(t, err.Error(), "invalid htu claim")
+	})
 }
 
 func TestDPoP_Match(t *testing.T) {

--- a/crypto/dpop/dpop_test.go
+++ b/crypto/dpop/dpop_test.go
@@ -243,6 +243,26 @@ func TestParseDPoP(t *testing.T) {
 		assert.ErrorIs(t, err, ErrInvalidDPoP)
 		assert.Contains(t, err.Error(), "invalid htu claim")
 	})
+	t.Run("non-string htu claim", func(t *testing.T) {
+		dpopToken := New(*request)
+		_ = dpopToken.Token.Set(HTUKey, 42)
+		dpopString, _ := dpopToken.Sign("kid", keyPair, alg)
+
+		_, err := Parse(dpopString)
+
+		require.Error(t, err)
+		assert.EqualError(t, err, "invalid DPoP token: missing htu claim")
+	})
+	t.Run("non-string htm claim", func(t *testing.T) {
+		dpopToken := New(*request)
+		_ = dpopToken.Token.Set(HTMKey, 42)
+		dpopString, _ := dpopToken.Sign("kid", keyPair, alg)
+
+		_, err := Parse(dpopString)
+
+		require.Error(t, err)
+		assert.EqualError(t, err, "invalid DPoP token: missing htm claim")
+	})
 }
 
 func TestDPoP_Match(t *testing.T) {

--- a/go.sum
+++ b/go.sum
@@ -398,8 +398,6 @@ github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b h1:80
 github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b/go.mod h1:6YUioYirD6/8IahZkoS4Ypc8xbeJW76Xdk1QKcziNTM=
 github.com/nuts-foundation/go-did v0.18.0 h1:IB0X8PrzDulpR1zAgDpaHfwoSjJpIhx5u1Tg8I2nnb8=
 github.com/nuts-foundation/go-did v0.18.0/go.mod h1:4od1gAmCi9HjHTQGEvHC8pLeuXdXACxidAcdA52YScc=
-github.com/nuts-foundation/go-leia/v4 v4.2.0 h1:o/bgYVCyTgsfgtaKmlrcUaJ2z4NwetERC98SUWwYajM=
-github.com/nuts-foundation/go-leia/v4 v4.2.0/go.mod h1:Gw6bXqJLOAmHSiXJJYbVoj+Mowp/PoBRywO0ZPsVzA0=
 github.com/nuts-foundation/go-leia/v4 v4.3.0 h1:R0qGISIeg2q/PCQTC9cuoBtA6cFu4WBV2DbmSOWKZyM=
 github.com/nuts-foundation/go-leia/v4 v4.3.0/go.mod h1:Gw6bXqJLOAmHSiXJJYbVoj+Mowp/PoBRywO0ZPsVzA0=
 github.com/nuts-foundation/go-stoabs v1.11.0 h1:q18jVruPdFcVhodDrnKuhq/24i0pUC/YXgzJS0glKUU=


### PR DESCRIPTION
## Summary

- `crypto/dpop/dpop.go` — `url.Parse` returns `(nil, error)` for inputs with invalid percent-encoded sequences (e.g. `%zz`). `strip()` ignored the error and immediately wrote to the nil pointer, causing a server panic. Fixed by validating the `htu` claim in `Parse()` (reject early) and changing `strip()` to propagate the error through `Match()`.

### Attack vector (before fix)
An attacker with access to the internal API crafts a DPoP JWT with `htu: "%zz"`, signs it with their own key, and POSTs it to `POST /internal/auth/v2/dpop/validate`. `dpop.Parse()` accepted the token (the only `htu` guard was `!= ""`), and the subsequent call to `Match()` → `strip()` → `url.Parse("%zz")` → `nil` → **panic**. The connection was reset; the server survived due to `net/http`'s per-connection recover, but the endpoint could be degraded by repeated calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)