### PR TITLE
Bump go directive to 1.26.4 to fix stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nuts-foundation/nuts-node
 
 // This is the minimal version, the actual go version is determined by the images in the Dockerfile
 // This version is used in automated tests such as the 'Scheduled govulncheck' action
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1


### PR DESCRIPTION
## Summary

- Bump the `go` directive in `go.mod` from `1.26.3` to `1.26.4`.

The Dockerfile already builds with `golang:1.26.4-alpine`; the `go.mod` directive is what pins the **govulncheck** scan (and the toolchain it resolves) to the vulnerable `1.26.3` stdlib. Bumping it clears the scan. No code changes.

Fixes the following vulnerabilities:

| Advisory | Package | Description |
|---|---|---|
| GO-2026-5039 | `net/textproto` | User input included in error messages, allowing log/error injection (CVE-2026-42507) |
| GO-2026-5037 | `crypto/x509` | `VerifyHostname` scales quadratically over large DNS SAN lists, enabling DoS on untrusted certs (CVE-2026-27145) |

Both are fixed in Go 1.26.4.

Assisted by AI