### PR TITLE
Upgrade Go to 1.26.2 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nuts-foundation/nuts-node
 
 // This is the minimal version, the actual go version is determined by the images in the Dockerfile
 // This version is used in automated tests such as the 'Scheduled govulncheck' action
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0


### PR DESCRIPTION
To silence CVE warning (already patched and released on v5.4 and v6.2)

## Summary
- Bump the minimum Go version in `go.mod` from 1.26.1 to 1.26.2, aligning it with the Dockerfile and release notes which already reference 1.26.2.

## Test plan
- [x] CI passes (govulncheck uses `go.mod`'s minimum version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)