### PR TITLE
feat(auth): configurable OpenID4VCI request profiles with built-in AET profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ nuts.yaml
 # Local scratch directory and Claude Code session state
 .scratch/
 .claude/scheduled_tasks.lock
+.claude/worktrees/

--- a/auth/api/auth/v1/api_test.go
+++ b/auth/api/auth/v1/api_test.go
@@ -91,6 +91,10 @@ func (m *mockAuthClient) OpenID4VCIClient() openid4vci.Client {
 	return nil
 }
 
+func (m *mockAuthClient) AuthorizationRequestProfile(_ string) (map[string][]string, bool) {
+	return nil, false
+}
+
 func (m *mockAuthClient) ContractNotary() services.ContractNotary {
 	return m.contractNotary
 }

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -1649,6 +1649,8 @@ type testCtx struct {
 	subjectManager   *didsubject.MockManager
 	jar              *MockJAR
 	openid4vciClient *openid4vci.MockClient
+	// authorizationRequestProfiles maps profile name to its authrequest params, returned by the auth mock's AuthorizationRequestProfile.
+	authorizationRequestProfiles map[string]map[string][]string
 }
 
 func newTestClient(t testing.TB) *testCtx {
@@ -1704,7 +1706,7 @@ func newCustomTestClient(t testing.TB, publicURL *url.URL, authEndpointEnabled b
 		jwtSigner:      jwtSigner,
 		jar:            mockJAR,
 	}
-	return &testCtx{
+	result := &testCtx{
 		ctrl:             ctrl,
 		authnServices:    authnServices,
 		policy:           policyInstance,
@@ -1724,4 +1726,10 @@ func newCustomTestClient(t testing.TB, publicURL *url.URL, authEndpointEnabled b
 		client:           client,
 		openid4vciClient: openid4vciClient,
 	}
+	// By default no request profiles exist. A test can set result.authorizationRequestProfiles to exercise the profile path.
+	authnServices.EXPECT().AuthorizationRequestProfile(gomock.Any()).DoAndReturn(func(name string) (map[string][]string, bool) {
+		profile, ok := result.authorizationRequestProfiles[name]
+		return profile, ok
+	}).AnyTimes()
+	return result
 }

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -261,13 +261,6 @@ type RequestOpenid4VCICredentialIssuanceJSONBody struct {
 	// issuance per call and only consumes the first entry.
 	AuthorizationDetails []AuthorizationDetail `json:"authorization_details"`
 
-	// AuthorizationRequestParams Optional key/value pairs added to the OpenID4VCI authorization request (the redirect to the
-	// Authorization Server's authorization_endpoint). These may only add parameters; they must not
-	// override the OpenID4VCI parameters set by the node (the request is rejected if they do).
-	// Prefer authorization_details (RFC 9396) where the issuer supports it; use this only for issuers
-	// that require non-standard authorization parameters (e.g. auth_method for AET smartcards).
-	AuthorizationRequestParams *map[string]string `json:"authorization_request_params,omitempty"`
-
 	// CredentialRequestParams Optional JSON object overlaid on top of the OpenID4VCI Credential Request body sent to
 	// the issuer's credential endpoint. Any field supplied here overrides the node's default —
 	// including credential_configuration_id, credential_identifier and proofs. Use this for

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -279,6 +279,13 @@ type RequestOpenid4VCICredentialIssuanceJSONBody struct {
 	// used to locate the OAuth2 Authorization Server metadata.
 	Issuer string `json:"issuer"`
 
+	// Profile Optional name of a request profile to apply to this flow. A profile is a curated, named bundle of
+	// request parameters, so callers don't have to spell out issuer-specific parameters themselves.
+	// Currently a profile sets authorization request parameters (see auth.experimental.profile.<name>.authrequest).
+	// Built-in: 'aet' for the AET UZI smartcard credential issuer. An unknown profile is rejected.
+	// EXPERIMENTAL: subject to change without notice.
+	Profile *string `json:"profile,omitempty"`
+
 	// RedirectUri The URL to which the user-agent will be redirected after the authorization request.
 	RedirectUri string `json:"redirect_uri"`
 

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -276,7 +276,6 @@ type RequestOpenid4VCICredentialIssuanceJSONBody struct {
 	// request parameters, so callers don't have to spell out issuer-specific parameters themselves.
 	// Currently a profile sets authorization request parameters (see auth.experimental.profile.<name>.authrequest).
 	// Built-in: 'aet' for the AET UZI smartcard credential issuer. An unknown profile is rejected.
-	// EXPERIMENTAL: subject to change without notice.
 	Profile *string `json:"profile,omitempty"`
 
 	// RedirectUri The URL to which the user-agent will be redirected after the authorization request.

--- a/auth/api/iam/openid4vci.go
+++ b/auth/api/iam/openid4vci.go
@@ -141,8 +141,8 @@ func (r Wrapper) RequestOpenid4VCICredentialIssuance(ctx context.Context, reques
 	for key, value := range authzParams {
 		authzQuery.Set(key, value)
 	}
-	// EXPERIMENTAL: apply the selected request profile (built-in default merged with operator config). Profiles are
-	// trusted config and may override node parameters; their authorization request parameters may be multi-valued.
+	// Apply the selected request profile (built-in default merged with operator config). A profile is trusted
+	// config and may override the parameters set above; its authorization request parameters may be multi-valued.
 	if request.Body.Profile != nil && *request.Body.Profile != "" {
 		profileParams, ok := r.auth.AuthorizationRequestProfile(*request.Body.Profile)
 		if !ok {

--- a/auth/api/iam/openid4vci.go
+++ b/auth/api/iam/openid4vci.go
@@ -34,7 +34,6 @@ import (
 	"github.com/nuts-foundation/nuts-node/auth/openid4vci"
 	"github.com/nuts-foundation/nuts-node/core"
 	"github.com/nuts-foundation/nuts-node/crypto"
-	nutsHttp "github.com/nuts-foundation/nuts-node/http"
 	"github.com/nuts-foundation/nuts-node/vdr/resolver"
 )
 
@@ -138,21 +137,40 @@ func (r Wrapper) RequestOpenid4VCICredentialIssuance(ctx context.Context, reques
 		oauth.CodeChallengeParam:        pkceParams.Challenge,
 		oauth.CodeChallengeMethodParam:  pkceParams.ChallengeMethod,
 	}
+	// Record the node-controlled parameters and seed the query. The raw authorization_request_params below may
+	// not override these; a request profile may (it is trusted built-in/operator config).
+	nodeParamKeys := make(map[string]struct{}, len(authzParams))
+	authzQuery := authorizationEndpoint.Query()
+	for key, value := range authzParams {
+		nodeParamKeys[key] = struct{}{}
+		authzQuery.Set(key, value)
+	}
+	// EXPERIMENTAL: apply the selected request profile (built-in default merged with operator config). Profiles are
+	// trusted config and may override node parameters; their authorization request parameters may be multi-valued.
+	if request.Body.Profile != nil && *request.Body.Profile != "" {
+		profileParams, ok := r.auth.AuthorizationRequestProfile(*request.Body.Profile)
+		if !ok {
+			return nil, core.InvalidInputError("unknown profile: %s", *request.Body.Profile)
+		}
+		for key, values := range profileParams {
+			authzQuery[key] = append([]string(nil), values...)
+		}
+	}
 	// Optional caller-supplied authorization request parameters, for issuers that need extras
 	// (e.g. auth_method=SmartCard). These may only add parameters; they must not override the
 	// OpenID4VCI parameters set by the node above, which are essential to the flow.
 	if request.Body.AuthorizationRequestParams != nil {
 		for key, value := range *request.Body.AuthorizationRequestParams {
-			if _, isNodeParam := authzParams[key]; isNodeParam {
+			if _, isNodeParam := nodeParamKeys[key]; isNodeParam {
 				return nil, core.InvalidInputError("authorization_request_params may not override the '%s' parameter set by the node", key)
 			}
-			authzParams[key] = value
+			authzQuery.Set(key, value)
 		}
 	}
-	redirectUrl := nutsHttp.AddQueryParams(*authorizationEndpoint, authzParams)
+	authorizationEndpoint.RawQuery = authzQuery.Encode()
 
 	return RequestOpenid4VCICredentialIssuance200JSONResponse{
-		RedirectURI: redirectUrl.String(),
+		RedirectURI: authorizationEndpoint.String(),
 	}, nil
 }
 

--- a/auth/api/iam/openid4vci.go
+++ b/auth/api/iam/openid4vci.go
@@ -137,12 +137,8 @@ func (r Wrapper) RequestOpenid4VCICredentialIssuance(ctx context.Context, reques
 		oauth.CodeChallengeParam:        pkceParams.Challenge,
 		oauth.CodeChallengeMethodParam:  pkceParams.ChallengeMethod,
 	}
-	// Record the node-controlled parameters and seed the query. The raw authorization_request_params below may
-	// not override these; a request profile may (it is trusted built-in/operator config).
-	nodeParamKeys := make(map[string]struct{}, len(authzParams))
 	authzQuery := authorizationEndpoint.Query()
 	for key, value := range authzParams {
-		nodeParamKeys[key] = struct{}{}
 		authzQuery.Set(key, value)
 	}
 	// EXPERIMENTAL: apply the selected request profile (built-in default merged with operator config). Profiles are
@@ -154,17 +150,6 @@ func (r Wrapper) RequestOpenid4VCICredentialIssuance(ctx context.Context, reques
 		}
 		for key, values := range profileParams {
 			authzQuery[key] = append([]string(nil), values...)
-		}
-	}
-	// Optional caller-supplied authorization request parameters, for issuers that need extras
-	// (e.g. auth_method=SmartCard). These may only add parameters; they must not override the
-	// OpenID4VCI parameters set by the node above, which are essential to the flow.
-	if request.Body.AuthorizationRequestParams != nil {
-		for key, value := range *request.Body.AuthorizationRequestParams {
-			if _, isNodeParam := nodeParamKeys[key]; isNodeParam {
-				return nil, core.InvalidInputError("authorization_request_params may not override the '%s' parameter set by the node", key)
-			}
-			authzQuery.Set(key, value)
 		}
 	}
 	authorizationEndpoint.RawQuery = authzQuery.Encode()

--- a/auth/api/iam/openid4vci_test.go
+++ b/auth/api/iam/openid4vci_test.go
@@ -103,6 +103,36 @@ func TestWrapper_RequestOpenid4VCICredentialIssuance(t *testing.T) {
 
 		assert.ErrorContains(t, err, "authorization_request_params may not override the 'client_id' parameter")
 	})
+	t.Run("ok - profile applies its authorization request parameters", func(t *testing.T) {
+		ctx := newTestClient(t)
+		ctx.authorizationRequestProfiles = map[string]map[string][]string{
+			"aet": {"auth_method": {"SmartCard"}, "scope": {"openid profile api"}},
+		}
+		ctx.openid4vciClient.EXPECT().OpenIDCredentialIssuerMetadata(nil, issuerClientID).Return(&metadata, nil)
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(nil, authServer).Return(&authzMetadata, nil)
+		req := requestCredentials(holderSubjectID, issuerClientID, redirectURI)
+		req.Body.Profile = to.Ptr("aet")
+
+		response, err := ctx.client.RequestOpenid4VCICredentialIssuance(nil, req)
+
+		require.NoError(t, err)
+		redirectUri, err := url.Parse(response.(RequestOpenid4VCICredentialIssuance200JSONResponse).RedirectURI)
+		require.NoError(t, err)
+		assert.Equal(t, "SmartCard", redirectUri.Query().Get("auth_method"))
+		assert.Equal(t, "openid profile api", redirectUri.Query().Get("scope"))
+		assert.Equal(t, "code", redirectUri.Query().Get("response_type")) // node parameters remain intact
+	})
+	t.Run("error - unknown profile", func(t *testing.T) {
+		ctx := newTestClient(t)
+		ctx.openid4vciClient.EXPECT().OpenIDCredentialIssuerMetadata(nil, issuerClientID).Return(&metadata, nil)
+		ctx.iamClient.EXPECT().AuthorizationServerMetadata(nil, authServer).Return(&authzMetadata, nil)
+		req := requestCredentials(holderSubjectID, issuerClientID, redirectURI)
+		req.Body.Profile = to.Ptr("does-not-exist")
+
+		_, err := ctx.client.RequestOpenid4VCICredentialIssuance(nil, req)
+
+		assert.ErrorContains(t, err, "unknown profile: does-not-exist")
+	})
 	t.Run("ok - credential_request_params persisted into session", func(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.openid4vciClient.EXPECT().OpenIDCredentialIssuerMetadata(nil, issuerClientID).Return(&metadata, nil)

--- a/auth/api/iam/openid4vci_test.go
+++ b/auth/api/iam/openid4vci_test.go
@@ -78,31 +78,6 @@ func TestWrapper_RequestOpenid4VCICredentialIssuance(t *testing.T) {
 		assert.Equal(t, "code", redirectUri.Query().Get("response_type"))
 		assert.Equal(t, `[{"credential_configuration_id":"UniversityDegreeCredential","format":"vc+sd-jwt","type":"openid_credential"}]`, redirectUri.Query().Get("authorization_details"))
 	})
-	t.Run("ok - authorization_request_params merged into authorization request", func(t *testing.T) {
-		ctx := newTestClient(t)
-		ctx.openid4vciClient.EXPECT().OpenIDCredentialIssuerMetadata(nil, issuerClientID).Return(&metadata, nil)
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(nil, authServer).Return(&authzMetadata, nil)
-		req := requestCredentials(holderSubjectID, issuerClientID, redirectURI)
-		req.Body.AuthorizationRequestParams = &map[string]string{"auth_method": "SmartCard"}
-
-		response, err := ctx.client.RequestOpenid4VCICredentialIssuance(nil, req)
-
-		require.NoError(t, err)
-		redirectUri, err := url.Parse(response.(RequestOpenid4VCICredentialIssuance200JSONResponse).RedirectURI)
-		require.NoError(t, err)
-		assert.Equal(t, "SmartCard", redirectUri.Query().Get("auth_method"))
-	})
-	t.Run("error - authorization_request_params may not override a node parameter", func(t *testing.T) {
-		ctx := newTestClient(t)
-		ctx.openid4vciClient.EXPECT().OpenIDCredentialIssuerMetadata(nil, issuerClientID).Return(&metadata, nil)
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(nil, authServer).Return(&authzMetadata, nil)
-		req := requestCredentials(holderSubjectID, issuerClientID, redirectURI)
-		req.Body.AuthorizationRequestParams = &map[string]string{oauth.ClientIDParam: "attacker"}
-
-		_, err := ctx.client.RequestOpenid4VCICredentialIssuance(nil, req)
-
-		assert.ErrorContains(t, err, "authorization_request_params may not override the 'client_id' parameter")
-	})
 	t.Run("ok - profile applies its authorization request parameters", func(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.authorizationRequestProfiles = map[string]map[string][]string{

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -150,6 +150,16 @@ func (auth *Auth) OpenID4VCIClient() openid4vci.Client {
 	return auth.openID4VCIClient
 }
 
+// AuthorizationRequestProfile returns the authorization request parameters of the named profile, or false when no
+// profile (built-in default or operator-configured) exists for the name. EXPERIMENTAL.
+func (auth *Auth) AuthorizationRequestProfile(name string) (map[string][]string, bool) {
+	profile, ok := auth.config.Experimental.Profiles[name]
+	if !ok {
+		return nil, false
+	}
+	return profile.AuthorizationRequest, true
+}
+
 // Configure the Auth struct by creating a validator and create an Irma server
 func (auth *Auth) Configure(config core.ServerConfig) error {
 	if auth.config.Irma.SchemeManager == "" {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -151,7 +151,7 @@ func (auth *Auth) OpenID4VCIClient() openid4vci.Client {
 }
 
 // AuthorizationRequestProfile returns the authorization request parameters of the named profile, or false when no
-// profile (built-in default or operator-configured) exists for the name. EXPERIMENTAL.
+// profile (built-in default or operator-configured) exists for the name.
 func (auth *Auth) AuthorizationRequestProfile(name string) (map[string][]string, bool) {
 	profile, ok := auth.config.Experimental.Profiles[name]
 	if !ok {

--- a/auth/config.go
+++ b/auth/config.go
@@ -41,6 +41,21 @@ type ExperimentalConfig struct {
 	// JwtBearerClient enables the RFC 7523 jwt-bearer two-VP token request flow.
 	// While disabled (the default), requests carrying a service-provider subject identifier are rejected.
 	JwtBearerClient bool `koanf:"jwtbearerclient"`
+	// Profiles are named bundles of request parameters for outbound flows against external issuers/authorization
+	// servers. A request selects a profile by name. Built-in profiles (e.g. "aet") are provided via DefaultConfig;
+	// operator config under the same name is layered over the default.
+	//
+	// EXPERIMENTAL: this configuration may change or be removed without further notice.
+	Profiles map[string]ProfileConfig `koanf:"profile"`
+}
+
+// ProfileConfig is a named bundle of request parameters for outbound OpenID4VCI flows.
+//
+// EXPERIMENTAL: this configuration may change or be removed without further notice.
+type ProfileConfig struct {
+	// AuthorizationRequest sets parameters on the OpenID4VCI authorization request. Each key may have multiple
+	// values (rendered as repeated query parameters; a single value is rendered as one parameter).
+	AuthorizationRequest map[string][]string `koanf:"authrequest"`
 }
 
 type AuthorizationEndpointConfig struct {
@@ -78,5 +93,17 @@ func DefaultConfig() Config {
 			selfsigned.ContractFormat,
 		},
 		AccessTokenLifeSpan: 60, // seconds, as specced in RFC003
+		Experimental: ExperimentalConfig{
+			// Built-in profiles. Operator config under auth.experimental.profile.<name> is layered over these.
+			Profiles: map[string]ProfileConfig{
+				// aet targets the AET ZORG-ID issuer, which requires smartcard auth and a specific scope on the authorization request.
+				"aet": {
+					AuthorizationRequest: map[string][]string{
+						"auth_method": {"SmartCard"},
+						"scope":       {"openid profile api"},
+					},
+				},
+			},
+		},
 	}
 }

--- a/auth/config.go
+++ b/auth/config.go
@@ -44,14 +44,10 @@ type ExperimentalConfig struct {
 	// Profiles are named bundles of request parameters for outbound flows against external issuers/authorization
 	// servers. A request selects a profile by name. Built-in profiles (e.g. "aet") are provided via DefaultConfig;
 	// operator config under the same name is layered over the default.
-	//
-	// EXPERIMENTAL: this configuration may change or be removed without further notice.
 	Profiles map[string]ProfileConfig `koanf:"profile"`
 }
 
 // ProfileConfig is a named bundle of request parameters for outbound OpenID4VCI flows.
-//
-// EXPERIMENTAL: this configuration may change or be removed without further notice.
 type ProfileConfig struct {
 	// AuthorizationRequest sets parameters on the OpenID4VCI authorization request. Each key may have multiple
 	// values (rendered as repeated query parameters; a single value is rendered as one parameter).

--- a/auth/interface.go
+++ b/auth/interface.go
@@ -38,7 +38,7 @@ type AuthenticationServices interface {
 	// OpenID4VCIClient returns the OpenID4VCI 1.0 HTTP client.
 	OpenID4VCIClient() openid4vci.Client
 	// AuthorizationRequestProfile returns the authorization request parameters of the named profile (built-in
-	// merged with operator config), or false if the name is unknown. EXPERIMENTAL.
+	// merged with operator config), or false if the name is unknown.
 	AuthorizationRequestProfile(name string) (map[string][]string, bool)
 	// RelyingParty returns the oauth.RelyingParty
 	RelyingParty() oauth.RelyingParty

--- a/auth/interface.go
+++ b/auth/interface.go
@@ -37,6 +37,9 @@ type AuthenticationServices interface {
 	IAMClient() iam.Client
 	// OpenID4VCIClient returns the OpenID4VCI 1.0 HTTP client.
 	OpenID4VCIClient() openid4vci.Client
+	// AuthorizationRequestProfile returns the authorization request parameters of the named profile (built-in
+	// merged with operator config), or false if the name is unknown. EXPERIMENTAL.
+	AuthorizationRequestProfile(name string) (map[string][]string, bool)
 	// RelyingParty returns the oauth.RelyingParty
 	RelyingParty() oauth.RelyingParty
 	// ContractNotary returns an instance of ContractNotary

--- a/auth/mock.go
+++ b/auth/mock.go
@@ -58,6 +58,21 @@ func (mr *MockAuthenticationServicesMockRecorder) AuthorizationEndpointEnabled()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizationEndpointEnabled", reflect.TypeOf((*MockAuthenticationServices)(nil).AuthorizationEndpointEnabled))
 }
 
+// AuthorizationRequestProfile mocks base method.
+func (m *MockAuthenticationServices) AuthorizationRequestProfile(name string) (map[string][]string, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthorizationRequestProfile", name)
+	ret0, _ := ret[0].(map[string][]string)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// AuthorizationRequestProfile indicates an expected call of AuthorizationRequestProfile.
+func (mr *MockAuthenticationServicesMockRecorder) AuthorizationRequestProfile(name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizationRequestProfile", reflect.TypeOf((*MockAuthenticationServices)(nil).AuthorizationRequestProfile), name)
+}
+
 // AuthzServer mocks base method.
 func (m *MockAuthenticationServices) AuthzServer() oauth.AuthorizationServer {
 	m.ctrl.T.Helper()

--- a/auth/profiles_test.go
+++ b/auth/profiles_test.go
@@ -1,0 +1,55 @@
+/*
+ * Nuts node
+ * Copyright (C) 2026 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuth_AuthorizationRequestProfile(t *testing.T) {
+	t.Run("built-in aet (from DefaultConfig)", func(t *testing.T) {
+		a := &Auth{config: DefaultConfig()}
+		params, ok := a.AuthorizationRequestProfile("aet")
+		require.True(t, ok)
+		assert.Equal(t, []string{"SmartCard"}, params["auth_method"])
+		assert.Equal(t, []string{"openid profile api"}, params["scope"])
+	})
+	t.Run("unknown profile returns false", func(t *testing.T) {
+		a := &Auth{config: DefaultConfig()}
+		params, ok := a.AuthorizationRequestProfile("does-not-exist")
+		assert.False(t, ok)
+		assert.Nil(t, params)
+	})
+	t.Run("operator-configured profile", func(t *testing.T) {
+		a := &Auth{config: Config{Experimental: ExperimentalConfig{Profiles: map[string]ProfileConfig{
+			"custom": {AuthorizationRequest: map[string][]string{"foo": {"bar", "baz"}}},
+		}}}}
+		params, ok := a.AuthorizationRequestProfile("custom")
+		require.True(t, ok)
+		assert.Equal(t, []string{"bar", "baz"}, params["foo"])
+	})
+	t.Run("no profiles configured returns false", func(t *testing.T) {
+		params, ok := (&Auth{}).AuthorizationRequestProfile("aet")
+		assert.False(t, ok)
+		assert.Nil(t, params)
+	})
+}

--- a/docs/_static/auth/v2.yaml
+++ b/docs/_static/auth/v2.yaml
@@ -201,6 +201,15 @@ paths:
                     {
                       "auth_method": "SmartCard"
                     }
+                profile:
+                  type: string
+                  description: |
+                    Optional name of a request profile to apply to this flow. A profile is a curated, named bundle of
+                    request parameters, so callers don't have to spell out issuer-specific parameters themselves.
+                    Currently a profile sets authorization request parameters (see auth.experimental.profile.<name>.authrequest).
+                    Built-in: 'aet' for the AET UZI smartcard credential issuer. An unknown profile is rejected.
+                    EXPERIMENTAL: subject to change without notice.
+                  example: aet
                 redirect_uri:
                   type: string
                   description: |

--- a/docs/_static/auth/v2.yaml
+++ b/docs/_static/auth/v2.yaml
@@ -194,7 +194,6 @@ paths:
                     request parameters, so callers don't have to spell out issuer-specific parameters themselves.
                     Currently a profile sets authorization request parameters (see auth.experimental.profile.<name>.authrequest).
                     Built-in: 'aet' for the AET UZI smartcard credential issuer. An unknown profile is rejected.
-                    EXPERIMENTAL: subject to change without notice.
                   example: aet
                 redirect_uri:
                   type: string

--- a/docs/_static/auth/v2.yaml
+++ b/docs/_static/auth/v2.yaml
@@ -187,20 +187,6 @@ paths:
                     {
                       "some-requested-credential-attribute": "900184590"
                     }
-                authorization_request_params:
-                  type: object
-                  additionalProperties:
-                    type: string
-                  description: |
-                    Optional key/value pairs added to the OpenID4VCI authorization request (the redirect to the
-                    Authorization Server's authorization_endpoint). These may only add parameters; they must not
-                    override the OpenID4VCI parameters set by the node (the request is rejected if they do).
-                    Prefer authorization_details (RFC 9396) where the issuer supports it; use this only for issuers
-                    that require non-standard authorization parameters (e.g. auth_method for AET smartcards).
-                  example: |
-                    {
-                      "auth_method": "SmartCard"
-                    }
                 profile:
                   type: string
                   description: |

--- a/e2e-tests/browser/client/iam/generated.go
+++ b/e2e-tests/browser/client/iam/generated.go
@@ -273,6 +273,13 @@ type RequestOpenid4VCICredentialIssuanceJSONBody struct {
 	// used to locate the OAuth2 Authorization Server metadata.
 	Issuer string `json:"issuer"`
 
+	// Profile Optional name of a request profile to apply to this flow. A profile is a curated, named bundle of
+	// request parameters, so callers don't have to spell out issuer-specific parameters themselves.
+	// Currently a profile sets authorization request parameters (see auth.experimental.profile.<name>.authrequest).
+	// Built-in: 'aet' for the AET UZI smartcard credential issuer. An unknown profile is rejected.
+	// EXPERIMENTAL: subject to change without notice.
+	Profile *string `json:"profile,omitempty"`
+
 	// RedirectUri The URL to which the user-agent will be redirected after the authorization request.
 	RedirectUri string `json:"redirect_uri"`
 

--- a/e2e-tests/browser/client/iam/generated.go
+++ b/e2e-tests/browser/client/iam/generated.go
@@ -270,7 +270,6 @@ type RequestOpenid4VCICredentialIssuanceJSONBody struct {
 	// request parameters, so callers don't have to spell out issuer-specific parameters themselves.
 	// Currently a profile sets authorization request parameters (see auth.experimental.profile.<name>.authrequest).
 	// Built-in: 'aet' for the AET UZI smartcard credential issuer. An unknown profile is rejected.
-	// EXPERIMENTAL: subject to change without notice.
 	Profile *string `json:"profile,omitempty"`
 
 	// RedirectUri The URL to which the user-agent will be redirected after the authorization request.

--- a/e2e-tests/browser/client/iam/generated.go
+++ b/e2e-tests/browser/client/iam/generated.go
@@ -255,13 +255,6 @@ type RequestOpenid4VCICredentialIssuanceJSONBody struct {
 	// issuance per call and only consumes the first entry.
 	AuthorizationDetails []AuthorizationDetail `json:"authorization_details"`
 
-	// AuthorizationRequestParams Optional key/value pairs added to the OpenID4VCI authorization request (the redirect to the
-	// Authorization Server's authorization_endpoint). These may only add parameters; they must not
-	// override the OpenID4VCI parameters set by the node (the request is rejected if they do).
-	// Prefer authorization_details (RFC 9396) where the issuer supports it; use this only for issuers
-	// that require non-standard authorization parameters (e.g. auth_method for AET smartcards).
-	AuthorizationRequestParams *map[string]string `json:"authorization_request_params,omitempty"`
-
 	// CredentialRequestParams Optional JSON object overlaid on top of the OpenID4VCI Credential Request body sent to
 	// the issuer's credential endpoint. Any field supplied here overrides the node's default —
 	// including credential_configuration_id, credential_identifier and proofs. Use this for


### PR DESCRIPTION
Implements #4338.

## What

Adds named request profiles. A profile is a curated bundle of request parameters selected by name, so callers (EHRs) don't have to spell out issuer-specific parameters themselves.

- New optional `profile` field on the `requestCredential` body.
- Config: `auth.experimental.profile.<name>.authrequest` (`map[string][]string`) sets authorization request parameters.
- Built-in `aet` profile (AET UZI smartcard issuer) is provided via `DefaultConfig()`: `auth_method=SmartCard`, `scope="openid profile api"`. Operator config under the same name is layered over the default by normal config loading.
- Removes the `authorization_request_params` field added in #4333: profiles replace it as the way issuers get extra authorization parameters, so the raw escape hatch is no longer needed. Supersedes #4349, which reverted #4333 separately.

```yaml
auth:
  experimental:
    profile:
      aet:
        authrequest:
          auth_method: [SmartCard]
          scope: ["openid profile api"]
```

```json
{
  "issuer": "https://issuer.example.com/oauth",
  "wallet_did": "did:web:example.com",
  "authorization_details": [ { "type": "openid_credential", "credential_configuration_id": "..." } ],
  "redirect_uri": "https://example.com/oauth2/org1/callback",
  "profile": "aet"
}
```
-> redirect: `.../authorize?...&auth_method=SmartCard&scope=openid+profile+api`.

## Behavior

- Apply order on the authorization request: parameters the node always sets (state, client_id, etc.) first, then the profile's `authrequest` (trusted config, may override them, multi-valued).
- Unknown profile name -> 400.
- `authrequest` is `map[string][]string` -> a single value renders as one query parameter; multiple values render as repeated parameters.
- Omitted `profile` -> unchanged behavior. Fully additive.

## Changes

- `auth/config.go`: `ExperimentalConfig.Profiles` + `ProfileConfig`; built-in `aet` in `DefaultConfig`.
- `auth/auth.go` + `auth/interface.go` (+ regenerated mocks): `AuthorizationRequestProfile` lookup.
- `docs/_static/auth/v2.yaml` + `make gen-api`: `profile` request field; removes `authorization_request_params`.
- `auth/api/iam/openid4vci.go`: resolve + apply the profile (multi-value query) in `RequestOpenid4VCICredentialIssuance`; drops the `authorization_request_params` handling.
- Tests: accessor (`auth`), handler (`auth/api/iam`: profile applied, unknown profile rejected; authorization_request_params tests removed).

## Notes

- Also running on `project-gf-pilot` (where it sits on top of the client-auth work).
- Commit history on the branch is messy ("wip"); will be squashed at merge.

Assisted by AI

