### PR TITLE
Upgrade Go to 1.26.2 to fix stdlib CVEs (v6.2.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # golang alpine
-FROM golang:1.26.1-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -3,6 +3,16 @@ Release notes
 #############
 
 ****************
+Peanut (v6.2.2)
+****************
+
+Release date: 2026-04-10
+
+- Upgrade Go to 1.26.2 to fix GO-2026-4865 (html/template XSS), GO-2026-4866 (crypto/x509 auth bypass), GO-2026-4869 (archive/tar DoS), GO-2026-4870 (crypto/tls DoS), GO-2026-4946 (crypto/x509 DoS)
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v6.2.1...v6.2.2
+
+****************
 Peanut (v6.2.1)
 ****************
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nuts-foundation/nuts-node
 
 // This is the minimal version, the actual go version is determined by the images in the Dockerfile
 // This version is used in automated tests such as the 'Scheduled govulncheck' action
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0


### PR DESCRIPTION
## Summary

- Upgrade Go from 1.26.1 to 1.26.2 in `go.mod` and `Dockerfile`
- Add release notes for v6.2.2

Fixes the following Go stdlib vulnerabilities:

| Advisory | Package | Description |
|---|---|---|
| GO-2026-4865 | `html/template` | XSS via incorrect JS template literal escaping |
| GO-2026-4866 | `crypto/x509` | Auth bypass via excluded DNS name constraints not applied to wildcard SANs |
| GO-2026-4869 | `archive/tar` | DoS via unbounded memory allocation in tar reader |
| GO-2026-4870 | `crypto/tls` | DoS via TLS 1.3 connection deadlock on multiple KeyUpdate messages |
| GO-2026-4946 | `crypto/x509` | DoS via inefficient policy validation with many policy mappings |

## Test plan

- [x] CI passes (govulncheck should report no stdlib vulnerabilities)
- [x] Docker image builds with `golang:1.26.2-alpine`

🤖 Generated with [Claude Code](https://claude.com/claude-code)