### PR TITLE
Client-side multi-scope token flow

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"github.com/nuts-foundation/nuts-node/auth/client/iam"
+	"github.com/nuts-foundation/nuts-node/policy"
 	"github.com/nuts-foundation/nuts-node/vdr"
 	"github.com/nuts-foundation/nuts-node/vdr/didjwk"
 	"github.com/nuts-foundation/nuts-node/vdr/didkey"
@@ -68,6 +69,7 @@ type Auth struct {
 	httpClientTimeout time.Duration
 	tlsConfig         *tls.Config
 	subjectManager    didsubject.Manager
+	policyBackend     policy.PDPBackend
 	// configuredDIDMethods contains the DID methods that are configured in the Nuts node,
 	// of which VDR will create DIDs.
 	configuredDIDMethods []string
@@ -100,7 +102,7 @@ func (auth *Auth) ContractNotary() services.ContractNotary {
 
 // NewAuthInstance accepts a Config with several Nuts Engines and returns an instance of Auth
 func NewAuthInstance(config Config, vdrInstance vdr.VDR, subjectManager didsubject.Manager, vcr vcr.VCR, keyStore crypto.KeyStore,
-	serviceResolver didman.CompoundServiceResolver, jsonldManager jsonld.JSONLD, pkiProvider pki.Provider) *Auth {
+	serviceResolver didman.CompoundServiceResolver, jsonldManager jsonld.JSONLD, pkiProvider pki.Provider, policyBackend policy.PDPBackend) *Auth {
 	return &Auth{
 		config:          config,
 		jsonldManager:   jsonldManager,
@@ -110,6 +112,7 @@ func NewAuthInstance(config Config, vdrInstance vdr.VDR, subjectManager didsubje
 		vcr:             vcr,
 		pkiProvider:     pkiProvider,
 		serviceResolver: serviceResolver,
+		policyBackend:   policyBackend,
 		shutdownFunc:    func() {},
 	}
 }
@@ -126,7 +129,7 @@ func (auth *Auth) RelyingParty() oauth.RelyingParty {
 
 func (auth *Auth) IAMClient() iam.Client {
 	keyResolver := resolver.DIDKeyResolver{Resolver: auth.vdrInstance.Resolver()}
-	return iam.NewClient(auth.vcr.Wallet(), keyResolver, auth.subjectManager, auth.keyStore, auth.jsonldManager.DocumentLoader(), auth.strictMode, auth.httpClientTimeout)
+	return iam.NewClient(auth.vcr.Wallet(), keyResolver, auth.subjectManager, auth.keyStore, auth.jsonldManager.DocumentLoader(), auth.policyBackend, auth.strictMode, auth.httpClientTimeout)
 }
 
 // Configure the Auth struct by creating a validator and create an Irma server

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -47,7 +47,7 @@ func TestAuth_Configure(t *testing.T) {
 		vdrInstance := vdr.NewMockVDR(ctrl)
 		vdrInstance.EXPECT().Resolver().AnyTimes()
 
-		i := NewAuthInstance(config, vdrInstance, nil, vcr.NewTestVCRInstance(t), crypto.NewMemoryCryptoInstance(t), nil, nil, pkiMock)
+		i := NewAuthInstance(config, vdrInstance, nil, vcr.NewTestVCRInstance(t), crypto.NewMemoryCryptoInstance(t), nil, nil, pkiMock, nil)
 
 		require.NoError(t, i.Configure(tlsServerConfig))
 	})
@@ -61,7 +61,7 @@ func TestAuth_Configure(t *testing.T) {
 		vdrInstance := vdr.NewMockVDR(ctrl)
 		vdrInstance.EXPECT().Resolver().AnyTimes()
 
-		i := NewAuthInstance(config, vdrInstance, nil, vcr.NewTestVCRInstance(t), crypto.NewMemoryCryptoInstance(t), nil, nil, pkiMock)
+		i := NewAuthInstance(config, vdrInstance, nil, vcr.NewTestVCRInstance(t), crypto.NewMemoryCryptoInstance(t), nil, nil, pkiMock, nil)
 
 		require.NoError(t, i.Configure(tlsServerConfig))
 	})
@@ -119,7 +119,7 @@ func TestAuth_IAMClient(t *testing.T) {
 		vdrInstance := vdr.NewMockVDR(ctrl)
 		vdrInstance.EXPECT().Resolver().AnyTimes()
 
-		i := NewAuthInstance(config, vdrInstance, nil, vcr.NewTestVCRInstance(t), crypto.NewMemoryCryptoInstance(t), nil, jsonld.NewTestJSONLDManager(t), pkiMock)
+		i := NewAuthInstance(config, vdrInstance, nil, vcr.NewTestVCRInstance(t), crypto.NewMemoryCryptoInstance(t), nil, jsonld.NewTestJSONLDManager(t), pkiMock, nil)
 
 		assert.NotNil(t, i.IAMClient())
 	})

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/http/client"
+	"github.com/nuts-foundation/nuts-node/policy"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vdr/didsubject"
 	"github.com/piprate/json-gold/ld"
@@ -60,23 +61,30 @@ type OpenID4VPClient struct {
 	wallet           holder.Wallet
 	ldDocumentLoader ld.DocumentLoader
 	subjectManager   didsubject.Manager
+	pdResolver       PresentationDefinitionResolver
 }
 
 // NewClient returns an implementation of Holder
 func NewClient(wallet holder.Wallet, keyResolver resolver.KeyResolver, subjectManager didsubject.Manager, jwtSigner nutsCrypto.JWTSigner,
-	ldDocumentLoader ld.DocumentLoader, strictMode bool, httpClientTimeout time.Duration) *OpenID4VPClient {
+	ldDocumentLoader ld.DocumentLoader, policyBackend policy.PDPBackend, strictMode bool, httpClientTimeout time.Duration) *OpenID4VPClient {
+	httpClient := HTTPClient{
+		strictMode:  strictMode,
+		httpClient:  client.NewWithCache(httpClientTimeout),
+		keyResolver: keyResolver,
+	}
 	return &OpenID4VPClient{
-		httpClient: HTTPClient{
-			strictMode:  strictMode,
-			httpClient:  client.NewWithCache(httpClientTimeout),
-			keyResolver: keyResolver,
-		},
+		httpClient:       httpClient,
 		keyResolver:      keyResolver,
 		jwtSigner:        jwtSigner,
 		ldDocumentLoader: ldDocumentLoader,
 		subjectManager:   subjectManager,
 		strictMode:       strictMode,
 		wallet:           wallet,
+		pdResolver: PresentationDefinitionResolver{
+			httpClient:    httpClient,
+			policyBackend: policyBackend,
+			strictMode:    strictMode,
+		},
 	}
 }
 
@@ -242,18 +250,12 @@ func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, clientID
 		return nil, err
 	}
 
-	// get the presentation definition from the verifier
-	parsedURL, err := core.ParsePublicURL(metadata.PresentationDefinitionEndpoint, c.strictMode)
+	// Resolve the presentation definition: from remote AS when available, local policy otherwise
+	resolved, err := c.pdResolver.Resolve(ctx, scopes, *metadata)
 	if err != nil {
 		return nil, err
 	}
-	presentationDefinitionURL := nutsHttp.AddQueryParams(*parsedURL, map[string]string{
-		"scope": scopes,
-	})
-	presentationDefinition, err := c.PresentationDefinition(ctx, presentationDefinitionURL.String())
-	if err != nil {
-		return nil, err
-	}
+	presentationDefinition := &resolved.PresentationDefinition
 
 	params := holder.BuildParams{
 		Audience:   authServerURL,
@@ -312,7 +314,7 @@ func (c *OpenID4VPClient) RequestRFC021AccessToken(ctx context.Context, clientID
 	data.Set(oauth.GrantTypeParam, oauth.VpTokenGrantType)
 	data.Set(oauth.AssertionParam, assertion)
 	data.Set(oauth.PresentationSubmissionParam, string(presentationSubmission))
-	data.Set(oauth.ScopeParam, scopes)
+	data.Set(oauth.ScopeParam, resolved.Scope)
 
 	// create DPoP header
 	var dpopHeader string

--- a/auth/client/iam/openid4vp.go
+++ b/auth/client/iam/openid4vp.go
@@ -72,7 +72,7 @@ func NewClient(wallet holder.Wallet, keyResolver resolver.KeyResolver, subjectMa
 		httpClient:  client.NewWithCache(httpClientTimeout),
 		keyResolver: keyResolver,
 	}
-	return &OpenID4VPClient{
+	client := &OpenID4VPClient{
 		httpClient:       httpClient,
 		keyResolver:      keyResolver,
 		jwtSigner:        jwtSigner,
@@ -80,12 +80,12 @@ func NewClient(wallet holder.Wallet, keyResolver resolver.KeyResolver, subjectMa
 		subjectManager:   subjectManager,
 		strictMode:       strictMode,
 		wallet:           wallet,
-		pdResolver: PresentationDefinitionResolver{
-			httpClient:    httpClient,
-			policyBackend: policyBackend,
-			strictMode:    strictMode,
-		},
 	}
+	client.pdResolver = PresentationDefinitionResolver{
+		pdFetcher:     client,
+		policyBackend: policyBackend,
+	}
+	return client
 }
 
 func (c *OpenID4VPClient) ClientMetadata(ctx context.Context, endpoint string) (*oauth.OAuthClientMetadata, error) {

--- a/auth/client/iam/openid4vp_test.go
+++ b/auth/client/iam/openid4vp_test.go
@@ -491,6 +491,12 @@ func createClientTestContext(t *testing.T, tlsConfig *tls.Config) *clientTestCon
 			},
 			jwtSigner:   jwtSigner,
 			keyResolver: keyResolver,
+			pdResolver: PresentationDefinitionResolver{
+				httpClient: HTTPClient{
+					strictMode: false,
+					httpClient: client.NewWithTLSConfig(10*time.Second, tlsConfig),
+				},
+			},
 		},
 		jwtSigner:      jwtSigner,
 		keyResolver:    keyResolver,

--- a/auth/client/iam/openid4vp_test.go
+++ b/auth/client/iam/openid4vp_test.go
@@ -479,25 +479,22 @@ func createClientTestContext(t *testing.T, tlsConfig *tls.Config) *clientTestCon
 	}
 	tlsConfig.InsecureSkipVerify = true
 
-	return &clientTestContext{
-		audit: audit.TestContext(),
-		ctrl:  ctrl,
-		client: &OpenID4VPClient{
-			wallet:         wallet,
-			subjectManager: subjectManager,
-			httpClient: HTTPClient{
-				strictMode: false,
-				httpClient: client.NewWithTLSConfig(10*time.Second, tlsConfig),
-			},
-			jwtSigner:   jwtSigner,
-			keyResolver: keyResolver,
-			pdResolver: PresentationDefinitionResolver{
-				httpClient: HTTPClient{
-					strictMode: false,
-					httpClient: client.NewWithTLSConfig(10*time.Second, tlsConfig),
-				},
-			},
+	testClient := &OpenID4VPClient{
+		wallet:         wallet,
+		subjectManager: subjectManager,
+		httpClient: HTTPClient{
+			strictMode: false,
+			httpClient: client.NewWithTLSConfig(10*time.Second, tlsConfig),
 		},
+		jwtSigner:   jwtSigner,
+		keyResolver: keyResolver,
+	}
+	testClient.pdResolver = PresentationDefinitionResolver{pdFetcher: testClient}
+
+	return &clientTestContext{
+		audit:          audit.TestContext(),
+		ctrl:           ctrl,
+		client:         testClient,
 		jwtSigner:      jwtSigner,
 		keyResolver:    keyResolver,
 		wallet:         wallet,

--- a/auth/client/iam/pd_resolver.go
+++ b/auth/client/iam/pd_resolver.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package iam
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nuts-foundation/nuts-node/auth/oauth"
+	"github.com/nuts-foundation/nuts-node/core"
+	nutsHttp "github.com/nuts-foundation/nuts-node/http"
+	"github.com/nuts-foundation/nuts-node/policy"
+	"github.com/nuts-foundation/nuts-node/vcr/pe"
+)
+
+// ResolvedPresentationDefinition contains a resolved PD and the scope to use in the token request.
+type ResolvedPresentationDefinition struct {
+	PresentationDefinition pe.PresentationDefinition
+	// Scope is the scope string to include in the token request.
+	// When resolved remotely, this is the original scope string (remote AS handles scope policy).
+	// When resolved locally, this depends on the configured scope policy.
+	Scope string
+}
+
+// PresentationDefinitionResolver resolves a PresentationDefinition for a given scope string.
+// It uses the remote AS's PD endpoint when available, falling back to local policy resolution.
+type PresentationDefinitionResolver struct {
+	httpClient    HTTPClient
+	policyBackend policy.PDPBackend
+	strictMode    bool
+}
+
+// Resolve resolves a PresentationDefinition for the given scope string.
+// If the remote AS metadata advertises a PD endpoint, the PD is fetched remotely
+// and the full scope string is returned (remote AS handles scope policy).
+// If no PD endpoint is available, the local policy backend is used and scope policy is enforced.
+func (r *PresentationDefinitionResolver) Resolve(ctx context.Context, scope string, metadata oauth.AuthorizationServerMetadata) (*ResolvedPresentationDefinition, error) {
+	if metadata.PresentationDefinitionEndpoint != "" {
+		return r.resolveRemote(ctx, scope, metadata)
+	}
+	return r.resolveLocal(ctx, scope)
+}
+
+func (r *PresentationDefinitionResolver) resolveRemote(ctx context.Context, scope string, metadata oauth.AuthorizationServerMetadata) (*ResolvedPresentationDefinition, error) {
+	parsedURL, err := core.ParsePublicURL(metadata.PresentationDefinitionEndpoint, r.strictMode)
+	if err != nil {
+		return nil, err
+	}
+	pdURL := nutsHttp.AddQueryParams(*parsedURL, map[string]string{
+		"scope": scope,
+	})
+	pd, err := r.httpClient.PresentationDefinition(ctx, pdURL)
+	if err != nil {
+		return nil, err
+	}
+	return &ResolvedPresentationDefinition{
+		PresentationDefinition: *pd,
+		Scope:                  scope,
+	}, nil
+}
+
+func (r *PresentationDefinitionResolver) resolveLocal(ctx context.Context, scope string) (*ResolvedPresentationDefinition, error) {
+	match, err := r.policyBackend.FindCredentialProfile(ctx, scope)
+	if err != nil {
+		return nil, fmt.Errorf("local PD resolution failed: %w", err)
+	}
+	if match.ScopePolicy == policy.ScopePolicyProfileOnly && len(match.OtherScopes) > 0 {
+		return nil, oauth.OAuth2Error{
+			Code:        oauth.InvalidScope,
+			Description: "scope policy 'profile-only' does not allow additional scopes",
+		}
+	}
+	// Select the organization PD (default for current single-VP flow).
+	// TODO: When #4080 adds two-VP support, this resolver will need to return multiple PDs.
+	pd, ok := match.WalletOwnerMapping[pe.WalletOwnerOrganization]
+	if !ok {
+		return nil, fmt.Errorf("no organization presentation definition for scope %q", match.CredentialProfileScope)
+	}
+	return &ResolvedPresentationDefinition{
+		PresentationDefinition: pd,
+		Scope:                  scope,
+	}, nil
+}

--- a/auth/client/iam/pd_resolver.go
+++ b/auth/client/iam/pd_resolver.go
@@ -76,6 +76,9 @@ func (r *PresentationDefinitionResolver) resolveRemote(ctx context.Context, scop
 }
 
 func (r *PresentationDefinitionResolver) resolveLocal(ctx context.Context, scope string) (*ResolvedPresentationDefinition, error) {
+	if r.policyBackend == nil {
+		return nil, fmt.Errorf("local PD resolution requires a policy backend, but none is configured")
+	}
 	match, err := r.policyBackend.FindCredentialProfile(ctx, scope)
 	if err != nil {
 		return nil, fmt.Errorf("local PD resolution failed: %w", err)
@@ -92,8 +95,14 @@ func (r *PresentationDefinitionResolver) resolveLocal(ctx context.Context, scope
 	if !ok {
 		return nil, fmt.Errorf("no organization presentation definition for scope %q", match.CredentialProfileScope)
 	}
+	// For passthrough and dynamic, forward all scopes to the remote AS.
+	// The client does not evaluate dynamic scopes — the server handles PDP evaluation at token-grant time (PR #4179).
+	resolvedScope := scope
+	if match.ScopePolicy == policy.ScopePolicyProfileOnly {
+		resolvedScope = match.CredentialProfileScope
+	}
 	return &ResolvedPresentationDefinition{
 		PresentationDefinition: pd,
-		Scope:                  scope,
+		Scope:                  resolvedScope,
 	}, nil
 }

--- a/auth/client/iam/pd_resolver.go
+++ b/auth/client/iam/pd_resolver.go
@@ -21,9 +21,9 @@ package iam
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
-	"github.com/nuts-foundation/nuts-node/core"
 	nutsHttp "github.com/nuts-foundation/nuts-node/http"
 	"github.com/nuts-foundation/nuts-node/policy"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
@@ -38,12 +38,16 @@ type ResolvedPresentationDefinition struct {
 	Scope string
 }
 
+// pdFetcher retrieves a PresentationDefinition from a fully-formed endpoint URL.
+type pdFetcher interface {
+	PresentationDefinition(ctx context.Context, endpoint string) (*pe.PresentationDefinition, error)
+}
+
 // PresentationDefinitionResolver resolves a PresentationDefinition for a given scope string.
 // It uses the remote AS's PD endpoint when available, falling back to local policy resolution.
 type PresentationDefinitionResolver struct {
-	httpClient    HTTPClient
+	pdFetcher     pdFetcher
 	policyBackend policy.PDPBackend
-	strictMode    bool
 }
 
 // Resolve resolves a PresentationDefinition for the given scope string.
@@ -58,14 +62,12 @@ func (r *PresentationDefinitionResolver) Resolve(ctx context.Context, scope stri
 }
 
 func (r *PresentationDefinitionResolver) resolveRemote(ctx context.Context, scope string, metadata oauth.AuthorizationServerMetadata) (*ResolvedPresentationDefinition, error) {
-	parsedURL, err := core.ParsePublicURL(metadata.PresentationDefinitionEndpoint, r.strictMode)
+	baseURL, err := url.Parse(metadata.PresentationDefinitionEndpoint)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid presentation definition endpoint: %w", err)
 	}
-	pdURL := nutsHttp.AddQueryParams(*parsedURL, map[string]string{
-		"scope": scope,
-	})
-	pd, err := r.httpClient.PresentationDefinition(ctx, pdURL)
+	pdURL := nutsHttp.AddQueryParams(*baseURL, map[string]string{"scope": scope})
+	pd, err := r.pdFetcher.PresentationDefinition(ctx, pdURL.String())
 	if err != nil {
 		return nil, err
 	}

--- a/auth/client/iam/pd_resolver_test.go
+++ b/auth/client/iam/pd_resolver_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	"github.com/nuts-foundation/nuts-node/http/client"
@@ -32,7 +33,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"time"
 )
 
 var testPD = pe.PresentationDefinition{
@@ -145,5 +145,45 @@ func TestPresentationDefinitionResolver_Resolve(t *testing.T) {
 
 			assert.ErrorIs(t, err, policy.ErrNotFound)
 		})
+		t.Run("no organization PD in wallet owner mapping returns error", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockPolicy := policy.NewMockPDPBackend(ctrl)
+			mockPolicy.EXPECT().FindCredentialProfile(gomock.Any(), "user-only-scope").Return(&policy.CredentialProfileMatch{
+				CredentialProfileScope: "user-only-scope",
+				WalletOwnerMapping:     pe.WalletOwnerMapping{pe.WalletOwnerUser: testPD},
+				ScopePolicy:            policy.ScopePolicyProfileOnly,
+			}, nil)
+
+			resolver := &PresentationDefinitionResolver{policyBackend: mockPolicy}
+			_, err := resolver.Resolve(context.Background(), "user-only-scope", metadata)
+
+			assert.ErrorContains(t, err, "no organization presentation definition")
+		})
+		t.Run("nil policy backend returns error", func(t *testing.T) {
+			resolver := &PresentationDefinitionResolver{policyBackend: nil}
+			_, err := resolver.Resolve(context.Background(), "any-scope", metadata)
+
+			assert.ErrorContains(t, err, "policy backend")
+		})
+	})
+	t.Run("remote PD endpoint returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		resolver := &PresentationDefinitionResolver{
+			httpClient: HTTPClient{
+				strictMode: false,
+				httpClient: client.New(10 * time.Second),
+			},
+		}
+		metadata := oauth.AuthorizationServerMetadata{
+			PresentationDefinitionEndpoint: server.URL + "/presentation_definition",
+		}
+
+		_, err := resolver.Resolve(context.Background(), "scope", metadata)
+
+		assert.Error(t, err)
 	})
 }

--- a/auth/client/iam/pd_resolver_test.go
+++ b/auth/client/iam/pd_resolver_test.go
@@ -27,9 +27,11 @@ import (
 
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	"github.com/nuts-foundation/nuts-node/http/client"
+	"github.com/nuts-foundation/nuts-node/policy"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	"time"
 )
 
@@ -65,5 +67,83 @@ func TestPresentationDefinitionResolver_Resolve(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "test-pd", result.PresentationDefinition.Id)
 		assert.Equal(t, "profile-scope extra-scope", result.Scope)
+	})
+	t.Run("no remote PD endpoint", func(t *testing.T) {
+		metadata := oauth.AuthorizationServerMetadata{} // no PD endpoint
+
+		t.Run("single scope, profile-only", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockPolicy := policy.NewMockPDPBackend(ctrl)
+			mockPolicy.EXPECT().FindCredentialProfile(gomock.Any(), "profile-scope").Return(&policy.CredentialProfileMatch{
+				CredentialProfileScope: "profile-scope",
+				WalletOwnerMapping:     pe.WalletOwnerMapping{pe.WalletOwnerOrganization: testPD},
+				ScopePolicy:            policy.ScopePolicyProfileOnly,
+			}, nil)
+
+			resolver := &PresentationDefinitionResolver{policyBackend: mockPolicy}
+			result, err := resolver.Resolve(context.Background(), "profile-scope", metadata)
+
+			require.NoError(t, err)
+			assert.Equal(t, "test-pd", result.PresentationDefinition.Id)
+			assert.Equal(t, "profile-scope", result.Scope)
+		})
+		t.Run("multi-scope, profile-only rejects", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockPolicy := policy.NewMockPDPBackend(ctrl)
+			mockPolicy.EXPECT().FindCredentialProfile(gomock.Any(), "profile-scope extra-scope").Return(&policy.CredentialProfileMatch{
+				CredentialProfileScope: "profile-scope",
+				OtherScopes:            []string{"extra-scope"},
+				WalletOwnerMapping:     pe.WalletOwnerMapping{pe.WalletOwnerOrganization: testPD},
+				ScopePolicy:            policy.ScopePolicyProfileOnly,
+			}, nil)
+
+			resolver := &PresentationDefinitionResolver{policyBackend: mockPolicy}
+			_, err := resolver.Resolve(context.Background(), "profile-scope extra-scope", metadata)
+
+			assert.ErrorContains(t, err, "does not allow additional scopes")
+		})
+		t.Run("multi-scope, passthrough forwards all scopes", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockPolicy := policy.NewMockPDPBackend(ctrl)
+			mockPolicy.EXPECT().FindCredentialProfile(gomock.Any(), "profile-scope extra-scope").Return(&policy.CredentialProfileMatch{
+				CredentialProfileScope: "profile-scope",
+				OtherScopes:            []string{"extra-scope"},
+				WalletOwnerMapping:     pe.WalletOwnerMapping{pe.WalletOwnerOrganization: testPD},
+				ScopePolicy:            policy.ScopePolicyPassthrough,
+			}, nil)
+
+			resolver := &PresentationDefinitionResolver{policyBackend: mockPolicy}
+			result, err := resolver.Resolve(context.Background(), "profile-scope extra-scope", metadata)
+
+			require.NoError(t, err)
+			assert.Equal(t, "test-pd", result.PresentationDefinition.Id)
+			assert.Equal(t, "profile-scope extra-scope", result.Scope)
+		})
+		t.Run("multi-scope, dynamic forwards all scopes", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockPolicy := policy.NewMockPDPBackend(ctrl)
+			mockPolicy.EXPECT().FindCredentialProfile(gomock.Any(), "profile-scope extra-scope").Return(&policy.CredentialProfileMatch{
+				CredentialProfileScope: "profile-scope",
+				OtherScopes:            []string{"extra-scope"},
+				WalletOwnerMapping:     pe.WalletOwnerMapping{pe.WalletOwnerOrganization: testPD},
+				ScopePolicy:            policy.ScopePolicyDynamic,
+			}, nil)
+
+			resolver := &PresentationDefinitionResolver{policyBackend: mockPolicy}
+			result, err := resolver.Resolve(context.Background(), "profile-scope extra-scope", metadata)
+
+			require.NoError(t, err)
+			assert.Equal(t, "profile-scope extra-scope", result.Scope)
+		})
+		t.Run("unknown scope returns error", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockPolicy := policy.NewMockPDPBackend(ctrl)
+			mockPolicy.EXPECT().FindCredentialProfile(gomock.Any(), "unknown").Return(nil, policy.ErrNotFound)
+
+			resolver := &PresentationDefinitionResolver{policyBackend: mockPolicy}
+			_, err := resolver.Resolve(context.Background(), "unknown", metadata)
+
+			assert.ErrorIs(t, err, policy.ErrNotFound)
+		})
 	})
 }

--- a/auth/client/iam/pd_resolver_test.go
+++ b/auth/client/iam/pd_resolver_test.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package iam
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nuts-foundation/nuts-node/auth/oauth"
+	"github.com/nuts-foundation/nuts-node/http/client"
+	"github.com/nuts-foundation/nuts-node/vcr/pe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"time"
+)
+
+var testPD = pe.PresentationDefinition{
+	Id: "test-pd",
+	InputDescriptors: []*pe.InputDescriptor{
+		{Id: "id1"},
+	},
+}
+
+func TestPresentationDefinitionResolver_Resolve(t *testing.T) {
+	t.Run("remote PD endpoint exists - fetches from remote and returns full scope", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/presentation_definition", r.URL.Path)
+			assert.Equal(t, "profile-scope extra-scope", r.URL.Query().Get("scope"))
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(testPD)
+		}))
+		defer server.Close()
+
+		resolver := &PresentationDefinitionResolver{
+			httpClient: HTTPClient{
+				strictMode: false,
+				httpClient: client.New(10 * time.Second),
+			},
+		}
+		metadata := oauth.AuthorizationServerMetadata{
+			PresentationDefinitionEndpoint: server.URL + "/presentation_definition",
+		}
+
+		result, err := resolver.Resolve(context.Background(), "profile-scope extra-scope", metadata)
+
+		require.NoError(t, err)
+		assert.Equal(t, "test-pd", result.PresentationDefinition.Id)
+		assert.Equal(t, "profile-scope extra-scope", result.Scope)
+	})
+}

--- a/auth/client/iam/pd_resolver_test.go
+++ b/auth/client/iam/pd_resolver_test.go
@@ -20,20 +20,27 @@ package iam
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
+	"errors"
 	"testing"
-	"time"
 
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
-	"github.com/nuts-foundation/nuts-node/http/client"
 	"github.com/nuts-foundation/nuts-node/policy"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
+
+type fakePDFetcher struct {
+	lastEndpoint string
+	pd           *pe.PresentationDefinition
+	err          error
+}
+
+func (f *fakePDFetcher) PresentationDefinition(_ context.Context, endpoint string) (*pe.PresentationDefinition, error) {
+	f.lastEndpoint = endpoint
+	return f.pd, f.err
+}
 
 var testPD = pe.PresentationDefinition{
 	Id: "test-pd",
@@ -44,22 +51,10 @@ var testPD = pe.PresentationDefinition{
 
 func TestPresentationDefinitionResolver_Resolve(t *testing.T) {
 	t.Run("remote PD endpoint exists - fetches from remote and returns full scope", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "/presentation_definition", r.URL.Path)
-			assert.Equal(t, "profile-scope extra-scope", r.URL.Query().Get("scope"))
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(testPD)
-		}))
-		defer server.Close()
-
-		resolver := &PresentationDefinitionResolver{
-			httpClient: HTTPClient{
-				strictMode: false,
-				httpClient: client.New(10 * time.Second),
-			},
-		}
+		fetcher := &fakePDFetcher{pd: &testPD}
+		resolver := &PresentationDefinitionResolver{pdFetcher: fetcher}
 		metadata := oauth.AuthorizationServerMetadata{
-			PresentationDefinitionEndpoint: server.URL + "/presentation_definition",
+			PresentationDefinitionEndpoint: "https://as.example.com/presentation_definition",
 		}
 
 		result, err := resolver.Resolve(context.Background(), "profile-scope extra-scope", metadata)
@@ -67,6 +62,7 @@ func TestPresentationDefinitionResolver_Resolve(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "test-pd", result.PresentationDefinition.Id)
 		assert.Equal(t, "profile-scope extra-scope", result.Scope)
+		assert.Equal(t, "https://as.example.com/presentation_definition?scope=profile-scope+extra-scope", fetcher.lastEndpoint)
 	})
 	t.Run("no remote PD endpoint", func(t *testing.T) {
 		metadata := oauth.AuthorizationServerMetadata{} // no PD endpoint
@@ -167,23 +163,14 @@ func TestPresentationDefinitionResolver_Resolve(t *testing.T) {
 		})
 	})
 	t.Run("remote PD endpoint returns error", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-		}))
-		defer server.Close()
-
-		resolver := &PresentationDefinitionResolver{
-			httpClient: HTTPClient{
-				strictMode: false,
-				httpClient: client.New(10 * time.Second),
-			},
-		}
+		fetcher := &fakePDFetcher{err: errors.New("PDP call failed")}
+		resolver := &PresentationDefinitionResolver{pdFetcher: fetcher}
 		metadata := oauth.AuthorizationServerMetadata{
-			PresentationDefinitionEndpoint: server.URL + "/presentation_definition",
+			PresentationDefinitionEndpoint: "https://as.example.com/presentation_definition",
 		}
 
 		_, err := resolver.Resolve(context.Background(), "scope", metadata)
 
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "PDP call failed")
 	})
 }

--- a/auth/test.go
+++ b/auth/test.go
@@ -44,5 +44,5 @@ func testInstance(t *testing.T, cfg Config) *Auth {
 	vdrInstance := vdr.NewMockVDR(ctrl)
 	vdrInstance.EXPECT().Resolver().AnyTimes()
 	subjectManager := didsubject.NewMockManager(ctrl)
-	return NewAuthInstance(cfg, vdrInstance, subjectManager, vcrInstance, cryptoInstance, nil, nil, pkiMock)
+	return NewAuthInstance(cfg, vdrInstance, subjectManager, vcrInstance, cryptoInstance, nil, nil, pkiMock, nil)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -201,11 +201,11 @@ func CreateSystem(shutdownCallback context.CancelFunc) *core.System {
 	credentialInstance := vcr.NewVCRInstance(cryptoInstance, vdrInstance, networkInstance, jsonld, eventManager, storageInstance, pkiInstance)
 	didmanInstance := didman.NewDidmanInstance(vdrInstance, credentialInstance, jsonld)
 	discoveryInstance := discovery.New(storageInstance, credentialInstance, vdrInstance, vdrInstance)
-	authInstance := auth.NewAuthInstance(auth.DefaultConfig(), vdrInstance, vdrInstance, credentialInstance, cryptoInstance, didmanInstance, jsonld, pkiInstance)
+	policyInstance := policy.New()
+	authInstance := auth.NewAuthInstance(auth.DefaultConfig(), vdrInstance, vdrInstance, credentialInstance, cryptoInstance, didmanInstance, jsonld, pkiInstance, policyInstance)
 	statusEngine := status.NewStatusEngine(system)
 	metricsEngine := core.NewMetricsEngine()
 	goldenHammer := golden_hammer.New(vdrInstance, didmanInstance)
-	policyInstance := policy.New()
 
 	// Register HTTP routes
 	didKeyResolver := resolver.DIDKeyResolver{Resolver: vdrInstance.Resolver()}


### PR DESCRIPTION
## Parent PRD

#4144

## Summary

Modifies the client-side S2S token request flow to support mixed OAuth2 scopes. Introduces a `PresentationDefinitionResolver` that decides whether to fetch the PD from the remote AS (Nuts-to-Nuts, trust the server) or fall back to local policy resolution (integration with non-Nuts AS), and enforces scope policy when resolving locally.

## What changed

**New `PresentationDefinitionResolver`** (`auth/client/iam/pd_resolver.go`):
- Resolves a PD + the scope string to forward in the token request
- Remote path: metadata has a PD endpoint → fetch from remote, forward all scopes unchanged
- Local path: no PD endpoint → call `FindCredentialProfile` locally; enforce scope policy (profile-only rejects extras; passthrough/dynamic forward all)
- Nil guard: resolver returns a clear error if no policy backend is configured but the remote has no PD endpoint

**`OpenID4VPClient` wiring** (`auth/client/iam/openid4vp.go`):
- `RequestRFC021AccessToken` replaces its direct PD fetch with `c.pdResolver.Resolve(...)` and uses `resolved.Scope` for the token request
- `OpenID4VPClient` gets a `pdResolver` field; `NewClient` takes a `policy.PDPBackend` parameter and wires the resolver internally

**Propagation through `Auth`** (`auth/auth.go`, `cmd/root.go`):
- `Auth` struct gets a `policyBackend` field
- `NewAuthInstance` takes `policy.PDPBackend` as a new parameter
- `cmd/root.go` reorders: `policy.New()` moves before `auth.NewAuthInstance` so it can be passed in

**Dynamic = passthrough on client:** the client doesn't call the AuthZen PDP. The server enforces dynamic at token-grant time (#4179).

## How to review

**Start with `pd_resolver.go`** — the core logic:
- `Resolve` dispatches to remote or local
- `resolveLocal` enforces scope policy and selects the organization PD (TODO comment for #4080 two-VP flow)
- Tests in `pd_resolver_test.go` cover both paths with all scope policies, nil guards, and missing-PD / unknown-scope edge cases (10 cases total)

**Then `openid4vp.go`** — the call site change is minimal (replacing the direct PD fetch with `pdResolver.Resolve`). The important detail is that `data.Set(oauth.ScopeParam, resolved.Scope)` uses the resolver's output, not the raw input.

**Wiring review** — `auth.go` and `cmd/root.go` add the policy backend dependency. Note the line reordering in `cmd/root.go` (policyInstance moved up).

## Deviations from spec

- **Spec targeted `presentationDefinitionForScope`, but that's server-side only.** The actual client-side flow goes through `RequestRFC021AccessToken`. The resolver replaces the direct PD fetch there.
- **Added remote-vs-local PD resolution** (not in original spec). The spec assumed the client always resolves PD locally. In practice the client-side flow fetches from the remote PD endpoint. Added local fallback explicitly for non-Nuts AS integrations — this is a meaningful new capability.
- **`PresentationDefinitionResolver` was added as an abstraction** instead of inlining the logic in `RequestRFC021AccessToken`. Keeps the OAuth client focused on the OAuth flow and makes PD resolution independently testable.
- **Profile-only returns canonical `CredentialProfileScope`** (not raw input) — caught during self-review to avoid echoing whitespace/formatting artifacts.

## Dependencies

**Depends on:** #4176 (base branch, provides `FindCredentialProfile` and scope policy types).

Independent of #4177 (AuthZen client) — client-side doesn't call the PDP. Can be reviewed in parallel with #4177.

## Design context

- PRD: #4144
- Fallback design: the fallback ordering (metadata-first, local fallback if no remote PD endpoint) was discussed during implementation — simpler than always consulting both.
- Resolver abstraction: decided to extract rather than inline, to keep the OAuth client focused
- TODO in code for #4080: resolver currently selects organization PD; when two-VP flow lands, resolver returns both

## Acceptance Criteria

- [x] `PresentationDefinitionResolver` resolves PD from remote when PD endpoint exists
- [x] Resolver falls back to local PD via `FindCredentialProfile` when no remote PD endpoint
- [x] Local fallback: profile-only rejects extra scopes
- [x] Local fallback: passthrough and dynamic forward all scopes
- [x] Remote path: all scopes forwarded, scope policy not enforced locally
- [x] `RequestRFC021AccessToken` uses resolver instead of direct PD fetch
- [x] Single-scope requests work unchanged (backwards compatible)
- [x] Unit tests cover both resolver paths with all scope policies
- [x] Nil policy backend guard (added during self-review)
- [x] Profile-only returns canonical scope, not raw input (added during self-review)

<details>
<summary>Original implementation spec (used during AI-assisted development)</summary>

## Parent PRD

#4144

## Implementation Spec

### Overview

Modify the client-side token request flow to support mixed OAuth2 scopes. Introduces a `PresentationDefinitionResolver` that abstracts the decision of whether to fetch a PD from the remote AS or fall back to local policy resolution. When using local resolution, scope policy is enforced.

### Design decisions

- **`PresentationDefinitionResolver` abstraction**: The client (`RequestRFC021AccessToken`) should not decide where the PD comes from. A resolver encapsulates the remote-vs-local decision and scope policy enforcement, keeping the client focused on the OAuth flow.
- **Remote PD endpoint → trust remote AS**: When the remote AS metadata advertises a PD endpoint, the resolver fetches the PD from there and returns the full scope string. The remote server enforces scope policy (covered by PR #4179).
- **No remote PD endpoint → local fallback**: When no PD endpoint exists, the resolver calls `FindCredentialProfile` locally to get the PD and scope classification. Scope policy is enforced locally: profile-only rejects extra scopes, passthrough/dynamic forward all scopes.
- **Dynamic same as passthrough on client side**: The client does not call the AuthZen PDP — the server handles dynamic scope evaluation at token-grant time (PR #4179).
- **Resolver on `OpenID4VPClient`**: The resolver is a struct dependency, wired through `Auth` → `NewClient`. Policy backend passed through `Auth` to enable local PD fallback.

### Deviations from original spec

- **Spec assumed `presentationDefinitionForScope` was the modification point**: That helper is server-side only. The actual client-side flow goes through `RequestRFC021AccessToken` → remote PD endpoint. The resolver replaces the direct PD fetch.
- **Spec didn't account for remote-vs-local PD resolution**: The client fetches PDs from the remote AS when possible, falling back to local only when no PD endpoint exists. This enables integration with external (non-Nuts) authorization servers.
- **Policy backend wired through `Auth` struct**: Added `policyBackend` parameter to `NewAuthInstance` and `iam.NewClient` to propagate the policy backend to the resolver.

### Modified flow

```
RequestRFC021AccessToken(ctx, ..., scope, ...)
    1. Fetch remote AS metadata
    2. resolved, err := c.pdResolver.Resolve(ctx, scope, metadata)
       Internally:
       a. If metadata has PD endpoint → fetch from remote, return full scope
       b. If no PD endpoint → FindCredentialProfile locally, enforce scope policy
    3. Build VP using resolved.PresentationDefinition
    4. Send token request with resolved.Scope
```

## Acceptance Criteria

- [x] `PresentationDefinitionResolver` resolves PD from remote when PD endpoint exists
- [x] Resolver falls back to local PD via `FindCredentialProfile` when no remote PD endpoint
- [x] Local fallback: profile-only rejects extra scopes
- [x] Local fallback: passthrough and dynamic forward all scopes
- [x] Remote path: all scopes forwarded, scope policy not enforced locally
- [x] `RequestRFC021AccessToken` uses resolver instead of direct PD fetch
- [x] Single-scope requests work unchanged (backwards compatible)
- [x] Unit tests cover both resolver paths with all scope policies
- [x] Nil policy backend guard (added during self-review)
- [x] Profile-only returns canonical scope, not raw input (added during self-review)

</details>
