### PR TITLE
docs: add v6.2.8 and v5.4.35 release notes to master

### DIFF
--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -14,6 +14,16 @@ Unreleased
 * #4233: ``request-credential`` API gains an optional ``credential_request_params`` JSON object overlaid on top of the OpenID4VCI Credential Request body sent to the issuer. Lets the wallet talk to issuers that accept additional fields, or to override the credential request entirely.
 
 ****************
+Peanut (v6.2.8)
+****************
+
+Release date: 2026-06-04
+
+- Upgrade Go to 1.26.4 to address `GO-2026-5037 <https://pkg.go.dev/vuln/GO-2026-5037>`_ (quadratic-time denial of service in ``crypto/x509`` ``VerifyHostname`` when verifying certificates with large DNS SAN lists) and `GO-2026-5039 <https://pkg.go.dev/vuln/GO-2026-5039>`_ (error message injection in ``net/textproto`` where user input is included unescaped in error messages).
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v6.2.7...v6.2.8
+
+****************
 Peanut (v6.2.7)
 ****************
 
@@ -489,6 +499,16 @@ The following features have been deprecated:
 - DIDMan v1 API, to be removed
 - Network v1 API, to be removed
 - VDR v1 API, replaced by VDR v2
+
+*************************
+Hazelnut update (v5.4.35)
+*************************
+
+Release date: 2026-06-04
+
+- Upgrade Go to 1.26.4 to address `GO-2026-5037 <https://pkg.go.dev/vuln/GO-2026-5037>`_ (quadratic-time denial of service in ``crypto/x509`` ``VerifyHostname`` when verifying certificates with large DNS SAN lists) and `GO-2026-5039 <https://pkg.go.dev/vuln/GO-2026-5039>`_ (error message injection in ``net/textproto`` where user input is included unescaped in error messages).
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v5.4.34...v5.4.35
 
 *************************
 Hazelnut update (v5.4.34)


### PR DESCRIPTION
## Summary

Sync release notes for the upcoming Go 1.26.4 CVE patch releases to master, ahead of the release-branch PRs being merged and tagged.

- Add `v6.2.8` (Peanut) section
- Add `v5.4.35` (Hazelnut update) section

Both releases upgrade Go to 1.26.4 to address:

| Advisory | Package | Description |
|---|---|---|
| GO-2026-5037 | `crypto/x509` | Quadratic-time DoS in `VerifyHostname` with large DNS SAN lists (CVE-2026-27145) |
| GO-2026-5039 | `net/textproto` | Error message injection via unescaped user input (CVE-2026-42507) |

Companion release-branch PRs: #4313 (V5.4), #4314 (V6.2).

Assisted by AI