### PR TITLE
Group dependabot updates into weekly PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,21 +5,42 @@ updates:
     # checks workflow files in /.github/workflows
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Go
   - package-ecosystem: "gomod"
     # checks /go.mod
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      go-modules:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Docker
   - package-ecosystem: "docker"
     # checks /Dockerfile
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      docker:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Python (PRs disabled)
   - package-ecosystem: "pip"


### PR DESCRIPTION
Switch `github-actions`, `gomod`, and `docker` ecosystems from daily, ungrouped updates to **weekly grouped** PRs.

## What changes

| Ecosystem | Before | After |
|---|---|---|
| github-actions | daily, ungrouped | weekly, grouped (minor+patch) |
| gomod | daily, ungrouped | weekly, grouped (minor+patch) |
| docker | daily, ungrouped | weekly, grouped (minor+patch) |
| pip | weekly, disabled | unchanged |

## Why

- Cuts the daily flood of individual PRs down to ~one grouped PR per ecosystem per week.
- Each group is scoped to `minor`+`patch`. **Major** bumps stay outside the groups as individual PRs, so cross-breaking-change updates that need judgment remain individually reviewable.
- Preserves soak time and anti-drift currency on master.

Assisted by AI