### PR TITLE
fix(vcr/verifier): handle unparseable issuer DID instead of panicking

### DIFF
--- a/vcr/verifier/verifier.go
+++ b/vcr/verifier/verifier.go
@@ -153,7 +153,10 @@ func (v verifier) Verify(credentialToVerify vc.VerifiableCredential, allowUntrus
 
 	// Check signature
 	if checkSignature {
-		issuerDID, _ := did.ParseDID(credentialToVerify.Issuer.String())
+		issuerDID, err := did.ParseDID(credentialToVerify.Issuer.String())
+		if err != nil {
+			return fmt.Errorf("could not parse issuer DID: %w", err)
+		}
 		metadata := resolver.ResolveMetadata{ResolveTime: validAt, AllowDeactivated: false}
 		rawJwt := credentialToVerify.Raw()
 		if rawJwt != "" {

--- a/vcr/verifier/verifier_test.go
+++ b/vcr/verifier/verifier_test.go
@@ -122,6 +122,25 @@ func TestVerifier_Verify(t *testing.T) {
 		})
 	})
 
+	t.Run("fails (instead of panicking) when issuer DID is unparseable", func(t *testing.T) {
+		// Regression test for #4235: an unparseable issuer DID (e.g. a did:x509 with trailing
+		// unsupported fields) must result in a validation error, not a nil-pointer panic.
+		ctx := newMockContext(t)
+		credID := ssi.MustParseURI("did:web:example.com#1")
+		cred := vc.VerifiableCredential{
+			Context:      []ssi.URI{vc.VCContextV1URI()},
+			Type:         []ssi.URI{vc.VerifiableCredentialTypeV1URI(), ssi.MustParseURI("ExampleCredential")},
+			ID:           &credID,
+			Issuer:       ssi.MustParseURI("did:x509:0:sha256:abc::san:otherName:1.2.3.4#extra"),
+			IssuanceDate: time.Now().Add(-time.Hour),
+		}
+		ctx.store.EXPECT().GetRevocations(credID).Return(nil, ErrNotFound)
+
+		validationErr := ctx.verifier.Verify(cred, true, true, nil)
+
+		assert.ErrorContains(t, validationErr, "could not parse issuer DID")
+	})
+
 	t.Run("invalid when revoked", func(t *testing.T) {
 		vc := testCredential(t)
 		ctx := newMockContext(t)


### PR DESCRIPTION
## Problem
`vcr/verifier/verifier.go` discarded the error from `did.ParseDID(issuer)` on the signature-check path, then dereferenced the resulting `nil` pointer. An unparseable issuer DID — e.g. a `did:x509` with trailing unsupported fields, as emitted by the AET ZORG-ID SDK — made `ParseDID` return `(nil, err)`, so the dereference panicked and crashed the entire node:

> runtime error: invalid memory address or nil pointer dereference

Reproducible by posting such a credential to `/internal/vcr/v2/holder/{subject}/vc`.

## Fix
Capture the parse error and return a clean validation error:

```go
issuerDID, err := did.ParseDID(credentialToVerify.Issuer.String())
if err != nil {
    return fmt.Errorf("could not parse issuer DID: %w", err)
}
```

## Why the validator didn't catch it first
Credentials with an unrecognized type fall back to `defaultCredentialValidator`, which only checks the issuer is non-empty — it never parses it as a DID. So a malformed issuer reaches the signature-check path untouched.

## Test
Added a regression test to `TestVerifier_Verify` using `did:x509:0:sha256:abc::san:otherName:1.2.3.4#extra` (valid URI, invalid DID). It asserts a `could not parse issuer DID` error; without the fix it panics.

Fixes #4235

Assisted by AI