### PR TITLE
feat(crypto): accept RS256 in SupportedAlgorithms

### DIFF
--- a/auth/services/oauth/authz_server_test.go
+++ b/auth/services/oauth/authz_server_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -575,19 +574,15 @@ func TestService_parseAndValidateJwtBearerToken(t *testing.T) {
 	})
 
 	t.Run("wrong signing algorithm", func(t *testing.T) {
-		t.Setenv("GODEBUG", "rsa1024min=0") // minimum key-length has changed to 1024 -> https://pkg.go.dev/crypto/rsa#hdr-Minimum_key_size
-		privateKey, err := rsa.GenerateKey(rand.Reader, 512)
-		require.NoError(t, err)
-
 		keyID := "did:nuts:somedid#key-id"
+		secret := []byte("test-hmac-secret")
 
-		ctx.keyResolver.EXPECT().ResolveKeyByID(keyID, nil, resolver.NutsSigningKeyType).Return(privateKey.Public(), nil)
+		ctx.keyResolver.EXPECT().ResolveKeyByID(keyID, nil, resolver.NutsSigningKeyType).Return(secret, nil)
 
-		// alg: RS256
 		token := jwt.New()
 		hdrs := jws.NewHeaders()
 		hdrs.Set(jws.KeyIDKey, keyID)
-		signedToken, err := jwt.Sign(token, jwt.WithKey(jwa.RS256, privateKey, jws.WithProtectedHeaders(hdrs)))
+		signedToken, err := jwt.Sign(token, jwt.WithKey(jwa.HS256, secret, jws.WithProtectedHeaders(hdrs)))
 		require.NoError(t, err)
 
 		tokenCtx := &validationContext{
@@ -595,7 +590,7 @@ func TestService_parseAndValidateJwtBearerToken(t *testing.T) {
 		}
 		err = ctx.oauthService.parseAndValidateJwtBearerToken(tokenCtx)
 		assert.Nil(t, tokenCtx.jwtBearerToken)
-		assert.Equal(t, "token signing algorithm is not supported: RS256", err.Error())
+		assert.Equal(t, "token signing algorithm is not supported: HS256", err.Error())
 	})
 
 	t.Run("valid token", func(t *testing.T) {

--- a/crypto/jwx/algorithm.go
+++ b/crypto/jwx/algorithm.go
@@ -27,7 +27,7 @@ import (
 // ErrUnsupportedSigningKey is returned when an unsupported private key is used to sign. Currently only ecdsa and rsa keys are supported
 var ErrUnsupportedSigningKey = errors.New("signing key algorithm not supported")
 
-var SupportedAlgorithms = []jwa.SignatureAlgorithm{jwa.ES256, jwa.EdDSA, jwa.ES384, jwa.ES512, jwa.PS256, jwa.PS384, jwa.PS512}
+var SupportedAlgorithms = []jwa.SignatureAlgorithm{jwa.ES256, jwa.EdDSA, jwa.ES384, jwa.ES512, jwa.PS256, jwa.PS384, jwa.PS512, jwa.RS256}
 
 const DefaultRsaEncryptionAlgorithm = jwa.RSA_OAEP_256
 const DefaultEcEncryptionAlgorithm = jwa.ECDH_ES_A256KW

--- a/crypto/jwx_test.go
+++ b/crypto/jwx_test.go
@@ -120,14 +120,14 @@ func TestSignJWT(t *testing.T) {
 
 func TestParseJWT(t *testing.T) {
 	t.Run("unsupported algorithm", func(t *testing.T) {
-		rsaKey := test.GenerateRSAKey()
+		secret := []byte("test-hmac-secret")
 		token := jwt.New()
-		signature, _ := jwt.Sign(token, jwt.WithKey(jwa.RS256, rsaKey))
+		signature, _ := jwt.Sign(token, jwt.WithKey(jwa.HS256, secret))
 		parsedToken, err := ParseJWT(string(signature), func(_ string) (crypto.PublicKey, error) {
-			return rsaKey.Public(), nil
+			return secret, nil
 		}, nil, nil)
 		assert.Nil(t, parsedToken)
-		assert.EqualError(t, err, "token signing algorithm is not supported: RS256")
+		assert.EqualError(t, err, "token signing algorithm is not supported: HS256")
 	})
 
 	t.Run("allow clock skew (default DefaultJWTClockSkew)", func(t *testing.T) {
@@ -595,7 +595,7 @@ func TestCrypto_convertHeaders(t *testing.T) {
 
 func Test_isAlgorithmSupported(t *testing.T) {
 	assert.True(t, jwx.IsAlgorithmSupported(jwa.PS256))
-	assert.False(t, jwx.IsAlgorithmSupported(jwa.RS256))
+	assert.True(t, jwx.IsAlgorithmSupported(jwa.RS256))
 	assert.False(t, jwx.IsAlgorithmSupported(""))
 }
 


### PR DESCRIPTION
## Summary

- Add `jwa.RS256` to `crypto/jwx.SupportedAlgorithms` so `ParseJWT` accepts RS256-signed JWS on input (wallet VC ingest, VP verification, OAuth bearer-token parsing).
- Network DAG transactions keep their own narrower allowlist (no RS256) untouched.
- Outbound signing is unaffected; the node continues to sign with PS256.

## Motivation

The AET ZORG-ID issuer used for `HealthCareProfessionalDelegationCredential` / `PatientEnrollmentCredential` in the LSPxNuts flows (#4188, #4233) signs all RSA-keyed soft certs with RS256 and exposes no algorithm knob. With the previous allowlist, every credential AET issued was rejected at `POST /internal/vcr/v2/holder/{subject}/vc` with:

```
token signing algorithm is not supported: RS256
```

Verified end-to-end: with this change the AET -> Nuts wallet round-trip (issuance, chain validation, persistence) succeeds.

Closes #4234

## Test plan

- [x] `go test ./...` (full suite passes locally)
- [x] `Test_isAlgorithmSupported` now asserts RS256 is accepted
- [x] `TestParseJWT/unsupported_algorithm` rewritten to use HS256 as the rejected algorithm
- [x] `TestService_parseAndValidateJwtBearerToken/wrong_signing_algorithm` rewritten to use HS256
- [x] Network DAG `parser_test.go` still asserts RS256 is rejected for transactions (separate allowlist, unchanged)
- [ ] Confirm AET -> wallet round-trip in the LSPxNuts integration environment

Assisted-by: AI