### PR TITLE
#4299: upgrade go-did to v0.21.0 for VP-JWT iss claim fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/nats-io/nats-server/v2 v2.14.1
 	github.com/nats-io/nats.go v1.52.0
 	github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b
-	github.com/nuts-foundation/go-did v0.20.0
+	github.com/nuts-foundation/go-did v0.21.0
 	github.com/nuts-foundation/go-leia/v4 v4.3.0
 	github.com/nuts-foundation/go-stoabs v1.11.1
 	github.com/nuts-foundation/sqlite v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -400,8 +400,8 @@ github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAm
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
 github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b h1:80icUxWHwE1MrIOOEK5rxrtyKOgZeq5Iu1IjAEkggTY=
 github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b/go.mod h1:6YUioYirD6/8IahZkoS4Ypc8xbeJW76Xdk1QKcziNTM=
-github.com/nuts-foundation/go-did v0.20.0 h1:JTUNZl622JdZC3c/OdfRWANlN7AMQypgSPSc7iGmCWY=
-github.com/nuts-foundation/go-did v0.20.0/go.mod h1:4od1gAmCi9HjHTQGEvHC8pLeuXdXACxidAcdA52YScc=
+github.com/nuts-foundation/go-did v0.21.0 h1:jQAr6O8afgVp88Rkwnfl1m5E0b0L0KTkSqM5iDnq0fw=
+github.com/nuts-foundation/go-did v0.21.0/go.mod h1:4od1gAmCi9HjHTQGEvHC8pLeuXdXACxidAcdA52YScc=
 github.com/nuts-foundation/go-leia/v4 v4.3.0 h1:R0qGISIeg2q/PCQTC9cuoBtA6cFu4WBV2DbmSOWKZyM=
 github.com/nuts-foundation/go-leia/v4 v4.3.0/go.mod h1:Gw6bXqJLOAmHSiXJJYbVoj+Mowp/PoBRywO0ZPsVzA0=
 github.com/nuts-foundation/go-stoabs v1.11.1 h1:ZQOeRKzC1+AfW6Ve5kBJMo+zYhHLBUI4KrLWKYkxoeI=

--- a/vcr/holder/presenter_test.go
+++ b/vcr/holder/presenter_test.go
@@ -190,6 +190,25 @@ func TestPresenter_buildPresentation(t *testing.T) {
 			})
 		})
 
+		t.Run("#4299: holder is encoded as iss claim, not vp.holder", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			keyResolver := resolver.NewMockKeyResolver(ctrl)
+			keyResolver.EXPECT().ResolveKey(testDID, nil, resolver.NutsSigningKeyType).Return(kid, key.PublicKey, nil)
+
+			w := presenter{documentLoader: jsonldManager.DocumentLoader(), signer: keyStore, keyResolver: keyResolver}
+
+			holderURI := testDID.URI()
+			optionsWithHolder := PresentationOptions{Format: JWTPresentationFormat, ProofOptions: proof.ProofOptions{Created: time.Now()}, Holder: &holderURI}
+			result, err := w.buildPresentation(ctx, &testDID, []vc.VerifiableCredential{testCredential}, optionsWithHolder)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, testDID.String(), result.JWT().Issuer(), "holder must be carried in the iss claim")
+			vpAsMap := result.JWT().PrivateClaims()["vp"].(map[string]any)
+			assert.NotContains(t, vpAsMap, "holder", "non-standard vp.holder must not be set")
+		})
+
 		t.Run("ok - multiple VCs", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 


### PR DESCRIPTION
Fixes #4299.

Bumps `github.com/nuts-foundation/go-did` from v0.20.0 to v0.21.0, pulling in [go-did#148](https://github.com/nuts-foundation/go-did/pull/148).

## What changed
- VP-JWTs now encode the presentation holder as the standard `iss` claim and no longer emit the non-standard `vp.holder` field, aligning with W3C VC Data Model v1.1.
- Regression test in `vcr/holder` asserting the holder lands in `iss` and `vp.holder` is gone.

## Why
AORTA testing rejected our VP-JWTs as non-compliant: the `iss` claim was missing and a `holder` field appeared inside the VP object. Root cause was in go-did.

## Scope
Dependency bump + regression test only — no production source changes. The existing parser already treats `iss` as the canonical holder. Full `vcr/...` and `auth/...` suites pass.

Assisted by AI