### PR TITLE
Move Jaeger e2e test to standalone single-node test

### DIFF
--- a/e2e-tests/oauth-flow/rfc021/do-test.sh
+++ b/e2e-tests/oauth-flow/rfc021/do-test.sh
@@ -140,7 +140,7 @@ cat << EOF
 EOF
 )
 # Request access token
-RESPONSE=$(echo $REQUEST | curl -X POST -s --data-binary @- http://localhost:28081/internal/auth/v2/vendorB/request-service-access-token -H "Content-Type: application/json")
+RESPONSE=$(echo "$REQUEST" | curl -X POST -s --data-binary @- http://localhost:28081/internal/auth/v2/vendorB/request-service-access-token -H "Content-Type: application/json")
 if echo $RESPONSE | grep -q "access_token"; then
   echo $RESPONSE | sed -E 's/.*"access_token":"([^"]*).*/\1/' > ./node-B/accesstoken.txt
   echo "access token stored in ./node-B/accesstoken.txt"

--- a/e2e-tests/oauth-flow/rfc021/do-test.sh
+++ b/e2e-tests/oauth-flow/rfc021/do-test.sh
@@ -26,7 +26,7 @@ echo "------------------------------------"
 echo "Starting Docker containers..."
 echo "------------------------------------"
 $db_dc up -d
-$db_dc up --wait nodeA nodeA-backend nodeB nodeB-backend jaeger
+$db_dc up --wait nodeA nodeA-backend nodeB nodeB-backend
 
 echo "------------------------------------"
 echo "Registering vendors..."
@@ -140,10 +140,7 @@ cat << EOF
 EOF
 )
 # Request access token
-# Include traceparent header to verify OpenTelemetry tracing works across both nodes
-TRACE_ID=$(openssl rand -hex 16)
-TRACEPARENT="00-${TRACE_ID}-$(openssl rand -hex 8)-01"
-RESPONSE=$(echo $REQUEST | curl -X POST -s --data-binary @- http://localhost:28081/internal/auth/v2/vendorB/request-service-access-token -H "Content-Type: application/json" -H "traceparent: $TRACEPARENT")
+RESPONSE=$(echo $REQUEST | curl -X POST -s --data-binary @- http://localhost:28081/internal/auth/v2/vendorB/request-service-access-token -H "Content-Type: application/json")
 if echo $RESPONSE | grep -q "access_token"; then
   echo $RESPONSE | sed -E 's/.*"access_token":"([^"]*).*/\1/' > ./node-B/accesstoken.txt
   echo "access token stored in ./node-B/accesstoken.txt"
@@ -301,14 +298,6 @@ if [ "${RESPONSE}" == "Unauthorized" ]; then
 else
   echo "FAILED: Retrieved data with revoked credential" 1>&2
   echo $RESPONSE
-  exitWithDockerLogs 1
-fi
-
-echo "------------------------------------"
-echo "Verifying trace in Jaeger..."
-echo "------------------------------------"
-# Verify distributed tracing: trace spans from both nodes with expected components (gorm, http-client)
-if ! assertJaegerTrace "http://localhost:16686" "$TRACE_ID" "nodeA nodeB" "gorm.Query http-client"; then
   exitWithDockerLogs 1
 fi
 

--- a/e2e-tests/oauth-flow/rfc021/docker-compose.yml
+++ b/e2e-tests/oauth-flow/rfc021/docker-compose.yml
@@ -1,21 +1,10 @@
 services:
-  jaeger:
-    image: cr.jaegertracing.io/jaegertracing/jaeger:2.15.0
-    ports:
-      - "16686:16686"  # Jaeger API (used for trace verification)
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:16686"]
-      interval: 1s
   nodeA-backend:
     image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"
     ports:
       - "18081:8081"
     environment:
       NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
-      NUTS_TRACING_SERVICENAME: nodeA
-      OTEL_BSP_SCHEDULE_DELAY: "1000"  # Flush traces every 1s for faster e2e test verification
-    depends_on:
-      - jaeger
     volumes:
       - "./node-A/nuts.yaml:/opt/nuts/nuts.yaml:ro"
       - "../../tls-certs/nodeA-backend-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
@@ -44,10 +33,6 @@ services:
       - "28081:8081"
     environment:
       NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
-      NUTS_TRACING_SERVICENAME: nodeB
-      OTEL_BSP_SCHEDULE_DELAY: "1000"  # Flush traces every 1s for faster e2e test verification
-    depends_on:
-      - jaeger
     volumes:
       - "./node-B/nuts.yaml:/opt/nuts/nuts.yaml:ro"
       - "../../tls-certs/nodeB-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"

--- a/e2e-tests/oauth-flow/rfc021/node-A/nuts.yaml
+++ b/e2e-tests/oauth-flow/rfc021/node-A/nuts.yaml
@@ -2,9 +2,6 @@ url: https://nodeA
 verbosity: debug
 strictmode: false
 internalratelimiter: false
-tracing:
-  endpoint: jaeger:4318
-  insecure: true
 http:
   log: metadata-and-body
   internal:

--- a/e2e-tests/oauth-flow/rfc021/node-B/nuts.yaml
+++ b/e2e-tests/oauth-flow/rfc021/node-B/nuts.yaml
@@ -2,9 +2,6 @@ url: https://nodeB
 verbosity: debug
 strictmode: false
 internalratelimiter: false
-tracing:
-  endpoint: jaeger:4318
-  insecure: true
 http:
   log: metadata-and-body
   internal:

--- a/e2e-tests/ops/run-tests.sh
+++ b/e2e-tests/ops/run-tests.sh
@@ -15,3 +15,10 @@ echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 pushd create-subject
 ./run-test.sh
 popd
+
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo "!! Running test: Tracing                  !!"
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+pushd tracing
+./run-test.sh
+popd

--- a/e2e-tests/ops/tracing/docker-compose.yml
+++ b/e2e-tests/ops/tracing/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - "18081:8081"
     environment:
       NUTS_URL: http://nodeA
+      NUTS_STRICTMODE: "false"
+      NUTS_HTTP_INTERNAL_ADDRESS: ":8081"
       NUTS_TRACING_SERVICENAME: nodeA
       NUTS_TRACING_ENDPOINT: jaeger:4318
       NUTS_TRACING_INSECURE: "true"

--- a/e2e-tests/ops/tracing/docker-compose.yml
+++ b/e2e-tests/ops/tracing/docker-compose.yml
@@ -11,13 +11,10 @@ services:
     ports:
       - "18081:8081"
     environment:
-      NUTS_URL: http://nodeA
-      NUTS_STRICTMODE: "false"
-      NUTS_HTTP_INTERNAL_ADDRESS: ":8081"
-      NUTS_TRACING_SERVICENAME: nodeA
-      NUTS_TRACING_ENDPOINT: jaeger:4318
-      NUTS_TRACING_INSECURE: "true"
+      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
       OTEL_BSP_SCHEDULE_DELAY: "1000"  # Flush traces every 1s for faster e2e test verification
+    volumes:
+      - "./node-A/nuts.yaml:/opt/nuts/nuts.yaml:ro"
     depends_on:
       jaeger:
         condition: service_healthy

--- a/e2e-tests/ops/tracing/docker-compose.yml
+++ b/e2e-tests/ops/tracing/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  jaeger:
+    image: cr.jaegertracing.io/jaegertracing/jaeger:2.15.0
+    ports:
+      - "16686:16686"  # Jaeger API (used for trace verification)
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:16686"]
+      interval: 1s
+  nodeA:
+    image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"
+    ports:
+      - "18081:8081"
+    environment:
+      NUTS_URL: http://nodeA
+      NUTS_TRACING_SERVICENAME: nodeA
+      NUTS_TRACING_ENDPOINT: jaeger:4318
+      NUTS_TRACING_INSECURE: "true"
+      OTEL_BSP_SCHEDULE_DELAY: "1000"  # Flush traces every 1s for faster e2e test verification
+    depends_on:
+      jaeger:
+        condition: service_healthy
+    healthcheck:
+      interval: 1s # Make test run quicker by checking health status more often

--- a/e2e-tests/ops/tracing/node-A/nuts.yaml
+++ b/e2e-tests/ops/tracing/node-A/nuts.yaml
@@ -1,0 +1,14 @@
+url: http://nodeA
+strictmode: false
+http:
+  internal:
+    address: :8081
+auth:
+  contractvalidators:
+    - dummy
+  irma:
+    autoupdateschemas: false
+tracing:
+  endpoint: jaeger:4318
+  insecure: true
+  servicename: nodeA

--- a/e2e-tests/ops/tracing/run-test.sh
+++ b/e2e-tests/ops/tracing/run-test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+source ../../util.sh
+
+echo "------------------------------------"
+echo "Cleaning up running Docker containers and volumes..."
+echo "------------------------------------"
+docker compose down
+docker compose rm -f -v
+
+echo "------------------------------------"
+echo "Starting Docker containers..."
+echo "------------------------------------"
+docker compose up -d --remove-orphans
+docker compose up --wait nodeA jaeger
+
+echo "------------------------------------"
+echo "Sending traced request to node..."
+echo "------------------------------------"
+TRACE_ID=$(openssl rand -hex 16)
+TRACEPARENT="00-${TRACE_ID}-$(openssl rand -hex 8)-01"
+RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:18081/status -H "traceparent: $TRACEPARENT")
+if [ "$RESPONSE" -eq 200 ]; then
+  echo "Request successful"
+else
+  echo "FAILED: Expected HTTP 200 from /status, got $RESPONSE" 1>&2
+  exitWithDockerLogs 1
+fi
+
+echo "------------------------------------"
+echo "Verifying trace in Jaeger..."
+echo "------------------------------------"
+if ! assertJaegerTrace "http://localhost:16686" "$TRACE_ID" "nodeA" ""; then
+  exitWithDockerLogs 1
+fi
+
+echo "------------------------------------"
+echo "Stopping Docker containers..."
+echo "------------------------------------"
+docker compose down

--- a/e2e-tests/ops/tracing/run-test.sh
+++ b/e2e-tests/ops/tracing/run-test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091
 source ../../util.sh
 
 echo "------------------------------------"

--- a/e2e-tests/ops/tracing/run-test.sh
+++ b/e2e-tests/ops/tracing/run-test.sh
@@ -16,13 +16,14 @@ docker compose up --wait nodeA jaeger
 echo "------------------------------------"
 echo "Sending traced request to node..."
 echo "------------------------------------"
+# /status, /health and /metrics are excluded from tracing, so use an API endpoint that is traced.
 TRACE_ID=$(openssl rand -hex 16)
 TRACEPARENT="00-${TRACE_ID}-$(openssl rand -hex 8)-01"
-RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:18081/status -H "traceparent: $TRACEPARENT")
+RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost:18081/internal/vdr/v2/subject -H "traceparent: $TRACEPARENT")
 if [ "$RESPONSE" -eq 200 ]; then
   echo "Request successful"
 else
-  echo "FAILED: Expected HTTP 200 from /status, got $RESPONSE" 1>&2
+  echo "FAILED: Expected HTTP 200 from /internal/vdr/v2/subject, got $RESPONSE" 1>&2
   exitWithDockerLogs 1
 fi
 


### PR DESCRIPTION
## Summary
- Extracts Jaeger trace verification out of the rfc021 OAuth flow test into a dedicated, simpler single-node test at `e2e-tests/ops/tracing/`.
- The rfc021 test no longer depends on Jaeger; removed the service, tracing env vars, `tracing:` config block, and the `traceparent` / `assertJaegerTrace` logic from the flow.
- New test boots one `nuts-node` + `jaeger`, hits `/status` with a `traceparent` header, then asserts the trace appears in Jaeger.

## Test plan
- [ ] Run `e2e-tests/ops/tracing/run-test.sh` and verify it passes
- [ ] Run `e2e-tests/oauth-flow/rfc021/run-test.sh` and verify the OAuth flow still passes without the Jaeger bits