### PR TITLE
feat(auth): add authorization_request_params to OpenID4VCI requestCredential API

### DIFF
--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -261,6 +261,12 @@ type RequestOpenid4VCICredentialIssuanceJSONBody struct {
 	// issuance per call and only consumes the first entry.
 	AuthorizationDetails []AuthorizationDetail `json:"authorization_details"`
 
+	// AuthorizationRequestParams Optional key/value pairs added to the OpenID4VCI authorization request (the redirect to the
+	// Authorization Server's authorization_endpoint). If a key is also set by the node, the value given
+	// here is used. Prefer authorization_details (RFC 9396) where the issuer supports it; use this only
+	// for issuers that require non-standard authorization parameters (e.g. auth_method for AET smartcards).
+	AuthorizationRequestParams *map[string]string `json:"authorization_request_params,omitempty"`
+
 	// CredentialRequestParams Optional JSON object overlaid on top of the OpenID4VCI Credential Request body sent to
 	// the issuer's credential endpoint. Any field supplied here overrides the node's default —
 	// including credential_configuration_id, credential_identifier and proofs. Use this for

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -262,9 +262,10 @@ type RequestOpenid4VCICredentialIssuanceJSONBody struct {
 	AuthorizationDetails []AuthorizationDetail `json:"authorization_details"`
 
 	// AuthorizationRequestParams Optional key/value pairs added to the OpenID4VCI authorization request (the redirect to the
-	// Authorization Server's authorization_endpoint). If a key is also set by the node, the value given
-	// here is used. Prefer authorization_details (RFC 9396) where the issuer supports it; use this only
-	// for issuers that require non-standard authorization parameters (e.g. auth_method for AET smartcards).
+	// Authorization Server's authorization_endpoint). These may only add parameters; they must not
+	// override the OpenID4VCI parameters set by the node (the request is rejected if they do).
+	// Prefer authorization_details (RFC 9396) where the issuer supports it; use this only for issuers
+	// that require non-standard authorization parameters (e.g. auth_method for AET smartcards).
 	AuthorizationRequestParams *map[string]string `json:"authorization_request_params,omitempty"`
 
 	// CredentialRequestParams Optional JSON object overlaid on top of the OpenID4VCI Credential Request body sent to

--- a/auth/api/iam/openid4vci.go
+++ b/auth/api/iam/openid4vci.go
@@ -128,7 +128,7 @@ func (r Wrapper) RequestOpenid4VCICredentialIssuance(ctx context.Context, reques
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse the authorization_endpoint: %w", err)
 	}
-	redirectUrl := nutsHttp.AddQueryParams(*authorizationEndpoint, map[string]string{
+	authzParams := map[string]string{
 		oauth.ResponseTypeParam:         oauth.CodeResponseType,
 		oauth.StateParam:                state,
 		oauth.ClientIDParam:             clientID.String(),
@@ -137,7 +137,15 @@ func (r Wrapper) RequestOpenid4VCICredentialIssuance(ctx context.Context, reques
 		oauth.RedirectURIParam:          redirectUri.String(),
 		oauth.CodeChallengeParam:        pkceParams.Challenge,
 		oauth.CodeChallengeMethodParam:  pkceParams.ChallengeMethod,
-	})
+	}
+	// Optional caller-supplied authorization request parameters, for issuers that need extras
+	// (e.g. auth_method=SmartCard). Applied after the node's own parameters, so caller values win.
+	if request.Body.AuthorizationRequestParams != nil {
+		for key, value := range *request.Body.AuthorizationRequestParams {
+			authzParams[key] = value
+		}
+	}
+	redirectUrl := nutsHttp.AddQueryParams(*authorizationEndpoint, authzParams)
 
 	return RequestOpenid4VCICredentialIssuance200JSONResponse{
 		RedirectURI: redirectUrl.String(),

--- a/auth/api/iam/openid4vci.go
+++ b/auth/api/iam/openid4vci.go
@@ -139,9 +139,13 @@ func (r Wrapper) RequestOpenid4VCICredentialIssuance(ctx context.Context, reques
 		oauth.CodeChallengeMethodParam:  pkceParams.ChallengeMethod,
 	}
 	// Optional caller-supplied authorization request parameters, for issuers that need extras
-	// (e.g. auth_method=SmartCard). Applied after the node's own parameters, so caller values win.
+	// (e.g. auth_method=SmartCard). These may only add parameters; they must not override the
+	// OpenID4VCI parameters set by the node above, which are essential to the flow.
 	if request.Body.AuthorizationRequestParams != nil {
 		for key, value := range *request.Body.AuthorizationRequestParams {
+			if _, isNodeParam := authzParams[key]; isNodeParam {
+				return nil, core.InvalidInputError("authorization_request_params may not override the '%s' parameter set by the node", key)
+			}
 			authzParams[key] = value
 		}
 	}

--- a/auth/api/iam/openid4vci_test.go
+++ b/auth/api/iam/openid4vci_test.go
@@ -92,6 +92,17 @@ func TestWrapper_RequestOpenid4VCICredentialIssuance(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "SmartCard", redirectUri.Query().Get("auth_method"))
 	})
+	t.Run("error - authorization_request_params may not override a node parameter", func(t *testing.T) {
+		ctx := newTestClient(t)
+		ctx.openid4vciClient.EXPECT().OpenIDCredentialIssuerMetadata(nil, issuerClientID).Return(&metadata, nil)
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(nil, authServer).Return(&authzMetadata, nil)
+		req := requestCredentials(holderSubjectID, issuerClientID, redirectURI)
+		req.Body.AuthorizationRequestParams = &map[string]string{oauth.ClientIDParam: "attacker"}
+
+		_, err := ctx.client.RequestOpenid4VCICredentialIssuance(nil, req)
+
+		assert.ErrorContains(t, err, "authorization_request_params may not override the 'client_id' parameter")
+	})
 	t.Run("ok - credential_request_params persisted into session", func(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.openid4vciClient.EXPECT().OpenIDCredentialIssuerMetadata(nil, issuerClientID).Return(&metadata, nil)

--- a/auth/api/iam/openid4vci_test.go
+++ b/auth/api/iam/openid4vci_test.go
@@ -78,6 +78,20 @@ func TestWrapper_RequestOpenid4VCICredentialIssuance(t *testing.T) {
 		assert.Equal(t, "code", redirectUri.Query().Get("response_type"))
 		assert.Equal(t, `[{"credential_configuration_id":"UniversityDegreeCredential","format":"vc+sd-jwt","type":"openid_credential"}]`, redirectUri.Query().Get("authorization_details"))
 	})
+	t.Run("ok - authorization_request_params merged into authorization request", func(t *testing.T) {
+		ctx := newTestClient(t)
+		ctx.openid4vciClient.EXPECT().OpenIDCredentialIssuerMetadata(nil, issuerClientID).Return(&metadata, nil)
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(nil, authServer).Return(&authzMetadata, nil)
+		req := requestCredentials(holderSubjectID, issuerClientID, redirectURI)
+		req.Body.AuthorizationRequestParams = &map[string]string{"auth_method": "SmartCard"}
+
+		response, err := ctx.client.RequestOpenid4VCICredentialIssuance(nil, req)
+
+		require.NoError(t, err)
+		redirectUri, err := url.Parse(response.(RequestOpenid4VCICredentialIssuance200JSONResponse).RedirectURI)
+		require.NoError(t, err)
+		assert.Equal(t, "SmartCard", redirectUri.Query().Get("auth_method"))
+	})
 	t.Run("ok - credential_request_params persisted into session", func(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.openid4vciClient.EXPECT().OpenIDCredentialIssuerMetadata(nil, issuerClientID).Return(&metadata, nil)

--- a/docs/_static/auth/v2.yaml
+++ b/docs/_static/auth/v2.yaml
@@ -193,9 +193,10 @@ paths:
                     type: string
                   description: |
                     Optional key/value pairs added to the OpenID4VCI authorization request (the redirect to the
-                    Authorization Server's authorization_endpoint). If a key is also set by the node, the value given
-                    here is used. Prefer authorization_details (RFC 9396) where the issuer supports it; use this only
-                    for issuers that require non-standard authorization parameters (e.g. auth_method for AET smartcards).
+                    Authorization Server's authorization_endpoint). These may only add parameters; they must not
+                    override the OpenID4VCI parameters set by the node (the request is rejected if they do).
+                    Prefer authorization_details (RFC 9396) where the issuer supports it; use this only for issuers
+                    that require non-standard authorization parameters (e.g. auth_method for AET smartcards).
                   example: |
                     {
                       "auth_method": "SmartCard"

--- a/docs/_static/auth/v2.yaml
+++ b/docs/_static/auth/v2.yaml
@@ -187,6 +187,19 @@ paths:
                     {
                       "some-requested-credential-attribute": "900184590"
                     }
+                authorization_request_params:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: |
+                    Optional key/value pairs added to the OpenID4VCI authorization request (the redirect to the
+                    Authorization Server's authorization_endpoint). If a key is also set by the node, the value given
+                    here is used. Prefer authorization_details (RFC 9396) where the issuer supports it; use this only
+                    for issuers that require non-standard authorization parameters (e.g. auth_method for AET smartcards).
+                  example: |
+                    {
+                      "auth_method": "SmartCard"
+                    }
                 redirect_uri:
                   type: string
                   description: |

--- a/e2e-tests/browser/client/iam/generated.go
+++ b/e2e-tests/browser/client/iam/generated.go
@@ -256,9 +256,10 @@ type RequestOpenid4VCICredentialIssuanceJSONBody struct {
 	AuthorizationDetails []AuthorizationDetail `json:"authorization_details"`
 
 	// AuthorizationRequestParams Optional key/value pairs added to the OpenID4VCI authorization request (the redirect to the
-	// Authorization Server's authorization_endpoint). If a key is also set by the node, the value given
-	// here is used. Prefer authorization_details (RFC 9396) where the issuer supports it; use this only
-	// for issuers that require non-standard authorization parameters (e.g. auth_method for AET smartcards).
+	// Authorization Server's authorization_endpoint). These may only add parameters; they must not
+	// override the OpenID4VCI parameters set by the node (the request is rejected if they do).
+	// Prefer authorization_details (RFC 9396) where the issuer supports it; use this only for issuers
+	// that require non-standard authorization parameters (e.g. auth_method for AET smartcards).
 	AuthorizationRequestParams *map[string]string `json:"authorization_request_params,omitempty"`
 
 	// CredentialRequestParams Optional JSON object overlaid on top of the OpenID4VCI Credential Request body sent to

--- a/e2e-tests/browser/client/iam/generated.go
+++ b/e2e-tests/browser/client/iam/generated.go
@@ -255,6 +255,12 @@ type RequestOpenid4VCICredentialIssuanceJSONBody struct {
 	// issuance per call and only consumes the first entry.
 	AuthorizationDetails []AuthorizationDetail `json:"authorization_details"`
 
+	// AuthorizationRequestParams Optional key/value pairs added to the OpenID4VCI authorization request (the redirect to the
+	// Authorization Server's authorization_endpoint). If a key is also set by the node, the value given
+	// here is used. Prefer authorization_details (RFC 9396) where the issuer supports it; use this only
+	// for issuers that require non-standard authorization parameters (e.g. auth_method for AET smartcards).
+	AuthorizationRequestParams *map[string]string `json:"authorization_request_params,omitempty"`
+
 	// CredentialRequestParams Optional JSON object overlaid on top of the OpenID4VCI Credential Request body sent to
 	// the issuer's credential endpoint. Any field supplied here overrides the node's default —
 	// including credential_configuration_id, credential_identifier and proofs. Use this for


### PR DESCRIPTION
Implements #4328.

## What

Adds an optional `authorization_request_params` field to the `requestCredential` API body. The node merges these key/value pairs into the OpenID4VCI **authorization request** (the redirect to the Authorization Server's `authorization_endpoint`), mirroring the existing `credential_request_params` field for the Credential Request.

```json
{
  "issuer": "https://issuer.example.com/oauth",
  "wallet_did": "did:web:example.com",
  "authorization_details": [ { "type": "openid_credential", "credential_configuration_id": "..." } ],
  "redirect_uri": "https://example.com/oauth2/org1/callback",
  "authorization_request_params": { "auth_method": "SmartCard" }
}
```
-> redirect: `.../oauth/connect/authorize?...&auth_method=SmartCard`.

## Why

The AET ZORG-ID issuer requires a non-standard `auth_method=SmartCard` query parameter on the authorization request to start smartcard login. The authorization request query was a fixed list with no caller hook (`auth/api/iam/openid4vci.go`). The standard mechanism (`authorization_details`, RFC 9396) is preferred and already sent, but AET does not accept the smartcard selection there.

## Behavior

- May only **add** parameters. Attempting to override an OpenID4VCI parameter the node sets (`response_type`, `state`, `client_id`, `client_id_scheme`, `authorization_details`, `redirect_uri`, `code_challenge`, `code_challenge_method`) fails loud with a 400 -- no silent override.
- Values are strings (`map[string]string`) -- URL query parameters.
- Omitted/absent -> no change to today's behavior. Fully additive.

## Changes

- `docs/_static/auth/v2.yaml` -- new request-body field; regenerated `auth/api/iam/generated.go` and `e2e-tests/browser/client/iam/generated.go` via `make gen-api`.
- `auth/api/iam/openid4vci.go` -- merge the params in `RequestOpenid4VCICredentialIssuance`, rejecting overrides of node parameters.
- `auth/api/iam/openid4vci_test.go` -- assert the param lands in the redirect query, and that overriding a node parameter is rejected.

## Notes

Also running on `project-gf-pilot` (where the field was first added as `authorization_params`, then renamed here to align with `credential_request_params`). The override-protection change in this PR is not yet on `project-gf-pilot`.

🤖 Assisted by AI