### PR TITLE
ci: fix zizmor security findings across all GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -10,34 +10,48 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# deny-all default; each job below grants only the scopes it needs
+permissions: {}
+
 jobs:
   binaries:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     strategy:
       matrix:
         arch: [ 'amd64', 'arm64' ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set version params
         id: version
         shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           echo "git_commit=$(echo ${GITHUB_SHA})" >> $GITHUB_OUTPUT
           echo "git_branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
-          echo "git_version=${{github.event.release.tag_name}}" >> $GITHUB_OUTPUT
+          echo "git_version=${RELEASE_TAG}" >> $GITHUB_OUTPUT
 
       - name: Print version params
+        env:
+          GIT_COMMIT: ${{ steps.version.outputs.git_commit }}
+          GIT_BRANCH: ${{ steps.version.outputs.git_branch }}
+          GIT_VERSION: ${{ steps.version.outputs.git_version }}
         run: |
-          echo "Commit: ${{ steps.version.outputs.git_commit }}"
-          echo "Branch: ${{ steps.version.outputs.git_branch }}"
-          echo "Version: ${{ steps.version.outputs.git_version }}"
+          echo "Commit: ${GIT_COMMIT}"
+          echo "Branch: ${GIT_BRANCH}"
+          echo "Version: ${GIT_VERSION}"
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Build
         run: |
@@ -45,6 +59,8 @@ jobs:
       - name:  Upload binary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          ARCH: ${{ matrix.arch }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} nuts-linux-${{ matrix.arch }}
-          
+          gh release upload "${RELEASE_TAG}" "nuts-linux-${ARCH}"
+

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -16,12 +16,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# deny-all default; each job below grants only the scopes it needs
+permissions: {}
+
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set version params
         id: version
@@ -31,22 +38,28 @@ jobs:
           echo "git_branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
           echo "git_version=$(git name-rev --tags --name-only $(git rev-parse HEAD))" >> $GITHUB_OUTPUT
 
-      - uses: actions-ecosystem/action-get-latest-tag@v1
+      - uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435 # v1
         id: get-latest-tag
         with:
           semver_only: true
 
       - name: Print version params
+        env:
+          GIT_COMMIT: ${{ steps.version.outputs.git_commit }}
+          GIT_BRANCH: ${{ steps.version.outputs.git_branch }}
+          GIT_VERSION: ${{ steps.version.outputs.git_version }}
+          LATEST_TAG: ${{ steps.get-latest-tag.outputs.tag }}
+          THIS_TAG: ${{ github.ref }}
         run: |
-          echo "Commit: ${{ steps.version.outputs.git_commit }}"
-          echo "Branch: ${{ steps.version.outputs.git_branch }}"
-          echo "Version: ${{ steps.version.outputs.git_version }}"
-          echo "Latest tag: ${{ steps.get-latest-tag.outputs.tag }}"
-          echo "This tag: ${{ github.ref }}"
+          echo "Commit: ${GIT_COMMIT}"
+          echo "Branch: ${GIT_BRANCH}"
+          echo "Version: ${GIT_VERSION}"
+          echo "Latest tag: ${LATEST_TAG}"
+          echo "This tag: ${THIS_TAG}"
 
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: nutsfoundation/nuts-node
           tags: |
@@ -58,20 +71,20 @@ jobs:
             latest=${{ steps.version.outputs.git_version == steps.get-latest-tag.outputs.tag }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Login to Docker Hub
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: Dockerfile
@@ -87,7 +100,7 @@ jobs:
 
       - name: Build and push development image
         if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master'}}
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: development/dev-image
           push: true

--- a/.github/workflows/codeql-analysis-cron-schedule.yml
+++ b/.github/workflows/codeql-analysis-cron-schedule.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '42 21 * * 0,3'
 
+# deny-all default; the job below grants only the scopes it needs
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze
@@ -29,19 +32,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ matrix.branches }}
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           # use go version from go.mod.
           go-version-file: 'go.mod'
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           languages: 'go'
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -52,7 +56,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -66,4 +70,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,9 @@ on:
     - 'master'
     - 'V*'
 
+# deny-all default; the job below grants only the scopes it needs
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze
@@ -41,17 +44,19 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v7
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
       with:
         # use go version from go.mod.
         go-version-file: 'go.mod'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -62,7 +67,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -76,4 +81,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -12,6 +12,8 @@ on:
       - master
       - 'V*'
 
+# deny-all default; each job below grants only the scopes it needs
+permissions: {}
 
 jobs:
   # Docs-only changes (docs/, markdown, rst) can't affect the e2e tests. Detected once here so the
@@ -22,13 +24,16 @@ jobs:
   # path filter.
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for non-doc changes
         id: filter
@@ -46,27 +51,31 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' && (github.event.pull_request.merged || github.event.pull_request.head.repo.full_name == github.repository) }}
     permissions:
+      contents: read
       packages: write
 
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           # use go version from go.mod.
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -81,7 +90,7 @@ jobs:
         run: echo "SHA=${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         if: ${{ github.actor != 'dependabot' }}
         with:
           context: .
@@ -95,7 +104,7 @@ jobs:
             GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SECRET }}
 
       - name: Build and push dependabot
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         if: ${{ github.actor == 'dependabot' }}
         with:
           context: .
@@ -109,12 +118,12 @@ jobs:
       - name: Run E2E tests
         run: |
             cd e2e-tests && \
-            find . -type f -name "docker-compose*.yml" | xargs -I{} sed -i 's~nutsfoundation/nuts-node:master~ghcr.io/nuts-foundation/nuts-node-ci:${{ env.SHA }}~g' {} && \
+            find . -type f -name "docker-compose*.yml" | xargs -I{} sed -i "s~nutsfoundation/nuts-node:master~ghcr.io/nuts-foundation/nuts-node-ci:${SHA}~g" {} && \
             find . -type f -name "run-test.sh" | xargs -I{} sed -i 's/docker-compose exec/docker-compose exec -T/g' {} && \
             ./run-tests.sh
 
       - name: package cleanup
-        uses: dataaxiom/ghcr-cleanup-action@v1
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1
         continue-on-error: true # action doesn't fail when this step fails
         if: ${{ github.actor != 'dependabot' }}
         with:
@@ -125,7 +134,7 @@ jobs:
           keep-n-tagged: 3
 
       - name: package cleanup dependabot
-        uses: dataaxiom/ghcr-cleanup-action@v1
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1
         continue-on-error: true # action doesn't fail when this step fails
         if: ${{ github.actor == 'dependabot' }}
         with:

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -7,6 +7,9 @@ on:
       - 'V*'
   pull_request:
 
+# deny-all default; each job below grants only the scopes it needs
+permissions: {}
+
 jobs:
   # Docs-only changes (docs/, markdown, rst) can't affect Go tests. Detected once here so the
   # (required) test job below can skip entirely on them: that keeps the check fast and avoids
@@ -15,11 +18,13 @@ jobs:
   # required status check, unlike skipping the workflow itself via a trigger-level path filter.
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -45,12 +50,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/govulncheck-cron-schedule.yaml
+++ b/.github/workflows/govulncheck-cron-schedule.yaml
@@ -11,10 +11,15 @@ on:
   # allow manually triggering workflow
   workflow_dispatch:
 
+# deny-all default; the job below grants only the scopes it needs
+permissions: {}
+
 jobs:
   govulncheck_job:
     runs-on: ubuntu-latest
     name: Run govulncheck
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -27,12 +32,13 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ matrix.branches }}
+          persist-credentials: false
 
       - name: govulncheck
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1
         with:
           go-version-input: '' # remove default to suppress github warning
           go-version-file: 'go.mod' # test against go.mod since 'stable' is not valid for older branches
@@ -42,7 +48,7 @@ jobs:
 
       - name: notify slack
         # this uses our own 'Github notifications' app in slack
-        uses: slackapi/slack-github-action@v4.0.0
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         if: ${{ failure() }} # only run this steps if one of the previous steps has failed
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_NUTS_CORE_TEAM }} # webhook is linked to a specific slack channel

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -15,13 +15,18 @@ on:
       - 'master'
       - 'V*'
 
+# deny-all default; the job below grants only the scopes it needs
+permissions: {}
+
 jobs:
   govulncheck_job:
     runs-on: ubuntu-latest
     name: Run govulncheck
+    permissions:
+      contents: read
     steps:
       - id: govulncheck
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1
         with:
           go-version-input: 'stable'
           go-package: ./...

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -5,14 +5,20 @@ on:
     branches:
       - 'master'
 
+# deny-all default; the job below grants only the scopes it needs
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure Git
         run: |
@@ -20,12 +26,12 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
         with:
           version: v3.8.0
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           mark_as_latest: false
         env:

--- a/.github/workflows/maintainer-pr-notify.yml
+++ b/.github/workflows/maintainer-pr-notify.yml
@@ -1,6 +1,10 @@
 name: Notify on maintainer PR
 
 on:
+  # zizmor: ignore[dangerous-triggers] no checkout, no PR-controlled shell commands: only
+  # same-repo (non-fork) PRs from an allowlisted set of maintainers reach the Slack step
+  # below, and all PR-derived values are passed through toJSON()/format() into a JSON
+  # payload rather than interpolated into a shell command.
   pull_request_target:
     types: [opened, ready_for_review]
     branches:


### PR DESCRIPTION
## Summary

qlty runs zizmor (a GitHub Actions security linter) on every PR. Running it repo-wide against `master` surfaced 71 findings across every workflow file (7 informational, 9 low, 9 medium, 46 high). This fixes all of them.

- **unpinned-uses** (40, high): every third-party/first-party action pinned to a commit SHA instead of a mutable version tag, so a compromised or force-moved tag can't silently swap in different code.
- **artipacked** (8): `persist-credentials: false` added to every `actions/checkout` step that doesn't need to push, so the job's `GITHUB_TOKEN` isn't left in `.git/config` for later steps to read.
- **excessive-permissions** (9, medium): least-privilege `permissions:` added to every job that was relying on broad default token permissions, plus a deny-all top-level `permissions: {}` on each workflow (same pattern already used in `maintainer-pr-notify.yml`) so a future job added without its own block gets nothing by default.
- **cache-poisoning** (2, high): `cache: false` on the two `actions/setup-go` steps that run in workflows publishing artifacts on `release`/`push` (`build-binaries.yaml`, `e2e-tests.yaml`), so a poisoned Go module cache can't taint a published build.
- **template-injection** (11): values interpolated from `${{ }}` expressions inside `run:` shell blocks routed through `env:` vars instead, so a value containing shell metacharacters can't break out of the intended string.
- **dangerous-triggers** (1, medium): `maintainer-pr-notify.yml`'s `pull_request_target` trigger flagged generically. Reviewed it — it's already safe (no checkout, restricted to same-repo PRs from an allowlist of maintainers, all PR data passed through `toJSON()`/`format()` rather than shell-interpolated). Added a `# zizmor: ignore[dangerous-triggers]` comment documenting why, instead of changing the trigger.

Verified locally with `zizmor .github/workflows/`: 0 findings under the default persona, 0 medium/high findings even under `--persona=pedantic`. The remaining pedantic-only findings (missing workflow `name:` fields, missing `concurrency:` blocks, undocumented permission comments) are cosmetic code-smell suggestions, not security issues, and out of scope here.

## Not included

This branch is off `master` directly and does **not** include the docs-only-CI-skip `changes` job pattern from #4459/#4455 — kept separate on purpose.

## Test plan

- [x] `zizmor` re-run locally confirms 0 findings (default persona) / 0 medium+ findings (pedantic persona)
- [x] YAML syntax validated for all 10 files
- [ ] Confirm `qlty check` shows 0 blocking issues on this PR
- [ ] Confirm all workflows still run successfully on this PR (build, test, e2e, govulncheck, CodeQL, docker)