### PR TITLE
refactor(auth): remove non-conformant Display from issuer metadata

### DIFF
--- a/auth/api/iam/openid4vci_test.go
+++ b/auth/api/iam/openid4vci_test.go
@@ -44,7 +44,6 @@ func TestWrapper_RequestOpenid4VCICredentialIssuance(t *testing.T) {
 		CredentialIssuer:     "issuer",
 		CredentialEndpoint:   "endpoint",
 		AuthorizationServers: []string{authServer},
-		Display:              nil,
 	}
 	authzMetadata := oauth.AuthorizationServerMetadata{
 		AuthorizationEndpoint:    "https://auth.server/authorize",
@@ -126,7 +125,6 @@ func TestWrapper_RequestOpenid4VCICredentialIssuance(t *testing.T) {
 				CredentialIssuer:     "issuer",
 				CredentialEndpoint:   "endpoint",
 				AuthorizationServers: []string{}, // empty
-				Display:              nil,
 			}
 			ctx.openid4vciClient.EXPECT().OpenIDCredentialIssuerMetadata(nil, issuerClientID).Return(&metadata, nil)
 			ctx.iamClient.EXPECT().AuthorizationServerMetadata(nil, issuerClientID).Return(nil, assert.AnError)

--- a/auth/openid4vci/types.go
+++ b/auth/openid4vci/types.go
@@ -43,11 +43,10 @@ const JWTTypeOpenID4VCIProof = "openid4vci-proof+jwt"
 // (Section 12.2). The document is OpenID4VCI-defined; it is not an OAuth
 // authorization-server metadata document.
 type OpenIDCredentialIssuerMetadata struct {
-	CredentialIssuer     string              `json:"credential_issuer"`
-	CredentialEndpoint   string              `json:"credential_endpoint"`
-	NonceEndpoint        string              `json:"nonce_endpoint,omitempty"`
-	AuthorizationServers []string            `json:"authorization_servers,omitempty"`
-	Display              []map[string]string `json:"display,omitempty"`
+	CredentialIssuer     string   `json:"credential_issuer"`
+	CredentialEndpoint   string   `json:"credential_endpoint"`
+	NonceEndpoint        string   `json:"nonce_endpoint,omitempty"`
+	AuthorizationServers []string `json:"authorization_servers,omitempty"`
 }
 
 // NonceResponse is the body returned by the Nonce Endpoint (Section 7.2).


### PR DESCRIPTION
## Summary

Remove the `display` field from `OpenIDCredentialIssuerMetadata`.

## Rationale

- The `display` field (typed `[]map[string]string`) was **not conform** the OpenID4VCI spec ([section 12.2.4](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-12.2.4)).
- Its values were never consumed.
- It caused issues with the AET integration (since AET SDK _does_ populate `display`)

Since nothing reads these values, removal is safe.

## Changes

- Drop the `Display` field from `auth/openid4vci/types.go`.
- Remove the two `Display: nil` references in `auth/api/iam/openid4vci_test.go`.

🤖 Assisted by AI