### PR TITLE
test(e2e): fix flaky e2e tests

### DIFF
--- a/e2e-tests/nuts-network/gossip/run-test.sh
+++ b/e2e-tests/nuts-network/gossip/run-test.sh
@@ -41,8 +41,8 @@ echo "------------------------------------"
 echo "Performing assertions..."
 echo "------------------------------------"
 
-waitForTXCount "NodeA" "http://localhost:18081/status/diagnostics" 81 10
-waitForTXCount "NodeD" "http://localhost:48081/status/diagnostics" 81 10
+waitForTXCount "NodeA" "http://localhost:18081/status/diagnostics" 81 30
+waitForTXCount "NodeD" "http://localhost:48081/status/diagnostics" 81 30
 
 echo "------------------------------------"
 echo "Stopping Docker containers..."

--- a/e2e-tests/util.sh
+++ b/e2e-tests/util.sh
@@ -190,7 +190,8 @@ urlencode() {
 }
 
 # assertJaegerTrace verifies a trace exists with expected services and span patterns
-# Fetches trace once and validates all expectations
+# Retries while expectations are not met: each node exports spans in batches on its
+# own schedule, so a trace may be visible in Jaeger before all services reported.
 # Args: Jaeger URL, trace ID, expected services (space-separated), span patterns (space-separated)
 function assertJaegerTrace() {
   local jaeger_url=$1
@@ -198,12 +199,17 @@ function assertJaegerTrace() {
   local expected_services=$3
   local expected_patterns=$4
 
-  for attempt in {1..5}; do
+  local failure=""
+  for attempt in {1..10}; do
+    if [ "$attempt" -gt 1 ]; then
+      sleep 1
+    fi
+
     local response=$(curl -s -m 10 "$jaeger_url/api/traces/$trace_id")
     local trace_count=$(echo "$response" | jq '.data | length')
 
     if [ "$trace_count" -eq 0 ]; then
-      sleep 1
+      failure="FAILED: Trace '$trace_id' not found"
       continue
     fi
 
@@ -211,12 +217,16 @@ function assertJaegerTrace() {
     local span_names=$(echo "$response" | jq -r '.data[0].spans[].operationName')
 
     # Check each expected service is present
+    local missing_services=""
     for svc in $expected_services; do
       if ! echo "$actual_services" | grep -q "$svc"; then
-        echo "FAILED: Trace '$trace_id' missing service '$svc' (found: $actual_services)" 1>&2
-        return 1
+        missing_services="$missing_services $svc"
       fi
     done
+    if [ -n "$missing_services" ]; then
+      failure="FAILED: Trace '$trace_id' missing service(s):$missing_services (found: $actual_services)"
+      continue
+    fi
 
     # Check each expected span pattern is present
     local missing=""
@@ -226,9 +236,8 @@ function assertJaegerTrace() {
       fi
     done
     if [ -n "$missing" ]; then
-      echo "FAILED: Trace '$trace_id' missing spans:$missing" 1>&2
-      echo "Available: $(echo "$span_names" | sort -u | tr '\n' ', ')" 1>&2
-      return 1
+      failure="FAILED: Trace '$trace_id' missing spans:$missing (available: $(echo "$span_names" | sort -u | tr '\n' ','))"
+      continue
     fi
 
     local span_count=$(echo "$response" | jq '.data[0].spans | length')
@@ -236,6 +245,6 @@ function assertJaegerTrace() {
     return 0
   done
 
-  echo "FAILED: Trace '$trace_id' not found after 5 attempts" 1>&2
+  echo "$failure after 10 attempts" 1>&2
   return 1
 }


### PR DESCRIPTION
## What

Fixes two e2e flakes that recently failed CI on unrelated PRs (#4427, #4439).

**Jaeger trace assertion (`util.sh`):** `assertJaegerTrace` only retried while the trace was entirely absent from Jaeger. Each node exports spans in batches on its own schedule (5s default interval), so the first query after a flow can find a partial trace containing only one node's spans, which failed the assertion immediately (observed on #4427: `FAILED: Trace '...' missing service 'nodeA' (found: nodeB)`, 30ms after the check started, while two earlier rfc021 variants passed the same check). Missing services or spans are now retried like a missing trace, up to 10 attempts with 1s sleeps, which comfortably covers the batch export interval. The success path is unchanged, and the final error message still reports what was missing on the last attempt.

**Gossip propagation deadline (`nuts-network/gossip/run-test.sh`):** the test waits for 81 transactions to propagate across 4 nodes but gave it only 10 seconds, the heaviest propagation assertion in the suite on the same budget as tests waiting for at most 41 transactions. Slow CI runners regularly miss that deadline (observed on #4439). The deadline is now 30 seconds; `waitForTXCount` polls every second, so passing runs are not slowed down.

To be backported to release branches later, since PR CI on those branches runs the `e2e-tests/` directory from their own merge ref.