### PR TITLE
ci: speed up PR feedback

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -75,7 +75,9 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          # On PRs we only verify the build doesn't break; arm64 under QEMU
+          # is ~5-8x slower and adds no signal there. Multi-arch on push/tag.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           build-args: |

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -60,6 +60,8 @@ jobs:
           platforms: linux/amd64
           push: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
           tags: ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}
+          cache-from: type=gha,scope=e2e
+          cache-to: type=gha,scope=e2e,mode=max
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SECRET }}
 
@@ -72,6 +74,8 @@ jobs:
           platforms: linux/amd64
           push: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
           tags: ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}
+          cache-from: type=gha,scope=e2e
+          cache-to: type=gha,scope=e2e,mode=max
 
       - name: Run E2E tests
         run: |

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -25,7 +25,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Test
-        run: go test -p 1 ./... -race -coverprofile=c_raw.out
+        run: go test ./... -race -coverprofile=c_raw.out
 
       - name: Filter coverage
         run: grep -v generated c_raw.out | grep -v mock | grep -v test > c.out

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ data
 
 /nuts-node
 nuts.yaml
+
+# Local scratch directory and Claude Code session state
+.scratch/
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary

Implements findings 1, 2, 3 from #4258. Three independent CI tweaks targeting the ~13 min PR wall-clock:

1. **`go-test.yaml`**: drop `-p 1`. Inherited from CircleCI's per-shard config during PR #4250 migration; the new GHA pipeline isn't sharded so the flag just serialized 137 packages on a single 2-core runner. Audit shows no inter-package parallelism hazards in the current codebase (no fixed-port `net.Listen`, no `os.Chdir`, no `TestMain`, no shared on-disk paths). Local empirical: `-p 1` takes 7m04s, `-p 2` takes 3m31s, both pass. Expected CI: 12m15s → ~6m on PRs that bust the Go test cache.
2. **`e2e-tests.yaml`**: add gha cache to both `Build and push` steps. Dockerfile already orders go.mod/go.sum download before `COPY .`, so the cache is effective on PRs that don't touch go.sum. Saves ~1-2 min after warm-up.
3. **`build-images.yaml`**: build amd64 only on PRs, multi-arch on push/tag. arm64 under QEMU is ~5-8x slower; PRs are `push: false` anyway, so we only verify build doesn't break - arm64 adds no signal. Saves ~20 runner-min/PR (not on critical path but reduces resource use).

Drive-by: add `.scratch/` and `.claude/scheduled_tasks.lock` to `.gitignore` so local agent state doesn't land in commits.

## Measurement

Compared against #4254 (most recent docs-only PR before this change, same cache profile shape):

| Step | #4254 (baseline) | #4259 (this PR) | Delta |
|---|---|---|---|
| `go-test` - `Test` | 12m 05s | **1m 01s** | -91% (see caveat) |
| `e2e-tests` - `Build and push` | 1m 45s | 3m 06s | +1m 21s (first-run cache write) |
| `e2e-tests` - `Run E2E tests` | 8m 25s | 8m 10s | -15s (noise) |
| `build-images` - `Build and push` | 23m 03s | **1m 38s** | **-93%** |

**Verdict per change:**

- **(1) Drop `-p 1`** - works as intended. The 1m 01s figure looks too good because Go's build/test cache is fully hot on this run (most packages show `(cached)` in the log). On a PR that *does* change Go code (the realistic case), expect the local empirical projection: ~6 min instead of ~12 min, based on the 7m04s → 3m31s drop measured locally on a 2-core-equivalent run.
- **(2) E2E gha cache** - neutral on this first run (+1m 21s as the cache writes for the first time). Will pay off on subsequent PRs once the cache exists. The `Run E2E tests` step itself is unaffected as designed (sharding from #4258 finding 4 is a separate change).
- **(3) Multi-arch off for PRs** - clear win. Build went from 23m 03s to 1m 38s, removing the arm64-under-QEMU bulk. No coverage lost on PRs since they don't publish.

**Combined PR wall-clock effect**:

Before this PR (last comparable run #4254): max(go-test 12m, e2e 10m, build-images 23m) = ~23 min total elapsed. After: max(~6m worst-case go-test, ~11m e2e, ~2m build-images) = **~11 min** elapsed. `build-images` no longer the long pole on PRs.

## Test plan
- [x] `Go test` workflow green; `Test` step substantially faster.
- [x] `E2E tests` workflow green (no regression).
- [x] `Build Docker images` workflow green and ~93% faster.
- [ ] Confirm subsequent PRs (different go.sum, e2e cache pre-populated) show the projected wall-clocks.

Refs #4258.

Assisted by AI