### PR TITLE
Upgrade Go to 1.26.5 to fix CVE (v6.2.10)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # golang alpine
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -2,6 +2,16 @@
 Release notes
 #############
 
+*****************
+Peanut (v6.2.10)
+*****************
+
+Release date: 2026-07-09
+
+- Upgrade Go to 1.26.5 to address `GO-2026-5856 <https://pkg.go.dev/vuln/GO-2026-5856>`_ (de-anonymization of Encrypted Client Hello (ECH) handshakes: PSK identities were disclosed in the unencrypted client hello, allowing passive network observers to de-anonymize sessions).
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v6.2.9...v6.2.10
+
 ****************
 Peanut (v6.2.9)
 ****************

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nuts-foundation/nuts-node
 
 // This is the minimal version, the actual go version is determined by the images in the Dockerfile
 // This version is used in automated tests such as the 'Scheduled govulncheck' action
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0


### PR DESCRIPTION
## Summary

- Upgrade Go to 1.26.5
- Add release notes for v6.2.10

Fixes the following vulnerabilities:

| Advisory | Package | Description |
|---|---|---|
| GO-2026-5856 | `crypto/tls` (stdlib) | De-anonymization of Encrypted Client Hello (ECH) handshakes: PSK identities were disclosed in the unencrypted client hello, allowing passive network observers to de-anonymize sessions |

Assisted by AI