### PR TITLE
fix(didx509): don't require serverAuth EKU on leaf cert

### DIFF
--- a/test/pki/test.go
+++ b/test/pki/test.go
@@ -110,7 +110,9 @@ func CertsToChain(certs []*x509.Certificate) *cert.Chain {
 }
 
 // BuildCertChain generates a certificate chain, including root, intermediate, and signing certificates.
-func BuildCertChain(identifiers []string, subjectSerialNumber string, signCertKeyUsage *x509.KeyUsage) ([]*x509.Certificate, []*rsa.PrivateKey, error) {
+// signCertExtKeyUsage is variadic so existing callers (which want the default of serverAuth)
+// don't need updating; pass it to override the leaf's Extended Key Usage.
+func BuildCertChain(identifiers []string, subjectSerialNumber string, signCertKeyUsage *x509.KeyUsage, signCertExtKeyUsage ...x509.ExtKeyUsage) ([]*x509.Certificate, []*rsa.PrivateKey, error) {
 	rootKey, rootCert, err := BuildRootCert()
 	if err != nil {
 		return nil, nil, err
@@ -126,7 +128,7 @@ func BuildCertChain(identifiers []string, subjectSerialNumber string, signCertKe
 	if subjectSerialNumber == "" {
 		subjectSerialNumber = "32121323"
 	}
-	signingKey, signingCert, err := BuildSigningCert(identifiers, intermediateL2Cert, intermediateL2Key, subjectSerialNumber, signCertKeyUsage)
+	signingKey, signingCert, err := BuildSigningCert(identifiers, intermediateL2Cert, intermediateL2Key, subjectSerialNumber, signCertKeyUsage, signCertExtKeyUsage...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -143,7 +145,10 @@ func BuildCertChain(identifiers []string, subjectSerialNumber string, signCertKe
 		}, nil
 }
 
-func BuildSigningCert(identifiers []string, intermediateL2Cert *x509.Certificate, intermediateL2Key *rsa.PrivateKey, serialNumber string, keyUsage *x509.KeyUsage) (*rsa.PrivateKey, *x509.Certificate, error) {
+// BuildSigningCert builds a leaf certificate signed by the given intermediate.
+// extKeyUsage is variadic so existing callers keep the template default (serverAuth);
+// pass it to override the leaf's Extended Key Usage.
+func BuildSigningCert(identifiers []string, intermediateL2Cert *x509.Certificate, intermediateL2Key *rsa.PrivateKey, serialNumber string, keyUsage *x509.KeyUsage, extKeyUsage ...x509.ExtKeyUsage) (*rsa.PrivateKey, *x509.Certificate, error) {
 	var ku x509.KeyUsage
 	if keyUsage != nil {
 		ku = *keyUsage
@@ -156,6 +161,9 @@ func BuildSigningCert(identifiers []string, intermediateL2Cert *x509.Certificate
 	}
 	signingTmpl, err := signingCertTemplate(nil, identifiers)
 	signingTmpl.KeyUsage = ku
+	if len(extKeyUsage) > 0 {
+		signingTmpl.ExtKeyUsage = extKeyUsage
+	}
 	if err != nil {
 		return nil, nil, err
 	}

--- a/test/pki/test.go
+++ b/test/pki/test.go
@@ -160,12 +160,12 @@ func BuildSigningCert(identifiers []string, intermediateL2Cert *x509.Certificate
 		return nil, nil, err
 	}
 	signingTmpl, err := signingCertTemplate(nil, identifiers)
+	if err != nil {
+		return nil, nil, err
+	}
 	signingTmpl.KeyUsage = ku
 	if len(extKeyUsage) > 0 {
 		signingTmpl.ExtKeyUsage = extKeyUsage
-	}
-	if err != nil {
-		return nil, nil, err
 	}
 	signingTmpl.Subject.SerialNumber = serialNumber
 	signingCert, err := createCert(signingTmpl, intermediateL2Cert, &signingKey.PublicKey, intermediateL2Key)

--- a/vdr/didx509/resolver.go
+++ b/vdr/didx509/resolver.go
@@ -105,9 +105,20 @@ func (r Resolver) Resolve(id did.DID, metadata *resolver.ResolveMetadata) (*did.
 	//         See https://github.com/nuts-foundation/nuts-node/pull/3606#issuecomment-2545051148
 	validationCert := chain[0]
 	trustStore := core.BuildTrustStore(chain[1:])
+	// KeyUsages is set to ExtKeyUsageAny to disable Go's default check that the leaf carries
+	// the TLS serverAuth Extended Key Usage. did:x509 chain validation is not a TLS context:
+	// the leaf is used to verify a VC/JWT signature, and the relevant constraint is the
+	// basic Key Usage extension (digitalSignature / keyAgreement), which is enforced below in
+	// createDidDocument by translating those bits into assertionMethod / keyAgreement
+	// verification methods. The credential verifier (via the key resolver) then picks the
+	// right verification method for the operation it performs, which is what actually
+	// enforces "this key is allowed for this use".
+	// Without this, e.g. UZI Zorgverlener signing certs (EKU = clientAuth + MS DocSigning,
+	// no serverAuth) would fail chain validation here. See issue #3956.
 	validatedChains, err := validationCert.Verify(x509.VerifyOptions{
 		Intermediates: core.NewCertPool(trustStore.IntermediateCAs),
 		Roots:         core.NewCertPool(trustStore.RootCAs),
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("did:509 certificate chain validation failed: %w", err)

--- a/vdr/didx509/resolver_test.go
+++ b/vdr/didx509/resolver_test.go
@@ -233,6 +233,26 @@ func TestManager_Resolve(t *testing.T) {
 
 		require.EqualError(t, err, "did:x509 certificate must have either digitalSignature or keyAgreement set as key usage bits")
 	})
+	t.Run("leaf certificate without serverAuth EKU resolves (e.g. UZI signing cert)", func(t *testing.T) {
+		// Regression test for #3956: UZI Zorgverlener smartcard signing certificates carry
+		// EKU = {clientAuth, MS DocSigning} and no serverAuth. Chain validation must not
+		// require serverAuth on the leaf.
+		keyUsage := x509.KeyUsageDigitalSignature
+		certs, _, err := testpki.BuildCertChain([]string{otherNameValue, otherNameValueSecondary}, "", &keyUsage, x509.ExtKeyUsageClientAuth)
+		require.NoError(t, err)
+
+		metadata := resolver.ResolveMetadata{
+			JwtProtectedHeaders: map[string]interface{}{
+				X509CertChainHeader: testpki.CertsToChain(certs),
+			},
+		}
+		rootDID := did.MustParseDID(fmt.Sprintf("did:x509:0:%s:%s", "sha256", sha256Sum(rootCertFromCerts(certs).Raw)))
+		didDocument, _, err := didResolver.Resolve(rootDID, &metadata)
+
+		require.NoError(t, err)
+		assert.Len(t, didDocument.AssertionMethod, 1)
+		assert.Empty(t, didDocument.KeyAgreement)
+	})
 	t.Run("invalid issuer signature of leaf certificate", func(t *testing.T) {
 		craftedCerts, _, err := testpki.BuildCertChain([]string{otherNameValue, otherNameValueSecondary}, "", nil)
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary

`x509.Verify` defaults `KeyUsages` to `ExtKeyUsageServerAuth`, so leaf certs without TLS `serverAuth` EKU (e.g. UZI Zorgverlener signing certs with `clientAuth` + MS DocSigning) failed did:x509 resolution with *"x509: certificate specifies an incompatible key usage"*.

did:x509 chain validation is not a TLS context. The relevant leaf constraint is the basic Key Usage extension (`digitalSignature` / `keyAgreement`), which is enforced downstream in `createDidDocument` by mapping those bits to `assertionMethod` / `keyAgreement` verification methods. The credential verifier (via the key resolver) then enforces the use-specific check by asking for the right VM relationship. CA `certSign` enforcement is unaffected.

- Set `KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny}` on `VerifyOptions` in `vdr/didx509/resolver.go`, with a documenting comment.
- Extended `test/pki.BuildSigningCert` / `BuildCertChain` with a variadic `ExtKeyUsage` parameter (backward-compatible) so the regression test can build a chain whose leaf doesn't carry `serverAuth`.
- Added `TestManager_Resolve/leaf_certificate_without_serverAuth_EKU_resolves` asserting resolution succeeds and the key lands in `assertionMethod` only.

Compatibility with both UZI cert variants:

| Cert | Basic KU | EKU | Before | After |
|---|---|---|---|---|
| UZI Zorgverlener (signing/smartcard) | `digitalSignature` | `clientAuth`, MS DocSigning | rejected | resolves |
| UZI Zorgaanbieder (server/TLS) | `digitalSignature`, `keyEncipherment` | `serverAuth`, `clientAuth` | resolves | resolves |

Fixes #3956.

## Test plan

- [x] `go test ./vdr/didx509/...` passes, including the new subtest
- [x] `go test ./test/pki/... ./vcr/verifier/... ./vcr/test/...` passes (callers of the modified helper)
- [x] `go build ./...` clean
- [ ] CI green

Assisted by AI