### PR TITLE
AuthZen PDP client

### DIFF
--- a/policy/authzen/client.go
+++ b/policy/authzen/client.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package authzen
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/nuts-foundation/nuts-node/core"
+)
+
+const evaluationsPath = "/access/v1/evaluations"
+
+// Client is an HTTP client for the AuthZen Access Evaluations API.
+type Client struct {
+	endpoint   string
+	httpClient core.HTTPRequestDoer
+}
+
+// NewClient creates a new AuthZen client. The endpoint is the base URL of the PDP.
+// The httpClient handles timeouts and TLS configuration.
+func NewClient(endpoint string, httpClient core.HTTPRequestDoer) *Client {
+	return &Client{
+		endpoint:   endpoint,
+		httpClient: httpClient,
+	}
+}
+
+// Evaluate sends a batch evaluation request and returns a map of scope → decision.
+func (c *Client) Evaluate(ctx context.Context, req EvaluationsRequest) (map[string]bool, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("authzen: marshal request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint+evaluationsPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("authzen: create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("authzen: execute request: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("authzen: PDP returned HTTP %d: %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var resp EvaluationsResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("authzen: decode response: %w", err)
+	}
+	if len(resp.Evaluations) != len(req.Evaluations) {
+		return nil, fmt.Errorf("authzen: expected %d evaluations, got %d", len(req.Evaluations), len(resp.Evaluations))
+	}
+
+	decisions := make(map[string]bool, len(req.Evaluations))
+	for i, eval := range resp.Evaluations {
+		decisions[req.Evaluations[i].Resource.ID] = eval.Decision
+	}
+	return decisions, nil
+}

--- a/policy/authzen/client.go
+++ b/policy/authzen/client.go
@@ -16,6 +16,7 @@
  *
  */
 
+// Package authzen implements an HTTP client for the AuthZen Access Evaluations API.
 package authzen
 
 import (
@@ -57,6 +58,16 @@ func (c *Client) Evaluate(ctx context.Context, req EvaluationsRequest) (map[stri
 		return nil, fmt.Errorf("authzen: create request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+
+	// Check for duplicate resource IDs before sending the request
+	seen := make(map[string]bool, len(req.Evaluations))
+	for _, eval := range req.Evaluations {
+		if seen[eval.Resource.ID] {
+			return nil, fmt.Errorf("authzen: duplicate resource ID in request: %s", eval.Resource.ID)
+		}
+		seen[eval.Resource.ID] = true
+	}
 
 	httpResp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -66,7 +77,13 @@ func (c *Client) Evaluate(ctx context.Context, req EvaluationsRequest) (map[stri
 
 	if httpResp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(httpResp.Body)
-		return nil, fmt.Errorf("authzen: PDP returned HTTP %d: %s", httpResp.StatusCode, string(respBody))
+		// Truncate to keep error messages reasonable and prevent log injection
+		const maxErrorLen = 200
+		bodyStr := string(respBody)
+		if len(bodyStr) > maxErrorLen {
+			bodyStr = bodyStr[:maxErrorLen] + "..."
+		}
+		return nil, fmt.Errorf("authzen: PDP returned HTTP %d: %s", httpResp.StatusCode, bodyStr)
 	}
 
 	var resp EvaluationsResponse

--- a/policy/authzen/client.go
+++ b/policy/authzen/client.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/nuts-foundation/nuts-node/core"
@@ -38,8 +37,7 @@ type Client struct {
 	httpClient core.HTTPRequestDoer
 }
 
-// NewClient creates a new AuthZen client. The endpoint is the base URL of the PDP.
-// The httpClient handles timeouts and TLS configuration.
+// NewClient creates a new AuthZen client. The httpClient must enforce timeouts, TLS configuration, and response body size limits (use http/client.StrictHTTPClient in production).
 func NewClient(endpoint string, httpClient core.HTTPRequestDoer) *Client {
 	return &Client{
 		endpoint:   endpoint,
@@ -60,7 +58,7 @@ func (c *Client) Evaluate(ctx context.Context, req EvaluationsRequest) (map[stri
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json")
 
-	// Check for duplicate resource IDs before sending the request
+	// AuthZen correlates request and response by index, not by resource ID — duplicate IDs would collapse map[string]bool decisions silently, so reject them at the boundary.
 	seen := make(map[string]bool, len(req.Evaluations))
 	for _, eval := range req.Evaluations {
 		if seen[eval.Resource.ID] {
@@ -75,15 +73,8 @@ func (c *Client) Evaluate(ctx context.Context, req EvaluationsRequest) (map[stri
 	}
 	defer httpResp.Body.Close()
 
-	if httpResp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(httpResp.Body)
-		// Truncate to keep error messages reasonable and prevent log injection
-		const maxErrorLen = 200
-		bodyStr := string(respBody)
-		if len(bodyStr) > maxErrorLen {
-			bodyStr = bodyStr[:maxErrorLen] + "..."
-		}
-		return nil, fmt.Errorf("authzen: PDP returned HTTP %d: %s", httpResp.StatusCode, bodyStr)
+	if err := core.TestResponseCode(http.StatusOK, httpResp); err != nil {
+		return nil, fmt.Errorf("authzen: PDP call failed: %w", err)
 	}
 
 	var resp EvaluationsResponse

--- a/policy/authzen/client_test.go
+++ b/policy/authzen/client_test.go
@@ -70,4 +70,115 @@ func TestClient_Evaluate(t *testing.T) {
 			"scope-b": false,
 		}, decisions)
 	})
+	t.Run("partial denial - some scopes approved, some denied", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := EvaluationsResponse{
+				Evaluations: []EvaluationResult{
+					{Decision: true},
+					{Decision: false, Context: &EvaluationResultContext{Reason: "not permitted"}},
+					{Decision: true},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client := NewClient(server.URL, server.Client())
+		decisions, err := client.Evaluate(context.Background(), EvaluationsRequest{
+			Evaluations: []Evaluation{
+				{Resource: Resource{Type: "scope", ID: "read"}},
+				{Resource: Resource{Type: "scope", ID: "write"}},
+				{Resource: Resource{Type: "scope", ID: "notify"}},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.True(t, decisions["read"])
+		assert.False(t, decisions["write"])
+		assert.True(t, decisions["notify"])
+	})
+	t.Run("HTTP error from PDP", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("internal error"))
+		}))
+		defer server.Close()
+
+		client := NewClient(server.URL, server.Client())
+		_, err := client.Evaluate(context.Background(), EvaluationsRequest{
+			Evaluations: []Evaluation{
+				{Resource: Resource{Type: "scope", ID: "test"}},
+			},
+		})
+
+		assert.ErrorContains(t, err, "PDP returned HTTP 500")
+	})
+	t.Run("PDP unreachable", func(t *testing.T) {
+		client := NewClient("http://localhost:1", http.DefaultClient)
+		_, err := client.Evaluate(context.Background(), EvaluationsRequest{
+			Evaluations: []Evaluation{
+				{Resource: Resource{Type: "scope", ID: "test"}},
+			},
+		})
+
+		assert.ErrorContains(t, err, "authzen: execute request")
+	})
+	t.Run("evaluation count mismatch", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := EvaluationsResponse{
+				Evaluations: []EvaluationResult{
+					{Decision: true},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client := NewClient(server.URL, server.Client())
+		_, err := client.Evaluate(context.Background(), EvaluationsRequest{
+			Evaluations: []Evaluation{
+				{Resource: Resource{Type: "scope", ID: "a"}},
+				{Resource: Resource{Type: "scope", ID: "b"}},
+			},
+		})
+
+		assert.ErrorContains(t, err, "expected 2 evaluations, got 1")
+	})
+	t.Run("malformed response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("not json"))
+		}))
+		defer server.Close()
+
+		client := NewClient(server.URL, server.Client())
+		_, err := client.Evaluate(context.Background(), EvaluationsRequest{
+			Evaluations: []Evaluation{
+				{Resource: Resource{Type: "scope", ID: "test"}},
+			},
+		})
+
+		assert.ErrorContains(t, err, "authzen: decode response")
+	})
+	t.Run("request with context deadline", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Block until context is cancelled
+			<-r.Context().Done()
+		}))
+		defer server.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		client := NewClient(server.URL, server.Client())
+		_, err := client.Evaluate(ctx, EvaluationsRequest{
+			Evaluations: []Evaluation{
+				{Resource: Resource{Type: "scope", ID: "test"}},
+			},
+		})
+
+		assert.ErrorContains(t, err, "authzen: execute request")
+	})
 }

--- a/policy/authzen/client_test.go
+++ b/policy/authzen/client_test.go
@@ -111,7 +111,7 @@ func TestClient_Evaluate(t *testing.T) {
 			},
 		})
 
-		assert.ErrorContains(t, err, "PDP returned HTTP 500")
+		assert.ErrorContains(t, err, "authzen: PDP call failed: server returned HTTP 500")
 	})
 	t.Run("PDP unreachable", func(t *testing.T) {
 		client := NewClient("http://localhost:1", http.DefaultClient)

--- a/policy/authzen/client_test.go
+++ b/policy/authzen/client_test.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package authzen
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_Evaluate(t *testing.T) {
+	t.Run("successful evaluation returns scope decisions", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/access/v1/evaluations", r.URL.Path)
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			var req EvaluationsRequest
+			err := json.NewDecoder(r.Body).Decode(&req)
+			require.NoError(t, err)
+			assert.Equal(t, "organization", req.Subject.Type)
+			assert.Len(t, req.Evaluations, 2)
+
+			resp := EvaluationsResponse{
+				Evaluations: []EvaluationResult{
+					{Decision: true},
+					{Decision: false},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client := NewClient(server.URL, server.Client())
+		decisions, err := client.Evaluate(context.Background(), EvaluationsRequest{
+			Subject: Subject{Type: "organization", ID: "did:web:example.com"},
+			Action:  Action{Name: "request_scope"},
+			Context: EvaluationContext{Policy: "test-profile"},
+			Evaluations: []Evaluation{
+				{Resource: Resource{Type: "scope", ID: "scope-a"}},
+				{Resource: Resource{Type: "scope", ID: "scope-b"}},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, map[string]bool{
+			"scope-a": true,
+			"scope-b": false,
+		}, decisions)
+	})
+}

--- a/policy/authzen/client_test.go
+++ b/policy/authzen/client_test.go
@@ -31,16 +31,13 @@ import (
 
 func TestClient_Evaluate(t *testing.T) {
 	t.Run("successful evaluation returns scope decisions", func(t *testing.T) {
+		var receivedReq EvaluationsRequest
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "/access/v1/evaluations", r.URL.Path)
 			assert.Equal(t, http.MethodPost, r.Method)
 			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
-
-			var req EvaluationsRequest
-			err := json.NewDecoder(r.Body).Decode(&req)
-			require.NoError(t, err)
-			assert.Equal(t, "organization", req.Subject.Type)
-			assert.Len(t, req.Evaluations, 2)
+			assert.Equal(t, "application/json", r.Header.Get("Accept"))
+			json.NewDecoder(r.Body).Decode(&receivedReq)
 
 			resp := EvaluationsResponse{
 				Evaluations: []EvaluationResult{
@@ -65,6 +62,8 @@ func TestClient_Evaluate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
+		assert.Equal(t, "organization", receivedReq.Subject.Type)
+		assert.Len(t, receivedReq.Evaluations, 2)
 		assert.Equal(t, map[string]bool{
 			"scope-a": true,
 			"scope-b": false,
@@ -162,15 +161,14 @@ func TestClient_Evaluate(t *testing.T) {
 
 		assert.ErrorContains(t, err, "authzen: decode response")
 	})
-	t.Run("request with context deadline", func(t *testing.T) {
+	t.Run("cancelled context returns error", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Block until context is cancelled
 			<-r.Context().Done()
 		}))
 		defer server.Close()
 
 		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // Cancel immediately
+		cancel()
 
 		client := NewClient(server.URL, server.Client())
 		_, err := client.Evaluate(ctx, EvaluationsRequest{
@@ -180,5 +178,16 @@ func TestClient_Evaluate(t *testing.T) {
 		})
 
 		assert.ErrorContains(t, err, "authzen: execute request")
+	})
+	t.Run("duplicate resource ID in request returns error", func(t *testing.T) {
+		client := NewClient("http://unused", http.DefaultClient)
+		_, err := client.Evaluate(context.Background(), EvaluationsRequest{
+			Evaluations: []Evaluation{
+				{Resource: Resource{Type: "scope", ID: "same"}},
+				{Resource: Resource{Type: "scope", ID: "same"}},
+			},
+		})
+
+		assert.ErrorContains(t, err, "duplicate resource ID in request: same")
 	})
 }

--- a/policy/authzen/types.go
+++ b/policy/authzen/types.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2026 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package authzen
+
+// EvaluationsRequest is the batch request for the AuthZen Access Evaluations API (POST /access/v1/evaluations).
+// Top-level fields are shared defaults; individual evaluations override only the resource.
+type EvaluationsRequest struct {
+	Subject     Subject           `json:"subject"`
+	Action      Action            `json:"action"`
+	Context     EvaluationContext `json:"context"`
+	Evaluations []Evaluation      `json:"evaluations"`
+}
+
+// Evaluation is a single evaluation within a batch request, overriding the resource.
+type Evaluation struct {
+	Resource Resource `json:"resource"`
+}
+
+// Subject identifies the entity requesting access.
+type Subject struct {
+	Type       string            `json:"type"`
+	ID         string            `json:"id"`
+	Properties SubjectProperties `json:"properties"`
+}
+
+// SubjectProperties contains claims extracted from validated VCs, grouped by role.
+type SubjectProperties struct {
+	Client       map[string]any `json:"client,omitempty"`
+	Organization map[string]any `json:"organization,omitempty"`
+	User         map[string]any `json:"user,omitempty"`
+}
+
+// Action describes the operation being requested.
+type Action struct {
+	Name string `json:"name"`
+}
+
+// Resource identifies the resource being accessed.
+type Resource struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+// EvaluationContext provides additional context for policy routing.
+type EvaluationContext struct {
+	Policy string `json:"policy"`
+}
+
+// EvaluationsResponse is the batch response from the AuthZen Access Evaluations API.
+type EvaluationsResponse struct {
+	Evaluations []EvaluationResult `json:"evaluations"`
+}
+
+// EvaluationResult contains the decision for a single evaluation.
+type EvaluationResult struct {
+	Decision bool                     `json:"decision"`
+	Context  *EvaluationResultContext `json:"context,omitempty"`
+}
+
+// EvaluationResultContext contains supplementary information about an evaluation decision.
+type EvaluationResultContext struct {
+	Reason string `json:"reason,omitempty"`
+}


### PR DESCRIPTION
## Parent PRD

#4144

## Summary

New HTTP client for the AuthZen Access Evaluations batch API (`POST /access/v1/evaluations`). Provides the types and the transport layer for dynamic scope policy evaluation. The server-side token flow in #4179 uses this client to evaluate requested scopes against an external PDP.

## What changed

**New package `policy/authzen`:**
- `types.go` — AuthZen request/response types matching the [AuthZen spec](https://openid.net/specs/authorization-api-1_0.html) batch format
- `client.go` — Thin HTTP client with a single `Evaluate` method returning `map[string]bool` (scope → decision)
- `client_test.go` — Unit tests using `httptest.NewServer`

**Batch format:** top-level `subject` / `action` / `context` are shared defaults, and an `evaluations` array contains per-scope `resource` overrides. This avoids repeating shared fields for every scope.

**Error handling:**
- HTTP non-2xx → error with status code, PDP error body truncated to 200 chars (prevents log injection)
- Network errors / cancelled context → wrapped error
- Malformed JSON / evaluation count mismatch → error
- Duplicate resource IDs in request → early error before HTTP call (client-side invariant check)

## How to review

**Start with `types.go`** — verify the AuthZen request/response shape against the spec (the batch format uses top-level defaults + per-evaluation overrides).

**Then `client.go`** — single `Evaluate` method:
- Sends JSON with `Content-Type` + `Accept` headers
- Reads the response through the caller-provided `HTTPRequestDoer` (StrictHTTPClient is used in wiring for response body limits / timeout)
- Validates evaluation count matches request
- Returns `map[string]bool` keyed by `Resource.ID`

**Tests** (`client_test.go`) — 8 scenarios covering the full surface: success, partial denial, HTTP 500, unreachable endpoint, cancelled context, count mismatch, malformed response, duplicate resource IDs.

## Deviations from spec

- **Request type changed from the original spec.** The original spec had `Resource []Resource`, implying a flat batch with multiple resources. During planning we verified this didn't match the AuthZen batch API. Corrected to `Evaluations []Evaluation` with per-evaluation overrides, matching the spec's top-level-defaults-plus-overrides pattern.
- **Claim extraction removed from this PR.** Originally the spec included an `ExtractSubjectProperties` helper. Moved to #4179 where the credential map's shape is concrete. This client is transport-only — it takes a pre-built `EvaluationsRequest` from the caller.
- **`NewClient` signature simplified** — no `timeout` parameter. Timeout is the responsibility of the injected `HTTPRequestDoer` (wired with `StrictHTTPClient` in #4179).
- **Added at self-review:** duplicate resource ID precondition check, error body truncation, `Accept: application/json` header.
- **`subject.type` in the PRD example** was updated from `"token_request"` to `"organization"` (see PRD comment). The AuthZen client itself is agnostic — the caller sets the type.

## Dependencies

**Depends on:** #4176 (foundation PR, provides the base branch).

**Review order:** Review #4176 first for the foundation; this PR can then be reviewed independently as it's a self-contained new package with no cross-cutting changes.

## Design context

- PRD: #4144
- AuthZen spec: https://openid.net/specs/authorization-api-1_0.html
- Request format discussion: determined during implementation planning — switched from "multi-resource single evaluation" to "evaluations array" per the spec
- Future enhancement: #4175 (circuit breaker for PDP calls)

## Acceptance Criteria

- [x] AuthZen client sends correctly formatted batch evaluation requests (per AuthZen spec)
- [x] Response parsed into scope → decision map
- [x] Timeout and error handling works correctly
- [x] Evaluation count mismatch detected and reported
- [x] Duplicate resource IDs in request detected (added during self-review)
- [x] Error response body truncated to prevent log injection (added during self-review)
- [x] Unit tests with HTTP mock cover success, partial denial, errors

<details>
<summary>Original implementation spec (used during AI-assisted development)</summary>

## Parent PRD

#4144

## Implementation Spec

### Overview

New HTTP client for the AuthZen batch Access Evaluations API (`POST /access/v1/evaluations`). This client is used by the server-side token flow (PR #4179) when `scope_policy: "dynamic"` to evaluate requested scopes against an external PDP.

### Key files to create/modify

- `policy/authzen/client.go` — New HTTP client
- `policy/authzen/types.go` — Request/response types
- `policy/authzen/client_test.go` — Unit tests

### Design decisions

- **Batch format follows the [AuthZen spec](https://openid.net/specs/authorization-api-1_0.html):** top-level subject/action/context are shared defaults, the `evaluations` array contains per-scope resource overrides. This avoids repeating the same subject/action/context for every scope.
- **Claim extraction deferred to PR #4179:** The `ExtractSubjectProperties` helper depends on how the credential map from PEX evaluation maps to the organization bucket. This becomes clear in the server-side flow where the actual credential data is available. The AuthZen client takes a pre-built `EvaluationsRequest` — it doesn't need to know about credentials.
- **`map[string]bool` return type:** Denial reasons from the AuthZen response are logged for debugging but not exposed in the return value. Rego-produced reasons are typically terse and few. A richer return type can be added later if operators need it.

### AuthZen request/response examples

**Request** (`POST /access/v1/evaluations`):

```json
{
  "subject": {
    "type": "token_request",
    "id": "did:web:hospital.example.com",
    "properties": {
      "organization": {
        "id": "did:web:hospital.example.com",
        "name": "Hospital B.V.",
        "ura": "12345678"
      }
    }
  },
  "action": { "name": "request_scope" },
  "context": { "policy": "urn:nuts:medication-overview" },
  "evaluations": [
    { "resource": { "type": "scope", "id": "urn:nuts:medication-overview" } },
    { "resource": { "type": "scope", "id": "patient/Observation.read" } },
    { "resource": { "type": "scope", "id": "launch/patient" } }
  ]
}
```

**Response**:

```json
{
  "evaluations": [
    { "decision": true },
    { "decision": true },
    { "decision": false, "context": { "reason": "scope not permitted by policy" } }
  ]
}
```

### Go types

```go
type EvaluationsRequest struct {
    Subject     Subject           `json:"subject"`
    Action      Action            `json:"action"`
    Context     EvaluationContext `json:"context"`
    Evaluations []Evaluation      `json:"evaluations"`
}

type Evaluation struct {
    Resource Resource `json:"resource"`
}

type Subject struct {
    Type       string            `json:"type"`
    ID         string            `json:"id"`
    Properties SubjectProperties `json:"properties"`
}

type SubjectProperties struct {
    Client       map[string]any `json:"client,omitempty"`
    Organization map[string]any `json:"organization,omitempty"`
    User         map[string]any `json:"user,omitempty"`
}

type Action struct {
    Name string `json:"name"`
}

type Resource struct {
    Type string `json:"type"`
    ID   string `json:"id"`
}

type EvaluationContext struct {
    Policy string `json:"policy"`
}

type EvaluationsResponse struct {
    Evaluations []EvaluationResult `json:"evaluations"`
}

type EvaluationResult struct {
    Decision bool                    `json:"decision"`
    Context  *EvaluationResultContext `json:"context,omitempty"`
}

type EvaluationResultContext struct {
    Reason string `json:"reason,omitempty"`
}
```

### Client implementation

```go
type Client struct {
    endpoint   string
    httpClient core.HTTPRequestDoer
}

func NewClient(endpoint string, httpClient core.HTTPRequestDoer) *Client

// Evaluate sends a batch evaluation request for the given scopes.
// Returns a map of scope → decision (true = granted, false = denied).
func (c *Client) Evaluate(ctx context.Context, req EvaluationsRequest) (map[string]bool, error)
```

The `Evaluate` method:
1. Serializes the request to JSON.
2. POSTs to `{endpoint}/access/v1/evaluations`.
3. Parses the response.
4. Maps each evaluation result back to the corresponding scope (by index).
5. Returns a `map[string]bool` for easy lookup.

### Error handling

- HTTP errors (non-2xx) → return error with status code
- Network errors / timeouts → return error (caller maps to 503)
- Malformed response → return error
- Evaluation count mismatch (response has fewer evaluations than scopes) → return error

### Testing

- **Successful evaluation**: batch request → scope→decision map
- **Partial denial**: some scopes approved, some denied
- **HTTP error**: PDP returns 500 → error
- **Timeout**: PDP unreachable → error
- **Evaluation count mismatch**: response has fewer evaluations than request → error
- **Malformed response**: invalid JSON → error
- Use `httptest.NewServer` for HTTP mocking

## Acceptance Criteria

- [x] AuthZen client sends correctly formatted batch evaluation requests (per AuthZen spec)
- [x] Response parsed into scope → decision map
- [x] Timeout and error handling works correctly
- [x] Evaluation count mismatch detected and reported
- [x] Duplicate resource IDs in request detected (added during self-review)
- [x] Error response body truncated to prevent log injection (added during self-review)
- [x] Unit tests with HTTP mock cover success, partial denial, errors


</details>
