### PR TITLE
Upgrade Go to 1.26.4 to fix CVEs (v6.2.8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # golang alpine
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -3,6 +3,16 @@ Release notes
 #############
 
 ****************
+Peanut (v6.2.8)
+****************
+
+Release date: 2026-06-04
+
+- Upgrade Go to 1.26.4 to address `GO-2026-5037 <https://pkg.go.dev/vuln/GO-2026-5037>`_ (quadratic-time denial of service in ``crypto/x509`` ``VerifyHostname`` when verifying certificates with large DNS SAN lists) and `GO-2026-5039 <https://pkg.go.dev/vuln/GO-2026-5039>`_ (error message injection in ``net/textproto`` where user input is included unescaped in error messages).
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v6.2.7...v6.2.8
+
+****************
 Peanut (v6.2.7)
 ****************
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nuts-foundation/nuts-node
 
 // This is the minimal version, the actual go version is determined by the images in the Dockerfile
 // This version is used in automated tests such as the 'Scheduled govulncheck' action
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0


### PR DESCRIPTION
## Summary

- Upgrade Go from 1.26.3 to 1.26.4 (`go.mod`, `Dockerfile`)
- Add release notes for v6.2.8

Fixes the following vulnerabilities:

| Advisory | Package | Description |
|---|---|---|
| GO-2026-5037 | `crypto/x509` | Quadratic-time DoS in `VerifyHostname` with large DNS SAN lists (CVE-2026-27145) |
| GO-2026-5039 | `net/textproto` | Error message injection via unescaped user input (CVE-2026-42507) |

Assisted by AI