### PR TITLE
test(network): fix flaky Test_conn_startSending

### DIFF
--- a/network/transport/grpc/connection_test.go
+++ b/network/transport/grpc/connection_test.go
@@ -116,14 +116,17 @@ func Test_conn_startSending(t *testing.T) {
 
 		assert.Equal(t, int32(2), connection.activeGoroutines) // startSending and startReceiving
 
-		stream.cancelFunc()
+		// Disconnect before cancelling the stream: this guarantees the connection context is
+		// cancelled before RecvMsg returns, so the receive loop drops the message instead of
+		// racing to store the stream error as close status.
 		connection.disconnect()
+		stream.cancelFunc()
 
 		test.WaitFor(t, func() (bool, error) {
 			return atomic.LoadInt32(&connection.activeGoroutines) == 0, nil
 		}, 5*time.Second, "waiting for all goroutines to exit")
 
-		// Last received message is dropped and no status is set. Default value is OK.
+		// A deliberate local disconnect must not record a close error. Default value is OK.
 		assert.Equal(t, codes.OK, connection.status.Load().Code())
 	})
 }


### PR DESCRIPTION
## Summary

`Test_conn_startSending/disconnect_does_not_panic` flaked on CI (seen on #4425): it cancelled the stream before calling `disconnect()`, racing the receive goroutine (which stores the stream error as close status, `codes.Unknown`) against `disconnect()` cancelling the connection context. Whichever won determined whether the final `codes.OK` assertion passed.

Reordering to disconnect first guarantees the connection context is cancelled before `RecvMsg` returns, so the receive loop deterministically drops the message without storing a status. This keeps the test's goroutine-exit and no-panic coverage, which master lost when it deleted the test entirely in #2618. Companion PRs re-add the fixed test on master and V6.2.

Verified with `go test -race -count=100`: 100/100 pass.

Assisted-by: AI