### PR TITLE
Accept explicit token endpoint on /internal/auth/v1/request-access-token

### DIFF
--- a/auth/api/auth/v1/api.go
+++ b/auth/api/auth/v1/api.go
@@ -260,13 +260,9 @@ func (w Wrapper) DrawUpContract(ctx context.Context, request DrawUpContractReque
 
 // CreateJwtGrant handles the http request (from the vendor's EPD/XIS) for creating a JWT bearer token which can be used to retrieve an access token from a remote Nuts node.
 func (w Wrapper) CreateJwtGrant(ctx context.Context, request CreateJwtGrantRequestObject) (CreateJwtGrantResponseObject, error) {
-
-	req := services.CreateJwtGrantRequest{
-		Requester:   request.Body.Requester,
-		Authorizer:  request.Body.Authorizer,
-		IdentityVP:  request.Body.Identity,
-		Service:     request.Body.Service,
-		Credentials: request.Body.Credentials,
+	req, err := toCreateJwtGrantRequest(request.Body)
+	if err != nil {
+		return nil, err
 	}
 
 	response, err := w.Auth.RelyingParty().CreateJwtGrant(ctx, req)
@@ -279,12 +275,9 @@ func (w Wrapper) CreateJwtGrant(ctx context.Context, request CreateJwtGrantReque
 
 // RequestAccessToken handles the HTTP request (from the vendor's EPD/XIS) for creating a JWT grant and using it as authorization grant to get an access token from the remote Nuts node.
 func (w Wrapper) RequestAccessToken(ctx context.Context, request RequestAccessTokenRequestObject) (RequestAccessTokenResponseObject, error) {
-	req := services.CreateJwtGrantRequest{
-		Requester:   request.Body.Requester,
-		Authorizer:  request.Body.Authorizer,
-		IdentityVP:  request.Body.Identity,
-		Service:     request.Body.Service,
-		Credentials: request.Body.Credentials,
+	req, err := toCreateJwtGrantRequest(request.Body)
+	if err != nil {
+		return nil, err
 	}
 
 	jwtGrant, err := w.Auth.RelyingParty().CreateJwtGrant(ctx, req)
@@ -428,6 +421,27 @@ func (w *Wrapper) resolveCredential(credentialID string) (*vc.VerifiableCredenti
 		return nil, err
 	}
 	return w.CredentialResolver.Resolve(*id, nil)
+}
+
+// toCreateJwtGrantRequest translates the generated API request body into the internal
+// services.CreateJwtGrantRequest. If authorization_server_endpoint is set, it is validated
+// as a URL; an invalid URL is surfaced as a 400 InvalidInputError so we don't produce a
+// signed JWT with a malformed audience.
+func toCreateJwtGrantRequest(body *JwtGrantBaseRequest) (services.CreateJwtGrantRequest, error) {
+	req := services.CreateJwtGrantRequest{
+		Requester:   body.Requester,
+		Authorizer:  body.Authorizer,
+		IdentityVP:  body.Identity,
+		Service:     body.Service,
+		Credentials: body.Credentials,
+	}
+	if body.AuthorizationServerEndpoint != nil && *body.AuthorizationServerEndpoint != "" {
+		if _, err := url.Parse(*body.AuthorizationServerEndpoint); err != nil {
+			return services.CreateJwtGrantRequest{}, core.InvalidInputError("invalid authorization_server_endpoint: %w", err)
+		}
+		req.AuthorizationServerEndpoint = *body.AuthorizationServerEndpoint
+	}
+	return req, nil
 }
 
 // convertToMap converts an object to a map[string]interface{} using json conversion

--- a/auth/api/auth/v1/api_test.go
+++ b/auth/api/auth/v1/api_test.go
@@ -444,6 +444,53 @@ func TestWrapper_CreateJwtGrant(t *testing.T) {
 		assert.Equal(t, expectedResponse, response)
 		assert.Nil(t, err)
 	})
+
+	t.Run("AuthorizationServerEndpoint is plumbed through", func(t *testing.T) {
+		ctx := createContext(t)
+		endpoint := "https://as.example.nl/ura/12345678/token"
+		body := CreateJwtGrantRequest{
+			Requester:                   vdr.TestDIDA.String(),
+			Authorizer:                  vdr.TestDIDB.String(),
+			Service:                     "service",
+			AuthorizationServerEndpoint: &endpoint,
+		}
+
+		expectedRequest := services.CreateJwtGrantRequest{
+			Requester:                   body.Requester,
+			Authorizer:                  body.Authorizer,
+			Service:                     "service",
+			AuthorizationServerEndpoint: endpoint,
+		}
+
+		ctx.relyingPartyMock.EXPECT().CreateJwtGrant(gomock.Any(), expectedRequest).Return(&services.JwtBearerTokenResult{
+			BearerToken:                 "jwt",
+			AuthorizationServerEndpoint: endpoint,
+		}, nil)
+
+		response, err := ctx.wrapper.CreateJwtGrant(ctx.audit, CreateJwtGrantRequestObject{Body: &body})
+
+		assert.NoError(t, err)
+		assert.Equal(t, CreateJwtGrant200JSONResponse{BearerToken: "jwt", AuthorizationServerEndpoint: endpoint}, response)
+	})
+
+	t.Run("invalid AuthorizationServerEndpoint returns 400", func(t *testing.T) {
+		ctx := createContext(t)
+		badEndpoint := "%invalid"
+		body := CreateJwtGrantRequest{
+			Requester:                   vdr.TestDIDA.String(),
+			Authorizer:                  vdr.TestDIDB.String(),
+			Service:                     "service",
+			AuthorizationServerEndpoint: &badEndpoint,
+		}
+
+		response, err := ctx.wrapper.CreateJwtGrant(ctx.audit, CreateJwtGrantRequestObject{Body: &body})
+
+		assert.Nil(t, response)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid authorization_server_endpoint")
+		require.Implements(t, new(core.HTTPStatusCodeError), err)
+		assert.Equal(t, http.StatusBadRequest, err.(core.HTTPStatusCodeError).StatusCode())
+	})
 }
 
 func TestWrapper_RequestAccessToken(t *testing.T) {

--- a/auth/api/auth/v1/client/generated.go
+++ b/auth/api/auth/v1/client/generated.go
@@ -89,16 +89,8 @@ type CreateAccessTokenRequest struct {
 	GrantType string `json:"grant_type"`
 }
 
-// CreateJwtGrantRequest Request for a JWT Grant. The grant can be used during a Access Token Request in the assertion field
-type CreateJwtGrantRequest struct {
-	Authorizer  string                  `json:"authorizer"`
-	Credentials []VerifiableCredential  `json:"credentials"`
-	Identity    *VerifiablePresentation `json:"identity,omitempty"`
-	Requester   string                  `json:"requester"`
-
-	// Service The service for which this access token can be used. The right oauth endpoint is selected based on the service.
-	Service string `json:"service"`
-}
+// CreateJwtGrantRequest Common fields shared by CreateJwtGrantRequest and RequestAccessTokenRequest.
+type CreateJwtGrantRequest = JwtGrantBaseRequest
 
 // DrawUpContractRequest defines model for DrawUpContractRequest.
 type DrawUpContractRequest struct {
@@ -122,19 +114,15 @@ type DrawUpContractRequest struct {
 	Version ContractVersion `json:"version"`
 }
 
-// JwtGrantResponse Response with a JWT Grant. It contains a JWT, signed with the private key of the requestor software vendor.
-type JwtGrantResponse struct {
-	// AuthorizationServerEndpoint The URL that corresponds to the oauth endpoint of the selected service.
-	AuthorizationServerEndpoint string `json:"authorization_server_endpoint"`
-	BearerToken                 string `json:"bearer_token"`
-}
-
-// LegalEntity DID of the organization as registered in the Nuts registry.
-type LegalEntity = string
-
-// RequestAccessTokenRequest Request for a JWT Grant and use it as authorization grant to get the access token from the authorizer
-type RequestAccessTokenRequest struct {
-	Authorizer string `json:"authorizer"`
+// JwtGrantBaseRequest Common fields shared by CreateJwtGrantRequest and RequestAccessTokenRequest.
+type JwtGrantBaseRequest struct {
+	// AuthorizationServerEndpoint Optional. OAuth token endpoint URL of the authorizer (RFC 8414 `token_endpoint`).
+	// When provided, this URL is used directly as the JWT `aud` claim, bypassing the
+	// compound-service lookup on the authorizer's DID document. `service` remains
+	// required and is still used as the `purposeOfUse` JWT claim. Intended for
+	// clients that discover the endpoint out-of-band (e.g. via FHIR mCSD).
+	AuthorizationServerEndpoint *string `json:"authorization_server_endpoint,omitempty"`
+	Authorizer                  string  `json:"authorizer"`
 
 	// Credentials Verifiable Credentials to be included in the access token. If no VCs are to be included in the access token, the array can be left empty.
 	Credentials []VerifiableCredential  `json:"credentials"`
@@ -144,6 +132,21 @@ type RequestAccessTokenRequest struct {
 	// Service The service for which this access token can be used. The right oauth endpoint is selected based on the service.
 	Service string `json:"service"`
 }
+
+// JwtGrantResponse Response with a JWT Grant. It contains a JWT, signed with the private key of the requestor software vendor.
+type JwtGrantResponse struct {
+	// AuthorizationServerEndpoint The OAuth token endpoint URL of the authorizer (RFC 8414 `token_endpoint`).
+	// Despite the field name, this is the concrete endpoint to which a JWT bearer
+	// grant is POSTed, not an Authorization Server metadata/issuer URL.
+	AuthorizationServerEndpoint string `json:"authorization_server_endpoint"`
+	BearerToken                 string `json:"bearer_token"`
+}
+
+// LegalEntity DID of the organization as registered in the Nuts registry.
+type LegalEntity = string
+
+// RequestAccessTokenRequest Common fields shared by CreateJwtGrantRequest and RequestAccessTokenRequest.
+type RequestAccessTokenRequest = JwtGrantBaseRequest
 
 // SignSessionRequest defines model for SignSessionRequest.
 type SignSessionRequest struct {

--- a/auth/api/auth/v1/generated.go
+++ b/auth/api/auth/v1/generated.go
@@ -108,16 +108,8 @@ type CreateAccessTokenRequest struct {
 	GrantType string `json:"grant_type"`
 }
 
-// CreateJwtGrantRequest Request for a JWT Grant. The grant can be used during a Access Token Request in the assertion field
-type CreateJwtGrantRequest struct {
-	Authorizer  string                  `json:"authorizer"`
-	Credentials []VerifiableCredential  `json:"credentials"`
-	Identity    *VerifiablePresentation `json:"identity,omitempty"`
-	Requester   string                  `json:"requester"`
-
-	// Service The service for which this access token can be used. The right oauth endpoint is selected based on the service.
-	Service string `json:"service"`
-}
+// CreateJwtGrantRequest Common fields shared by CreateJwtGrantRequest and RequestAccessTokenRequest.
+type CreateJwtGrantRequest = JwtGrantBaseRequest
 
 // DrawUpContractRequest defines model for DrawUpContractRequest.
 type DrawUpContractRequest struct {
@@ -141,19 +133,15 @@ type DrawUpContractRequest struct {
 	Version ContractVersion `json:"version"`
 }
 
-// JwtGrantResponse Response with a JWT Grant. It contains a JWT, signed with the private key of the requestor software vendor.
-type JwtGrantResponse struct {
-	// AuthorizationServerEndpoint The URL that corresponds to the oauth endpoint of the selected service.
-	AuthorizationServerEndpoint string `json:"authorization_server_endpoint"`
-	BearerToken                 string `json:"bearer_token"`
-}
-
-// LegalEntity DID of the organization as registered in the Nuts registry.
-type LegalEntity = string
-
-// RequestAccessTokenRequest Request for a JWT Grant and use it as authorization grant to get the access token from the authorizer
-type RequestAccessTokenRequest struct {
-	Authorizer string `json:"authorizer"`
+// JwtGrantBaseRequest Common fields shared by CreateJwtGrantRequest and RequestAccessTokenRequest.
+type JwtGrantBaseRequest struct {
+	// AuthorizationServerEndpoint Optional. OAuth token endpoint URL of the authorizer (RFC 8414 `token_endpoint`).
+	// When provided, this URL is used directly as the JWT `aud` claim, bypassing the
+	// compound-service lookup on the authorizer's DID document. `service` remains
+	// required and is still used as the `purposeOfUse` JWT claim. Intended for
+	// clients that discover the endpoint out-of-band (e.g. via FHIR mCSD).
+	AuthorizationServerEndpoint *string `json:"authorization_server_endpoint,omitempty"`
+	Authorizer                  string  `json:"authorizer"`
 
 	// Credentials Verifiable Credentials to be included in the access token. If no VCs are to be included in the access token, the array can be left empty.
 	Credentials []VerifiableCredential  `json:"credentials"`
@@ -163,6 +151,21 @@ type RequestAccessTokenRequest struct {
 	// Service The service for which this access token can be used. The right oauth endpoint is selected based on the service.
 	Service string `json:"service"`
 }
+
+// JwtGrantResponse Response with a JWT Grant. It contains a JWT, signed with the private key of the requestor software vendor.
+type JwtGrantResponse struct {
+	// AuthorizationServerEndpoint The OAuth token endpoint URL of the authorizer (RFC 8414 `token_endpoint`).
+	// Despite the field name, this is the concrete endpoint to which a JWT bearer
+	// grant is POSTed, not an Authorization Server metadata/issuer URL.
+	AuthorizationServerEndpoint string `json:"authorization_server_endpoint"`
+	BearerToken                 string `json:"bearer_token"`
+}
+
+// LegalEntity DID of the organization as registered in the Nuts registry.
+type LegalEntity = string
+
+// RequestAccessTokenRequest Common fields shared by CreateJwtGrantRequest and RequestAccessTokenRequest.
+type RequestAccessTokenRequest = JwtGrantBaseRequest
 
 // SignSessionRequest defines model for SignSessionRequest.
 type SignSessionRequest struct {

--- a/auth/services/messages.go
+++ b/auth/services/messages.go
@@ -47,11 +47,12 @@ type CreateAccessTokenRequest struct {
 
 // CreateJwtGrantRequest contains all information to create a JwtBearerToken
 type CreateJwtGrantRequest struct {
-	Requester   string
-	Authorizer  string
-	IdentityVP  *vc.VerifiablePresentation
-	Service     string
-	Credentials []vc.VerifiableCredential
+	Requester                   string
+	Authorizer                  string
+	IdentityVP                  *vc.VerifiablePresentation
+	Service                     string
+	AuthorizationServerEndpoint string
+	Credentials                 []vc.VerifiableCredential
 }
 
 // JwtBearerTokenResult defines the return value back to the api for the createJwtBearerToken method

--- a/auth/services/oauth/relying_party.go
+++ b/auth/services/oauth/relying_party.go
@@ -91,9 +91,14 @@ func (s *relyingParty) CreateJwtGrant(ctx context.Context, request services.Crea
 		}
 	}
 
-	endpointURL, err := s.serviceResolver.GetCompoundServiceEndpoint(*authorizer, request.Service, services.OAuthEndpointType, true)
-	if err != nil {
-		return nil, fmt.Errorf("could not fetch authorizer's 'oauth' endpoint from compound service: %w", err)
+	var endpointURL string
+	if request.AuthorizationServerEndpoint != "" {
+		endpointURL = request.AuthorizationServerEndpoint
+	} else {
+		endpointURL, err = s.serviceResolver.GetCompoundServiceEndpoint(*authorizer, request.Service, services.OAuthEndpointType, true)
+		if err != nil {
+			return nil, fmt.Errorf("could not fetch authorizer's 'oauth' endpoint from compound service: %w", err)
+		}
 	}
 
 	keyVals := claimsFromRequest(request, endpointURL)

--- a/auth/services/oauth/relying_party_test.go
+++ b/auth/services/oauth/relying_party_test.go
@@ -200,6 +200,33 @@ func TestService_CreateJwtBearerToken(t *testing.T) {
 		assert.Empty(t, token)
 	})
 
+	t.Run("AuthorizationServerEndpoint overrides service-based resolution", func(t *testing.T) {
+		ctx := createRPContext(t, nil)
+		const explicitEndpoint = "https://as.example.nl/ura/12345678/token"
+
+		// serviceResolver must NOT be called when AuthorizationServerEndpoint is provided.
+		ctx.didResolver.EXPECT().Resolve(authorizerDID, gomock.Any()).Return(authorizerDIDDocument, nil, nil).AnyTimes()
+		ctx.keyResolver.EXPECT().ResolveKey(requesterDID, nil, resolver.NutsSigningKeyType).MinTimes(1).Return(requesterSigningKeyID, requesterSigningKey, nil)
+
+		var capturedClaims map[string]interface{}
+		ctx.keyStore.EXPECT().SignJWT(gomock.Any(), gomock.Any(), nil, requesterSigningKeyID).
+			DoAndReturn(func(_ context.Context, claims map[string]interface{}, _ interface{}, _ interface{}) (string, error) {
+				capturedClaims = claims
+				return "token", nil
+			})
+
+		overrideRequest := request
+		overrideRequest.AuthorizationServerEndpoint = explicitEndpoint
+
+		token, err := ctx.relyingParty.CreateJwtGrant(ctx.audit, overrideRequest)
+
+		require.NoError(t, err)
+		assert.Equal(t, "token", token.BearerToken)
+		assert.Equal(t, explicitEndpoint, token.AuthorizationServerEndpoint)
+		assert.Equal(t, explicitEndpoint, capturedClaims["aud"], "JWT aud should be the provided endpoint")
+		assert.Equal(t, expectedService, capturedClaims[purposeOfUseClaim], "purposeOfUse claim must still come from request.Service")
+	})
+
 	t.Run("authorizer without endpoint", func(t *testing.T) {
 		ctx := createRPContext(t, nil)
 		document := getAuthorizerDIDDocument()

--- a/docs/_static/auth/v1.yaml
+++ b/docs/_static/auth/v1.yaml
@@ -503,45 +503,8 @@ components:
     #
     # Everything related to JWT Grants
     #
-    CreateJwtGrantRequest:
-      description: Request for a JWT Grant. The grant can be used during a Access Token Request in the assertion field
-      required:
-        - authorizer
-        - requester
-        - service
-        - credentials
-      properties:
-        authorizer:
-          type: string
-        requester:
-          type: string
-        identity:
-          $ref: "#/components/schemas/VerifiablePresentation"
-        service:
-          type: string
-          description: The service for which this access token can be used. The right oauth endpoint is selected based on the service.
-          example: nuts-patient-transfer
-        credentials:
-          type: array
-          items:
-            $ref: '#/components/schemas/VerifiableCredential'
-    JwtGrantResponse:
-      description: Response with a JWT Grant. It contains a JWT, signed with the private key of the requestor software vendor.
-      required:
-        - bearer_token
-        - authorization_server_endpoint
-      properties:
-        bearer_token:
-          type: string
-        authorization_server_endpoint:
-          description: The URL that corresponds to the oauth endpoint of the selected service.
-          type: string
-
-    #
-    # Everything related to Access Tokens
-    #
-    RequestAccessTokenRequest:
-      description: Request for a JWT Grant and use it as authorization grant to get the access token from the authorizer
+    JwtGrantBaseRequest:
+      description: Common fields shared by CreateJwtGrantRequest and RequestAccessTokenRequest.
       required:
         - authorizer
         - requester
@@ -558,11 +521,47 @@ components:
           type: string
           description: The service for which this access token can be used. The right oauth endpoint is selected based on the service.
           example: nuts-patient-transfer
+        authorization_server_endpoint:
+          type: string
+          format: uri
+          description: |
+            Optional. OAuth token endpoint URL of the authorizer (RFC 8414 `token_endpoint`).
+            When provided, this URL is used directly as the JWT `aud` claim, bypassing the
+            compound-service lookup on the authorizer's DID document. `service` remains
+            required and is still used as the `purposeOfUse` JWT claim. Intended for
+            clients that discover the endpoint out-of-band (e.g. via FHIR mCSD).
+          example: https://as.example.nl/ura/12345678/token
         credentials:
           description: Verifiable Credentials to be included in the access token. If no VCs are to be included in the access token, the array can be left empty.
           type: array
           items:
             $ref: '#/components/schemas/VerifiableCredential'
+    CreateJwtGrantRequest:
+      description: Request for a JWT Grant. The grant can be used during a Access Token Request in the assertion field
+      allOf:
+        - $ref: '#/components/schemas/JwtGrantBaseRequest'
+    JwtGrantResponse:
+      description: Response with a JWT Grant. It contains a JWT, signed with the private key of the requestor software vendor.
+      required:
+        - bearer_token
+        - authorization_server_endpoint
+      properties:
+        bearer_token:
+          type: string
+        authorization_server_endpoint:
+          description: |
+            The OAuth token endpoint URL of the authorizer (RFC 8414 `token_endpoint`).
+            Despite the field name, this is the concrete endpoint to which a JWT bearer
+            grant is POSTed, not an Authorization Server metadata/issuer URL.
+          type: string
+
+    #
+    # Everything related to Access Tokens
+    #
+    RequestAccessTokenRequest:
+      description: Request for a JWT Grant and use it as authorization grant to get the access token from the authorizer
+      allOf:
+        - $ref: '#/components/schemas/JwtGrantBaseRequest'
     CreateAccessTokenRequest:
       description: Request as described in RFC7523 section 2.1
       required:


### PR DESCRIPTION
## Summary

Adds an optional `authorization_server_endpoint` field to `/internal/auth/v1/jwt-grant` and `/internal/auth/v1/request-access-token`. When provided, it is used directly as the JWT `aud` claim, bypassing the compound-service lookup on the authorizer's DID document.

  - `service` remains required and still drives the `purposeOfUse` JWT claim — this only overrides endpoint resolution.
  - No metadata discovery added in the node; the client hands over a final token endpoint URL.
  - Request schemas `CreateJwtGrantRequest` and `RequestAccessTokenRequest` are refactored onto a shared `JwtGrantBaseRequest` via `allOf` so the new field lives in one place.
  - Existing response field `authorization_server_endpoint` kept as-is (description clarified, despite the name, it's the RFC 8414 `token_endpoint`).

## Why

Preparing for the FHIR mCSD transition. Clients already perform mCSD lookups for data-access endpoints, so letting them pass the OAuth token endpoint explicitly keeps nuts-node agnostic of the discovery mechanism.