### PR TITLE
Backport: fix flaky Test_grpcConnectionManager_Peers (#4276)

### DIFF
--- a/network/transport/grpc/connection_manager_test.go
+++ b/network/transport/grpc/connection_manager_test.go
@@ -494,7 +494,7 @@ func Test_grpcConnectionManager_Peers(t *testing.T) {
 		}, time.Second*2, "waiting for peer 1 to connect")
 	})
 	t.Run("outbound stream triggers observer", func(t *testing.T) {
-		_, authenticator1, _, listener := create(t)
+		cm1, authenticator1, _, listener := create(t)
 		cm2, authenticator2, _, _ := create(t, withBufconnDialer(listener))
 		authenticator1.EXPECT().Authenticate(*nodeDID, gomock.Any()).Return(transport.Peer{ID: "1"}, nil)
 		authenticator2.EXPECT().Authenticate(*nodeDID, gomock.Any()).Return(transport.Peer{ID: "2"}, nil)
@@ -507,9 +507,11 @@ func Test_grpcConnectionManager_Peers(t *testing.T) {
 
 		cm2.Connect("bufnet", *nodeDID, nil)
 
+		// Wait until both sides have authenticated, otherwise the mock controller may
+		// run Finish() before authenticator1 fires and report a missing call.
 		test.WaitFor(t, func() (bool, error) {
-			return capturedPeer.Load() != nil, nil
-		}, time.Second*2, "waiting for peer 2 observers")
+			return capturedPeer.Load() != nil && len(cm1.Peers()) > 0, nil
+		}, time.Second*2, "waiting for both sides to authenticate")
 		assert.Equal(t, transport.Peer{ID: "2"}, capturedPeer.Load())
 		assert.Equal(t, transport.StateConnected, capturedState.Load())
 
@@ -533,9 +535,11 @@ func Test_grpcConnectionManager_Peers(t *testing.T) {
 
 		cm2.Connect("bufnet", *nodeDID, nil)
 
+		// Wait until both sides have authenticated, otherwise the mock controller may
+		// run Finish() before authenticator2 fires and report a missing call.
 		test.WaitFor(t, func() (bool, error) {
-			return capturedPeer.Load() != nil, nil
-		}, time.Second*2, "waiting for peer 1 observers")
+			return capturedPeer.Load() != nil && len(cm2.Peers()) > 0, nil
+		}, time.Second*2, "waiting for both sides to authenticate")
 		assert.Equal(t, transport.Peer{ID: "1"}, capturedPeer.Load())
 		assert.Equal(t, transport.StateConnected, capturedState.Load())
 


### PR DESCRIPTION
## Summary

Backports #4276 (already on master since d6ab80fd) to V5.4.

`Test_grpcConnectionManager_Peers/inbound_stream_triggers_observer` (and the mirror outbound subtest) sets `Authenticate` expectations on both peers' mocks, but only waited for one side's observer before tearing down. When the unobserved side's authentication was still in flight, `t.Cleanup` ran gomock's `Finish()` before that call landed, reporting a missing call.

V5.4 never received this fix, so PRs targeting this branch still hit the flake — see #4380.

## Test plan

- [x] `go test -race -count=20 -run Test_grpcConnectionManager_Peers ./network/transport/grpc/` passes locally

Related to #4380