### PR TITLE
test: verify docs-only CI skip (do not merge)

### DIFF
--- a/docs/pages/deployment/logging.rst
+++ b/docs/pages/deployment/logging.rst
@@ -1,5 +1,7 @@
 .. _nuts-node-logging:
 
+.. Throwaway test comment for #4455 (docs-only CI skip verification). Not rendered. Safe to ignore/close without merging.
+
 Logging
 #######
 


### PR DESCRIPTION
## Purpose

Throwaway PR to verify #4455's new job-level docs-only skip actually works end to end. This change touches only `docs/pages/deployment/logging.rst` (a no-op RST comment, not rendered).

## Expected result

- `changes` job (in both `go-test.yaml` and `e2e-tests.yaml`) passes quickly.
- `test` and `e2e-test` show as **skipped** (not run) and still report as passing checks, since this diff matches none of the "code" filter patterns.
- All other checks (CodeQL, docker, qlty, etc.) behave as normal — they don't have the docs-skip gate.

**Do not merge.** Close once verified.