### PR TITLE
Server-side multi-scope flow & scope policy evaluation

### DIFF
--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -190,7 +190,7 @@ func TestWrapper_PresentationDefinition(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		test := newTestClient(t)
-		test.policy.EXPECT().FindCredentialProfile(gomock.Any(), "example-scope").Return(&policy.CredentialProfileMatch{WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+		test.policy.EXPECT().FindCredentialProfile(gomock.Any(), "example-scope").Return(&policy.CredentialProfileMatch{CredentialProfileScope: "example-scope", WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 
 		response, err := test.client.PresentationDefinition(ctx, PresentationDefinitionRequestObject{SubjectID: verifierSubject, Params: PresentationDefinitionParams{Scope: "example-scope"}})
 
@@ -215,7 +215,7 @@ func TestWrapper_PresentationDefinition(t *testing.T) {
 		walletOwnerMapping := pe.WalletOwnerMapping{pe.WalletOwnerUser: pe.PresentationDefinition{Id: "test"}}
 
 		test := newTestClient(t)
-		test.policy.EXPECT().FindCredentialProfile(gomock.Any(), "example-scope").Return(&policy.CredentialProfileMatch{WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+		test.policy.EXPECT().FindCredentialProfile(gomock.Any(), "example-scope").Return(&policy.CredentialProfileMatch{CredentialProfileScope: "example-scope", WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 
 		response, err := test.client.PresentationDefinition(ctx, PresentationDefinitionRequestObject{SubjectID: verifierSubject, Params: PresentationDefinitionParams{Scope: "example-scope", WalletOwnerType: &userWalletType}})
 
@@ -227,7 +227,7 @@ func TestWrapper_PresentationDefinition(t *testing.T) {
 
 	t.Run("err - unknown wallet type", func(t *testing.T) {
 		test := newTestClient(t)
-		test.policy.EXPECT().FindCredentialProfile(gomock.Any(), "example-scope").Return(&policy.CredentialProfileMatch{WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+		test.policy.EXPECT().FindCredentialProfile(gomock.Any(), "example-scope").Return(&policy.CredentialProfileMatch{CredentialProfileScope: "example-scope", WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 
 		response, err := test.client.PresentationDefinition(ctx, PresentationDefinitionRequestObject{SubjectID: verifierSubject, Params: PresentationDefinitionParams{Scope: "example-scope", WalletOwnerType: &userWalletType}})
 
@@ -289,7 +289,7 @@ func TestWrapper_HandleAuthorizeRequest(t *testing.T) {
 				OpenIDProvider: serverMetadata,
 			},
 		}
-		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), "test").Return(&policy.CredentialProfileMatch{WalletOwnerMapping: pe.WalletOwnerMapping{pe.WalletOwnerOrganization: pe.PresentationDefinition{Id: "test"}}, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), "test").Return(&policy.CredentialProfileMatch{CredentialProfileScope: "test", WalletOwnerMapping: pe.WalletOwnerMapping{pe.WalletOwnerOrganization: pe.PresentationDefinition{Id: "test"}}, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 		ctx.iamClient.EXPECT().OpenIDConfiguration(gomock.Any(), holderURL.String()).Return(&configuration, nil)
 		ctx.jar.EXPECT().Create(verifierDID, verifierURL.String(), holderClientID, gomock.Any()).DoAndReturn(func(client did.DID, clientID string, audience string, modifier requestObjectModifier) jarRequest {
 			req := createJarRequest(client, clientID, audience, modifier)
@@ -1578,7 +1578,8 @@ type testCtx struct {
 	iamClient      *iam.MockClient
 	jwtSigner      *cryptoNuts.MockJWTSigner
 	keyResolver    *resolver.MockKeyResolver
-	policy         *policy.MockPDPBackend
+	policy            *policy.MockPDPBackend
+	authzenEvaluator  *policy.MockAuthZenEvaluator
 	resolver       *resolver.MockDIDResolver
 	relyingParty   *oauthServices.MockRelyingParty
 	vcr            *vcr.MockVCR
@@ -1600,6 +1601,7 @@ func newCustomTestClient(t testing.TB, publicURL *url.URL, authEndpointEnabled b
 	storageEngine := storage.NewTestStorageEngine(t)
 	authnServices := auth.NewMockAuthenticationServices(ctrl)
 	policyInstance := policy.NewMockPDPBackend(ctrl)
+	authzenEvaluator := policy.NewMockAuthZenEvaluator(ctrl)
 	mockResolver := resolver.NewMockDIDResolver(ctrl)
 	relyingPary := oauthServices.NewMockRelyingParty(ctrl)
 	vcIssuer := issuer.NewMockIssuer(ctrl)
@@ -1641,10 +1643,11 @@ func newCustomTestClient(t testing.TB, publicURL *url.URL, authEndpointEnabled b
 		jar:            mockJAR,
 	}
 	return &testCtx{
-		ctrl:           ctrl,
-		authnServices:  authnServices,
-		policy:         policyInstance,
-		relyingParty:   relyingPary,
+		ctrl:             ctrl,
+		authnServices:    authnServices,
+		policy:           policyInstance,
+		authzenEvaluator: authzenEvaluator,
+		relyingParty:     relyingPary,
 		vcIssuer:       vcIssuer,
 		vcVerifier:     vcVerifier,
 		resolver:       mockResolver,

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -1571,24 +1571,24 @@ func statusCodeFrom(err error) int {
 }
 
 type testCtx struct {
-	authnServices  *auth.MockAuthenticationServices
-	ctrl           *gomock.Controller
-	client         *Wrapper
-	documentOwner  *didsubject.MockDocumentOwner
-	iamClient      *iam.MockClient
-	jwtSigner      *cryptoNuts.MockJWTSigner
-	keyResolver    *resolver.MockKeyResolver
-	policy            *policy.MockPDPBackend
-	authzenEvaluator  *policy.MockAuthZenEvaluator
-	resolver       *resolver.MockDIDResolver
-	relyingParty   *oauthServices.MockRelyingParty
-	vcr            *vcr.MockVCR
-	vdr            *vdr.MockVDR
-	vcIssuer       *issuer.MockIssuer
-	vcVerifier     *verifier.MockVerifier
-	wallet         *holder.MockWallet
-	subjectManager *didsubject.MockManager
-	jar            *MockJAR
+	authnServices    *auth.MockAuthenticationServices
+	ctrl             *gomock.Controller
+	client           *Wrapper
+	documentOwner    *didsubject.MockDocumentOwner
+	iamClient        *iam.MockClient
+	jwtSigner        *cryptoNuts.MockJWTSigner
+	keyResolver      *resolver.MockKeyResolver
+	policy           *policy.MockPDPBackend
+	authzenEvaluator *policy.MockAuthZenEvaluator
+	resolver         *resolver.MockDIDResolver
+	relyingParty     *oauthServices.MockRelyingParty
+	vcr              *vcr.MockVCR
+	vdr              *vdr.MockVDR
+	vcIssuer         *issuer.MockIssuer
+	vcVerifier       *verifier.MockVerifier
+	wallet           *holder.MockWallet
+	subjectManager   *didsubject.MockManager
+	jar              *MockJAR
 }
 
 func newTestClient(t testing.TB) *testCtx {
@@ -1648,17 +1648,17 @@ func newCustomTestClient(t testing.TB, publicURL *url.URL, authEndpointEnabled b
 		policy:           policyInstance,
 		authzenEvaluator: authzenEvaluator,
 		relyingParty:     relyingPary,
-		vcIssuer:       vcIssuer,
-		vcVerifier:     vcVerifier,
-		resolver:       mockResolver,
-		documentOwner:  mockDocumentOwner,
-		subjectManager: subjectManager,
-		iamClient:      iamClient,
-		vcr:            mockVCR,
-		wallet:         mockWallet,
-		keyResolver:    keyResolver,
-		jwtSigner:      jwtSigner,
-		jar:            mockJAR,
-		client:         client,
+		vcIssuer:         vcIssuer,
+		vcVerifier:       vcVerifier,
+		resolver:         mockResolver,
+		documentOwner:    mockDocumentOwner,
+		subjectManager:   subjectManager,
+		iamClient:        iamClient,
+		vcr:              mockVCR,
+		wallet:           mockWallet,
+		keyResolver:      keyResolver,
+		jwtSigner:        jwtSigner,
+		jar:              mockJAR,
+		client:           client,
 	}
 }

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -111,7 +111,7 @@ func (r Wrapper) handleAuthorizeRequestFromHolder(ctx context.Context, subject s
 	// Determine which PEX Presentation Definitions we want to see fulfilled during authorization through OpenID4VP.
 	// Each Presentation Definition triggers 1 OpenID4VP flow.
 	// TODO: Support multiple scopes?
-	presentationDefinitions, err := r.presentationDefinitionForScope(ctx, params.get(oauth.ScopeParam))
+	match, err := r.findCredentialProfile(ctx, params.get(oauth.ScopeParam))
 	if err != nil {
 		return nil, withCallbackURI(err, redirectURL)
 	}
@@ -122,7 +122,7 @@ func (r Wrapper) handleAuthorizeRequestFromHolder(ctx context.Context, subject s
 		OwnSubject:        &subject,
 		ClientState:       params.get(oauth.StateParam),
 		RedirectURI:       redirectURL.String(),
-		OpenID4VPVerifier: newPEXConsumer(presentationDefinitions),
+		OpenID4VPVerifier: newPEXConsumer(match.WalletOwnerMapping),
 		PKCEParams: PKCEParams{ // store params, when generating authorization code we take the params from the nonceStore and encrypt them in the authorization code
 			Challenge:       params.get(oauth.CodeChallengeParam),
 			ChallengeMethod: params.get(oauth.CodeChallengeMethodParam),

--- a/auth/api/iam/openid4vp_test.go
+++ b/auth/api/iam/openid4vp_test.go
@@ -126,7 +126,7 @@ func TestWrapper_handleAuthorizeRequestFromHolder(t *testing.T) {
 	})
 	t.Run("failed to generate authorization request", func(t *testing.T) {
 		ctx := newTestClient(t)
-		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), "test").Return(&policy.CredentialProfileMatch{WalletOwnerMapping: pe.WalletOwnerMapping{pe.WalletOwnerOrganization: PresentationDefinition{}}, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), "test").Return(&policy.CredentialProfileMatch{CredentialProfileScope: "test", WalletOwnerMapping: pe.WalletOwnerMapping{pe.WalletOwnerOrganization: PresentationDefinition{}}, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 		params := defaultParams()
 		ctx.iamClient.EXPECT().OpenIDConfiguration(context.Background(), holderClientID).Return(&oauth.OpenIDConfiguration{
 			Metadata: oauth.EntityStatementMetadata{
@@ -142,7 +142,7 @@ func TestWrapper_handleAuthorizeRequestFromHolder(t *testing.T) {
 	})
 	t.Run("failed to resolve OpenID configuration", func(t *testing.T) {
 		ctx := newTestClient(t)
-		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), "test").Return(&policy.CredentialProfileMatch{WalletOwnerMapping: pe.WalletOwnerMapping{pe.WalletOwnerOrganization: PresentationDefinition{}}, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), "test").Return(&policy.CredentialProfileMatch{CredentialProfileScope: "test", WalletOwnerMapping: pe.WalletOwnerMapping{pe.WalletOwnerOrganization: PresentationDefinition{}}, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 		params := defaultParams()
 		ctx.iamClient.EXPECT().OpenIDConfiguration(context.Background(), holderClientID).Return(nil, assert.AnError)
 

--- a/auth/api/iam/s2s_vptoken.go
+++ b/auth/api/iam/s2s_vptoken.go
@@ -28,6 +28,7 @@ import (
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
+	"github.com/nuts-foundation/nuts-node/policy"
 	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
@@ -76,6 +77,12 @@ func (r Wrapper) handleS2SAccessTokenRequest(ctx context.Context, clientID strin
 	match, err := r.findCredentialProfile(ctx, scope)
 	if err != nil {
 		return nil, err
+	}
+	if match.ScopePolicy == policy.ScopePolicyProfileOnly && len(match.OtherScopes) > 0 {
+		return nil, oauth.OAuth2Error{
+			Code:        oauth.InvalidScope,
+			Description: "scope policy 'profile-only' does not allow additional scopes",
+		}
 	}
 	pexConsumer := newPEXConsumer(match.WalletOwnerMapping)
 	if err := pexConsumer.fulfill(*submission, *pexEnvelope); err != nil {

--- a/auth/api/iam/s2s_vptoken.go
+++ b/auth/api/iam/s2s_vptoken.go
@@ -166,7 +166,11 @@ func (r Wrapper) evaluateDynamicScopes(ctx context.Context, match *policy.Creden
 	}
 	credentialMap, err := pexState.credentialMap()
 	if err != nil {
-		return "", err
+		return "", oauth.OAuth2Error{
+			Code:          oauth.ServerError,
+			Description:   "failed to extract credentials for scope evaluation",
+			InternalError: err,
+		}
 	}
 	claims, err := resolveInputDescriptorValues(pexState.RequiredPresentationDefinitions, credentialMap)
 	if err != nil {
@@ -191,9 +195,11 @@ func (r Wrapper) evaluateDynamicScopes(ctx context.Context, match *policy.Creden
 
 	decisions, err := evaluator.Evaluate(ctx, request)
 	if err != nil {
+		// Keep Description generic to avoid leaking PDP internals to the OAuth2 client.
+		// Details remain available in InternalError for server-side logging.
 		return "", oauth.OAuth2Error{
 			Code:          oauth.ServerError,
-			Description:   "AuthZen PDP evaluation failed: " + err.Error(),
+			Description:   "policy decision point unavailable",
 			InternalError: err,
 		}
 	}

--- a/auth/api/iam/s2s_vptoken.go
+++ b/auth/api/iam/s2s_vptoken.go
@@ -73,11 +73,11 @@ func (r Wrapper) handleS2SAccessTokenRequest(ctx context.Context, clientID strin
 			return nil, err
 		}
 	}
-	walletOwnerMapping, err := r.presentationDefinitionForScope(ctx, scope)
+	match, err := r.findCredentialProfile(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
-	pexConsumer := newPEXConsumer(walletOwnerMapping)
+	pexConsumer := newPEXConsumer(match.WalletOwnerMapping)
 	if err := pexConsumer.fulfill(*submission, *pexEnvelope); err != nil {
 		return nil, oauthError(oauth.InvalidRequest, err.Error())
 	}

--- a/auth/api/iam/s2s_vptoken.go
+++ b/auth/api/iam/s2s_vptoken.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nuts-foundation/go-did/vc"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	"github.com/nuts-foundation/nuts-node/policy"
+	"github.com/nuts-foundation/nuts-node/policy/authzen"
 	"github.com/nuts-foundation/nuts-node/storage"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
@@ -117,7 +118,7 @@ func (r Wrapper) handleS2SAccessTokenRequest(ctx context.Context, clientID strin
 
 	// Compute granted scopes based on scope policy. Never pass through the raw input scope
 	// directly — always derive granted scopes from the policy decision.
-	grantedScope, err := grantedScopesForPolicy(match)
+	grantedScope, err := r.grantedScopesForPolicy(ctx, match, credentialSubjectID, *pexConsumer)
 	if err != nil {
 		return nil, err
 	}
@@ -133,8 +134,8 @@ func (r Wrapper) handleS2SAccessTokenRequest(ctx context.Context, clientID strin
 
 // grantedScopesForPolicy returns the scopes to include in the access token based on the scope policy.
 // Profile-only grants only the credential profile scope. Passthrough grants the credential profile
-// scope plus all other requested scopes. Dynamic requires PDP evaluation and is not yet handled here.
-func grantedScopesForPolicy(match *policy.CredentialProfileMatch) (string, error) {
+// scope plus all other requested scopes. Dynamic calls the configured AuthZen PDP for per-scope evaluation.
+func (r Wrapper) grantedScopesForPolicy(ctx context.Context, match *policy.CredentialProfileMatch, subjectDID did.DID, pexState PEXConsumer) (string, error) {
 	switch match.ScopePolicy {
 	case policy.ScopePolicyProfileOnly:
 		return match.CredentialProfileScope, nil
@@ -142,16 +143,73 @@ func grantedScopesForPolicy(match *policy.CredentialProfileMatch) (string, error
 		scopes := append([]string{match.CredentialProfileScope}, match.OtherScopes...)
 		return strings.Join(scopes, " "), nil
 	case policy.ScopePolicyDynamic:
-		return "", oauth.OAuth2Error{
-			Code:        oauth.ServerError,
-			Description: "dynamic scope policy evaluation not yet implemented",
-		}
+		return r.evaluateDynamicScopes(ctx, match, subjectDID, pexState)
 	default:
 		return "", oauth.OAuth2Error{
 			Code:        oauth.ServerError,
 			Description: fmt.Sprintf("unsupported scope policy: %s", match.ScopePolicy),
 		}
 	}
+}
+
+// evaluateDynamicScopes calls the AuthZen PDP to evaluate each requested scope.
+// Returns the space-joined granted scopes. If the PDP denies the credential profile scope,
+// the request is rejected. Other denied scopes are simply excluded from the granted set.
+func (r Wrapper) evaluateDynamicScopes(ctx context.Context, match *policy.CredentialProfileMatch, subjectDID did.DID, pexState PEXConsumer) (string, error) {
+	evaluator := r.policyBackend.AuthZenEvaluator()
+	if evaluator == nil {
+		// Should be caught at startup by policy.LocalPDP.Configure, but guard here defensively.
+		return "", oauth.OAuth2Error{
+			Code:        oauth.ServerError,
+			Description: "dynamic scope policy configured but no AuthZen evaluator available",
+		}
+	}
+	credentialMap, err := pexState.credentialMap()
+	if err != nil {
+		return "", err
+	}
+	claims, err := resolveInputDescriptorValues(pexState.RequiredPresentationDefinitions, credentialMap)
+	if err != nil {
+		return "", err
+	}
+	allScopes := append([]string{match.CredentialProfileScope}, match.OtherScopes...)
+	request := authzen.EvaluationsRequest{
+		Subject: authzen.Subject{
+			Type: "organization",
+			ID:   subjectDID.String(),
+			Properties: authzen.SubjectProperties{
+				Organization: claims,
+			},
+		},
+		Action:      authzen.Action{Name: "request_scope"},
+		Context:     authzen.EvaluationContext{Policy: match.CredentialProfileScope},
+		Evaluations: make([]authzen.Evaluation, len(allScopes)),
+	}
+	for i, s := range allScopes {
+		request.Evaluations[i] = authzen.Evaluation{Resource: authzen.Resource{Type: "scope", ID: s}}
+	}
+
+	decisions, err := evaluator.Evaluate(ctx, request)
+	if err != nil {
+		return "", oauth.OAuth2Error{
+			Code:          oauth.ServerError,
+			Description:   "AuthZen PDP evaluation failed: " + err.Error(),
+			InternalError: err,
+		}
+	}
+	if !decisions[match.CredentialProfileScope] {
+		return "", oauth.OAuth2Error{
+			Code:        oauth.AccessDenied,
+			Description: fmt.Sprintf("PDP denied credential profile scope %q", match.CredentialProfileScope),
+		}
+	}
+	granted := []string{match.CredentialProfileScope}
+	for _, s := range match.OtherScopes {
+		if decisions[s] {
+			granted = append(granted, s)
+		}
+	}
+	return strings.Join(granted, " "), nil
 }
 
 func resolveInputDescriptorValues(presentationDefinitions pe.WalletOwnerMapping, credentialMap map[string]vc.VerifiableCredential) (map[string]any, error) {

--- a/auth/api/iam/s2s_vptoken.go
+++ b/auth/api/iam/s2s_vptoken.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/nuts-foundation/go-did/did"
@@ -114,13 +115,43 @@ func (r Wrapper) handleS2SAccessTokenRequest(ctx context.Context, clientID strin
 		}
 	}
 
+	// Compute granted scopes based on scope policy. Never pass through the raw input scope
+	// directly — always derive granted scopes from the policy decision.
+	grantedScope, err := grantedScopesForPolicy(match)
+	if err != nil {
+		return nil, err
+	}
+
 	// All OK, allow access
 	issuerURL := r.subjectToBaseURL(subject)
-	response, err := r.createAccessToken(issuerURL.String(), clientID, time.Now(), scope, *pexConsumer, dpopProof)
+	response, err := r.createAccessToken(issuerURL.String(), clientID, time.Now(), grantedScope, *pexConsumer, dpopProof)
 	if err != nil {
 		return nil, err
 	}
 	return HandleTokenRequest200JSONResponse(*response), nil
+}
+
+// grantedScopesForPolicy returns the scopes to include in the access token based on the scope policy.
+// Profile-only grants only the credential profile scope. Passthrough grants the credential profile
+// scope plus all other requested scopes. Dynamic requires PDP evaluation and is not yet handled here.
+func grantedScopesForPolicy(match *policy.CredentialProfileMatch) (string, error) {
+	switch match.ScopePolicy {
+	case policy.ScopePolicyProfileOnly:
+		return match.CredentialProfileScope, nil
+	case policy.ScopePolicyPassthrough:
+		scopes := append([]string{match.CredentialProfileScope}, match.OtherScopes...)
+		return strings.Join(scopes, " "), nil
+	case policy.ScopePolicyDynamic:
+		return "", oauth.OAuth2Error{
+			Code:        oauth.ServerError,
+			Description: "dynamic scope policy evaluation not yet implemented",
+		}
+	default:
+		return "", oauth.OAuth2Error{
+			Code:        oauth.ServerError,
+			Description: fmt.Sprintf("unsupported scope policy: %s", match.ScopePolicy),
+		}
+	}
 }
 
 func resolveInputDescriptorValues(presentationDefinitions pe.WalletOwnerMapping, credentialMap map[string]vc.VerifiableCredential) (map[string]any, error) {

--- a/auth/api/iam/s2s_vptoken_test.go
+++ b/auth/api/iam/s2s_vptoken_test.go
@@ -435,6 +435,65 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		tokenResponse := TokenResponse(resp.(HandleTokenRequest200JSONResponse))
 		assert.Equal(t, "example-scope extra-scope", *tokenResponse.Scope)
 	})
+	t.Run("dynamic scope policy - PDP partial denial excludes denied scopes", func(t *testing.T) {
+		ctx := newTestClient(t)
+		ctx.vcVerifier.EXPECT().VerifyVP(gomock.Any(), true, true, gomock.Any()).Return(presentation.VerifiableCredential, nil)
+		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), "example-scope extra-scope other-scope").Return(&policy.CredentialProfileMatch{
+			CredentialProfileScope: "example-scope",
+			WalletOwnerMapping:     walletOwnerMapping,
+			ScopePolicy:            policy.ScopePolicyDynamic,
+			OtherScopes:            []string{"extra-scope", "other-scope"},
+		}, nil)
+		ctx.policy.EXPECT().AuthZenEvaluator().Return(ctx.authzenEvaluator)
+		ctx.authzenEvaluator.EXPECT().Evaluate(gomock.Any(), gomock.Any()).Return(map[string]bool{
+			"example-scope": true,
+			"extra-scope":   true,
+			"other-scope":   false,
+		}, nil)
+
+		resp, err := ctx.client.handleS2SAccessTokenRequest(contextWithValue, clientID, issuerSubjectID, "example-scope extra-scope other-scope", submissionJSON, presentation.Raw())
+
+		require.NoError(t, err)
+		tokenResponse := TokenResponse(resp.(HandleTokenRequest200JSONResponse))
+		assert.Equal(t, "example-scope extra-scope", *tokenResponse.Scope)
+	})
+	t.Run("dynamic scope policy - PDP denies credential profile scope - access_denied", func(t *testing.T) {
+		ctx := newTestClient(t)
+		ctx.vcVerifier.EXPECT().VerifyVP(gomock.Any(), true, true, gomock.Any()).Return(presentation.VerifiableCredential, nil)
+		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), "example-scope extra-scope").Return(&policy.CredentialProfileMatch{
+			CredentialProfileScope: "example-scope",
+			WalletOwnerMapping:     walletOwnerMapping,
+			ScopePolicy:            policy.ScopePolicyDynamic,
+			OtherScopes:            []string{"extra-scope"},
+		}, nil)
+		ctx.policy.EXPECT().AuthZenEvaluator().Return(ctx.authzenEvaluator)
+		ctx.authzenEvaluator.EXPECT().Evaluate(gomock.Any(), gomock.Any()).Return(map[string]bool{
+			"example-scope": false,
+			"extra-scope":   true,
+		}, nil)
+
+		resp, err := ctx.client.handleS2SAccessTokenRequest(contextWithValue, clientID, issuerSubjectID, "example-scope extra-scope", submissionJSON, presentation.Raw())
+
+		_ = assertOAuthErrorWithCode(t, err, oauth.AccessDenied, `PDP denied credential profile scope "example-scope"`)
+		assert.Nil(t, resp)
+	})
+	t.Run("dynamic scope policy - PDP error returns server_error", func(t *testing.T) {
+		ctx := newTestClient(t)
+		ctx.vcVerifier.EXPECT().VerifyVP(gomock.Any(), true, true, gomock.Any()).Return(presentation.VerifiableCredential, nil)
+		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), "example-scope extra-scope").Return(&policy.CredentialProfileMatch{
+			CredentialProfileScope: "example-scope",
+			WalletOwnerMapping:     walletOwnerMapping,
+			ScopePolicy:            policy.ScopePolicyDynamic,
+			OtherScopes:            []string{"extra-scope"},
+		}, nil)
+		ctx.policy.EXPECT().AuthZenEvaluator().Return(ctx.authzenEvaluator)
+		ctx.authzenEvaluator.EXPECT().Evaluate(gomock.Any(), gomock.Any()).Return(nil, errors.New("PDP unreachable"))
+
+		resp, err := ctx.client.handleS2SAccessTokenRequest(contextWithValue, clientID, issuerSubjectID, "example-scope extra-scope", submissionJSON, presentation.Raw())
+
+		_ = assertOAuthErrorWithCode(t, err, oauth.ServerError, "AuthZen PDP evaluation failed: PDP unreachable")
+		assert.Nil(t, resp)
+	})
 }
 
 func TestWrapper_createAccessToken(t *testing.T) {

--- a/auth/api/iam/s2s_vptoken_test.go
+++ b/auth/api/iam/s2s_vptoken_test.go
@@ -413,6 +413,28 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		tokenResponse := TokenResponse(resp.(HandleTokenRequest200JSONResponse))
 		assert.Equal(t, "example-scope extra-scope", *tokenResponse.Scope)
 	})
+	t.Run("dynamic scope policy - PDP approves all scopes", func(t *testing.T) {
+		ctx := newTestClient(t)
+		ctx.vcVerifier.EXPECT().VerifyVP(gomock.Any(), true, true, gomock.Any()).Return(presentation.VerifiableCredential, nil)
+		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), "example-scope extra-scope").Return(&policy.CredentialProfileMatch{
+			CredentialProfileScope: "example-scope",
+			WalletOwnerMapping:     walletOwnerMapping,
+			ScopePolicy:            policy.ScopePolicyDynamic,
+			OtherScopes:            []string{"extra-scope"},
+		}, nil)
+		ctx.policy.EXPECT().AuthZenEvaluator().Return(ctx.authzenEvaluator)
+		ctx.authzenEvaluator.EXPECT().Evaluate(gomock.Any(), gomock.Any()).Return(map[string]bool{
+			"example-scope": true,
+			"extra-scope":   true,
+		}, nil)
+
+		resp, err := ctx.client.handleS2SAccessTokenRequest(contextWithValue, clientID, issuerSubjectID, "example-scope extra-scope", submissionJSON, presentation.Raw())
+
+		require.NoError(t, err)
+		require.IsType(t, HandleTokenRequest200JSONResponse{}, resp)
+		tokenResponse := TokenResponse(resp.(HandleTokenRequest200JSONResponse))
+		assert.Equal(t, "example-scope extra-scope", *tokenResponse.Scope)
+	})
 }
 
 func TestWrapper_createAccessToken(t *testing.T) {

--- a/auth/api/iam/s2s_vptoken_test.go
+++ b/auth/api/iam/s2s_vptoken_test.go
@@ -396,6 +396,23 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		_ = assertOAuthErrorWithCode(t, err, oauth.InvalidScope, "scope policy 'profile-only' does not allow additional scopes")
 		assert.Nil(t, resp)
 	})
+	t.Run("passthrough scope policy grants all requested scopes", func(t *testing.T) {
+		ctx := newTestClient(t)
+		ctx.vcVerifier.EXPECT().VerifyVP(presentation, true, true, gomock.Any()).Return(presentation.VerifiableCredential, nil)
+		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), "example-scope extra-scope").Return(&policy.CredentialProfileMatch{
+			CredentialProfileScope: "example-scope",
+			WalletOwnerMapping:     walletOwnerMapping,
+			ScopePolicy:            policy.ScopePolicyPassthrough,
+			OtherScopes:            []string{"extra-scope"},
+		}, nil)
+
+		resp, err := ctx.client.handleS2SAccessTokenRequest(contextWithValue, clientID, issuerSubjectID, "example-scope extra-scope", submissionJSON, presentation.Raw())
+
+		require.NoError(t, err)
+		require.IsType(t, HandleTokenRequest200JSONResponse{}, resp)
+		tokenResponse := TokenResponse(resp.(HandleTokenRequest200JSONResponse))
+		assert.Equal(t, "example-scope extra-scope", *tokenResponse.Scope)
+	})
 }
 
 func TestWrapper_createAccessToken(t *testing.T) {

--- a/auth/api/iam/s2s_vptoken_test.go
+++ b/auth/api/iam/s2s_vptoken_test.go
@@ -118,7 +118,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 	t.Run("JSON-LD VP", func(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.vcVerifier.EXPECT().VerifyVP(presentation, true, true, gomock.Any()).Return(presentation.VerifiableCredential, nil)
-		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{CredentialProfileScope: requestedScope, WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 
 		resp, err := ctx.client.handleS2SAccessTokenRequest(contextWithValue, clientID, issuerSubjectID, requestedScope, submissionJSON, presentation.Raw())
 
@@ -165,7 +165,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		presentation, _ := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
 			require.NoError(t, token.Set(jwt.AudienceKey, issuerClientID))
 		}, verifiableCredential)
-		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{CredentialProfileScope: requestedScope, WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 		ctx.vcVerifier.EXPECT().VerifyVP(presentation, true, true, gomock.Any()).Return(presentation.VerifiableCredential, nil)
 
 		resp, err := ctx.client.handleS2SAccessTokenRequest(contextWithValue, clientID, issuerSubjectID, requestedScope, submissionJSON, presentation.Raw())
@@ -200,7 +200,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		t.Run("replay attack (nonce is reused)", func(t *testing.T) {
 			ctx := newTestClient(t)
 			ctx.vcVerifier.EXPECT().VerifyVP(presentation, true, true, gomock.Any()).Return(presentation.VerifiableCredential, nil)
-			ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil).Times(2)
+			ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{CredentialProfileScope: requestedScope, WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil).Times(2)
 
 			_, err := ctx.client.handleS2SAccessTokenRequest(contextWithValue, clientID, issuerSubjectID, requestedScope, submissionJSON, presentation.Raw())
 			require.NoError(t, err)
@@ -211,7 +211,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		})
 		t.Run("JSON-LD VP is missing nonce", func(t *testing.T) {
 			ctx := newTestClient(t)
-			ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+			ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{CredentialProfileScope: requestedScope, WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 			proofVisitor := test.LDProofVisitor(func(proof *proof.LDProof) {
 				proof.Domain = &issuerClientID
 				proof.Nonce = nil
@@ -224,7 +224,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		})
 		t.Run("JSON-LD VP has empty nonce", func(t *testing.T) {
 			ctx := newTestClient(t)
-			ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+			ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{CredentialProfileScope: requestedScope, WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 			proofVisitor := test.LDProofVisitor(func(proof *proof.LDProof) {
 				proof.Domain = &issuerClientID
 				proof.Nonce = new(string)
@@ -237,7 +237,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		})
 		t.Run("JWT VP is missing nonce", func(t *testing.T) {
 			ctx := newTestClient(t)
-			ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+			ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{CredentialProfileScope: requestedScope, WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 			presentation, _ := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
 				_ = token.Set(jwt.AudienceKey, issuerClientID)
 				_ = token.Remove("nonce")
@@ -249,7 +249,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		})
 		t.Run("JWT VP has empty nonce", func(t *testing.T) {
 			ctx := newTestClient(t)
-			ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+			ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{CredentialProfileScope: requestedScope, WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 			presentation, _ := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
 				_ = token.Set(jwt.AudienceKey, issuerClientID)
 				_ = token.Set("nonce", "")
@@ -261,7 +261,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		})
 		t.Run("JWT VP nonce is not a string", func(t *testing.T) {
 			ctx := newTestClient(t)
-			ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+			ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{CredentialProfileScope: requestedScope, WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 			presentation, _ := test.CreateJWTPresentation(t, *subjectDID, func(token jwt.Token) {
 				_ = token.Set(jwt.AudienceKey, issuerClientID)
 				_ = token.Set("nonce", true)
@@ -297,7 +297,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 	t.Run("VP verification fails", func(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.vcVerifier.EXPECT().VerifyVP(presentation, true, true, gomock.Any()).Return(nil, errors.New("invalid"))
-		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{CredentialProfileScope: requestedScope, WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 
 		resp, err := ctx.client.handleS2SAccessTokenRequest(contextWithValue, clientID, issuerSubjectID, requestedScope, submissionJSON, presentation.Raw())
 
@@ -364,7 +364,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		presentation := test.CreateJSONLDPresentation(t, *subjectDID, proofVisitor, otherVerifiableCredential)
 
 		ctx := newTestClient(t)
-		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{CredentialProfileScope: requestedScope, WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 
 		resp, err := ctx.client.handleS2SAccessTokenRequest(context.Background(), clientID, issuerSubjectID, requestedScope, submissionJSON, presentation.Raw())
 		assert.EqualError(t, err, "invalid_request - presentation submission does not conform to presentation definition (id=)")
@@ -375,7 +375,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		httpRequest := &http.Request{Header: http.Header{"Dpop": []string{"invalid"}}}
 		httpRequest.Header.Set("DPoP", "invalid")
 		contextWithValue := context.WithValue(context.Background(), httpRequestContextKey{}, httpRequest)
-		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
+		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), requestedScope).Return(&policy.CredentialProfileMatch{CredentialProfileScope: requestedScope, WalletOwnerMapping: walletOwnerMapping, ScopePolicy: policy.ScopePolicyProfileOnly}, nil)
 
 		resp, err := ctx.client.handleS2SAccessTokenRequest(contextWithValue, clientID, issuerSubjectID, requestedScope, submissionJSON, presentation.Raw())
 
@@ -398,7 +398,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 	})
 	t.Run("passthrough scope policy grants all requested scopes", func(t *testing.T) {
 		ctx := newTestClient(t)
-		ctx.vcVerifier.EXPECT().VerifyVP(presentation, true, true, gomock.Any()).Return(presentation.VerifiableCredential, nil)
+		ctx.vcVerifier.EXPECT().VerifyVP(gomock.Any(), true, true, gomock.Any()).Return(presentation.VerifiableCredential, nil)
 		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), "example-scope extra-scope").Return(&policy.CredentialProfileMatch{
 			CredentialProfileScope: "example-scope",
 			WalletOwnerMapping:     walletOwnerMapping,

--- a/auth/api/iam/s2s_vptoken_test.go
+++ b/auth/api/iam/s2s_vptoken_test.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	"github.com/nuts-foundation/nuts-node/policy"
+	"github.com/nuts-foundation/nuts-node/policy/authzen"
 	"go.uber.org/mock/gomock"
 	"net/http"
 	"testing"
@@ -423,10 +424,21 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 			OtherScopes:            []string{"extra-scope"},
 		}, nil)
 		ctx.policy.EXPECT().AuthZenEvaluator().Return(ctx.authzenEvaluator)
-		ctx.authzenEvaluator.EXPECT().Evaluate(gomock.Any(), gomock.Any()).Return(map[string]bool{
-			"example-scope": true,
-			"extra-scope":   true,
-		}, nil)
+		// Verify the AuthZen request shape matches the PRD contract.
+		ctx.authzenEvaluator.EXPECT().Evaluate(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, req authzen.EvaluationsRequest) (map[string]bool, error) {
+				assert.Equal(t, "organization", req.Subject.Type)
+				assert.Equal(t, "request_scope", req.Action.Name)
+				assert.Equal(t, "example-scope", req.Context.Policy)
+				require.Len(t, req.Evaluations, 2)
+				assert.Equal(t, "scope", req.Evaluations[0].Resource.Type)
+				assert.Equal(t, "example-scope", req.Evaluations[0].Resource.ID)
+				assert.Equal(t, "extra-scope", req.Evaluations[1].Resource.ID)
+				return map[string]bool{
+					"example-scope": true,
+					"extra-scope":   true,
+				}, nil
+			})
 
 		resp, err := ctx.client.handleS2SAccessTokenRequest(contextWithValue, clientID, issuerSubjectID, "example-scope extra-scope", submissionJSON, presentation.Raw())
 
@@ -491,7 +503,7 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 
 		resp, err := ctx.client.handleS2SAccessTokenRequest(contextWithValue, clientID, issuerSubjectID, "example-scope extra-scope", submissionJSON, presentation.Raw())
 
-		_ = assertOAuthErrorWithCode(t, err, oauth.ServerError, "AuthZen PDP evaluation failed: PDP unreachable")
+		_ = assertOAuthErrorWithCode(t, err, oauth.ServerError, "policy decision point unavailable")
 		assert.Nil(t, resp)
 	})
 }

--- a/auth/api/iam/s2s_vptoken_test.go
+++ b/auth/api/iam/s2s_vptoken_test.go
@@ -382,6 +382,20 @@ func TestWrapper_handleS2SAccessTokenRequest(t *testing.T) {
 		_ = assertOAuthErrorWithCode(t, err, oauth.InvalidDPopProof, "DPoP header is invalid")
 		assert.Nil(t, resp)
 	})
+	t.Run("profile-only scope policy rejects extra scopes", func(t *testing.T) {
+		ctx := newTestClient(t)
+		ctx.policy.EXPECT().FindCredentialProfile(gomock.Any(), "example-scope extra-scope").Return(&policy.CredentialProfileMatch{
+			CredentialProfileScope: "example-scope",
+			WalletOwnerMapping:     walletOwnerMapping,
+			ScopePolicy:            policy.ScopePolicyProfileOnly,
+			OtherScopes:            []string{"extra-scope"},
+		}, nil)
+
+		resp, err := ctx.client.handleS2SAccessTokenRequest(contextWithValue, clientID, issuerSubjectID, "example-scope extra-scope", submissionJSON, presentation.Raw())
+
+		_ = assertOAuthErrorWithCode(t, err, oauth.InvalidScope, "scope policy 'profile-only' does not allow additional scopes")
+		assert.Nil(t, resp)
+	})
 }
 
 func TestWrapper_createAccessToken(t *testing.T) {

--- a/auth/api/iam/validation.go
+++ b/auth/api/iam/validation.go
@@ -27,7 +27,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/auth/oauth"
 	"github.com/nuts-foundation/nuts-node/policy"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
-	"github.com/nuts-foundation/nuts-node/vcr/pe"
 )
 
 // validatePresentationSigner checks if the presenter of the VP is the same as the subject of the VCs being presented.
@@ -78,7 +77,7 @@ func (r Wrapper) validatePresentationAudience(presentation vc.VerifiablePresenta
 	}
 }
 
-func (r Wrapper) presentationDefinitionForScope(ctx context.Context, scope string) (pe.WalletOwnerMapping, error) {
+func (r Wrapper) findCredentialProfile(ctx context.Context, scope string) (*policy.CredentialProfileMatch, error) {
 	match, err := r.policyBackend.FindCredentialProfile(ctx, scope)
 	if err != nil {
 		if errors.Is(err, policy.ErrNotFound) || errors.Is(err, policy.ErrAmbiguousScope) {
@@ -94,5 +93,5 @@ func (r Wrapper) presentationDefinitionForScope(ctx context.Context, scope strin
 			Description:   fmt.Sprintf("failed to retrieve presentation definition for scope (%s): %s", scope, err.Error()),
 		}
 	}
-	return match.WalletOwnerMapping, nil
+	return match, nil
 }

--- a/policy/interface.go
+++ b/policy/interface.go
@@ -61,7 +61,8 @@ type CredentialProfileMatch struct {
 }
 
 // AuthZenEvaluator evaluates OAuth2 scopes against an external AuthZen-compatible PDP.
-// Defined here so PDPBackend can expose it without callers importing the authzen package directly.
+// The interface allows PDPBackend implementations to provide the evaluator (or nil
+// when no endpoint is configured) without exposing concrete client types.
 type AuthZenEvaluator interface {
 	Evaluate(ctx context.Context, req authzen.EvaluationsRequest) (map[string]bool, error)
 }

--- a/policy/interface.go
+++ b/policy/interface.go
@@ -21,6 +21,7 @@ package policy
 import (
 	"context"
 	"errors"
+	"github.com/nuts-foundation/nuts-node/policy/authzen"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
 )
 
@@ -59,6 +60,12 @@ type CredentialProfileMatch struct {
 	OtherScopes []string
 }
 
+// AuthZenEvaluator evaluates OAuth2 scopes against an external AuthZen-compatible PDP.
+// Defined here so PDPBackend can expose it without callers importing the authzen package directly.
+type AuthZenEvaluator interface {
+	Evaluate(ctx context.Context, req authzen.EvaluationsRequest) (map[string]bool, error)
+}
+
 // PDPBackend is the interface for the policy backend.
 // Both the remote and local policy backend implement this interface.
 type PDPBackend interface {
@@ -66,4 +73,7 @@ type PDPBackend interface {
 	// It parses the space-delimited scope string, identifies exactly one credential profile scope,
 	// and returns the matched profile along with any remaining scopes.
 	FindCredentialProfile(ctx context.Context, scope string) (*CredentialProfileMatch, error)
+	// AuthZenEvaluator returns the configured AuthZen evaluator for dynamic scope policy evaluation.
+	// Returns nil when no AuthZen endpoint is configured.
+	AuthZenEvaluator() AuthZenEvaluator
 }

--- a/policy/local.go
+++ b/policy/local.go
@@ -23,14 +23,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/core"
+	httpClient "github.com/nuts-foundation/nuts-node/http/client"
 	"github.com/nuts-foundation/nuts-node/policy/authzen"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
 	v2 "github.com/nuts-foundation/nuts-node/vcr/pe/schema/v2"
 	"io"
-	"net/http"
 	"os"
 	"strings"
+	"time"
 )
+
+// authzenTimeout is the default timeout for AuthZen PDP requests.
+const authzenTimeout = 10 * time.Second
 
 func (sp ScopePolicy) valid() bool {
 	switch sp {
@@ -87,7 +91,8 @@ func (b *LocalPDP) Configure(_ core.ServerConfig) error {
 			}
 		}
 	} else {
-		b.authzenClient = authzen.NewClient(b.config.AuthZen.Endpoint, http.DefaultClient)
+		// Use StrictHTTPClient: enforces TLS, bounds response body size, applies timeout.
+		b.authzenClient = authzen.NewClient(b.config.AuthZen.Endpoint, httpClient.New(authzenTimeout))
 	}
 	return nil
 }

--- a/policy/local.go
+++ b/policy/local.go
@@ -23,9 +23,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/nuts-foundation/nuts-node/core"
+	"github.com/nuts-foundation/nuts-node/policy/authzen"
 	"github.com/nuts-foundation/nuts-node/vcr/pe"
 	v2 "github.com/nuts-foundation/nuts-node/vcr/pe/schema/v2"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 )
@@ -52,6 +54,9 @@ type LocalPDP struct {
 	config Config
 	// mapping holds the credential profile configuration per scope
 	mapping map[string]credentialProfileConfig
+	// authzenClient is created during Configure when an AuthZen endpoint is configured.
+	// It is nil when no endpoint is configured.
+	authzenClient AuthZenEvaluator
 }
 
 func (b *LocalPDP) Name() string {
@@ -81,8 +86,15 @@ func (b *LocalPDP) Configure(_ core.ServerConfig) error {
 				return fmt.Errorf("credential profile %q has scope_policy %q but no AuthZen endpoint is configured (policy.authzen.endpoint)", scope, ScopePolicyDynamic)
 			}
 		}
+	} else {
+		b.authzenClient = authzen.NewClient(b.config.AuthZen.Endpoint, http.DefaultClient)
 	}
 	return nil
+}
+
+// AuthZenEvaluator returns the AuthZen evaluator, or nil when no endpoint is configured.
+func (b *LocalPDP) AuthZenEvaluator() AuthZenEvaluator {
+	return b.authzenClient
 }
 
 func (b *LocalPDP) Config() interface{} {

--- a/policy/mock.go
+++ b/policy/mock.go
@@ -13,8 +13,48 @@ import (
 	context "context"
 	reflect "reflect"
 
+	authzen "github.com/nuts-foundation/nuts-node/policy/authzen"
 	gomock "go.uber.org/mock/gomock"
 )
+
+// MockAuthZenEvaluator is a mock of AuthZenEvaluator interface.
+type MockAuthZenEvaluator struct {
+	ctrl     *gomock.Controller
+	recorder *MockAuthZenEvaluatorMockRecorder
+	isgomock struct{}
+}
+
+// MockAuthZenEvaluatorMockRecorder is the mock recorder for MockAuthZenEvaluator.
+type MockAuthZenEvaluatorMockRecorder struct {
+	mock *MockAuthZenEvaluator
+}
+
+// NewMockAuthZenEvaluator creates a new mock instance.
+func NewMockAuthZenEvaluator(ctrl *gomock.Controller) *MockAuthZenEvaluator {
+	mock := &MockAuthZenEvaluator{ctrl: ctrl}
+	mock.recorder = &MockAuthZenEvaluatorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAuthZenEvaluator) EXPECT() *MockAuthZenEvaluatorMockRecorder {
+	return m.recorder
+}
+
+// Evaluate mocks base method.
+func (m *MockAuthZenEvaluator) Evaluate(ctx context.Context, req authzen.EvaluationsRequest) (map[string]bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Evaluate", ctx, req)
+	ret0, _ := ret[0].(map[string]bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Evaluate indicates an expected call of Evaluate.
+func (mr *MockAuthZenEvaluatorMockRecorder) Evaluate(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Evaluate", reflect.TypeOf((*MockAuthZenEvaluator)(nil).Evaluate), ctx, req)
+}
 
 // MockPDPBackend is a mock of PDPBackend interface.
 type MockPDPBackend struct {
@@ -38,6 +78,20 @@ func NewMockPDPBackend(ctrl *gomock.Controller) *MockPDPBackend {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPDPBackend) EXPECT() *MockPDPBackendMockRecorder {
 	return m.recorder
+}
+
+// AuthZenEvaluator mocks base method.
+func (m *MockPDPBackend) AuthZenEvaluator() AuthZenEvaluator {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthZenEvaluator")
+	ret0, _ := ret[0].(AuthZenEvaluator)
+	return ret0
+}
+
+// AuthZenEvaluator indicates an expected call of AuthZenEvaluator.
+func (mr *MockPDPBackendMockRecorder) AuthZenEvaluator() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthZenEvaluator", reflect.TypeOf((*MockPDPBackend)(nil).AuthZenEvaluator))
 }
 
 // FindCredentialProfile mocks base method.


### PR DESCRIPTION
## Parent PRD

#4144

## Summary

Enforces scope policy on the server side of the S2S (RFC021) token flow. Rejects extra scopes in profile-only mode, forwards all in passthrough, and calls an AuthZen PDP for dynamic evaluation. The access token's `scope` field reflects the granted scopes, never the raw request.

## What changed

**Server-side token handler** (`auth/api/iam/s2s_vptoken.go`):
- `grantedScopesForPolicy` switch derives granted scopes explicitly per policy — never passes the raw input through
- `evaluateDynamicScopes` builds an AuthZen `EvaluationsRequest`, calls the PDP, and maps per-scope decisions to the granted set
- Profile-only rejects extras early (before expensive VP verification)
- Dynamic: PDP denial of credential profile scope → `access_denied`; other denials simply excluded; PDP error → generic `server_error` (details in `InternalError`, not in `Description`)

**Policy interface** (`policy/interface.go`, `policy/local.go`):
- New `AuthZenEvaluator` interface in the `policy` package (`Evaluate(ctx, req) (map[string]bool, error)`)
- `PDPBackend` gets an `AuthZenEvaluator()` method returning the evaluator or `nil`
- `LocalPDP.Configure` creates an `authzen.Client` (via `StrictHTTPClient` — 1MB body limit, 10s timeout, TLS enforced) when an endpoint is configured

**Helper rename** (`auth/api/iam/validation.go`):
- `presentationDefinitionForScope` → `findCredentialProfile`, now returns the full `*CredentialProfileMatch`
- Call sites in `s2s_vptoken.go` and `openid4vp.go` updated to use `match.WalletOwnerMapping` where they only needed the PDs

**Claim extraction:** reuses the existing `resolveInputDescriptorValues` (same pattern as introspection) to build `Subject.Properties.Organization` — no new helper needed.

**Mock regenerated:** `policy.MockPDPBackend` now has `AuthZenEvaluator()`; new `policy.MockAuthZenEvaluator` added.

## How to review

**Start with `s2s_vptoken.go`** — the policy-dispatch is the core of this PR:
- `handleS2SAccessTokenRequest` — placement of the profile-only early reject (before VP verification) and the call to `grantedScopesForPolicy` after verification
- `grantedScopesForPolicy` — the switch statement, easy to follow
- `evaluateDynamicScopes` — AuthZen request construction, error paths (nil evaluator, PDP error, profile scope denial)

**Then `policy/interface.go` + `policy/local.go`** — the evaluator wiring:
- `AuthZenEvaluator` interface is one-method, kept on the policy side so callers don't import `policy/authzen` directly for the type
- `LocalPDP.Configure` creates the client when endpoint is configured — note `StrictHTTPClient` usage for body limit / timeout

**Tests** (`s2s_vptoken_test.go`):
- 8 new subtests cover all three policies + dynamic error paths
- The "PDP approves all" test verifies request shape on the wire (subject.type, action.name, context.policy, evaluations layout) via `DoAndReturn` — catches regressions in request construction

## Deviations from spec

- **Claim extraction simpler than planned:** the PRD mentioned a dedicated `ExtractSubjectProperties` helper. Instead reused `resolveInputDescriptorValues` — same extraction as introspection, no new helper.
- **AuthZen client on the policy module, not the Wrapper:** the PRD suggested wiring the AuthZen client as "an optional dependency on the Wrapper". Moved it behind `PDPBackend.AuthZenEvaluator()` — keeps ownership with the module that owns the config and avoids dependency-order issues in `cmd/root.go` (config isn't loaded when `RegisterRoutes` runs).
- **Helper renamed from `presentationDefinitionForScope` to `findCredentialProfile`** — the return value now is the full match, not just a mapping.

## Known follow-ups

- **#4202** — apply scope policy to the OpenID4VP / auth-code flow. This PR only enforces it on the S2S (RFC021) flow. The auth-code path still passes raw scopes through.
- **Claim role-bucket mismatch** — `resolveInputDescriptorValues` merges claims across wallet owner types (organization + user) into a single map, dumped into `Subject.Properties.Organization`. Correct for today's single-VP / organization-only flow. The two-VP flow in #4080 will need to split claims by role.

## Dependencies

**Depends on:**
- #4176 (scope parsing, policy types)
- #4177 (AuthZen client types + transport)

**Review order:** Review #4176 and #4177 first; this PR builds directly on both.

## Design context

- PRD: #4144
- Memory #4185 — always bound HTTP response body; that's why `StrictHTTPClient` is used for the AuthZen client.
- AuthZen request shape (subject.type, action.name, context.policy) discussed in PRD comments
- Follow-up tracker: #4202 (auth-code flow)

## Acceptance Criteria

- [x] Server parses multi-scope strings and validates VP against credential profile scope's PD
- [x] Profile-only rejects extra scopes (before expensive VP verification)
- [x] Passthrough grants all requested scopes
- [x] Dynamic calls AuthZen PDP and respects per-scope decisions
- [x] PDP denial of credential profile scope → access_denied error
- [x] PDP unreachable/timeout → server_error
- [x] Token response `scope` field contains only granted scopes
- [x] AuthZen client wired via `PDPBackend.AuthZenEvaluator()` (nil when not configured)
- [x] Unit tests cover all three scope policies and error cases
- [x] AuthZen request shape verified in tests
- [x] HTTP client uses timeout + response body limit (memory #4185)
- [ ] Auth-code flow scope policy enforcement — deferred to #4202

<details>
<summary>Original implementation spec (used during AI-assisted development)</summary>

## Parent PRD

#4144

## Implementation Spec

### Overview

Modify the server-side token request flow to support mixed OAuth2 scopes with scope policy evaluation. The server parses the incoming scope string, validates the VP against the credential profile scope's PD, then applies the scope policy to determine which scopes are granted.

### Key files modified

- `auth/api/iam/validation.go` — Renamed `presentationDefinitionForScope` → `findCredentialProfile`, returns full `CredentialProfileMatch`
- `auth/api/iam/s2s_vptoken.go` — Scope policy enforcement, dynamic PDP evaluation via AuthZen
- `auth/api/iam/openid4vp.go` — Updated caller to use new helper
- `auth/api/iam/api.go` — No Wrapper changes (evaluator accessed via `policyBackend.AuthZenEvaluator()`)
- `policy/interface.go` — Added `AuthZenEvaluator` interface + `AuthZenEvaluator()` method on `PDPBackend`
- `policy/local.go` — Creates `authzen.Client` during `Configure` when endpoint is set (using `StrictHTTPClient`)

### Design decisions

- **AuthZen client ownership in policy module**: The `policy` module owns the config and creates the AuthZen client during `Configure()` (when config is loaded). `PDPBackend` exposes it via `AuthZenEvaluator()`. This avoids wiring through `cmd/root.go` before config is available.
- **Explicit granted scopes derivation**: `grantedScopesForPolicy` explicitly computes granted scopes per policy — no implicit pass-through of raw input. Prevents silent scope leakage when new policies are added.
- **Claims via `resolveInputDescriptorValues`**: Same extraction pattern as introspection. `InputDescriptorConstraintIdMap` is reused as the AuthZen `Subject.Properties.Organization` payload.
- **StrictHTTPClient**: AuthZen client uses `http/client.New(timeout)` — enforces TLS, bounds response body size to 1MB, applies 10s timeout (memory #4185).

### Deviations from original spec

- **Claim extraction simpler than planned**: The PRD mentioned building a dedicated `ExtractSubjectProperties` helper. Instead we reuse `resolveInputDescriptorValues` which already does the extraction for introspection. Single pattern, no new helper.
- **AuthZen client on policy module, not Wrapper**: The PRD suggested wiring the AuthZen client as an "optional dependency on the Wrapper". Moving it behind `PDPBackend.AuthZenEvaluator()` keeps ownership with the module that owns the config and avoids dependency order issues in `cmd/root.go`.

### Known follow-ups

- **#4202**: Apply scope policy to the OpenID4VP / auth-code flow. This PR only enforces it on the S2S (RFC021) flow. The auth-code flow still passes raw scopes through — fix deferred to a separate issue.
- **Claim role-bucket mismatch**: `resolveInputDescriptorValues` merges claims across wallet owner types (organization + user). Currently dumped into `Subject.Properties.Organization`. This is correct for today's single-VP flow (organization-only). The two-VP flow in #4080 will need to split claims by role.

## Acceptance Criteria

- [x] Server parses multi-scope strings and validates VP against credential profile scope's PD
- [x] Profile-only rejects extra scopes (before expensive VP verification)
- [x] Passthrough grants all requested scopes
- [x] Dynamic calls AuthZen PDP and respects per-scope decisions
- [x] PDP denial of credential profile scope → access_denied error
- [x] PDP unreachable/timeout → server_error
- [x] Token response `scope` field contains only granted scopes
- [x] AuthZen client wired via `PDPBackend.AuthZenEvaluator()` (evaluates to nil when not configured)
- [x] Unit tests cover all three scope policies and error cases
- [x] AuthZen request shape verified in tests (subject.type, action.name, context.policy, evaluations)
- [x] HTTP client uses timeout + response body limit (memory #4185)
- [ ] Auth-code flow scope policy enforcement (deferred to #4202)

</details>
