### PR TITLE
docs: add v6.2.7 and v5.4.34 release notes to master

### DIFF
--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -14,6 +14,18 @@ Unreleased
 * #4233: ``request-credential`` API gains an optional ``credential_request_params`` JSON object overlaid on top of the OpenID4VCI Credential Request body sent to the issuer. Lets the wallet talk to issuers that accept additional fields, or to override the credential request entirely.
 
 ****************
+Peanut (v6.2.7)
+****************
+
+Release date: 2026-05-27
+
+- Upgrade ``golang.org/x/crypto`` to v0.52.0 and ``golang.org/x/net`` to v0.55.0 to address `GO-2026-5018 <https://pkg.go.dev/vuln/GO-2026-5018>`_ (DoS via unbounded RSA/DSA key sizes in ``golang.org/x/crypto/ssh`` public key parsers) and `GO-2026-5026 <https://pkg.go.dev/vuln/GO-2026-5026>`_ (privilege escalation in ``golang.org/x/net/idna`` where ``ToASCII``/``ToUnicode`` accept Punycode-encoded labels that decode to ASCII-only labels).
+- Upgrade ``github.com/go-jose/go-jose/v4`` to v4.1.4 to address `GO-2026-4945 <https://pkg.go.dev/vuln/GO-2026-4945>`_ (panic during JWE decryption of crafted tokens).
+- Upgrade OpenTelemetry OTLP HTTP exporters (``otlplog/otlploghttp`` to v0.19.0, ``otlptrace/otlptracehttp`` to v1.43.0) to address `GO-2026-4985 <https://pkg.go.dev/vuln/GO-2026-4985>`_ (memory exhaustion from oversized OTLP HTTP response bodies).
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v6.2.6...v6.2.7
+
+****************
 Peanut (v6.2.6)
 ****************
 
@@ -477,6 +489,17 @@ The following features have been deprecated:
 - DIDMan v1 API, to be removed
 - Network v1 API, to be removed
 - VDR v1 API, replaced by VDR v2
+
+*************************
+Hazelnut update (v5.4.34)
+*************************
+
+Release date: 2026-05-27
+
+- Upgrade ``golang.org/x/crypto`` to v0.52.0 and ``golang.org/x/net`` to v0.55.0 to address `GO-2026-5018 <https://pkg.go.dev/vuln/GO-2026-5018>`_ (DoS via unbounded RSA/DSA key sizes in ``golang.org/x/crypto/ssh`` public key parsers) and `GO-2026-5026 <https://pkg.go.dev/vuln/GO-2026-5026>`_ (privilege escalation in ``golang.org/x/net/idna`` where ``ToASCII``/``ToUnicode`` accept Punycode-encoded labels that decode to ASCII-only labels).
+- Upgrade ``github.com/go-jose/go-jose/v4`` to v4.1.4 to address `GO-2026-4945 <https://pkg.go.dev/vuln/GO-2026-4945>`_ (panic during JWE decryption of crafted tokens).
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v5.4.33...v5.4.34
 
 *************************
 Hazelnut update (v5.4.33)


### PR DESCRIPTION
## Summary

Sync v6.2.7 and v5.4.34 release-notes entries from the V6.2 and V5.4 branches into master.

- v6.2.7 — security release ([GO-2026-5018](https://pkg.go.dev/vuln/GO-2026-5018), [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026), [GO-2026-4945](https://pkg.go.dev/vuln/GO-2026-4945), [GO-2026-4985](https://pkg.go.dev/vuln/GO-2026-4985))
- v5.4.34 — security release ([GO-2026-5018](https://pkg.go.dev/vuln/GO-2026-5018), [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026), [GO-2026-4945](https://pkg.go.dev/vuln/GO-2026-4945))

Docs-only.

Assisted by AI