### PR TITLE
ci: skip test and e2e-test jobs for docs-only changes

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -23,20 +23,41 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Docs-only changes (docs/, markdown, rst) can't affect the e2e tests. Skipping them keeps
+      # this required check fast and avoids the cost of building/pushing images and running the
+      # full e2e suite for changes that can't have broken anything it tests.
+      - name: Check for non-doc changes
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.rst'
 
       - name: Set up Go
+        if: steps.filter.outputs.code == 'true'
         uses: actions/setup-go@v6
         with:
           # use go version from go.mod.
           go-version-file: 'go.mod'
 
       - name: Set up QEMU
+        if: steps.filter.outputs.code == 'true'
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
+        if: steps.filter.outputs.code == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Login to ghcr.io
+        if: steps.filter.outputs.code == 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -44,16 +65,16 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setting git SHA to PR head
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ steps.filter.outputs.code == 'true' && github.event_name == 'pull_request' }}
         run: echo "SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
       - name: Setting git SHA to branch head
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ steps.filter.outputs.code == 'true' && github.event_name != 'pull_request' }}
         run: echo "SHA=${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Build and push
         uses: docker/build-push-action@v7
-        if: ${{ github.actor != 'dependabot' }}
+        if: ${{ steps.filter.outputs.code == 'true' && github.actor != 'dependabot' }}
         with:
           context: .
           file: Dockerfile
@@ -67,7 +88,7 @@ jobs:
 
       - name: Build and push dependabot
         uses: docker/build-push-action@v7
-        if: ${{ github.actor == 'dependabot' }}
+        if: ${{ steps.filter.outputs.code == 'true' && github.actor == 'dependabot' }}
         with:
           context: .
           file: Dockerfile
@@ -78,6 +99,7 @@ jobs:
           cache-to: type=gha,scope=e2e,mode=max
 
       - name: Run E2E tests
+        if: steps.filter.outputs.code == 'true'
         run: |
             cd e2e-tests && \
             find . -type f -name "docker-compose*.yml" | xargs -I{} sed -i 's~nutsfoundation/nuts-node:master~ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}~g' {} && \
@@ -87,7 +109,7 @@ jobs:
       - name: package cleanup
         uses: dataaxiom/ghcr-cleanup-action@v1
         continue-on-error: true # action doesn't fail when this step fails
-        if: ${{ github.actor != 'dependabot' }}
+        if: ${{ steps.filter.outputs.code == 'true' && github.actor != 'dependabot' }}
         with:
           owner: nuts-foundation
           package: nuts-node-ci
@@ -98,7 +120,7 @@ jobs:
       - name: package cleanup dependabot
         uses: dataaxiom/ghcr-cleanup-action@v1
         continue-on-error: true # action doesn't fail when this step fails
-        if: ${{ github.actor == 'dependabot' }}
+        if: ${{ steps.filter.outputs.code == 'true' && github.actor == 'dependabot' }}
         with:
           owner: nuts-foundation
           package: nuts-node-ci

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -14,21 +14,22 @@ on:
 
 
 jobs:
-  e2e-test:
-    if: ${{ github.event.pull_request.merged || github.event.pull_request.head.repo.full_name == github.repository }}
-    permissions:
-      packages: write
-
+  # Docs-only changes (docs/, markdown, rst) can't affect the e2e tests. Detected once here so the
+  # (required) e2e-test job below can skip entirely on them: that keeps the check fast and avoids
+  # the cost of building/pushing images and running the full e2e suite for changes that can't have
+  # broken anything it tests. A job skipped via `if:` reports as a passing check, so this still
+  # satisfies the required status check, unlike skipping the workflow itself via a trigger-level
+  # path filter.
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      # Docs-only changes (docs/, markdown, rst) can't affect the e2e tests. Skipping them keeps
-      # this required check fast and avoids the cost of building/pushing images and running the
-      # full e2e suite for changes that can't have broken anything it tests.
       - name: Check for non-doc changes
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -41,23 +42,30 @@ jobs:
               - '!**/*.md'
               - '!**/*.rst'
 
+  e2e-test:
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' && (github.event.pull_request.merged || github.event.pull_request.head.repo.full_name == github.repository) }}
+    permissions:
+      packages: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Set up Go
-        if: steps.filter.outputs.code == 'true'
         uses: actions/setup-go@v6
         with:
           # use go version from go.mod.
           go-version-file: 'go.mod'
 
       - name: Set up QEMU
-        if: steps.filter.outputs.code == 'true'
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        if: steps.filter.outputs.code == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Login to ghcr.io
-        if: steps.filter.outputs.code == 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -65,16 +73,16 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setting git SHA to PR head
-        if: ${{ steps.filter.outputs.code == 'true' && github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' }}
         run: echo "SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
       - name: Setting git SHA to branch head
-        if: ${{ steps.filter.outputs.code == 'true' && github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' }}
         run: echo "SHA=${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Build and push
         uses: docker/build-push-action@v7
-        if: ${{ steps.filter.outputs.code == 'true' && github.actor != 'dependabot' }}
+        if: ${{ github.actor != 'dependabot' }}
         with:
           context: .
           file: Dockerfile
@@ -88,7 +96,7 @@ jobs:
 
       - name: Build and push dependabot
         uses: docker/build-push-action@v7
-        if: ${{ steps.filter.outputs.code == 'true' && github.actor == 'dependabot' }}
+        if: ${{ github.actor == 'dependabot' }}
         with:
           context: .
           file: Dockerfile
@@ -99,7 +107,6 @@ jobs:
           cache-to: type=gha,scope=e2e,mode=max
 
       - name: Run E2E tests
-        if: steps.filter.outputs.code == 'true'
         run: |
             cd e2e-tests && \
             find . -type f -name "docker-compose*.yml" | xargs -I{} sed -i 's~nutsfoundation/nuts-node:master~ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}~g' {} && \
@@ -109,7 +116,7 @@ jobs:
       - name: package cleanup
         uses: dataaxiom/ghcr-cleanup-action@v1
         continue-on-error: true # action doesn't fail when this step fails
-        if: ${{ steps.filter.outputs.code == 'true' && github.actor != 'dependabot' }}
+        if: ${{ github.actor != 'dependabot' }}
         with:
           owner: nuts-foundation
           package: nuts-node-ci
@@ -120,7 +127,7 @@ jobs:
       - name: package cleanup dependabot
         uses: dataaxiom/ghcr-cleanup-action@v1
         continue-on-error: true # action doesn't fail when this step fails
-        if: ${{ steps.filter.outputs.code == 'true' && github.actor == 'dependabot' }}
+        if: ${{ github.actor == 'dependabot' }}
         with:
           owner: nuts-foundation
           package: nuts-node-ci

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -18,22 +18,41 @@ jobs:
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      # Docs-only changes (docs/, markdown, rst) can't affect Go tests. Skipping them keeps this
+      # required check fast and avoids spending CI minutes (and hitting flaky tests) on changes
+      # that can't have broken anything it tests.
+      - name: Check for non-doc changes
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.rst'
 
       - name: Set up Go
+        if: steps.filter.outputs.code == 'true'
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
 
       - name: Test
+        if: steps.filter.outputs.code == 'true'
         run: go test ./... -race -coverprofile=c_raw.out
 
       - name: Filter coverage
+        if: steps.filter.outputs.code == 'true'
         run: grep -v generated c_raw.out | grep -v mock | grep -v test > c.out
 
       - name: Upload coverage to Qlty
         # Skip on PRs from forks: GitHub does not grant id-token: write to
         # cross-repository workflow runs, so the OIDC upload cannot authenticate.
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.filter.outputs.code == 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: qltysh/qlty-action/coverage@08a0a862c159eae9b9003081da6663d96efef637 # v2.3.0
         with:
           oidc: true

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -8,11 +8,15 @@ on:
   pull_request:
 
 jobs:
-  test:
+  # Docs-only changes (docs/, markdown, rst) can't affect Go tests. Detected once here so the
+  # (required) test job below can skip entirely on them: that keeps the check fast and avoids
+  # spending CI minutes (and hitting flaky tests) on changes that can't have broken anything it
+  # tests. A job skipped via `if:` reports as a passing check, so this still satisfies the
+  # required status check, unlike skipping the workflow itself via a trigger-level path filter.
+  changes:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -20,9 +24,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      # Docs-only changes (docs/, markdown, rst) can't affect Go tests. Skipping them keeps this
-      # required check fast and avoids spending CI minutes (and hitting flaky tests) on changes
-      # that can't have broken anything it tests.
       - name: Check for non-doc changes
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -35,24 +36,34 @@ jobs:
               - '!**/*.md'
               - '!**/*.rst'
 
+  test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
       - name: Set up Go
-        if: steps.filter.outputs.code == 'true'
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
 
       - name: Test
-        if: steps.filter.outputs.code == 'true'
         run: go test ./... -race -coverprofile=c_raw.out
 
       - name: Filter coverage
-        if: steps.filter.outputs.code == 'true'
         run: grep -v generated c_raw.out | grep -v mock | grep -v test > c.out
 
       - name: Upload coverage to Qlty
         # Skip on PRs from forks: GitHub does not grant id-token: write to
         # cross-repository workflow runs, so the OIDC upload cannot authenticate.
-        if: steps.filter.outputs.code == 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: qltysh/qlty-action/coverage@08a0a862c159eae9b9003081da6663d96efef637 # v2.3.0
         with:
           oidc: true


### PR DESCRIPTION
## What

`test` and `e2e-test` are required status checks. Both now check whether the PR/push diff touches anything outside `docs/`, `*.md` and `*.rst` (via `dorny/paths-filter`), and skip their actual work when it doesn't.

## Why

All the code checks, especially the unit and e2e tests, are slow and consume resources that aren't required - not very sustainable.

Docs-only changes can't affect Go code or e2e behavior, so there's nothing for either job to catch — but skipping them entirely at the workflow-trigger level (`paths-ignore`) would leave the required check stuck pending forever and block merging, since GitHub doesn't auto-satisfy a required check that never ran. Gating the *steps* instead of the *trigger* keeps the job itself running (so the required check resolves quickly with a pass) while skipping the actual test/build/e2e work.

This also sidesteps spending CI minutes, and occasionally hitting flaky tests (e.g. the embedded-NATS timing flake in `TestNetwork_Reprocess`), on changes that can't have broken anything either job tests.

## Scope

`.github/workflows/go-test.yaml` and `.github/workflows/e2e-tests.yaml` only. This PR itself touches `.github/**`, not `docs/**`, so it exercises the full test/e2e run as normal.

Backports to V6.2 and V5.4 to follow once this is reviewed.