### PR TITLE
test(storage): fix flaky minimemcached nil-pointer panic

### DIFF
--- a/storage/session_memcached_test.go
+++ b/storage/session_memcached_test.go
@@ -170,11 +170,13 @@ func memcachedTestServer(t *testing.T) *minimemcached.MiniMemcached {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Workaround for https://github.com/daangn/minimemcached/issues/14 (fix proposed in PR #13).
 	// Wait until the server's accept loop is actually serving connections before returning.
 	// minimemcached.Run spawns a goroutine that calls Accept() on the listener; Close() nils that
 	// listener. On really short tests Close() (in the cleanup below) could run before the goroutine
 	// entered Accept(), causing a nil pointer dereference in the dependency. Probing the server until
 	// it answers guarantees the accept loop is parked in Accept(), so Close() unblocks it cleanly.
+	// Remove this workaround once a minimemcached release includes the upstream fix.
 	require.Eventually(t, func() bool {
 		conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", m.Port()), time.Second)
 		if err != nil {

--- a/storage/session_memcached_test.go
+++ b/storage/session_memcached_test.go
@@ -170,11 +170,25 @@ func memcachedTestServer(t *testing.T) *minimemcached.MiniMemcached {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Wait until the server's accept loop is actually serving connections before returning.
+	// minimemcached.Run spawns a goroutine that calls Accept() on the listener; Close() nils that
+	// listener. On really short tests Close() (in the cleanup below) could run before the goroutine
+	// entered Accept(), causing a nil pointer dereference in the dependency. Probing the server until
+	// it answers guarantees the accept loop is parked in Accept(), so Close() unblocks it cleanly.
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", m.Port()), time.Second)
+		if err != nil {
+			return false
+		}
+		defer conn.Close()
+		if _, err = conn.Write([]byte("version\r\n")); err != nil {
+			return false
+		}
+		buf := make([]byte, 1)
+		_, err = conn.Read(buf)
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond, "memcached server did not start serving")
 	t.Cleanup(func() {
-		// Note on DATA RACE
-		// 		minimemcached.Run creates a new go routine to listen for new connections.
-		// 		In certain cases the new go routine may be created after/simultaneous with this cleanup resulting in a data race / nil pointer dereference.
-		// 		Mostly happens on CI during really short tests.
 		m.Close()
 	})
 	return m


### PR DESCRIPTION
## Problem
The `storage` test job intermittently fails with a panic, crashing the whole test binary:

```
panic: runtime error: invalid memory address or nil pointer dereference
  github.com/daangn/minimemcached.(*MiniMemcached).serve()  minimemcached.go:125
```

## Root cause
`minimemcached.Run` synchronously creates the listener, then spawns a goroutine that loops on `m.l.Accept()`. `Close()` (called from `t.Cleanup`) sets that listener to `nil`. On very short tests the cleanup's `Close()` can run *before* the goroutine reaches `Accept()`, so `m.l.Accept()` dereferences a nil listener. The panic happens in a dependency-spawned goroutine, so no test can recover it — the binary dies.

This is an upstream bug; v1.2.0 is the latest release, so there's no version to bump to.

## Fix
Block in the test helper until the server actually answers a probe connection (`version\r\n`). That guarantees `serve()` is parked inside `Accept()` before the test proceeds, so the cleanup `Close()` unblocks it via `listener.Close()` cleanly instead of racing goroutine startup.

## Verification
`go test ./storage/ -run Memcached -count=10 -race` passes.