### PR TITLE
Replace per-subject OAuth callback with org-agnostic /oauth2/callback

### DIFF
--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -29,13 +29,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/nuts-node/core/to"
 	"html/template"
 	"net/http"
 	"net/url"
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/nuts-foundation/nuts-node/core/to"
 
 	"github.com/labstack/echo/v4"
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -164,7 +165,7 @@ func (r Wrapper) Routes(router core.EchoRouter) {
 			paths := []string{
 				"/oauth2/:subjectID/user",
 				"/oauth2/:subjectID/authorize",
-				"/oauth2/:subjectID/callback",
+				"/oauth2/callback",
 			}
 			for _, path := range paths {
 				if c.Path() == path {
@@ -261,11 +262,6 @@ func (r Wrapper) Callback(ctx context.Context, request CallbackRequestObject) (C
 		}
 	}
 	// validate request
-	// check did in path
-	err := r.subjectExists(ctx, request.SubjectID)
-	if err != nil {
-		return nil, err
-	}
 	// check if state is present and resolves to a client state
 	if request.Params.State == nil || *request.Params.State == "" {
 		// without state it is an invalid request, but try to provide as much useful information as possible
@@ -277,12 +273,8 @@ func (r Wrapper) Callback(ctx context.Context, request CallbackRequestObject) (C
 		return nil, oauthError(oauth.InvalidRequest, "missing state parameter")
 	}
 	oauthSession := new(OAuthSession)
-	if err = r.oauthClientStateStore().Get(*request.Params.State, oauthSession); err != nil {
+	if err := r.oauthClientStateStore().Get(*request.Params.State, oauthSession); err != nil {
 		return nil, oauthError(oauth.InvalidRequest, "invalid or expired state", err)
-	}
-	if request.SubjectID != *oauthSession.OwnSubject {
-		// TODO: this is a manipulated request, add error logging?
-		return nil, withCallbackURI(oauthError(oauth.InvalidRequest, "session subject does not match request"), oauthSession.redirectURI())
 	}
 
 	// if error is present, redirect error back to application initiating the flow
@@ -983,6 +975,10 @@ func (r Wrapper) authzRequestObjectStore() storage.SessionStore {
 
 func (r Wrapper) subjectToBaseURL(subject string) url.URL {
 	return *r.auth.PublicURL().JoinPath("oauth2", subject)
+}
+
+func (r Wrapper) callbackURL() *url.URL {
+	return r.auth.PublicURL().JoinPath("oauth2", oauth.CallbackPath)
 }
 
 // subjectExists checks whether the given subject is known on the local node.

--- a/auth/api/iam/api.go
+++ b/auth/api/iam/api.go
@@ -165,7 +165,6 @@ func (r Wrapper) Routes(router core.EchoRouter) {
 			paths := []string{
 				"/oauth2/:subjectID/user",
 				"/oauth2/:subjectID/authorize",
-				"/oauth2/callback",
 			}
 			for _, path := range paths {
 				if c.Path() == path {

--- a/auth/api/iam/api_test.go
+++ b/auth/api/iam/api_test.go
@@ -444,7 +444,7 @@ func TestWrapper_Callback(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		ctx := newCustomTestClient(t, verifierURL, false)
 
-		response, err := ctx.client.Callback(nil, CallbackRequestObject{SubjectID: holderSubjectID})
+		response, err := ctx.client.Callback(nil, CallbackRequestObject{})
 
 		requireOAuthError(t, err, oauth.InvalidRequest, "callback endpoint is disabled")
 		assert.Nil(t, response)
@@ -454,7 +454,6 @@ func TestWrapper_Callback(t *testing.T) {
 		putState(ctx, "state", session)
 
 		res, err := ctx.client.Callback(nil, CallbackRequestObject{
-			SubjectID: holderSubjectID,
 			Params: CallbackParams{
 				State:            &state,
 				Error:            &errorCode,
@@ -478,10 +477,9 @@ func TestWrapper_Callback(t *testing.T) {
 		putState(ctx, "state", withDPoP)
 		putToken(ctx, token)
 		codeVerifier := getState(ctx, state).PKCEParams.Verifier
-		ctx.iamClient.EXPECT().AccessToken(gomock.Any(), code, session.TokenEndpoint, "https://example.com/oauth2/holder/callback", holderSubjectID, holderClientID, codeVerifier, true).Return(&oauth.TokenResponse{AccessToken: "access"}, nil)
+		ctx.iamClient.EXPECT().AccessToken(gomock.Any(), code, session.TokenEndpoint, "https://example.com/oauth2/callback", holderSubjectID, holderClientID, codeVerifier, true).Return(&oauth.TokenResponse{AccessToken: "access"}, nil)
 
 		res, err := ctx.client.Callback(nil, CallbackRequestObject{
-			SubjectID: holderSubjectID,
 			Params: CallbackParams{
 				Code:  &code,
 				State: &state,
@@ -512,10 +510,9 @@ func TestWrapper_Callback(t *testing.T) {
 		})
 		putToken(ctx, token)
 		codeVerifier := getState(ctx, state).PKCEParams.Verifier
-		ctx.iamClient.EXPECT().AccessToken(gomock.Any(), code, session.TokenEndpoint, "https://example.com/oauth2/holder/callback", holderSubjectID, holderClientID, codeVerifier, false).Return(&oauth.TokenResponse{AccessToken: "access"}, nil)
+		ctx.iamClient.EXPECT().AccessToken(gomock.Any(), code, session.TokenEndpoint, "https://example.com/oauth2/callback", holderSubjectID, holderClientID, codeVerifier, false).Return(&oauth.TokenResponse{AccessToken: "access"}, nil)
 
 		res, err := ctx.client.Callback(nil, CallbackRequestObject{
-			SubjectID: holderSubjectID,
 			Params: CallbackParams{
 				Code:  &code,
 				State: &state,
@@ -525,27 +522,10 @@ func TestWrapper_Callback(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, res)
 	})
-	t.Run("err - did mismatch", func(t *testing.T) {
-		ctx := newTestClient(t)
-		putState(ctx, "state", session)
-
-		res, err := ctx.client.Callback(nil, CallbackRequestObject{
-			SubjectID: verifierSubject,
-			Params: CallbackParams{
-				Code:  &code,
-				State: &state,
-			},
-		})
-
-		assert.Nil(t, res)
-		requireOAuthError(t, err, oauth.InvalidRequest, "session subject does not match request")
-
-	})
 	t.Run("err - missing state", func(t *testing.T) {
 		ctx := newTestClient(t)
 
 		_, err := ctx.client.Callback(nil, CallbackRequestObject{
-			SubjectID: holderSubjectID,
 			Params: CallbackParams{
 				Code: &code,
 			},
@@ -557,7 +537,6 @@ func TestWrapper_Callback(t *testing.T) {
 		ctx := newTestClient(t)
 
 		_, err := ctx.client.Callback(nil, CallbackRequestObject{
-			SubjectID: holderSubjectID,
 			Params: CallbackParams{
 				Error:            &errorCode,
 				ErrorDescription: &errorDescription,
@@ -571,7 +550,6 @@ func TestWrapper_Callback(t *testing.T) {
 		ctx := newTestClient(t)
 
 		_, err := ctx.client.Callback(nil, CallbackRequestObject{
-			SubjectID: verifierSubject,
 			Params: CallbackParams{
 				Code:  &code,
 				State: &state,
@@ -585,7 +563,6 @@ func TestWrapper_Callback(t *testing.T) {
 		putState(ctx, "state", session)
 
 		_, err := ctx.client.Callback(nil, CallbackRequestObject{
-			SubjectID: holderSubjectID,
 			Params: CallbackParams{
 				State: &state,
 			},
@@ -601,7 +578,6 @@ func TestWrapper_Callback(t *testing.T) {
 		})
 
 		_, err := ctx.client.Callback(nil, CallbackRequestObject{
-			SubjectID: holderSubjectID,
 			Params: CallbackParams{
 				Code:  &code,
 				State: &state,

--- a/auth/api/iam/generated.go
+++ b/auth/api/iam/generated.go
@@ -300,11 +300,6 @@ type RequestServiceAccessTokenParams struct {
 	CacheControl *string `json:"Cache-Control,omitempty"`
 }
 
-// HandleAuthorizeRequestParams defines parameters for HandleAuthorizeRequest.
-type HandleAuthorizeRequestParams struct {
-	Params *map[string]string `form:"params,omitempty" json:"params,omitempty"`
-}
-
 // CallbackParams defines parameters for Callback.
 type CallbackParams struct {
 	// Code The authorization code received from the authorization server.
@@ -318,6 +313,11 @@ type CallbackParams struct {
 
 	// ErrorDescription The error description.
 	ErrorDescription *string `form:"error_description,omitempty" json:"error_description,omitempty"`
+}
+
+// HandleAuthorizeRequestParams defines parameters for HandleAuthorizeRequest.
+type HandleAuthorizeRequestParams struct {
+	Params *map[string]string `form:"params,omitempty" json:"params,omitempty"`
 }
 
 // PresentationDefinitionParams defines parameters for PresentationDefinition.
@@ -645,12 +645,12 @@ type ServerInterface interface {
 	// EXPERIMENTAL Start the authorization code flow to get an access token from a remote authorization server when user context is required.
 	// (POST /internal/auth/v2/{subjectID}/request-user-access-token)
 	RequestUserAccessToken(ctx echo.Context, subjectID string) error
+	// The OAuth2 callback endpoint of the client.
+	// (GET /oauth2/callback)
+	Callback(ctx echo.Context, params CallbackParams) error
 	// Used by resource owners (the browser) to initiate the authorization code flow.
 	// (GET /oauth2/{subjectID}/authorize)
 	HandleAuthorizeRequest(ctx echo.Context, subjectID string, params HandleAuthorizeRequestParams) error
-	// The OAuth2 callback endpoint of the client.
-	// (GET /oauth2/{subjectID}/callback)
-	Callback(ctx echo.Context, subjectID string, params CallbackParams) error
 	// Get the OAuth2 Client metadata
 	// (GET /oauth2/{subjectID}/oauth-client)
 	OAuthClientMetadata(ctx echo.Context, subjectID string) error
@@ -855,43 +855,9 @@ func (w *ServerInterfaceWrapper) RequestUserAccessToken(ctx echo.Context) error 
 	return err
 }
 
-// HandleAuthorizeRequest converts echo context to params.
-func (w *ServerInterfaceWrapper) HandleAuthorizeRequest(ctx echo.Context) error {
-	var err error
-	// ------------- Path parameter "subjectID" -------------
-	var subjectID string
-
-	err = runtime.BindStyledParameterWithOptions("simple", "subjectID", ctx.Param("subjectID"), &subjectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter subjectID: %s", err))
-	}
-
-	ctx.Set(JwtBearerAuthScopes, []string{})
-
-	// Parameter object where we will unmarshal all parameters from the context
-	var params HandleAuthorizeRequestParams
-	// ------------- Optional query parameter "params" -------------
-
-	err = runtime.BindQueryParameter("form", true, false, "params", ctx.QueryParams(), &params.Params)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter params: %s", err))
-	}
-
-	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.HandleAuthorizeRequest(ctx, subjectID, params)
-	return err
-}
-
 // Callback converts echo context to params.
 func (w *ServerInterfaceWrapper) Callback(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "subjectID" -------------
-	var subjectID string
-
-	err = runtime.BindStyledParameterWithOptions("simple", "subjectID", ctx.Param("subjectID"), &subjectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter subjectID: %s", err))
-	}
 
 	ctx.Set(JwtBearerAuthScopes, []string{})
 
@@ -926,7 +892,34 @@ func (w *ServerInterfaceWrapper) Callback(ctx echo.Context) error {
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.Callback(ctx, subjectID, params)
+	err = w.Handler.Callback(ctx, params)
+	return err
+}
+
+// HandleAuthorizeRequest converts echo context to params.
+func (w *ServerInterfaceWrapper) HandleAuthorizeRequest(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "subjectID" -------------
+	var subjectID string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "subjectID", ctx.Param("subjectID"), &subjectID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter subjectID: %s", err))
+	}
+
+	ctx.Set(JwtBearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params HandleAuthorizeRequestParams
+	// ------------- Optional query parameter "params" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "params", ctx.QueryParams(), &params.Params)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter params: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.HandleAuthorizeRequest(ctx, subjectID, params)
 	return err
 }
 
@@ -1128,8 +1121,8 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.POST(baseURL+"/internal/auth/v2/:subjectID/request-credential", wrapper.RequestOpenid4VCICredentialIssuance)
 	router.POST(baseURL+"/internal/auth/v2/:subjectID/request-service-access-token", wrapper.RequestServiceAccessToken)
 	router.POST(baseURL+"/internal/auth/v2/:subjectID/request-user-access-token", wrapper.RequestUserAccessToken)
+	router.GET(baseURL+"/oauth2/callback", wrapper.Callback)
 	router.GET(baseURL+"/oauth2/:subjectID/authorize", wrapper.HandleAuthorizeRequest)
-	router.GET(baseURL+"/oauth2/:subjectID/callback", wrapper.Callback)
 	router.GET(baseURL+"/oauth2/:subjectID/oauth-client", wrapper.OAuthClientMetadata)
 	router.GET(baseURL+"/oauth2/:subjectID/presentation_definition", wrapper.PresentationDefinition)
 	router.GET(baseURL+"/oauth2/:subjectID/request.jwt/:id", wrapper.RequestJWTByGet)
@@ -1487,6 +1480,49 @@ func (response RequestUserAccessTokendefaultApplicationProblemPlusJSONResponse) 
 	return json.NewEncoder(w).Encode(response.Body)
 }
 
+type CallbackRequestObject struct {
+	Params CallbackParams
+}
+
+type CallbackResponseObject interface {
+	VisitCallbackResponse(w http.ResponseWriter) error
+}
+
+type Callback302ResponseHeaders struct {
+	Location string
+}
+
+type Callback302Response struct {
+	Headers Callback302ResponseHeaders
+}
+
+func (response Callback302Response) VisitCallbackResponse(w http.ResponseWriter) error {
+	w.Header().Set("Location", fmt.Sprint(response.Headers.Location))
+	w.WriteHeader(302)
+	return nil
+}
+
+type CallbackdefaultApplicationProblemPlusJSONResponse struct {
+	Body struct {
+		// Detail A human-readable explanation specific to this occurrence of the problem.
+		Detail string `json:"detail"`
+
+		// Status HTTP statuscode
+		Status float32 `json:"status"`
+
+		// Title A short, human-readable summary of the problem type.
+		Title string `json:"title"`
+	}
+	StatusCode int
+}
+
+func (response CallbackdefaultApplicationProblemPlusJSONResponse) VisitCallbackResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(response.StatusCode)
+
+	return json.NewEncoder(w).Encode(response.Body)
+}
+
 type HandleAuthorizeRequestRequestObject struct {
 	SubjectID string `json:"subjectID"`
 	Params    HandleAuthorizeRequestParams
@@ -1527,50 +1563,6 @@ func (response HandleAuthorizeRequest302Response) VisitHandleAuthorizeRequestRes
 	w.Header().Set("Location", fmt.Sprint(response.Headers.Location))
 	w.WriteHeader(302)
 	return nil
-}
-
-type CallbackRequestObject struct {
-	SubjectID string `json:"subjectID"`
-	Params    CallbackParams
-}
-
-type CallbackResponseObject interface {
-	VisitCallbackResponse(w http.ResponseWriter) error
-}
-
-type Callback302ResponseHeaders struct {
-	Location string
-}
-
-type Callback302Response struct {
-	Headers Callback302ResponseHeaders
-}
-
-func (response Callback302Response) VisitCallbackResponse(w http.ResponseWriter) error {
-	w.Header().Set("Location", fmt.Sprint(response.Headers.Location))
-	w.WriteHeader(302)
-	return nil
-}
-
-type CallbackdefaultApplicationProblemPlusJSONResponse struct {
-	Body struct {
-		// Detail A human-readable explanation specific to this occurrence of the problem.
-		Detail string `json:"detail"`
-
-		// Status HTTP statuscode
-		Status float32 `json:"status"`
-
-		// Title A short, human-readable summary of the problem type.
-		Title string `json:"title"`
-	}
-	StatusCode int
-}
-
-func (response CallbackdefaultApplicationProblemPlusJSONResponse) VisitCallbackResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(response.StatusCode)
-
-	return json.NewEncoder(w).Encode(response.Body)
 }
 
 type OAuthClientMetadataRequestObject struct {
@@ -1862,12 +1854,12 @@ type StrictServerInterface interface {
 	// EXPERIMENTAL Start the authorization code flow to get an access token from a remote authorization server when user context is required.
 	// (POST /internal/auth/v2/{subjectID}/request-user-access-token)
 	RequestUserAccessToken(ctx context.Context, request RequestUserAccessTokenRequestObject) (RequestUserAccessTokenResponseObject, error)
+	// The OAuth2 callback endpoint of the client.
+	// (GET /oauth2/callback)
+	Callback(ctx context.Context, request CallbackRequestObject) (CallbackResponseObject, error)
 	// Used by resource owners (the browser) to initiate the authorization code flow.
 	// (GET /oauth2/{subjectID}/authorize)
 	HandleAuthorizeRequest(ctx context.Context, request HandleAuthorizeRequestRequestObject) (HandleAuthorizeRequestResponseObject, error)
-	// The OAuth2 callback endpoint of the client.
-	// (GET /oauth2/{subjectID}/callback)
-	Callback(ctx context.Context, request CallbackRequestObject) (CallbackResponseObject, error)
 	// Get the OAuth2 Client metadata
 	// (GET /oauth2/{subjectID}/oauth-client)
 	OAuthClientMetadata(ctx context.Context, request OAuthClientMetadataRequestObject) (OAuthClientMetadataResponseObject, error)
@@ -2198,6 +2190,31 @@ func (sh *strictHandler) RequestUserAccessToken(ctx echo.Context, subjectID stri
 	return nil
 }
 
+// Callback operation middleware
+func (sh *strictHandler) Callback(ctx echo.Context, params CallbackParams) error {
+	var request CallbackRequestObject
+
+	request.Params = params
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.Callback(ctx.Request().Context(), request.(CallbackRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "Callback")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(CallbackResponseObject); ok {
+		return validResponse.VisitCallbackResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
 // HandleAuthorizeRequest operation middleware
 func (sh *strictHandler) HandleAuthorizeRequest(ctx echo.Context, subjectID string, params HandleAuthorizeRequestParams) error {
 	var request HandleAuthorizeRequestRequestObject
@@ -2218,32 +2235,6 @@ func (sh *strictHandler) HandleAuthorizeRequest(ctx echo.Context, subjectID stri
 		return err
 	} else if validResponse, ok := response.(HandleAuthorizeRequestResponseObject); ok {
 		return validResponse.VisitHandleAuthorizeRequestResponse(ctx.Response())
-	} else if response != nil {
-		return fmt.Errorf("unexpected response type: %T", response)
-	}
-	return nil
-}
-
-// Callback operation middleware
-func (sh *strictHandler) Callback(ctx echo.Context, subjectID string, params CallbackParams) error {
-	var request CallbackRequestObject
-
-	request.SubjectID = subjectID
-	request.Params = params
-
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.Callback(ctx.Request().Context(), request.(CallbackRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "Callback")
-	}
-
-	response, err := handler(ctx, request)
-
-	if err != nil {
-		return err
-	} else if validResponse, ok := response.(CallbackResponseObject); ok {
-		return validResponse.VisitCallbackResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}

--- a/auth/api/iam/openid4vci.go
+++ b/auth/api/iam/openid4vci.go
@@ -101,7 +101,6 @@ func (r Wrapper) RequestOpenid4VCICredentialIssuance(ctx context.Context, reques
 	pkceParams := generatePKCEParams()
 
 	// Figure out our own redirect URL by parsing the did:web and extracting the host.
-	redirectUri := clientID.JoinPath(oauth.CallbackPath)
 	// Store the session
 	err = r.oauthClientStateStore().Put(state, &OAuthSession{
 		AuthorizationServerMetadata: authzServerMetadata,
@@ -134,7 +133,7 @@ func (r Wrapper) RequestOpenid4VCICredentialIssuance(ctx context.Context, reques
 		oauth.ClientIDParam:             clientID.String(),
 		oauth.ClientIDSchemeParam:       entityClientIDScheme,
 		oauth.AuthorizationDetailsParam: string(authorizationDetails),
-		oauth.RedirectURIParam:          redirectUri.String(),
+		oauth.RedirectURIParam:          r.callbackURL().String(),
 		oauth.CodeChallengeParam:        pkceParams.Challenge,
 		oauth.CodeChallengeMethodParam:  pkceParams.ChallengeMethod,
 	}
@@ -159,16 +158,14 @@ func (r Wrapper) RequestOpenid4VCICredentialIssuance(ctx context.Context, reques
 func (r Wrapper) handleOpenID4VCICallback(ctx context.Context, authorizationCode string, oauthSession *OAuthSession) (CallbackResponseObject, error) {
 	appCallbackURI := oauthSession.redirectURI()
 
-	baseURL := r.subjectToBaseURL(*oauthSession.OwnSubject)
-	clientID := baseURL.String()
-	checkURL := baseURL.JoinPath(oauth.CallbackPath)
+	clientID := r.subjectToBaseURL(*oauthSession.OwnSubject)
 
 	if oauthSession.OwnDID == nil {
 		return nil, withCallbackURI(oauthError(oauth.ServerError, "missing wallet DID in session"), appCallbackURI)
 	}
 
 	// use code to request access token from remote token endpoint
-	tokenResponse, err := r.auth.IAMClient().AccessToken(ctx, authorizationCode, oauthSession.TokenEndpoint, checkURL.String(), *oauthSession.OwnSubject, clientID, oauthSession.PKCEParams.Verifier, false)
+	tokenResponse, err := r.auth.IAMClient().AccessToken(ctx, authorizationCode, oauthSession.TokenEndpoint, r.callbackURL().String(), *oauthSession.OwnSubject, clientID.String(), oauthSession.PKCEParams.Verifier, false)
 	if err != nil {
 		return nil, withCallbackURI(oauthError(oauth.AccessDenied, fmt.Sprintf("error while fetching the access_token from endpoint: %s, error: %s", oauthSession.TokenEndpoint, err.Error())), appCallbackURI)
 	}

--- a/auth/api/iam/openid4vci_test.go
+++ b/auth/api/iam/openid4vci_test.go
@@ -72,7 +72,7 @@ func TestWrapper_RequestOpenid4VCICredentialIssuance(t *testing.T) {
 		assert.Equal(t, "/authorize", redirectUri.Path)
 		assert.True(t, redirectUri.Query().Has("state"))
 		assert.True(t, redirectUri.Query().Has("code_challenge"))
-		assert.Equal(t, "https://example.com/oauth2/holder/callback", redirectUri.Query().Get("redirect_uri"))
+		assert.Equal(t, "https://example.com/oauth2/callback", redirectUri.Query().Get("redirect_uri"))
 		assert.Equal(t, holderClientID, redirectUri.Query().Get("client_id"))
 		assert.Equal(t, "S256", redirectUri.Query().Get("code_challenge_method"))
 		assert.Equal(t, "code", redirectUri.Query().Get("response_type"))
@@ -242,7 +242,7 @@ func requestCredentials(subjectID string, issuer string, redirectURI string) Req
 }
 
 func TestWrapper_handleOpenID4VCICallback(t *testing.T) {
-	redirectURI := "https://example.com/oauth2/holder/callback"
+	redirectURI := "https://example.com/oauth2/callback"
 	authServer := "https://auth.server"
 	tokenEndpoint := authServer + "/token"
 	nonceEndpoint := authServer + "/nonce"
@@ -304,10 +304,9 @@ func TestWrapper_handleOpenID4VCICallback(t *testing.T) {
 		ctx.wallet.EXPECT().Put(nil, *verifiableCredential)
 
 		callback, err := ctx.client.Callback(nil, CallbackRequestObject{
-			SubjectID: holderSubjectID,
 			Params: CallbackParams{
-				Code:  to.Ptr(code),
-				State: to.Ptr(state),
+				Code:  new(code),
+				State: new(state),
 			},
 		})
 

--- a/auth/api/iam/openid4vp.go
+++ b/auth/api/iam/openid4vp.go
@@ -731,12 +731,10 @@ func (r Wrapper) handleCallback(ctx context.Context, authorizationCode string, o
 
 	// send callback URL for verification (this method is the handler for that URL) to authorization server to check against earlier redirect_uri
 	// we call it checkURL here because it is used by the authorization server to check if the code is valid
-	baseURL := r.subjectToBaseURL(*oauthSession.OwnSubject)
-	clientID := baseURL.String()
-	checkURL := baseURL.JoinPath(oauth.CallbackPath)
+	clientID := r.subjectToBaseURL(*oauthSession.OwnSubject)
 
 	// use code to request access token from remote token endpoint
-	tokenResponse, err := r.auth.IAMClient().AccessToken(ctx, authorizationCode, oauthSession.TokenEndpoint, checkURL.String(), *oauthSession.OwnSubject, clientID, oauthSession.PKCEParams.Verifier, oauthSession.UseDPoP)
+	tokenResponse, err := r.auth.IAMClient().AccessToken(ctx, authorizationCode, oauthSession.TokenEndpoint, r.callbackURL().String(), *oauthSession.OwnSubject, clientID.String(), oauthSession.PKCEParams.Verifier, oauthSession.UseDPoP)
 	if err != nil {
 		return nil, withCallbackURI(oauthError(oauth.ServerError, fmt.Sprintf("failed to retrieve access token: %s", err.Error())), appCallbackURI)
 	}

--- a/auth/api/iam/openid4vp_test.go
+++ b/auth/api/iam/openid4vp_test.go
@@ -750,7 +750,7 @@ func Test_handleCallback(t *testing.T) {
 	}
 	t.Run("err - failed to retrieve access token", func(t *testing.T) {
 		ctx := newTestClient(t)
-		callbackURI := "https://example.com/oauth2/holder/callback"
+		callbackURI := "https://example.com/oauth2/callback"
 		codeVerifier := session.PKCEParams.Verifier
 
 		ctx.iamClient.EXPECT().AccessToken(gomock.Any(), code, session.TokenEndpoint, callbackURI, holderSubjectID, holderClientID, codeVerifier, false).Return(nil, assert.AnError)
@@ -852,7 +852,7 @@ func expectPostError(t *testing.T, ctx *testCtx, errorCode oauth.ErrorCode, desc
 		assert.Equal(t, description, err.Description)
 		assert.Equal(t, expectedResponseURI, responseURI)
 		assert.Equal(t, verifierClientState, state)
-		return holderURL.JoinPath("callback").String(), nil
+		return "https://example.com/oauth2/callback", nil
 	})
 }
 

--- a/auth/api/iam/user.go
+++ b/auth/api/iam/user.go
@@ -123,13 +123,10 @@ func (r Wrapper) handleUserLanding(echoCtx echo.Context) error {
 		return err
 	}
 
-	// construct callback URL to be used in (Signed)AuthorizationRequest
-	baseURL := r.subjectToBaseURL(redirectSession.SubjectID)
-	callbackURL := baseURL.JoinPath(oauth.CallbackPath)
 	modifier := func(values map[string]string) {
 		values[oauth.CodeChallengeParam] = oauthSession.PKCEParams.Challenge
 		values[oauth.CodeChallengeMethodParam] = oauthSession.PKCEParams.ChallengeMethod
-		values[oauth.RedirectURIParam] = callbackURL.String()
+		values[oauth.RedirectURIParam] = r.callbackURL().String()
 		values[oauth.ResponseTypeParam] = oauth.CodeResponseType
 		values[oauth.StateParam] = oauthSession.ClientState
 		values[oauth.ScopeParam] = accessTokenRequest.Body.Scope

--- a/auth/oauth/openid.go
+++ b/auth/oauth/openid.go
@@ -42,5 +42,5 @@ func DefaultOpenIDSupportedFormats() map[string]map[string][]string {
 }
 
 // CallbackPath is the node specific callback for an OAuth flow. The full callback URL is constructed as
-// <node_url>/iam/{id}/callback
+// <node_url>/oauth2/callback
 const CallbackPath = "callback"

--- a/docs/_static/auth/iam.partial.yaml
+++ b/docs/_static/auth/iam.partial.yaml
@@ -160,7 +160,7 @@ paths:
                 "$ref": "#/components/schemas/RequestObjectResponse"
         default:
           $ref: '../common/error_response.yaml'
-  /oauth2/{subjectID}/callback:
+  /oauth2/callback:
     get:
       summary: The OAuth2 callback endpoint of the client.
       description: |
@@ -168,18 +168,11 @@ paths:
         This can be the result of a successful authorization request or an error.
         The result of this callback is a redirect back to the calling application.
         
-        This callback is used as the redirect_uri in multiple authorization request flows.
+        This callback is used as the redirect_uri in authorized code, OpenID4VP, and OpenID4VCI flows.
       operationId: callback
       tags:
         - oauth2
       parameters:
-        - name: subjectID
-          in: path
-          required: true
-          description: the subject of the callback
-          schema:
-            type: string
-            example: 90BC1AE9-752B-432F-ADC3-DD9F9C61843C
         - name: code
           in: query
           description: The authorization code received from the authorization server.


### PR DESCRIPTION
Closes #4339

## Problem

The node's OAuth callback URL embedded the healthcare-org subject in the path (`/oauth2/{subjectID}/callback`), so every org got a distinct `redirect_uri`. IDPs that require pre-registered redirect URIs (e.g. AET's OpenIddict) would then need each org registered individually — which doesn't scale and conflicts with a single registered `client_id` (#4316).

## Change

Replace the per-subject callback with a single org-agnostic endpoint `/oauth2/callback`. The healthcare-org context is recovered from the unguessable, single-use `state` that already keys the `OAuthSession` holding `OwnSubject` — so the binding is preserved without the path segment.

- Spec: remove `/oauth2/{subjectID}/callback`, add `/oauth2/callback`; regen `generated.go`.
- `Callback` handler: drop the now-dead path-subject lines (`subjectExists` check and `SubjectID != *oauthSession.OwnSubject` guard).
- Both flows (OpenID4VCI auth-code, OpenID4VP user flow) build `redirect_uri` as `<pub>/oauth2/callback` via a new `callbackURL()` helper instead of `subjectToBaseURL`.
- Fix the `CallbackPath` doc comment.

## Safety

The callback endpoint isn't used in production yet; its only callers both migrate here. Binding now rests solely on the unguessable, single-use `state`. No new config or key material.

## Testing

- `go build ./...` passes.
- `go test ./auth/api/iam/... ./auth/oauth/...` passes.
- Tests assert `redirect_uri = <pub>/oauth2/callback` (no subject) and that the callback resolves the correct `OwnSubject` from `state`.

Assisted by AI