### PR TITLE
Backport: add index for auth creds (#3562) to V5.4

### DIFF
--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -4,6 +4,16 @@ Release notes
 #############
 
 *************************
+Hazelnut update (v5.4.32)
+*************************
+
+Release date: 2026-04-17
+
+- Backport compound leia index ``index_auth_subject_purpose_resources`` on ``credentialSubject.id`` + ``purposeOfUse`` + ``resources.path`` (see `#3562 <https://github.com/nuts-foundation/nuts-node/pull/3562>`_). Fixes slow ``POST /internal/vcr/v2/search`` queries against ``NutsAuthorizationCredential`` where large issuers previously forced go-leia to fall back to ``index_issuer`` and scan every VC issued by the requesting care organization.
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v5.4.31...v5.4.32
+
+*************************
 Hazelnut update (v5.4.31)
 *************************
 

--- a/e2e-tests/storage/vault/docker-compose.yml
+++ b/e2e-tests/storage/vault/docker-compose.yml
@@ -10,6 +10,9 @@ services:
       - "./nuts.yaml:/opt/nuts/nuts.yaml:ro"
       - "../../tls-certs/nodeA-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
       - "../../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
+    depends_on:
+      vault-adapter:
+        condition: service_healthy
     healthcheck:
       interval: 1s # Make test run quicker by checking health status more often
   vault-adapter:
@@ -17,9 +20,31 @@ services:
     environment:
       VAULT_ADDR: http://vault:8200
       VAULT_TOKEN: root
+    depends_on:
+      vault:
+        condition: service_healthy
+    healthcheck:
+      # The image already defines a HEALTHCHECK using curl against /health.
+      # Override only the interval to make the e2e test start faster.
+      interval: 1s
+      timeout: 2s
+      retries: 30
   vault:
     image: hashicorp/vault
     cap_add:
       - IPC_LOCK
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: root
+      VAULT_ADDR: http://127.0.0.1:8200
+      # Skip setcap on the vault binary at container startup. Some CI runners
+      # don't grant CAP_SETFCAP, which causes vault's entrypoint to fail with
+      # "unable to set CAP_SETFCAP effective capability: Operation not permitted".
+      # mlock isn't required for dev mode.
+      SKIP_SETCAP: "true"
+    healthcheck:
+      # vault CLI returns exit 0 when the API is reachable and vault is unsealed
+      # (dev mode is always unsealed), exit 1/2 otherwise.
+      test: ["CMD", "vault", "status"]
+      interval: 1s
+      timeout: 2s
+      retries: 30

--- a/e2e-tests/storage/vault/run-test.sh
+++ b/e2e-tests/storage/vault/run-test.sh
@@ -11,7 +11,8 @@ docker compose rm -f -v
 echo "------------------------------------"
 echo "Setting up Vault..."
 echo "------------------------------------"
-docker compose up --wait vault && sleep 2
+# Wait for vault-adapter to become healthy; this transitively waits for vault to be reachable.
+docker compose up --wait vault-adapter
 docker compose exec -e VAULT_TOKEN=root vault vault secrets enable -version=1 -address=http://localhost:8200 kv
 
 echo "------------------------------------"

--- a/vcr/assets/assets/default.index.yaml
+++ b/vcr/assets/assets/default.index.yaml
@@ -5,9 +5,6 @@ indices:
   - name: index_issuer
     parts:
       - iriPath: ["https://www.w3.org/2018/credentials#issuer"]
-  - name: index_subject
-    parts:
-      - iriPath: ["https://www.w3.org/2018/credentials#credentialSubject"]
   - name: index_subject_organization
     parts:
       - iriPath: ["https://www.w3.org/2018/credentials#credentialSubject"]
@@ -48,4 +45,18 @@ indices:
           [
             "https://www.w3.org/2018/credentials#credentialSubject",
             "https://nuts.nl/credentials/v1#subject",
+          ]
+  - name: index_auth_subject_purpose_resources
+    parts:
+      - iriPath: ["https://www.w3.org/2018/credentials#credentialSubject"]
+      - iriPath:
+          [
+            "https://www.w3.org/2018/credentials#credentialSubject",
+            "https://nuts.nl/credentials/v1#purposeOfUse",
+          ]
+      - iriPath:
+          [
+            "https://www.w3.org/2018/credentials#credentialSubject",
+            "https://nuts.nl/credentials/v1#resources",
+            "https://nuts.nl/credentials/v1#path",
           ]

--- a/vcr/vcr_test.go
+++ b/vcr/vcr_test.go
@@ -151,8 +151,8 @@ func TestVCR_Start(t *testing.T) {
 			}
 			assert.NotNil(t, mainBucket.Bucket([]byte("index_id")))
 			assert.NotNil(t, mainBucket.Bucket([]byte("index_issuer")))
-			assert.NotNil(t, mainBucket.Bucket([]byte("index_subject")))
 			assert.NotNil(t, mainBucket.Bucket([]byte("index_organization")))
+			assert.NotNil(t, mainBucket.Bucket([]byte("index_auth_subject_purpose_resources")))
 
 			return nil
 		})


### PR DESCRIPTION
## Summary

Backports #3562 / #3564 ("add index for auth creds") to the V5.4 release branch.

- Adds the compound index `index_auth_subject_purpose_resources` on `credentialSubject.id` + `purposeOfUse` + `resources.path`
- Removes the now-redundant `index_subject` (its single part `[credentialSubject]` is a prefix of the new index)

## Why

`POST /internal/vcr/v2/search` queries against `NutsAuthorizationCredential` currently fall back to `index_issuer` on V5.4, because V5.4's index set only has single-part indices that score 1 for this query — `findIndex` takes the first such match by yaml order, i.e. `index_issuer`. That forces go-leia to scan every credential issued by the requesting care organization.

Reporter case on v5.4.26 shows `documents_scanned=730`, `documents_matched=2`, `leia_index_used=index_issuer` for this exact query shape.

With the new compound index, the same query scores 3 on `index_auth_subject_purpose_resources` and wins — scan set collapses from "all issued VCs" to "issued VCs matching (subject, purposeOfUse, path)".

## Test plan

- [x] Updated `TestVCR_Start` bucket assertions
- [x] Full `go test ./vcr/...` passes locally
- [ ] On reporter deployment: confirm `leia_index_used` switches to `index_auth_subject_purpose_resources` and search latency drops
