### PR TITLE
docs: add v6.2.6 release notes to master

### DIFF
--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -11,6 +11,17 @@ Unreleased
 * #4233: ``request-credential`` API gains an optional ``credential_request_params`` JSON object overlaid on top of the OpenID4VCI Credential Request body sent to the issuer. Lets the wallet talk to issuers that accept additional fields, or to override the credential request entirely.
 
 ****************
+Peanut (v6.2.6)
+****************
+
+Release date: 2026-05-18
+
+- Exclude retraction presentations from Discovery Service search results (backport of `#4193 <https://github.com/nuts-foundation/nuts-node/pull/4193>`_).
+- Make HTTP error handler idempotent on already-committed responses to prevent double-write attempts (backport of `#4243 <https://github.com/nuts-foundation/nuts-node/pull/4243>`_).
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v6.2.5...v6.2.6
+
+****************
 Peanut (v6.2.5)
 ****************
 


### PR DESCRIPTION
## Summary
Syncs the v6.2.6 release notes from `V6.2` to `master` so the published docs stay consistent across branches.

## Test plan
- [x] Render `docs/pages/release_notes.rst` on Read the Docs and verify the v6.2.6 section appears between Unreleased and v6.2.5.

Assisted by AI