### PR TITLE
Revert "feat(auth): add authorization_request_params to OpenID4VCI requestCredential API (#4333)"

### DIFF
--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -261,13 +261,6 @@ type RequestOpenid4VCICredentialIssuanceJSONBody struct {
 	// issuance per call and only consumes the first entry.
 	AuthorizationDetails []AuthorizationDetail `json:"authorization_details"`
 
-	// AuthorizationRequestParams Optional key/value pairs added to the OpenID4VCI authorization request (the redirect to the
-	// Authorization Server's authorization_endpoint). These may only add parameters; they must not
-	// override the OpenID4VCI parameters set by the node (the request is rejected if they do).
-	// Prefer authorization_details (RFC 9396) where the issuer supports it; use this only for issuers
-	// that require non-standard authorization parameters (e.g. auth_method for AET smartcards).
-	AuthorizationRequestParams *map[string]string `json:"authorization_request_params,omitempty"`
-
 	// CredentialRequestParams Optional JSON object overlaid on top of the OpenID4VCI Credential Request body sent to
 	// the issuer's credential endpoint. Any field supplied here overrides the node's default —
 	// including credential_configuration_id, credential_identifier and proofs. Use this for

--- a/auth/api/iam/openid4vci.go
+++ b/auth/api/iam/openid4vci.go
@@ -128,7 +128,7 @@ func (r Wrapper) RequestOpenid4VCICredentialIssuance(ctx context.Context, reques
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse the authorization_endpoint: %w", err)
 	}
-	authzParams := map[string]string{
+	redirectUrl := nutsHttp.AddQueryParams(*authorizationEndpoint, map[string]string{
 		oauth.ResponseTypeParam:         oauth.CodeResponseType,
 		oauth.StateParam:                state,
 		oauth.ClientIDParam:             clientID.String(),
@@ -137,19 +137,7 @@ func (r Wrapper) RequestOpenid4VCICredentialIssuance(ctx context.Context, reques
 		oauth.RedirectURIParam:          redirectUri.String(),
 		oauth.CodeChallengeParam:        pkceParams.Challenge,
 		oauth.CodeChallengeMethodParam:  pkceParams.ChallengeMethod,
-	}
-	// Optional caller-supplied authorization request parameters, for issuers that need extras
-	// (e.g. auth_method=SmartCard). These may only add parameters; they must not override the
-	// OpenID4VCI parameters set by the node above, which are essential to the flow.
-	if request.Body.AuthorizationRequestParams != nil {
-		for key, value := range *request.Body.AuthorizationRequestParams {
-			if _, isNodeParam := authzParams[key]; isNodeParam {
-				return nil, core.InvalidInputError("authorization_request_params may not override the '%s' parameter set by the node", key)
-			}
-			authzParams[key] = value
-		}
-	}
-	redirectUrl := nutsHttp.AddQueryParams(*authorizationEndpoint, authzParams)
+	})
 
 	return RequestOpenid4VCICredentialIssuance200JSONResponse{
 		RedirectURI: redirectUrl.String(),

--- a/auth/api/iam/openid4vci_test.go
+++ b/auth/api/iam/openid4vci_test.go
@@ -78,31 +78,6 @@ func TestWrapper_RequestOpenid4VCICredentialIssuance(t *testing.T) {
 		assert.Equal(t, "code", redirectUri.Query().Get("response_type"))
 		assert.Equal(t, `[{"credential_configuration_id":"UniversityDegreeCredential","format":"vc+sd-jwt","type":"openid_credential"}]`, redirectUri.Query().Get("authorization_details"))
 	})
-	t.Run("ok - authorization_request_params merged into authorization request", func(t *testing.T) {
-		ctx := newTestClient(t)
-		ctx.openid4vciClient.EXPECT().OpenIDCredentialIssuerMetadata(nil, issuerClientID).Return(&metadata, nil)
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(nil, authServer).Return(&authzMetadata, nil)
-		req := requestCredentials(holderSubjectID, issuerClientID, redirectURI)
-		req.Body.AuthorizationRequestParams = &map[string]string{"auth_method": "SmartCard"}
-
-		response, err := ctx.client.RequestOpenid4VCICredentialIssuance(nil, req)
-
-		require.NoError(t, err)
-		redirectUri, err := url.Parse(response.(RequestOpenid4VCICredentialIssuance200JSONResponse).RedirectURI)
-		require.NoError(t, err)
-		assert.Equal(t, "SmartCard", redirectUri.Query().Get("auth_method"))
-	})
-	t.Run("error - authorization_request_params may not override a node parameter", func(t *testing.T) {
-		ctx := newTestClient(t)
-		ctx.openid4vciClient.EXPECT().OpenIDCredentialIssuerMetadata(nil, issuerClientID).Return(&metadata, nil)
-		ctx.iamClient.EXPECT().AuthorizationServerMetadata(nil, authServer).Return(&authzMetadata, nil)
-		req := requestCredentials(holderSubjectID, issuerClientID, redirectURI)
-		req.Body.AuthorizationRequestParams = &map[string]string{oauth.ClientIDParam: "attacker"}
-
-		_, err := ctx.client.RequestOpenid4VCICredentialIssuance(nil, req)
-
-		assert.ErrorContains(t, err, "authorization_request_params may not override the 'client_id' parameter")
-	})
 	t.Run("ok - credential_request_params persisted into session", func(t *testing.T) {
 		ctx := newTestClient(t)
 		ctx.openid4vciClient.EXPECT().OpenIDCredentialIssuerMetadata(nil, issuerClientID).Return(&metadata, nil)

--- a/docs/_static/auth/v2.yaml
+++ b/docs/_static/auth/v2.yaml
@@ -187,20 +187,6 @@ paths:
                     {
                       "some-requested-credential-attribute": "900184590"
                     }
-                authorization_request_params:
-                  type: object
-                  additionalProperties:
-                    type: string
-                  description: |
-                    Optional key/value pairs added to the OpenID4VCI authorization request (the redirect to the
-                    Authorization Server's authorization_endpoint). These may only add parameters; they must not
-                    override the OpenID4VCI parameters set by the node (the request is rejected if they do).
-                    Prefer authorization_details (RFC 9396) where the issuer supports it; use this only for issuers
-                    that require non-standard authorization parameters (e.g. auth_method for AET smartcards).
-                  example: |
-                    {
-                      "auth_method": "SmartCard"
-                    }
                 redirect_uri:
                   type: string
                   description: |

--- a/e2e-tests/browser/client/iam/generated.go
+++ b/e2e-tests/browser/client/iam/generated.go
@@ -255,13 +255,6 @@ type RequestOpenid4VCICredentialIssuanceJSONBody struct {
 	// issuance per call and only consumes the first entry.
 	AuthorizationDetails []AuthorizationDetail `json:"authorization_details"`
 
-	// AuthorizationRequestParams Optional key/value pairs added to the OpenID4VCI authorization request (the redirect to the
-	// Authorization Server's authorization_endpoint). These may only add parameters; they must not
-	// override the OpenID4VCI parameters set by the node (the request is rejected if they do).
-	// Prefer authorization_details (RFC 9396) where the issuer supports it; use this only for issuers
-	// that require non-standard authorization parameters (e.g. auth_method for AET smartcards).
-	AuthorizationRequestParams *map[string]string `json:"authorization_request_params,omitempty"`
-
 	// CredentialRequestParams Optional JSON object overlaid on top of the OpenID4VCI Credential Request body sent to
 	// the issuer's credential endpoint. Any field supplied here overrides the node's default —
 	// including credential_configuration_id, credential_identifier and proofs. Use this for


### PR DESCRIPTION
Reverts #4333.

Reverts merged commit `fa89c810`, which added the `authorization_request_params` field to the OpenID4VCI `requestCredential` API. Instead, we'll introduces profiles: https://github.com/nuts-foundation/nuts-node/pull/4340

Affected files:
- `auth/api/iam/openid4vci.go` + `auth/api/iam/openid4vci_test.go`
- `auth/api/iam/generated.go`, `e2e-tests/browser/client/iam/generated.go` (generated)
- `docs/_static/auth/v2.yaml` (OpenAPI spec)

No later commits on `master` depend on it, so the revert applies cleanly.

Assisted by AI