### PR TITLE
ci: speed up PR feedback (project-gf)

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -77,7 +77,9 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          # On PRs we only verify the build doesn't break; arm64 under QEMU
+          # is ~5-8x slower and adds no signal there. Multi-arch on push/tag.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           build-args: |

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -60,6 +60,8 @@ jobs:
           platforms: linux/amd64
           push: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
           tags: ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}
+          cache-from: type=gha,scope=e2e
+          cache-to: type=gha,scope=e2e,mode=max
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SECRET }}
 
@@ -72,6 +74,8 @@ jobs:
           platforms: linux/amd64
           push: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
           tags: ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}
+          cache-from: type=gha,scope=e2e
+          cache-to: type=gha,scope=e2e,mode=max
 
       - name: Run E2E tests
         run: |

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -25,7 +25,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Test
-        run: go test -p 1 ./... -race -coverprofile=c_raw.out
+        run: go test ./... -race -coverprofile=c_raw.out
 
       - name: Filter coverage
         run: grep -v generated c_raw.out | grep -v mock | grep -v test > c.out


### PR DESCRIPTION
Backports CI speedups to **project-gf** (already on GitHub Actions, so no CircleCI removal needed).

Ports merged master PR #4259 — speed up PR feedback.

## Changes (CI only)
- `go-test`: drop `-p 1` so packages test in parallel
- `build-images`: build only `linux/amd64` on PRs, full multi-arch on push/tag
- `e2e-tests`: enable GHA layer cache (`type=gha,scope=e2e`)

No production code changes.