### PR TITLE
Fix node startup failure when syncing on slow disk (v6.2)

### DIFF
--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -3,6 +3,16 @@ Release notes
 #############
 
 ****************
+Peanut (v6.2.4)
+****************
+
+Release date: 2026-04-16
+
+- Fix node failing to start when syncing many transactions on a slow disk (e.g. SMB/Azure Files): concurrent read transactions were incorrectly blocked by pending write transactions at the Go level, causing read lock timeouts during startup. See `#4162 <https://github.com/nuts-foundation/nuts-node/issues/4162>`_.
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v6.2.3...v6.2.4
+
+****************
 Peanut (v6.2.3)
 ****************
 

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b
 	github.com/nuts-foundation/go-did v0.17.0
 	github.com/nuts-foundation/go-leia/v4 v4.2.0
-	github.com/nuts-foundation/go-stoabs v1.11.0
+	github.com/nuts-foundation/go-stoabs v1.11.1
 	github.com/nuts-foundation/sqlite v1.0.0
 	// check the oapi-codegen tool version in the makefile when upgrading the runtime
 	github.com/oapi-codegen/runtime v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -400,8 +400,8 @@ github.com/nuts-foundation/go-did v0.17.0 h1:nLmMiiKjIJwgZsfJ98ywATiCb9VHomnb3r8
 github.com/nuts-foundation/go-did v0.17.0/go.mod h1:8VLZhVjkFH9VgGu//3y7ICowwItpym3NWkOih1Ka1fw=
 github.com/nuts-foundation/go-leia/v4 v4.2.0 h1:o/bgYVCyTgsfgtaKmlrcUaJ2z4NwetERC98SUWwYajM=
 github.com/nuts-foundation/go-leia/v4 v4.2.0/go.mod h1:Gw6bXqJLOAmHSiXJJYbVoj+Mowp/PoBRywO0ZPsVzA0=
-github.com/nuts-foundation/go-stoabs v1.11.0 h1:q18jVruPdFcVhodDrnKuhq/24i0pUC/YXgzJS0glKUU=
-github.com/nuts-foundation/go-stoabs v1.11.0/go.mod h1:w2OgcHXO0Jl/vN1nG0ksApaeOaPOY3sSBJLaZz7cCY0=
+github.com/nuts-foundation/go-stoabs v1.11.1 h1:ZQOeRKzC1+AfW6Ve5kBJMo+zYhHLBUI4KrLWKYkxoeI=
+github.com/nuts-foundation/go-stoabs v1.11.1/go.mod h1:LzD3RhINBVJUpVRV9IM86IXcZoBSRx43PpCWRZGbEfs=
 github.com/nuts-foundation/sqlite v1.0.0 h1:gLKyVIHZqYfYpEy5Ji6vjNUH8rs0luiY3DWNcOSBBzM=
 github.com/nuts-foundation/sqlite v1.0.0/go.mod h1:2GHDXCw5Sul9L3h8T5k0+558scm4ol4iXG+wVyYqueI=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=


### PR DESCRIPTION
## Summary

Backport of #4170 to V6.2. Bumps go-stoabs from v1.11.0 to v1.11.1, which removes an unnecessary Go-level read lock from the BBolt wrapper ([go-stoabs#146](https://github.com/nuts-foundation/go-stoabs/pull/146)).

## Problem

Nodes with a large transaction log fail to start when disk I/O is slow (e.g. SMB/Azure Files volume mounts on Azure ACI):

```
unable to start Network: failed to start notifiers: unable to obtain BBolt read lock: database error: context deadline exceeded
```

On startup, `connectToKnownNodes()` triggers many incoming transactions. Each write transaction holds a Go-level write lock while committing (including a slow `fdatasync` over SMB). The go-stoabs wrapper used a `sync.RWMutex` with writer-preference, which blocked all concurrent read transactions — including network notifiers trying to start. After 1 second, the notifiers time out and the node shuts down.

## Fix

go-stoabs v1.11.1 replaces the `sync.RWMutex` with a plain `sync.Mutex` that only serializes write transactions. Read transactions now go directly to BBolt's native locking, which handles concurrent reads independently of writes. This eliminates the "unable to obtain BBolt read lock" error class entirely.

V6.2 already has the newer go-redis/miniredis/testify versions, so this port is just the go-stoabs bump plus the v6.2.4 release note. No code changes were needed.

See #4170 (V5.4) and #4162 for full root-cause analysis.

Fixes #4162

## Test plan

- [x] Verify all existing tests pass
- [x] Verify node starts successfully when syncing many transactions on a slow disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)