### PR TITLE
Upgrade Go to 1.26.4 to fix CVEs (v5.4.35)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     parallelism: 8
     docker:
-      - image: cimg/go:1.26.3
+      - image: cimg/go:1.26.4
     steps:
       - checkout
 
@@ -37,7 +37,7 @@ jobs:
 
   report:
     docker:
-      - image: cimg/go:1.26.3
+      - image: cimg/go:1.26.4
     steps:
       - checkout
       - attach_workspace:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # golang alpine
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -4,6 +4,16 @@ Release notes
 #############
 
 *************************
+Hazelnut update (v5.4.35)
+*************************
+
+Release date: 2026-06-04
+
+- Upgrade Go to 1.26.4 to address `GO-2026-5037 <https://pkg.go.dev/vuln/GO-2026-5037>`_ (quadratic-time denial of service in ``crypto/x509`` ``VerifyHostname`` when verifying certificates with large DNS SAN lists) and `GO-2026-5039 <https://pkg.go.dev/vuln/GO-2026-5039>`_ (error message injection in ``net/textproto`` where user input is included unescaped in error messages).
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v5.4.34...v5.4.35
+
+*************************
 Hazelnut update (v5.4.34)
 *************************
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nuts-foundation/nuts-node
 
 // This is the minimal version, the actual go version is determined by the images in the Dockerfile
 // This version is used in automated tests such as the 'Scheduled govulncheck' action
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/alicebob/miniredis/v2 v2.34.0


### PR DESCRIPTION
## Summary

- Upgrade Go from 1.26.3 to 1.26.4 (`go.mod`, `Dockerfile`, `.circleci/config.yml`)
- Add release notes for v5.4.35

Fixes the following vulnerabilities:

| Advisory | Package | Description |
|---|---|---|
| GO-2026-5037 | `crypto/x509` | Quadratic-time DoS in `VerifyHostname` with large DNS SAN lists (CVE-2026-27145) |
| GO-2026-5039 | `net/textproto` | Error message injection via unescaped user input (CVE-2026-42507) |

Assisted by AI