### PR TITLE
test(network): fix race in TestNotifier_Notify/OK - updates DB

### DIFF
--- a/network/dag/notifier_test.go
+++ b/network/dag/notifier_test.go
@@ -322,20 +322,21 @@ func TestNotifier_Notify(t *testing.T) {
 		// we use retry here since Notify will run notifyNow twice asynchronously
 		s.retry(event)
 
+		// counter.N is incremented by the receiver callback, but notifyNow persists
+		// the updated event (Retries, Latest) only after the callback returns. Wait
+		// for the persisted event instead of the in-memory counter, otherwise the
+		// read may observe the event before Latest is set and dereference a nil pointer.
+		var e *Event
 		test.WaitFor(t, func() (bool, error) {
-			return counter.N.Load() == 1, nil
+			kvStore.ReadShelf(ctx, s.shelfName(), func(reader stoabs.Reader) error {
+				e, _ = s.readEvent(reader, hash.EmptyHash())
+				return nil
+			})
+			return e != nil && e.Latest != nil, nil
 		}, time.Second, "timeout while waiting for receiver")
-		kvStore.ReadShelf(ctx, s.shelfName(), func(reader stoabs.Reader) error {
-			e, err := s.readEvent(reader, hash.EmptyHash())
 
-			assert.NoError(t, err)
-			require.NotNil(t, e)
-			assert.Equal(t, 1, e.Retries)
-			assert.True(t, now.Equal(*e.Latest))
-
-			return nil
-		})
-
+		assert.Equal(t, 1, e.Retries)
+		assert.True(t, now.Equal(*e.Latest))
 		assert.Equal(t, int64(1), counter.N.Load())
 	})
 


### PR DESCRIPTION
## Problem

`TestNotifier_Notify/OK - updates DB` is flaky. It surfaced as a 10-minute test timeout on PR #4273 (job [77338232466](https://github.com/nuts-foundation/nuts-node/actions/runs/26275378334)); a rerun went green.

## Root cause

The subtest waited on the in-memory callback counter (`counter.N == 1`), then opened a bbolt read transaction and asserted `now.Equal(*e.Latest)`.

`notifyNow` increments the counter (via the receiver callback) **before** it persists the updated event. So the read could observe the event before `Latest` was written, dereferencing a nil `*time.Time`.

The nil-pointer panic unwound through the still-open `ReadShelf` transaction, leaking it. The deferred `store.Close()` test cleanup then deadlocked on bbolt's `mmaplock` (held by the leaked read tx) — turning a one-line assertion failure into a 10-minute timeout.

## Fix

Wait for the *persisted* event (`Latest != nil`) inside the `WaitFor` loop and assert outside the transaction — the pattern already used by the other persistency subtests in this file (e.g. `TestNotifier_Run` "fails and stops at max attempts").

Verified: 20× with `-race` on the subtest, 3× with `-race` on the full `TestNotifier` suite.

🤖 Assisted by AI