### PR TITLE
test: bump StartServer startup poll timeout to 10s

### DIFF
--- a/test/node/server.go
+++ b/test/node/server.go
@@ -97,7 +97,7 @@ func StartServer(t *testing.T, configFunc ...func(internalHttpServerURL, publicH
 	if !test.WaitFor(t, func() (bool, error) {
 		resp, err := client.Get(internalHttpServerURL + "/status")
 		return err == nil && resp.StatusCode == http.StatusOK, nil
-	}, time.Second*5, "Timeout while waiting for node to become available") {
+	}, time.Second*10, "Timeout while waiting for node to become available") {
 		t.Fatal("time-out")
 	}
 


### PR DESCRIPTION
## Summary

- Bumps the `test.WaitFor` budget in `test/node/server.StartServer` from 5s to 10s.
- Eliminates flaky timeouts seen on CircleCI's 1/4-CPU runners, where the node's heavier engines (VDR, VCR, NATS, embedded gRPC listener) occasionally need more than 5s to bring `/status` online.
- The polling cadence (10ms + `runtime.Gosched`, see `test/predicates.go`) is unchanged, so this only enlarges the worst-case wait — happy-path tests still finish in well under a second.

Observed flake locally and on CI with `TestOpenID4VCIHappyFlow`; PR #4057 didn't touch the startup path, so the 5s budget was simply too tight for slow runners.

## Test plan

- [x] CI passes on this branch
- [x] No new flakes in `TestOpenID4VCIHappyFlow` / `TestOpenID4VCIErrorResponses`

🤖 Generated with [Claude Code](https://claude.com/claude-code)