### PR TITLE
test(storage): fix flaky Test_logLeiaQueryStats

### DIFF
--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -334,6 +334,17 @@ func Test_engine_sessionDatabase(t *testing.T) {
 }
 
 func Test_logLeiaQueryStats(t *testing.T) {
+	// logLeiaQueryStats logs to the global logrus logger, which other tests and background
+	// goroutines also write to concurrently. Match the specific entry by message rather than
+	// relying on LastEntry(), which is racy.
+	findEntry := func(hook *logTest.Hook, substr string) *logrus.Entry {
+		for _, entry := range hook.AllEntries() {
+			if strings.Contains(entry.Message, substr) {
+				return entry
+			}
+		}
+		return nil
+	}
 	t.Run("full table scan logs warning without index", func(t *testing.T) {
 		hook := &logTest.Hook{}
 		logrus.AddHook(hook)
@@ -350,9 +361,9 @@ func Test_logLeiaQueryStats(t *testing.T) {
 			FilterEfficiency:      0,
 		})
 
-		require.NotNil(t, hook.LastEntry())
-		assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
-		assert.Contains(t, hook.LastEntry().Message, "full table scan")
+		entry := findEntry(hook, "full table scan")
+		require.NotNil(t, entry)
+		assert.Equal(t, logrus.WarnLevel, entry.Level)
 	})
 	t.Run("suboptimal index usage logs warning with index name", func(t *testing.T) {
 		hook := &logTest.Hook{}
@@ -370,9 +381,9 @@ func Test_logLeiaQueryStats(t *testing.T) {
 			FilterEfficiency:      0.05,
 		})
 
-		require.NotNil(t, hook.LastEntry())
-		assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
-		assert.Contains(t, hook.LastEntry().Message, "suboptimal index")
-		assert.Equal(t, "field1_index", hook.LastEntry().Data["leia_index_used"])
+		entry := findEntry(hook, "suboptimal index")
+		require.NotNil(t, entry)
+		assert.Equal(t, logrus.WarnLevel, entry.Level)
+		assert.Equal(t, "field1_index", entry.Data["leia_index_used"])
 	})
 }


### PR DESCRIPTION
## Summary

`Test_logLeiaQueryStats` intermittently fails (seen on #4331's CI run).

## Root cause

`logLeiaQueryStats` logs via `log.Logger()`, which wraps the **global** `logrus.StandardLogger()`. The test hooks that global logger and asserts on `hook.LastEntry()`. Other tests and background goroutines (e.g. BBolt store backups) write to the same global logger concurrently, so `LastEntry()` can return an unrelated entry — failing the level/message/field assertions.

## Fix

Match the specific entry by message substring via `hook.AllEntries()` instead of relying on `LastEntry()`. No production code change.

Verified stable with `go test ./storage/ -run Test_logLeiaQueryStats -count=20`.

Assisted by AI