### PR TITLE
Upgrade Go to 1.26.2 to fix stdlib CVEs (v5.4.30)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     parallelism: 8
     docker:
-      - image: cimg/go:1.26.1
+      - image: cimg/go:1.26.2
     steps:
       - checkout
 
@@ -37,7 +37,7 @@ jobs:
 
   report:
     docker:
-      - image: cimg/go:1.26.1
+      - image: cimg/go:1.26.2
     steps:
       - checkout
       - attach_workspace:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # golang alpine
-FROM golang:1.26.1-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -4,6 +4,16 @@ Release notes
 #############
 
 *************************
+Hazelnut update (v5.4.30)
+*************************
+
+Release date: 2026-04-10
+
+- Upgrade Go to 1.26.2 to fix GO-2026-4865 (html/template XSS), GO-2026-4866 (crypto/x509 auth bypass), GO-2026-4869 (archive/tar DoS), GO-2026-4870 (crypto/tls DoS), GO-2026-4946 (crypto/x509 DoS)
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v5.4.29...v5.4.30
+
+*************************
 Hazelnut update (v5.4.29)
 *************************
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nuts-foundation/nuts-node
 
 // This is the minimal version, the actual go version is determined by the images in the Dockerfile
 // This version is used in automated tests such as the 'Scheduled govulncheck' action
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/alicebob/miniredis/v2 v2.34.0


### PR DESCRIPTION
## Summary

- Upgrade Go from 1.26.1 to 1.26.2 in `go.mod` and `Dockerfile`
- Add release notes for v5.4.30

Fixes the following Go stdlib vulnerabilities:

| Advisory | Package | Description |
|---|---|---|
| GO-2026-4865 | `html/template` | XSS via incorrect JS template literal escaping |
| GO-2026-4866 | `crypto/x509` | Auth bypass via excluded DNS name constraints not applied to wildcard SANs |
| GO-2026-4869 | `archive/tar` | DoS via unbounded memory allocation in tar reader |
| GO-2026-4870 | `crypto/tls` | DoS via TLS 1.3 connection deadlock on multiple KeyUpdate messages |
| GO-2026-4946 | `crypto/x509` | DoS via inefficient policy validation with many policy mappings |

## Test plan

- [x] CI passes (govulncheck should report no stdlib vulnerabilities)
- [x] Docker image builds with `golang:1.26.2-alpine`

🤖 Generated with [Claude Code](https://claude.com/claude-code)