### PR TITLE
ci(go-test): skip coverage upload on fork PRs

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -31,6 +31,9 @@ jobs:
         run: grep -v generated c_raw.out | grep -v mock | grep -v test > c.out
 
       - name: Upload coverage to Qlty
+        # Skip on PRs from forks: GitHub does not grant id-token: write to
+        # cross-repository workflow runs, so the OIDC upload cannot authenticate.
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: qltysh/qlty-action/coverage@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
         with:
           oidc: true


### PR DESCRIPTION
## Summary
- The Go test workflow fails on PRs from forks because GitHub does not grant `id-token: write` to cross-repository runs, so `qlty-action`'s OIDC upload errors with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable` — turning the whole job red for external contributors (e.g. #4247, [run 25824280714](https://github.com/nuts-foundation/nuts-node/actions/runs/25824280714/job/76166464551?pr=4247)).
- Gate the upload step on `push` events and same-repo PRs. Tests still run on fork PRs; coverage continues to upload on push to `master` / `V*` and on internal PRs.

## Test plan
- [ ] Confirm a fork PR's Go test job now reaches green (the upload step is skipped, not failed).
- [ ] Confirm an internal PR still uploads coverage to Qlty.
- [ ] Confirm push to `master` still uploads coverage to Qlty.

Assisted by AI