### PR TITLE
Backport #4203: Bump alpine from 3.23.3 to 3.23.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY . .
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s -X 'github.com/nuts-foundation/nuts-node/core.GitCommit=${GIT_COMMIT}' -X 'github.com/nuts-foundation/nuts-node/core.GitBranch=${GIT_BRANCH}' -X 'github.com/nuts-foundation/nuts-node/core.GitVersion=${GIT_VERSION}'" -o /opt/nuts/nuts
 
 # alpine
-FROM alpine:3.23.3
+FROM alpine:3.23.4
 RUN apk update \
   && apk add --no-cache \
              tzdata \

--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -3,6 +3,16 @@ Release notes
 #############
 
 ****************
+Peanut (v6.2.5)
+****************
+
+Release date: 2026-04-16
+
+- Update Alpine base image to 3.23.4 to pick up musl, OpenSSL and zlib security fixes.
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v6.2.4...v6.2.5
+
+****************
 Peanut (v6.2.4)
 ****************
 


### PR DESCRIPTION
Backport of #4203 to V6.2.

Bumps alpine base image from 3.23.3 to 3.23.4. Includes Alpine 3.23.4 security fixes (musl, OpenSSL, zlib CVEs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)