### PR TITLE
docs(deployment): document node-http-services-baseurl as a required setup step

### DIFF
--- a/docs/pages/deployment/configuration.rst
+++ b/docs/pages/deployment/configuration.rst
@@ -65,6 +65,38 @@ the options table must be regenerated using the Makefile:
 
     $ make docs
 
+.. _node-http-services-baseurl:
+
+Registering ``node-http-services-baseurl``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``did:nuts`` DIDs receive private Verifiable Credentials over OpenID4VCI: a synchronous HTTP push, from the issuer's node directly to the holder's node, at issuance time.
+For a node to be reachable this way (as issuer or holder), its ``did:nuts`` DID document needs a ``node-http-services-baseurl`` service, pointing other nodes at the public base URL where its OpenID4VCI (and other ``/n2n``) HTTP endpoints can be reached.
+Without it, the node can't be discovered over OpenID4VCI: offers to it fail, and offers from it fall back to the deprecated gRPC/Nuts network, or fail outright if that's disabled too.
+
+This service is **not** registered automatically.
+GoldenHammer (a background module that periodically fixes a handful of common DID document issues) will add it if it detects it's missing, but GoldenHammer is scheduled for removal once OpenID4VCI becomes the only way to exchange credentials
+(see `issue #2318 <https://github.com/nuts-foundation/nuts-node/issues/2318>`_) and, being a periodic best-effort fix, can't guarantee the service is present the moment it's actually needed.
+Register it explicitly as part of node setup, the same way the required ``NutsComm`` service is registered, using the DIDMan API's endpoint:
+
+.. code-block:: shell
+
+    $ curl -X POST https://internal.example.com/internal/didman/v1/did/<did>/endpoint \
+        -H "Content-Type: application/json" \
+        -d '{"type": "node-http-services-baseurl", "endpoint": "https://your-node.example.com"}'
+
+For a vendor DID document (the one whose ``NutsComm`` service is a concrete URL, e.g. ``grpc://host:5555``), register the node's actual public base URL as the ``endpoint`` value, as above.
+
+Any care-organization/subject DID document whose ``NutsComm`` service is instead a *reference* to that vendor DID should get a matching reference for ``node-http-services-baseurl``, rather than a duplicate concrete URL, so all subject DIDs of the same vendor stay in sync with a single registration:
+
+.. code-block:: shell
+
+    $ curl -X POST https://internal.example.com/internal/didman/v1/did/<subject-did>/endpoint \
+        -H "Content-Type: application/json" \
+        -d '{"type": "node-http-services-baseurl", "endpoint": "<vendor-did>/serviceEndpoint?type=node-http-services-baseurl"}'
+
+If a node's own DID document is missing this service, its log will show a warning like ``Local DID document is not properly configured for OpenID4VCI issuance``, naming the affected DID.
+
 Secrets
 *******
 

--- a/docs/pages/deployment/configuration.rst
+++ b/docs/pages/deployment/configuration.rst
@@ -70,14 +70,23 @@ the options table must be regenerated using the Makefile:
 Registering ``node-http-services-baseurl``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``did:nuts`` DIDs receive private Verifiable Credentials over OpenID4VCI: a synchronous HTTP push, from the issuer's node directly to the holder's node, at issuance time.
-For a node to be reachable this way (as issuer or holder), its ``did:nuts`` DID document needs a ``node-http-services-baseurl`` service, pointing other nodes at the public base URL where its OpenID4VCI (and other ``/n2n``) HTTP endpoints can be reached.
-Without it, the node can't be discovered over OpenID4VCI: offers to it fail, and offers from it fall back to the deprecated gRPC/Nuts network, or fail outright if that's disabled too.
+``did:nuts`` DIDs receive private Verifiable Credentials via server-to-server issuance: the issuer's node pushes the credential directly to the holder's node over HTTP, at issuance time.
+If a node can't be reached for server-to-server issuance, delivery falls back to the older gRPC/Nuts network instead, which publishes credentials (encrypted) for the holder to fetch rather than pushing them directly - a mechanism we're moving away from in favor of server-to-server issuance.
+For a node to be reachable for server-to-server issuance (as issuer or holder), its ``did:nuts`` DID document needs a ``node-http-services-baseurl`` service, pointing other nodes at the public base URL where its HTTP services (including server-to-server issuance, and other ``/n2n`` endpoints) can be reached.
+Without it, its server-to-server issuance endpoints can't be discovered, triggering the gRPC fallback described above (or an outright failure if that's disabled too).
+Given ``<base-url>`` and a DID, the endpoints it needs to be reachable at are:
 
-This service is **not** registered automatically.
-GoldenHammer (a background module that periodically fixes a handful of common DID document issues) will add it if it detects it's missing, but GoldenHammer is scheduled for removal once OpenID4VCI becomes the only way to exchange credentials
-(see `issue #2318 <https://github.com/nuts-foundation/nuts-node/issues/2318>`_) and, being a periodic best-effort fix, can't guarantee the service is present the moment it's actually needed.
-Register it explicitly as part of node setup, the same way the required ``NutsComm`` service is registered, using the DIDMan API's endpoint:
+- ``<base-url>/n2n/identity/<did>/.well-known/openid-credential-issuer`` - credential issuer metadata
+- ``<base-url>/n2n/identity/<did>/.well-known/oauth-authorization-server`` - OAuth/provider metadata
+- ``<base-url>/n2n/identity/<did>/openid4vci/credential`` - credential endpoint (issuer side)
+- ``<base-url>/n2n/identity/<did>/openid4vci/credential_offer`` - credential offer endpoint (wallet/holder side)
+
+This isn't an exhaustive list to configure individually: any reverse proxy or firewall in front of the node must forward the entire ``/n2n`` path prefix to it, not just these specific paths.
+
+This service is normally registered automatically (by a background module, GoldenHammer), as long as the node can reach itself: for each hostname in its own TLS certificate, it does a ``HEAD`` request to ``https://<hostname>/n2n/identity/<did>/.well-known/openid-credential-issuer`` and registers the first hostname that responds with ``200 OK`` and ``Content-Type: application/json``.
+If it's missing, that's usually why: check that the node can actually reach itself that way - DNS, firewall, and reverse-proxy routing are the usual suspects.
+
+You can also register the service manually via the DIDMan API, e.g. to have it in place immediately after setup rather than waiting for the next automatic check, or as a fallback if a subject DID's vendor reference can't be resolved automatically for any reason:
 
 .. code-block:: shell
 
@@ -94,8 +103,6 @@ Any care-organization/subject DID document whose ``NutsComm`` service is instead
     $ curl -X POST https://internal.example.com/internal/didman/v1/did/<subject-did>/endpoint \
         -H "Content-Type: application/json" \
         -d '{"type": "node-http-services-baseurl", "endpoint": "<vendor-did>/serviceEndpoint?type=node-http-services-baseurl"}'
-
-If a node's own DID document is missing this service, its log will show a warning like ``Local DID document is not properly configured for OpenID4VCI issuance``, naming the affected DID.
 
 Secrets
 *******

--- a/docs/pages/deployment/configuration.rst
+++ b/docs/pages/deployment/configuration.rst
@@ -65,45 +65,6 @@ the options table must be regenerated using the Makefile:
 
     $ make docs
 
-.. _node-http-services-baseurl:
-
-Registering ``node-http-services-baseurl``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-``did:nuts`` DIDs receive private Verifiable Credentials via server-to-server issuance: the issuer's node pushes the credential directly to the holder's node over HTTP, at issuance time.
-If a node can't be reached for server-to-server issuance, delivery falls back to the older gRPC/Nuts network instead, which publishes credentials (encrypted) for the holder to fetch rather than pushing them directly - a mechanism we're moving away from in favor of server-to-server issuance.
-For a node to be reachable for server-to-server issuance (as issuer or holder), its ``did:nuts`` DID document needs a ``node-http-services-baseurl`` service, pointing other nodes at the public base URL where its HTTP services (including server-to-server issuance, and other ``/n2n`` endpoints) can be reached.
-Without it, its server-to-server issuance endpoints can't be discovered, triggering the gRPC fallback described above (or an outright failure if that's disabled too).
-Given ``<base-url>`` and a DID, the endpoints it needs to be reachable at are:
-
-- ``<base-url>/n2n/identity/<did>/.well-known/openid-credential-issuer`` - credential issuer metadata
-- ``<base-url>/n2n/identity/<did>/.well-known/oauth-authorization-server`` - OAuth/provider metadata
-- ``<base-url>/n2n/identity/<did>/openid4vci/credential`` - credential endpoint (issuer side)
-- ``<base-url>/n2n/identity/<did>/openid4vci/credential_offer`` - credential offer endpoint (wallet/holder side)
-
-This isn't an exhaustive list to configure individually: any reverse proxy or firewall in front of the node must forward the entire ``/n2n`` path prefix to it, not just these specific paths.
-
-This service is normally registered automatically (by a background module, GoldenHammer), as long as the node can reach itself: for each hostname in its own TLS certificate, it does a ``HEAD`` request to ``https://<hostname>/n2n/identity/<did>/.well-known/openid-credential-issuer`` and registers the first hostname that responds with ``200 OK`` and ``Content-Type: application/json``.
-If it's missing, that's usually why: check that the node can actually reach itself that way - DNS, firewall, and reverse-proxy routing are the usual suspects.
-
-You can also register the service manually via the DIDMan API, e.g. to have it in place immediately after setup rather than waiting for the next automatic check, or as a fallback if a subject DID's vendor reference can't be resolved automatically for any reason:
-
-.. code-block:: shell
-
-    $ curl -X POST https://internal.example.com/internal/didman/v1/did/<did>/endpoint \
-        -H "Content-Type: application/json" \
-        -d '{"type": "node-http-services-baseurl", "endpoint": "https://your-node.example.com"}'
-
-For a vendor DID document (the one whose ``NutsComm`` service is a concrete URL, e.g. ``grpc://host:5555``), register the node's actual public base URL as the ``endpoint`` value, as above.
-
-Any care-organization/subject DID document whose ``NutsComm`` service is instead a *reference* to that vendor DID should get a matching reference for ``node-http-services-baseurl``, rather than a duplicate concrete URL, so all subject DIDs of the same vendor stay in sync with a single registration:
-
-.. code-block:: shell
-
-    $ curl -X POST https://internal.example.com/internal/didman/v1/did/<subject-did>/endpoint \
-        -H "Content-Type: application/json" \
-        -d '{"type": "node-http-services-baseurl", "endpoint": "<vendor-did>/serviceEndpoint?type=node-http-services-baseurl"}'
-
 Secrets
 *******
 
@@ -138,3 +99,42 @@ and the ``internalratelimiter`` is always on.
 Interacting with remote Nuts nodes requires HTTPS: it will refuse to connect to plain HTTP endpoints when in strict mode.
 Strict mode additionally rejects outbound URLs whose host is an RFC 2606 reserved hostname/TLD (e.g. ``*.localhost``, ``*.test``, ``example.com/net/org``); non-public IP addresses are refused too, unless explicitly permitted via ``http.client.allowedinternalcidrs``.
 This applies to every outbound HTTP call made via the shared HTTP client (OpenID4VCI, OAuth relying-party, IAM, Discovery, did:web resolution, etc.) and to every redirect target along the way.
+
+.. _node-http-services-baseurl:
+
+Registering ``node-http-services-baseurl``
+********************************************
+
+``did:nuts`` DIDs receive private Verifiable Credentials via server-to-server issuance: the issuer's node pushes the credential directly to the holder's node over HTTP, at issuance time.
+If a node can't be reached for server-to-server issuance, delivery falls back to the older gRPC/Nuts network instead, which publishes credentials (encrypted) for the holder to fetch rather than pushing them directly - a mechanism we're moving away from in favor of server-to-server issuance.
+For a node to be reachable for server-to-server issuance (as issuer or holder), its ``did:nuts`` DID document needs a ``node-http-services-baseurl`` service, pointing other nodes at the public base URL where its HTTP services (including server-to-server issuance, and other ``/n2n`` endpoints) can be reached.
+Without it, its server-to-server issuance endpoints can't be discovered, triggering the gRPC fallback described above (or an outright failure if that's disabled too).
+Given ``<base-url>`` and a DID, the endpoints it needs to be reachable at are:
+
+- ``<base-url>/n2n/identity/<did>/.well-known/openid-credential-issuer`` - credential issuer metadata
+- ``<base-url>/n2n/identity/<did>/.well-known/oauth-authorization-server`` - OAuth/provider metadata
+- ``<base-url>/n2n/identity/<did>/openid4vci/credential`` - credential endpoint (issuer side)
+- ``<base-url>/n2n/identity/<did>/openid4vci/credential_offer`` - credential offer endpoint (wallet/holder side)
+
+This isn't an exhaustive list to configure individually: any reverse proxy or firewall in front of the node must forward the entire ``/n2n`` path prefix to it, not just these specific paths.
+
+This service is normally registered automatically (by a background module, GoldenHammer), as long as the node can reach itself: for each hostname in its own TLS certificate, it does a ``HEAD`` request to ``https://<hostname>/n2n/identity/<did>/.well-known/openid-credential-issuer`` and registers the first hostname that responds with ``200 OK`` and ``Content-Type: application/json``.
+If it's missing, that's usually why: check that the node can actually reach itself that way - DNS, firewall, and reverse-proxy routing are the usual suspects.
+
+You can also register the service manually via the DIDMan API, e.g. to have it in place immediately after setup rather than waiting for the next automatic check, or as a fallback if a subject DID's vendor reference can't be resolved automatically for any reason:
+
+.. code-block:: shell
+
+    $ curl -X POST https://internal.example.com/internal/didman/v1/did/<did>/endpoint \
+        -H "Content-Type: application/json" \
+        -d '{"type": "node-http-services-baseurl", "endpoint": "https://your-node.example.com"}'
+
+For a vendor DID document (the one whose ``NutsComm`` service is a concrete URL, e.g. ``grpc://host:5555``), register the node's actual public base URL as the ``endpoint`` value, as above.
+
+Any care-organization/subject DID document whose ``NutsComm`` service is instead a *reference* to that vendor DID should get a matching reference for ``node-http-services-baseurl``, rather than a duplicate concrete URL, so all subject DIDs of the same vendor stay in sync with a single registration:
+
+.. code-block:: shell
+
+    $ curl -X POST https://internal.example.com/internal/didman/v1/did/<subject-did>/endpoint \
+        -H "Content-Type: application/json" \
+        -d '{"type": "node-http-services-baseurl", "endpoint": "<vendor-did>/serviceEndpoint?type=node-http-services-baseurl"}'

--- a/docs/pages/deployment/configuration.rst
+++ b/docs/pages/deployment/configuration.rst
@@ -106,9 +106,9 @@ Registering ``node-http-services-baseurl``
 ********************************************
 
 ``did:nuts`` DIDs receive private Verifiable Credentials via server-to-server issuance: the issuer's node pushes the credential directly to the holder's node over HTTP, at issuance time.
-If a node can't be reached for server-to-server issuance, delivery falls back to the older gRPC/Nuts network instead, which publishes credentials (encrypted) for the holder to fetch rather than pushing them directly - a mechanism we're moving away from in favor of server-to-server issuance.
-For a node to be reachable for server-to-server issuance (as issuer or holder), its ``did:nuts`` DID document needs a ``node-http-services-baseurl`` service, pointing other nodes at the public base URL where its HTTP services (including server-to-server issuance, and other ``/n2n`` endpoints) can be reached.
-Without it, its server-to-server issuance endpoints can't be discovered, triggering the gRPC fallback described above (or an outright failure if that's disabled too).
+If a node can't be reached for server-to-server issuance, delivery falls back to the older gRPC/Nuts network instead: it publishes a transaction (with the recipient list encrypted) referencing the credential to the whole network, and the holder fetches the actual credential separately over an authenticated connection - a mechanism we're moving away from in favor of server-to-server issuance.
+For a node to be reachable for server-to-server issuance (as issuer or holder), its ``did:nuts`` DID document needs a ``node-http-services-baseurl`` service endpoint, pointing other nodes at the public base URL where its HTTP services (including server-to-server issuance, and other ``/n2n`` endpoints) can be reached.
+Without this DID Document service endpoint, its server-to-server issuance endpoints can't be discovered, triggering the gRPC fallback described above (or an outright failure if that's disabled too).
 Given ``<base-url>`` and a DID, the endpoints it needs to be reachable at are:
 
 - ``<base-url>/n2n/identity/<did>/.well-known/openid-credential-issuer`` - credential issuer metadata
@@ -118,10 +118,10 @@ Given ``<base-url>`` and a DID, the endpoints it needs to be reachable at are:
 
 This isn't an exhaustive list to configure individually: any reverse proxy or firewall in front of the node must forward the entire ``/n2n`` path prefix to it, not just these specific paths.
 
-This service is normally registered automatically (by a background module, GoldenHammer), as long as the node can reach itself: for each hostname in its own TLS certificate, it does a ``HEAD`` request to ``https://<hostname>/n2n/identity/<did>/.well-known/openid-credential-issuer`` and registers the first hostname that responds with ``200 OK`` and ``Content-Type: application/json``.
-If it's missing, that's usually why: check that the node can actually reach itself that way - DNS, firewall, and reverse-proxy routing are the usual suspects.
+The DID Document service endpoint is added automatically when possible, to ease configuration: a background module, GoldenHammer, tests each hostname in the node's own TLS certificate with a ``HEAD`` request to ``https://<hostname>/n2n/identity/<did>/.well-known/openid-credential-issuer``, and registers the first hostname that responds with ``200 OK`` and ``Content-Type: application/json``.
+This can fail if the node can't reach itself that way - DNS, firewall, and reverse-proxy routing are the usual suspects - in which case the endpoint stays missing.
 
-You can also register the service manually via the DIDMan API, e.g. to have it in place immediately after setup rather than waiting for the next automatic check, or as a fallback if a subject DID's vendor reference can't be resolved automatically for any reason:
+You can also register the service endpoint manually via the DIDMan API, e.g. to have it in place immediately after setup rather than waiting for the next automatic check, or as a fallback if a subject DID's vendor reference can't be resolved automatically for any reason:
 
 .. code-block:: shell
 

--- a/docs/pages/deployment/recommended-deployment.rst
+++ b/docs/pages/deployment/recommended-deployment.rst
@@ -130,6 +130,7 @@ If your use case does not require ``did:nuts`` DIDs and/or the gRPC network, you
 
 * **/n2n** (public): for providing Nuts services to other nodes (e.g. creating access tokens).
    The local node also calls other nodes on their ``/n2n`` endpoint, these outgoing calls are subject to the same security requirements.
+   Server-to-server credential issuance for ``did:nuts`` DIDs also runs over this endpoint; see :ref:`Registering node-http-services-baseurl <node-http-services-baseurl>` for how nodes discover each other's ``/n2n`` base URL.
 
    *Users*: Other Nuts nodes.
 


### PR DESCRIPTION
Related: #4469

## Problem

`did:nuts` DIDs have historically relied on the gRPC/Nuts network to exchange credentials. We want to move away from that in favor of server-to-server issuance over HTTP instead, but nothing documents `node-http-services-baseurl` - the DID service required for a node to be reachable that way - as a setup step at all.

## Solution

Adds a "Registering `node-http-services-baseurl`" section to `docs/pages/deployment/configuration.rst`, right after the existing did:nuts/gRPC options table:

- Frames the mechanism as "server-to-server issuance" (currently OpenID4VCI, but that's an implementation detail that may change) rather than centering on OpenID4VCI by name, and the gRPC/Nuts network as the fallback we're moving away from.
- Lists the concrete `/n2n` endpoints involved, and notes the whole `/n2n` prefix must be proxied through, not just these specific paths.
- Explains that the service is normally registered automatically by GoldenHammer, and precisely how: it probes each hostname in the node's own TLS certificate (not `config.URL` - verified GoldenHammer predates that, from v5.4) with a HEAD request to the credential-issuer-metadata well-known path, registering the first one that responds. Points at the usual causes (DNS/firewall/reverse-proxy) when it's missing.
- Shows manual registration via the DIDMan API, for both a vendor DID (concrete URL) and a subject DID referencing a vendor's `NutsComm` service (matching reference, not a duplicate URL).

Also cross-references the new section from the `/n2n` endpoint description in `docs/pages/deployment/recommended-deployment.rst`'s "Legacy Endpoints" section, since server-to-server issuance runs over that same endpoint.

Verified with a clean sphinx build using `docs/Dockerfile` - 0 new warnings; the 4 pre-existing ones (`release_notes.rst`, `discovery.rst`) are unrelated.

## Test plan

- [x] `sphinx-build -M html . _build -W` via `docs/Dockerfile`, clean

Assisted by AI