### PR TITLE
test(network/grpc): fix race in Test_grpcConnectionManager_Peers

### DIFF
--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -493,7 +493,7 @@ func Test_grpcConnectionManager_Peers(t *testing.T) {
 		}, time.Second*2, "waiting for peer 1 to connect")
 	})
 	t.Run("outbound stream triggers observer", func(t *testing.T) {
-		_, authenticator1, _, listener := create(t)
+		cm1, authenticator1, _, listener := create(t)
 		cm2, authenticator2, _, _ := create(t, withBufconnDialer(listener))
 		authenticator1.EXPECT().Authenticate(*nodeDID, gomock.Any()).Return(transport.Peer{ID: "1"}, nil)
 		authenticator2.EXPECT().Authenticate(*nodeDID, gomock.Any()).Return(transport.Peer{ID: "2"}, nil)
@@ -506,9 +506,11 @@ func Test_grpcConnectionManager_Peers(t *testing.T) {
 
 		cm2.Connect("bufnet", *nodeDID, nil)
 
+		// Wait until both sides have authenticated, otherwise the mock controller may
+		// run Finish() before authenticator1 fires and report a missing call.
 		test.WaitFor(t, func() (bool, error) {
-			return capturedPeer.Load() != nil, nil
-		}, time.Second*2, "waiting for peer 2 observers")
+			return capturedPeer.Load() != nil && len(cm1.Peers()) > 0, nil
+		}, time.Second*2, "waiting for both sides to authenticate")
 		assert.Equal(t, transport.Peer{ID: "2"}, capturedPeer.Load())
 		assert.Equal(t, transport.StateConnected, capturedState.Load())
 
@@ -532,9 +534,11 @@ func Test_grpcConnectionManager_Peers(t *testing.T) {
 
 		cm2.Connect("bufnet", *nodeDID, nil)
 
+		// Wait until both sides have authenticated, otherwise the mock controller may
+		// run Finish() before authenticator2 fires and report a missing call.
 		test.WaitFor(t, func() (bool, error) {
-			return capturedPeer.Load() != nil, nil
-		}, time.Second*2, "waiting for peer 1 observers")
+			return capturedPeer.Load() != nil && len(cm2.Peers()) > 0, nil
+		}, time.Second*2, "waiting for both sides to authenticate")
 		assert.Equal(t, transport.Peer{ID: "1"}, capturedPeer.Load())
 		assert.Equal(t, transport.StateConnected, capturedState.Load())
 


### PR DESCRIPTION
## Problem

\`Test_grpcConnectionManager_Peers/inbound_stream_triggers_observer\` (and the mirror outbound subtest) is flaky on CI. Example failure: PR #4275, [run 26294161548](https://github.com/nuts-foundation/nuts-node/actions/runs/26294161548/job/77402080317).

The failure message:

\`\`\`
controller.go:97: missing call(s) to *grpc.MockAuthenticator.Authenticate(is equal to did:nuts:test (did.DID), is anything)
\`\`\`

## Root cause

Both subtests set up two peers (cm1 and cm2) with separate \`MockAuthenticator\` mocks, and expect \`Authenticate\` to be called on **both**:

\`\`\`go
authenticator1.EXPECT().Authenticate(*nodeDID, gomock.Any()).Return(transport.Peer{ID: "1"}, nil)
authenticator2.EXPECT().Authenticate(*nodeDID, gomock.Any()).Return(transport.Peer{ID: "2"}, nil)
\`\`\`

But the wait condition only watches **one** side's observer:

\`\`\`go
test.WaitFor(t, func() (bool, error) {
    return capturedPeer.Load() != nil, nil
}, time.Second*2, "waiting for peer 1 observers")
\`\`\`

Both authentications happen in parallel on opposite ends of the bufconn. When the observed side wins the race, \`cm2.Stop()\` runs while the other side's \`Authenticate\` is still in flight, and \`t.Cleanup\` triggers gomock's \`Finish()\` before the mock call lands.

## Fix

Extend the wait condition to also require the unobserved side's \`Peers()\` list to be non-empty. A side only adds a remote to its \`Peers()\` list after its own \`Authenticate\` returns, so this guarantees both expectations have been satisfied before teardown.

## Test plan

- [x] \`go test -count=20 -run "Test_grpcConnectionManager_Peers" ./network/transport/grpc/\` passes locally (20/20)
- [ ] CI passes