### PR TITLE
Backport 4 security fixes to V5.4

### DIFF
--- a/crypto/ecies.go
+++ b/crypto/ecies.go
@@ -27,9 +27,52 @@ import (
 
 // EciesDecrypt decrypts the `cipherText` using the Elliptic Curve Integrated Encryption Scheme
 func EciesDecrypt(privateKey *ecdsa.PrivateKey, cipherText []byte) ([]byte, error) {
+	if err := validateEciesCiphertextLength(privateKey, cipherText); err != nil {
+		return nil, err
+	}
+
 	key := ecies.ImportECDSA(privateKey)
 
 	return key.Decrypt(cipherText, nil, nil)
+}
+
+// validateEciesCiphertextLength rejects a ciphertext too short to decrypt without
+// ecies.PrivateKey.Decrypt computing a negative slice length and panicking. That function accepts
+// anything of at least rLen+hLen+1 bytes (the ephemeral public key plus the MAC plus one byte),
+// but then hands the rLen+hLen bytes after that to symDecrypt, which subtracts a full cipher block
+// size from their length before allocating - anything short of rLen+hLen+BlockSize underflows.
+// rLen, hLen and BlockSize are reproduced here exactly as ecies.PrivateKey.Decrypt computes them
+// (see its source, ecies.go, and the params it looks up in params.go), using the same per-curve
+// parameter lookup, so this covers every curve the library supports, not just P-256.
+//
+// For P-256 (what this codebase actually uses): rLen=65 (uncompressed EC point), hLen=32 (SHA-256),
+// BlockSize=16 (AES), so this rejects anything under 113 bytes. That's below what honestly
+// encrypted data ever produces: ecies.Encrypt pads the body to at least one cipher block, and
+// additionally refuses to encrypt a plaintext that would produce a body of exactly one block
+// (len(em) <= BlockSize check in Encrypt), so the smallest real ciphertext is for a 1-byte
+// plaintext at rLen+hLen+(BlockSize+1) = 114 bytes - one byte above this floor. Verified
+// empirically (encrypt/decrypt round-trip for 0/1/2/5-byte plaintexts against a fresh P-256 key):
+// 0 bytes -> Encrypt returns (nil, nil) (pre-existing library behaviour, unrelated to this
+// change), 1 byte -> 114-byte ciphertext, round-trips; 2 bytes -> 115; 5 bytes -> 118. So this
+// check never rejects anything the library's own Encrypt can produce - only ciphertext that was
+// never honestly encrypted, exactly the attacker-forged case this closes.
+func validateEciesCiphertextLength(privateKey *ecdsa.PrivateKey, cipherText []byte) error {
+	curve := privateKey.PublicKey.Curve
+	params := ecies.ParamsFromCurve(curve)
+	if params == nil {
+		return ecies.ErrUnsupportedECIESParameters
+	}
+	// rLen is copied verbatim from ecies.PrivateKey.Decrypt (see ecies.go in the crypto-ecies
+	// module), not re-derived here: this check only works because it predicts exactly what that
+	// function is about to compute. A "more correct" version of this formula could disagree with
+	// the library's own arithmetic on some curve and let something through - or reject something
+	// valid - so it has to match, not just be equivalent.
+	rLen := (curve.Params().BitSize + 7) / 4
+	hLen := params.Hash().Size()
+	if len(cipherText) < rLen+hLen+params.BlockSize {
+		return ecies.ErrInvalidMessage
+	}
+	return nil
 }
 
 // EciesEncrypt encrypts the `plainText` using the Elliptic Curve Integrated Encryption Scheme

--- a/crypto/ecies_test.go
+++ b/crypto/ecies_test.go
@@ -19,9 +19,17 @@
 package crypto
 
 import (
+	"crypto/elliptic"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
 	"testing"
 
+	ecies "github.com/nuts-foundation/crypto-ecies"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEciesEncrypt(t *testing.T) {
@@ -37,6 +45,23 @@ func TestEciesEncrypt(t *testing.T) {
 	assert.NotEqual(t, cipherText1, cipherText2)
 }
 
+// TestEciesEncryptDecrypt_SmallestPlaintext backs the claim in validateEciesCiphertextLength's
+// godoc that the shortest ciphertext ecies.Encrypt can ever legitimately produce (114 bytes, for a
+// 1-byte P-256 plaintext) is already 1 byte above that function's 113-byte reject threshold, so
+// the length check never rejects honestly encrypted data.
+func TestEciesEncryptDecrypt_SmallestPlaintext(t *testing.T) {
+	key, err := generateECKeyPair()
+	require.NoError(t, err)
+
+	cipherText, err := EciesEncrypt(&key.PublicKey, []byte{0x01})
+	require.NoError(t, err)
+	require.Len(t, cipherText, 114)
+
+	plainText, err := EciesDecrypt(key, cipherText)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x01}, plainText)
+}
+
 func TestEciesDecrypt(t *testing.T) {
 	key, err := generateECKeyPair()
 	assert.NoError(t, err)
@@ -48,4 +73,98 @@ func TestEciesDecrypt(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, []byte("hello world"), plainText)
+}
+
+// TestEciesDecrypt_ShortCiphertext checks the length boundary on its own: too-short input is
+// rejected uniformly regardless of content, since the length check runs before anything is parsed
+// as an EC point or MAC. It doesn't by itself prove the original panic is gone, because
+// ecies.PrivateKey.Decrypt rejects non-point garbage (ErrInvalidPublicKey) before it would ever
+// reach the vulnerable code; see TestEciesDecrypt_ForgedShortCiphertext for that.
+func TestEciesDecrypt_ShortCiphertext(t *testing.T) {
+	key, err := generateECKeyPair()
+	require.NoError(t, err)
+
+	t.Run("below the corrected minimum (rLen+hLen+BlockSize=113 for P-256) is rejected", func(t *testing.T) {
+		for _, length := range []int{0, 1, 10, 97, 98, 100, 112} {
+			t.Run(fmt.Sprintf("%d bytes", length), func(t *testing.T) {
+				cipherText := make([]byte, length)
+				if length > 0 {
+					cipherText[0] = 4 // ecies.PrivateKey.Decrypt only proceeds past its own check for prefix 2, 3 or 4
+				}
+
+				plainText, err := EciesDecrypt(key, cipherText)
+
+				assert.ErrorIs(t, err, ecies.ErrInvalidMessage)
+				assert.Nil(t, plainText)
+			})
+		}
+	})
+	t.Run("at the corrected minimum length, decryption is attempted (and fails cleanly on garbage input)", func(t *testing.T) {
+		cipherText := make([]byte, 113)
+		cipherText[0] = 4
+
+		plainText, err := EciesDecrypt(key, cipherText)
+
+		assert.Error(t, err)
+		assert.Nil(t, plainText)
+	})
+}
+
+// TestEciesDecrypt_ForgedShortCiphertext reproduces the actual attack from the issue this fixes:
+// a genuine ephemeral key and a correctly-computed MAC (the attacker only needs the victim's
+// public key for both, which is published in its DID document) wrapped around a 1-byte body,
+// assembled into a 98-byte ciphertext. Before the fix, ecies.PrivateKey.Decrypt's own length check
+// (rLen+hLen+1 = 98 bytes) let this through, and symDecrypt then computed
+// make([]byte, len(ct)-BlockSize) with len(ct)=1, panicking. EciesEncrypt can't produce this
+// shape itself -- symEncrypt always pads to at least one full block (16 bytes) -- so this has to
+// be forged by hand, replicating ecies.PrivateKey.Decrypt's own key derivation and tagging
+// (deriveKeys/messageTag) exactly, since those aren't exported.
+func TestEciesDecrypt_ForgedShortCiphertext(t *testing.T) {
+	victim, err := generateECKeyPair()
+	require.NoError(t, err)
+
+	ephemeral, err := ecies.GenerateKey(rand.Reader, elliptic.P256(), ecies.ECIES_AES128_SHA256)
+	require.NoError(t, err)
+
+	z, err := ephemeral.GenerateShared(ecies.ImportECDSAPublic(&victim.PublicKey), 16, 16)
+	require.NoError(t, err)
+	_, km := deriveKeysForTest(z, 16)
+
+	body := []byte{0x42} // 1-byte body, as in the issue's PoC
+	tag := hmac.New(sha256.New, km)
+	tag.Write(body)
+	mac := tag.Sum(nil)
+
+	r := elliptic.Marshal(elliptic.P256(), ephemeral.PublicKey.X, ephemeral.PublicKey.Y) // 65 bytes
+	cipherText := append(append(append([]byte{}, r...), body...), mac...)
+	require.Len(t, cipherText, 98) // matches the issue's PoC exactly
+
+	plainText, err := EciesDecrypt(victim, cipherText)
+
+	assert.ErrorIs(t, err, ecies.ErrInvalidMessage)
+	assert.Nil(t, plainText)
+}
+
+// deriveKeysForTest replicates ecies.deriveKeys (NIST SP 800-56 concatenation KDF followed by a
+// hash over Km), which isn't exported. s1 is nil, matching how decryptPAL calls EciesDecrypt.
+func deriveKeysForTest(z []byte, keyLen int) (ke, km []byte) {
+	h := sha256.New()
+	counter := uint32(1)
+	var k []byte
+	for len(k) < 2*keyLen {
+		var counterBytes [4]byte
+		binary.BigEndian.PutUint32(counterBytes[:], counter)
+		h.Reset()
+		h.Write(counterBytes[:])
+		h.Write(z)
+		k = h.Sum(k)
+		counter++
+	}
+	k = k[:2*keyLen]
+	ke = k[:keyLen]
+	km = k[keyLen:]
+	h.Reset()
+	h.Write(km)
+	km = h.Sum(nil)
+	return ke, km
 }

--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -4,6 +4,19 @@ Release notes
 #############
 
 *************************
+Hazelnut update (v5.4.38)
+*************************
+
+Release date: 2026-08-11
+
+- Reject non-canonical JWS transaction encoding.
+- Reject undersized ECIES ciphertext before it reaches decryption.
+- Restrict private transaction payload serving to the authoring node.
+- Cap PAL entries at 2, closing the decrypt-amplification DoS.
+
+**Full Changelog**: https://github.com/nuts-foundation/nuts-node/compare/v5.4.37...v5.4.38
+
+*************************
 Hazelnut update (v5.4.37)
 *************************
 

--- a/network/dag/pal.go
+++ b/network/dag/pal.go
@@ -36,6 +36,14 @@ import (
 // palHeaderDIDSeparator holds the character(s) that separate DID entries in the PAL header, before being encrypted.
 const palHeaderDIDSeparator = "\n"
 
+// palEntryCount is the exact number of entries a transaction's PAL (encrypted participant list) must
+// contain, both encrypted (one entry per recipient) and, once decrypted, in the participant list
+// itself. Every private transaction has exactly 2 participants (sender and receiver); a peer-
+// controlled PAL with more entries forces a decrypt attempt against every local keyAgreement key for
+// each one, with no early exit, and a single decrypted entry's plaintext is otherwise unbounded since
+// it's entirely attacker-chosen.
+const palEntryCount = 2
+
 // PAL holds the list of participants of a transaction.
 type PAL []did.DID
 
@@ -121,8 +129,17 @@ outer:
 		return nil, nil
 	}
 
+	parts := strings.Split(string(decrypted), palHeaderDIDSeparator)
+	// The encrypted-entry check in parsePAL/NewTransaction bounds how many expensive decrypt attempts
+	// this function makes, but not what's inside a single entry once it does decrypt - that plaintext
+	// is entirely attacker-chosen. Without this, one successfully-decrypted entry could still contain
+	// an unbounded number of newline-separated fake DIDs, each fed through did.ParseDID below.
+	if len(parts) != palEntryCount {
+		return nil, fmt.Errorf("decrypted pal must contain exactly %d entries, got %d", palEntryCount, len(parts))
+	}
+
 	var participants []did.DID
-	for _, curr := range strings.Split(string(decrypted), palHeaderDIDSeparator) {
+	for _, curr := range parts {
 		participant, err := did.ParseDID(curr)
 		if err != nil {
 			return nil, fmt.Errorf("invalid participant (did=%s): %w", curr, err)

--- a/network/dag/pal_test.go
+++ b/network/dag/pal_test.go
@@ -108,11 +108,40 @@ func TestDecryptPal(t *testing.T) {
 		cryptoInstance := crypto.NewTestCryptoInstance(keyStore)
 		keyStore.SavePrivateKey(ctx, "kid-1", pk)
 
-		cipherText, _ := crypto.EciesEncrypt(pk.Public().(*ecdsa.PublicKey), []byte{1, 2, 3})
+		// Exactly 2 entries so the count check passes and parsing reaches the invalid one.
+		plaintext := append(append([]byte{1, 2, 3}, '\n'), []byte("did:nuts:test")...)
+		cipherText, _ := crypto.EciesEncrypt(pk.Public().(*ecdsa.PublicKey), plaintext)
 
 		actual, err := EncryptedPAL{cipherText}.Decrypt(ctx, []string{"kid-1"}, cryptoInstance)
 		assert.Nil(t, actual)
 		assert.EqualError(t, err, "invalid participant (did=\x01\x02\x03): invalid DID: input length is less than 7")
+	})
+	t.Run("error - too many entries in decrypted PAL", func(t *testing.T) {
+		// The encrypted-entry check doesn't bound what's inside a single entry once it decrypts -
+		// this is a single, legitimately-decryptable entry whose plaintext claims more participants
+		// than allowed.
+		keyStore := crypto.NewMemoryStorage()
+		cryptoInstance := crypto.NewTestCryptoInstance(keyStore)
+		_ = keyStore.SavePrivateKey(ctx, "kid-1", pk)
+
+		plaintext := []byte("did:nuts:A\ndid:nuts:B\ndid:nuts:C")
+		cipherText, _ := crypto.EciesEncrypt(pk.Public().(*ecdsa.PublicKey), plaintext)
+
+		actual, err := EncryptedPAL{cipherText}.Decrypt(ctx, []string{"kid-1"}, cryptoInstance)
+		assert.Nil(t, actual)
+		assert.EqualError(t, err, "decrypted pal must contain exactly 2 entries, got 3")
+	})
+	t.Run("error - too few entries in decrypted PAL", func(t *testing.T) {
+		keyStore := crypto.NewMemoryStorage()
+		cryptoInstance := crypto.NewTestCryptoInstance(keyStore)
+		_ = keyStore.SavePrivateKey(ctx, "kid-1", pk)
+
+		plaintext := []byte("did:nuts:A")
+		cipherText, _ := crypto.EciesEncrypt(pk.Public().(*ecdsa.PublicKey), plaintext)
+
+		actual, err := EncryptedPAL{cipherText}.Decrypt(ctx, []string{"kid-1"}, cryptoInstance)
+		assert.Nil(t, actual)
+		assert.EqualError(t, err, "decrypted pal must contain exactly 2 entries, got 1")
 	})
 }
 

--- a/network/dag/parser.go
+++ b/network/dag/parser.go
@@ -22,6 +22,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/lestrrat-go/jwx/jwa"
@@ -31,8 +32,19 @@ import (
 	"github.com/nuts-foundation/nuts-node/crypto/hash"
 )
 
+// errNonCanonicalJWS is returned when the input is not the unique canonical compact JWS encoding of
+// its own header, payload and signature; see validateCanonicalCompactSerialization.
+var errNonCanonicalJWS = errors.New("JWS is not canonically encoded compact serialization")
+
 // ParseTransaction parses the input as Nuts Network Transaction according to RFC004.
 func ParseTransaction(input []byte) (Transaction, error) {
+	// RFC004 only defines compact serialization. This vendored jwx version has no compact-only
+	// parse option, so validateCanonicalCompactSerialization does that job itself: it requires
+	// input to be exactly 3 canonical base64url segments, which JSON serialization (or anything
+	// else) can't satisfy, before jws.Parse's own format auto-detection ever runs.
+	if err := validateCanonicalCompactSerialization(input); err != nil {
+		return nil, fmt.Errorf(unableToParseTransactionErrFmt, err)
+	}
 	message, err := jws.Parse(input)
 	if err != nil {
 		return nil, fmt.Errorf(unableToParseTransactionErrFmt, err)
@@ -73,6 +85,36 @@ func transactionValidationError(format string, args ...interface{}) error {
 		return fmt.Errorf(transactionNotValidErrFmt, errors.New(format))
 	}
 	return fmt.Errorf(transactionNotValidErrFmt, fmt.Errorf(format, args...))
+}
+
+// validateCanonicalCompactSerialization rejects a compact JWS whose bytes aren't the unique
+// canonical encoding of its own header, payload and signature. jws.Parse, even restricted to
+// compact serialization, still accepts and verifies encodings that decode to the same content as
+// the canonical one - e.g. surrounding whitespace, or base64 with non-zero unused trailing bits -
+// because verification checks the decoded content, not the received bytes. Transaction identity
+// (Ref(), see transaction.go) is the hash of the received bytes, so a non-canonical variant hashes
+// to a different ref than the original while carrying an equally valid signature: anyone who has
+// seen one signed transaction could mint unlimited "new" ones from it without the signing key.
+// Re-deriving the canonical form and requiring an exact match closes that regardless of which
+// specific leniency jws.Parse has today or gains later, and never rejects anything jws.Sign
+// produces, since that output is already canonical.
+func validateCanonicalCompactSerialization(input []byte) error {
+	parts := strings.Split(string(input), ".")
+	if len(parts) != 3 {
+		return errNonCanonicalJWS
+	}
+	canonical := make([]string, len(parts))
+	for i, part := range parts {
+		decoded, err := base64.RawURLEncoding.DecodeString(part)
+		if err != nil {
+			return errNonCanonicalJWS
+		}
+		canonical[i] = base64.RawURLEncoding.EncodeToString(decoded)
+	}
+	if strings.Join(canonical, ".") != string(input) {
+		return errNonCanonicalJWS
+	}
+	return nil
 }
 
 // transactionParseStep defines a function that parses a part of a JWS, building the internal representation of a transaction.
@@ -189,6 +231,9 @@ func parsePAL(transaction *transaction, headers jws.Headers, _ *jws.Message) err
 	palEncoded, ok := rawPal.([]interface{})
 	if !ok {
 		return transactionValidationError(invalidHeaderErrFmt, palHeader)
+	}
+	if len(palEncoded) != palEntryCount {
+		return transactionValidationError("pal header must contain exactly %d entries, got %d", palEntryCount, len(palEncoded))
 	}
 	var pal [][]byte
 	for _, curr := range palEncoded {

--- a/network/dag/parser_test.go
+++ b/network/dag/parser_test.go
@@ -22,7 +22,9 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"encoding/base64"
+	"fmt"
 	"github.com/stretchr/testify/require"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,7 +42,7 @@ func TestParseTransaction(t *testing.T) {
 	payloadAsBytes := []byte(payload.String())
 	t.Run("v1", func(t *testing.T) {
 		headers := makeJWSHeaders(key, "123", true)
-		_ = headers.Set("pal", []string{base64.StdEncoding.EncodeToString([]byte{5, 6, 7})})
+		_ = headers.Set("pal", []string{base64.StdEncoding.EncodeToString([]byte{5, 6, 7}), base64.StdEncoding.EncodeToString([]byte{8, 9, 10})})
 		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
 
 		transaction, err := ParseTransaction(signature)
@@ -59,13 +61,13 @@ func TestParseTransaction(t *testing.T) {
 		assert.Equal(t, "foo/bar", transaction.PayloadType())
 		assert.Equal(t, time.UTC, transaction.SigningTime().Location())
 		assert.Equal(t, headers.PrivateParams()[previousHeader].([]string)[0], transaction.Previous()[0].String())
-		assert.Equal(t, transaction.PAL(), [][]byte{{5, 6, 7}})
+		assert.Equal(t, transaction.PAL(), [][]byte{{5, 6, 7}, {8, 9, 10}})
 		assert.NotNil(t, transaction.Data())
 		assert.False(t, transaction.Ref().Empty())
 	})
 	t.Run("ok v2", func(t *testing.T) {
 		headers := makeJWSHeaders(key, "123", true)
-		_ = headers.Set("pal", []string{base64.StdEncoding.EncodeToString([]byte{5, 6, 7})})
+		_ = headers.Set("pal", []string{base64.StdEncoding.EncodeToString([]byte{5, 6, 7}), base64.StdEncoding.EncodeToString([]byte{8, 9, 10})})
 		_ = headers.Set(versionHeader, 2)
 		_ = headers.Set(jws.CriticalKey, []string{signingTimeHeader, versionHeader, previousHeader, lamportClockHeader})
 		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
@@ -86,19 +88,48 @@ func TestParseTransaction(t *testing.T) {
 		assert.Equal(t, "foo/bar", transaction.PayloadType())
 		assert.Equal(t, time.UTC, transaction.SigningTime().Location())
 		assert.Equal(t, headers.PrivateParams()[previousHeader].([]string)[0], transaction.Previous()[0].String())
-		assert.Equal(t, transaction.PAL(), [][]byte{{5, 6, 7}})
+		assert.Equal(t, transaction.PAL(), [][]byte{{5, 6, 7}, {8, 9, 10}})
 		assert.NotNil(t, transaction.Data())
 		assert.False(t, transaction.Ref().Empty())
 	})
 	t.Run("error - input not a JWS (compact serialization format)", func(t *testing.T) {
 		tx, err := ParseTransaction([]byte("not a JWS"))
 		assert.Nil(t, tx)
-		assert.EqualError(t, err, "unable to parse transaction: invalid compact serialization format: invalid number of segments")
+		assert.EqualError(t, err, "unable to parse transaction: JWS is not canonically encoded compact serialization")
 	})
 	t.Run("error - input not a JWS (JSON serialization format)", func(t *testing.T) {
 		tx, err := ParseTransaction([]byte("{}"))
 		assert.Nil(t, tx)
-		assert.EqualError(t, err, "unable to parse transaction: failed to unmarshal jws message: required field \"signatures\" not present")
+		assert.EqualError(t, err, "unable to parse transaction: JWS is not canonically encoded compact serialization")
+	})
+	t.Run("error - input not a JWS (flattened JSON serialization, same signing input as a valid compact JWS)", func(t *testing.T) {
+		headers := makeJWSHeaders(key, "123", false)
+		compact, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+		parts := strings.SplitN(string(compact), ".", 3)
+		flattened := fmt.Sprintf(`{"protected":%q,"payload":%q,"signature":%q}`, parts[0], parts[1], parts[2])
+
+		tx, err := ParseTransaction([]byte(flattened))
+
+		assert.Nil(t, tx)
+		assert.ErrorContains(t, err, "unable to parse transaction")
+	})
+	t.Run("error - non-canonical compact serialization (trailing newline)", func(t *testing.T) {
+		headers := makeJWSHeaders(key, "123", false)
+		compact, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		tx, err := ParseTransaction(append(compact, '\n'))
+
+		assert.Nil(t, tx)
+		assert.EqualError(t, err, "unable to parse transaction: JWS is not canonically encoded compact serialization")
+	})
+	t.Run("ok - canonical compact serialization is accepted", func(t *testing.T) {
+		headers := makeJWSHeaders(key, "123", false)
+		compact, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		tx, err := ParseTransaction(compact)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, tx)
 	})
 	t.Run("error - pal header has invalid type", func(t *testing.T) {
 		headers := makeJWSHeaders(key, "123", false)
@@ -110,6 +141,34 @@ func TestParseTransaction(t *testing.T) {
 
 		assert.Nil(t, transaction)
 		assert.EqualError(t, err, "transaction validation failed: invalid pal header")
+	})
+	t.Run("error - pal header has too many entries", func(t *testing.T) {
+		headers := makeJWSHeaders(key, "123", false)
+		_ = headers.Set("pal", []string{
+			base64.StdEncoding.EncodeToString([]byte{1}),
+			base64.StdEncoding.EncodeToString([]byte{2}),
+			base64.StdEncoding.EncodeToString([]byte{3}),
+		})
+
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		transaction, err := ParseTransaction(signature)
+
+		assert.Nil(t, transaction)
+		assert.EqualError(t, err, "transaction validation failed: pal header must contain exactly 2 entries, got 3")
+	})
+	t.Run("error - pal header has too few entries", func(t *testing.T) {
+		headers := makeJWSHeaders(key, "123", false)
+		_ = headers.Set("pal", []string{
+			base64.StdEncoding.EncodeToString([]byte{1}),
+		})
+
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		transaction, err := ParseTransaction(signature)
+
+		assert.Nil(t, transaction)
+		assert.EqualError(t, err, "transaction validation failed: pal header must contain exactly 2 entries, got 1")
 	})
 	t.Run("error - sigt header is missing", func(t *testing.T) {
 		headers := makeJWSHeaders(key, "123", false)
@@ -259,6 +318,35 @@ func TestParseTransaction(t *testing.T) {
 
 		assert.Nil(t, transaction)
 		assert.Contains(t, err.Error(), "transaction validation failed: invalid payload")
+	})
+}
+
+func TestValidateCanonicalCompactSerialization(t *testing.T) {
+	t.Run("ok - canonical compact JWS", func(t *testing.T) {
+		assert.NoError(t, validateCanonicalCompactSerialization([]byte("AA.AA.AA")))
+	})
+	t.Run("error - not compact serialization (JSON)", func(t *testing.T) {
+		assert.ErrorIs(t, validateCanonicalCompactSerialization([]byte(`{"protected":"AA"}`)), errNonCanonicalJWS)
+	})
+	t.Run("error - wrong number of segments", func(t *testing.T) {
+		assert.ErrorIs(t, validateCanonicalCompactSerialization([]byte("AA.AA")), errNonCanonicalJWS)
+		assert.ErrorIs(t, validateCanonicalCompactSerialization([]byte("AA.AA.AA.AA")), errNonCanonicalJWS)
+	})
+	t.Run("error - segment not valid base64url", func(t *testing.T) {
+		assert.ErrorIs(t, validateCanonicalCompactSerialization([]byte("AA.A+.AA")), errNonCanonicalJWS)
+	})
+	t.Run("error - trailing whitespace", func(t *testing.T) {
+		assert.ErrorIs(t, validateCanonicalCompactSerialization([]byte("AA.AA.AA\n")), errNonCanonicalJWS)
+	})
+	t.Run("error - leading whitespace", func(t *testing.T) {
+		assert.ErrorIs(t, validateCanonicalCompactSerialization([]byte(" AA.AA.AA")), errNonCanonicalJWS)
+	})
+	t.Run("error - non-canonical base64 (unused trailing bits set)", func(t *testing.T) {
+		// "AP" and "AA" both decode to the single byte 0x00 - the last 4 bits of "AP" are unused by
+		// a 1-byte payload and a canonical encoder always zeroes them, but a lenient decoder ignores
+		// whatever they're set to. "AP" is therefore a valid but non-canonical encoding of the same
+		// byte "AA" represents.
+		assert.ErrorIs(t, validateCanonicalCompactSerialization([]byte("AA.AP.AA")), errNonCanonicalJWS)
 	})
 }
 

--- a/network/dag/transaction.go
+++ b/network/dag/transaction.go
@@ -22,6 +22,7 @@ package dag
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -125,6 +126,9 @@ type Transaction interface {
 func NewTransaction(payload hash.SHA256Hash, payloadType string, prevs []hash.SHA256Hash, pal EncryptedPAL, lamportClock uint32) (UnsignedTransaction, error) {
 	if !ValidatePayloadType(payloadType) {
 		return nil, errInvalidPayloadType
+	}
+	if len(pal) > 0 && len(pal) != palEntryCount {
+		return nil, fmt.Errorf("pal must contain exactly %d entries, got %d", palEntryCount, len(pal))
 	}
 	for _, prev := range prevs {
 		if prev.Empty() {

--- a/network/dag/transaction_test.go
+++ b/network/dag/transaction_test.go
@@ -73,6 +73,21 @@ func TestNewTransaction(t *testing.T) {
 		assert.EqualError(t, err, errInvalidPrevs.Error())
 		assert.Nil(t, transaction)
 	})
+	t.Run("error - too many pal entries", func(t *testing.T) {
+		transaction, err := NewTransaction(payloadHash, "some/type", nil, [][]byte{{1}, {2}, {3}}, 0)
+		assert.EqualError(t, err, "pal must contain exactly 2 entries, got 3")
+		assert.Nil(t, transaction)
+	})
+	t.Run("error - too few pal entries", func(t *testing.T) {
+		transaction, err := NewTransaction(payloadHash, "some/type", nil, [][]byte{{1}}, 0)
+		assert.EqualError(t, err, "pal must contain exactly 2 entries, got 1")
+		assert.Nil(t, transaction)
+	})
+	t.Run("ok - no pal is a public transaction", func(t *testing.T) {
+		transaction, err := NewTransaction(payloadHash, "some/type", nil, nil, 0)
+		assert.NoError(t, err)
+		assert.NotNil(t, transaction)
+	})
 }
 
 func Test_transaction_Getters(t *testing.T) {

--- a/network/network.go
+++ b/network/network.go
@@ -639,6 +639,20 @@ func (n *Network) CreateTransaction(ctx context.Context, template Template) (dag
 		if n.nodeDID.Empty() {
 			return nil, errors.New("node DID must be configured to create private transactions")
 		}
+		if template.AttachKey {
+			// A private transaction always needs to be servable by its author later on (see
+			// TransactionPayloadQuery handling), which is only possible if the signing key can be
+			// looked up by KID. WithAttachKey transactions are signed with an embedded key instead,
+			// so they can never be recognized as self-authored afterwards.
+			return nil, errors.New("private transactions can't use an embedded key, keys must be identified by the RFC7515 `kid` header")
+		}
+		if kidURL, err := did.ParseDIDURL(template.Key.KID()); err != nil || kidURL.Fragment == "" {
+			// The authorship check (see TransactionPayloadQuery handling) trusts kid-string equality
+			// against the local key store. That's only collision-safe when the kid is a DID URL, whose
+			// DID part is self-certifying (derived from the key's own material), rather than a free-form
+			// caller-chosen string two different keys could coincidentally share.
+			return nil, errors.New("private transactions must be signed with a DID URL kid (did:<method>:<id>#<fragment>)")
+		}
 	}
 
 	// get head

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	testPKI "github.com/nuts-foundation/nuts-node/test/pki"
 	"hash/crc32"
-	"math/rand"
 	"net/url"
 	"path"
 	"strings"
@@ -66,6 +65,16 @@ var mutex = sync.Mutex{}
 var receivedTransactions = make(map[string][]dag.Transaction, 0)
 var didStore didstore.Store
 var keyStore nutsCrypto.KeyStore
+
+// bootstrapDIDDocumentTX holds the real, signed transaction that published a node's DID document
+// during resetIntegrationTest, so tests can add it to a specific node's own DAG (see
+// addBootstrapDIDDocument) before creating further transactions signed with that document's key.
+type bootstrapDIDDocumentTX struct {
+	tx      dag.Transaction
+	payload []byte
+}
+
+var bootstrapDIDDocumentTXs map[string]bootstrapDIDDocumentTX
 
 func TestNetworkIntegration_HappyFlow(t *testing.T) {
 	testDirectory := io.TestDirectory(t)
@@ -495,7 +504,6 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 	t.Run("happy flow", func(t *testing.T) {
 		testDirectory := io.TestDirectory(t)
 		resetIntegrationTest(t)
-		key := nutsCrypto.NewTestKey("key")
 
 		// Start 2 nodes: node1 and node2, node1 sends a private TX to node 2
 		node1 := startNode(t, "node1", testDirectory, func(_ *core.ServerConfig, cfg *Config) {
@@ -513,8 +521,11 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 
 		node1DID := node1.network.nodeDID
 		node2DID := node2.network.nodeDID
-		tpl := TransactionTemplate(payloadType, []byte("private TX"), key).
-			WithAttachKey().
+		bootstrapRef := addBootstrapDIDDocument(t, node1, "did:nuts:node1")
+		signingKey, err := keyStore.Resolve(ctx, "did:nuts:node1#key-1")
+		require.NoError(t, err)
+		tpl := TransactionTemplate(payloadType, []byte("private TX"), signingKey).
+			WithAdditionalPrevs([]hash.SHA256Hash{bootstrapRef}).
 			WithPrivate([]did.DID{node1DID, node2DID})
 		tx, err := node1.network.CreateTransaction(ctx, tpl)
 		require.NoError(t, err)
@@ -529,7 +540,6 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 	t.Run("event received", func(t *testing.T) {
 		testDirectory := io.TestDirectory(t)
 		resetIntegrationTest(t)
-		key := nutsCrypto.NewTestKey("key")
 
 		// Start 2 nodes: node1 and node2, node1 sends a private TX to node 2
 		node1 := startNode(t, "node1", testDirectory, func(_ *core.ServerConfig, cfg *Config) {
@@ -562,8 +572,11 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 
 		node1DID := node1.network.nodeDID
 		node2DID := node2.network.nodeDID
-		tpl := TransactionTemplate(payloadType, []byte("private TX"), key).
-			WithAttachKey().
+		bootstrapRef := addBootstrapDIDDocument(t, node1, "did:nuts:node1")
+		signingKey, err := keyStore.Resolve(ctx, "did:nuts:node1#key-1")
+		require.NoError(t, err)
+		tpl := TransactionTemplate(payloadType, []byte("private TX"), signingKey).
+			WithAdditionalPrevs([]hash.SHA256Hash{bootstrapRef}).
 			WithPrivate([]did.DID{node1DID, node2DID})
 		_, err = node1.network.CreateTransaction(ctx, tpl)
 		require.NoError(t, err)
@@ -578,7 +591,6 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 	t.Run("third node knows nothing", func(t *testing.T) {
 		testDirectory := io.TestDirectory(t)
 		resetIntegrationTest(t)
-		key := nutsCrypto.NewTestKey("key")
 
 		// Start 2 nodes: node1 and node2, node1 sends a private TX to node 2
 		node1 := startNode(t, "node1", testDirectory, func(_ *core.ServerConfig, cfg *Config) {
@@ -600,8 +612,11 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 
 		node1DID := node1.network.nodeDID
 		node2DID := node2.network.nodeDID
-		tpl := TransactionTemplate(payloadType, []byte("private TX"), key).
-			WithAttachKey().
+		bootstrapRef := addBootstrapDIDDocument(t, node1, "did:nuts:node1")
+		signingKey, err := keyStore.Resolve(ctx, "did:nuts:node1#key-1")
+		require.NoError(t, err)
+		tpl := TransactionTemplate(payloadType, []byte("private TX"), signingKey).
+			WithAdditionalPrevs([]hash.SHA256Hash{bootstrapRef}).
 			WithPrivate([]did.DID{node1DID, node2DID})
 		tx, err := node1.network.CreateTransaction(ctx, tpl)
 		require.NoError(t, err)
@@ -620,55 +635,9 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 		assert.False(t, arrived)
 	})
 
-	t.Run("three participants", func(t *testing.T) {
-		testDirectory := io.TestDirectory(t)
-		resetIntegrationTest(t)
-		key := nutsCrypto.NewTestKey("key")
-
-		// Start 3 nodes: node1, node2 and node3. Node 1 sends a private TX to node 2 and node 3, which both should receive.
-		node1 := startNode(t, "node1", testDirectory, func(_ *core.ServerConfig, cfg *Config) {
-			cfg.NodeDID = "did:nuts:node1"
-		})
-		node2 := startNode(t, "node2", testDirectory, func(_ *core.ServerConfig, cfg *Config) {
-			cfg.NodeDID = "did:nuts:node2"
-		})
-		node3 := startNode(t, "node3", testDirectory, func(_ *core.ServerConfig, cfg *Config) {
-			cfg.NodeDID = "did:nuts:node3"
-		})
-		// Make a full mesh
-		node1.network.connectionManager.Connect(nameToAddress(t, "node2"), did.MustParseDID("did:nuts:node2"), nil)
-		node2.network.connectionManager.Connect(nameToAddress(t, "node3"), did.MustParseDID("did:nuts:node3"), nil)
-
-		test.WaitFor(t, func() (bool, error) {
-			return len(node1.network.connectionManager.Peers()) == 1, nil
-		}, defaultTimeout, "time-out while waiting for nodes to connect")
-		test.WaitFor(t, func() (bool, error) {
-			return len(node2.network.connectionManager.Peers()) == 2, nil
-		}, defaultTimeout, "time-out while waiting for nodes to connect")
-		test.WaitFor(t, func() (bool, error) {
-			return len(node3.network.connectionManager.Peers()) == 1, nil
-		}, defaultTimeout, "time-out while waiting for nodes to connect")
-
-		node1DID := node1.network.nodeDID
-		node2DID := node2.network.nodeDID
-		node3DID := node3.network.nodeDID
-		// Random order for PAL header
-		pal := []did.DID{node1DID, node2DID, node3DID}
-		rand.Shuffle(len(pal), func(i, j int) {
-			pal[i], pal[j] = pal[j], pal[i]
-		})
-		tpl := TransactionTemplate(payloadType, []byte("private TX"), key).
-			WithAttachKey().
-			WithPrivate(pal)
-		tx, err := node1.network.CreateTransaction(ctx, tpl)
-		require.NoError(t, err)
-		waitForTransaction(t, tx, "node1", "node2", "node3")
-	})
-
 	t.Run("large amount of private transactions", func(t *testing.T) {
 		testDirectory := io.TestDirectory(t)
 		resetIntegrationTest(t)
-		key := nutsCrypto.NewTestKey("key")
 
 		// Start 2 nodes: node1 and node2, node1 sends a private TX to node 2
 		node1 := startNode(t, "node1", testDirectory, func(_ *core.ServerConfig, cfg *Config) {
@@ -681,9 +650,12 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 		// create some transactions
 		node1DID := node1.network.nodeDID
 		node2DID := node2.network.nodeDID
+		bootstrapRef := addBootstrapDIDDocument(t, node1, "did:nuts:node1")
+		signingKey, err := keyStore.Resolve(ctx, "did:nuts:node1#key-1")
+		require.NoError(t, err)
 		for i := 0; i < 10; i++ {
-			tpl := TransactionTemplate(payloadType, []byte(fmt.Sprintf("private TX%d", i)), key).
-				WithAttachKey().
+			tpl := TransactionTemplate(payloadType, []byte(fmt.Sprintf("private TX%d", i)), signingKey).
+				WithAdditionalPrevs([]hash.SHA256Hash{bootstrapRef}).
 				WithPrivate([]did.DID{node1DID, node2DID})
 			_, err := node1.network.CreateTransaction(ctx, tpl)
 			require.NoError(t, err)
@@ -706,7 +678,6 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 	t.Run("TLS disabled", func(t *testing.T) {
 		testDirectory := io.TestDirectory(t)
 		resetIntegrationTest(t)
-		key := nutsCrypto.NewTestKey("key")
 
 		// Start 2 nodes: node1 and node2, node1 sends a private TX to node 2
 		node1 := startNode(t, "noTLS1", testDirectory, func(serverConfig *core.ServerConfig, cfg *Config) {
@@ -728,8 +699,11 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 
 		node1DID := node1.network.nodeDID
 		node2DID := node2.network.nodeDID
-		tpl := TransactionTemplate(payloadType, []byte("private TX"), key).
-			WithAttachKey().
+		bootstrapRef := addBootstrapDIDDocument(t, node1, "did:nuts:node1")
+		signingKey, err := keyStore.Resolve(ctx, "did:nuts:node1#key-1")
+		require.NoError(t, err)
+		tpl := TransactionTemplate(payloadType, []byte("private TX"), signingKey).
+			WithAdditionalPrevs([]hash.SHA256Hash{bootstrapRef}).
 			WithPrivate([]did.DID{node1DID, node2DID})
 		tx, err := node1.network.CreateTransaction(ctx, tpl)
 		require.NoError(t, err)
@@ -744,7 +718,6 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 	t.Run("spoofing peerID does not change the recipient of a response message", func(t *testing.T) {
 		testDirectory := io.TestDirectory(t)
 		resetIntegrationTest(t)
-		key := nutsCrypto.NewTestKey("key")
 
 		// Start 2 nodes: node1 and node2, node1 sends a private TX to node 2
 		node1 := startNode(t, "node1", testDirectory, func(_ *core.ServerConfig, cfg *Config) {
@@ -774,8 +747,11 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 
 		node1DID := node1.network.nodeDID
 		node2DID := node2.network.nodeDID
-		tpl := TransactionTemplate(payloadType, []byte("private TX"), key).
-			WithAttachKey().
+		bootstrapRef := addBootstrapDIDDocument(t, node1, "did:nuts:node1")
+		signingKey, err := keyStore.Resolve(ctx, "did:nuts:node1#key-1")
+		require.NoError(t, err)
+		tpl := TransactionTemplate(payloadType, []byte("private TX"), signingKey).
+			WithAdditionalPrevs([]hash.SHA256Hash{bootstrapRef}).
 			WithPrivate([]did.DID{node1DID, node2DID})
 		tx, err := node1.network.CreateTransaction(ctx, tpl)
 		require.NoError(t, err)
@@ -1001,6 +977,7 @@ func resetIntegrationTest(t *testing.T) {
 
 	didStore = didstore.NewTestStore(t)
 	keyStore = nutsCrypto.NewMemoryCryptoInstance()
+	bootstrapDIDDocumentTXs = make(map[string]bootstrapDIDDocumentTX)
 
 	// Write DID Document for node1
 	writeDIDDocument := func(subject string) {
@@ -1020,8 +997,14 @@ func resetIntegrationTest(t *testing.T) {
 			ServiceEndpoint: "grpc://nuts.nl:5555", // Must match TLS SAN DNSName
 		}}
 		docBytes, _ := json.Marshal(document)
-		tx, _, _ := dag.CreateTestTransactionEx(0, hash.SHA256Sum(docBytes), nil)
-		err := didStore.Add(document, didstore.Transaction{
+		// Sign for real (embedded key, like a real DID document creation transaction), so this
+		// transaction can be added to a node's own DAG and later referenced as a prev, allowing
+		// transactions signed with kid (not embedded) to resolve back to this document.
+		unsignedTx, err := dag.NewTransaction(hash.SHA256Sum(docBytes), "application/did+json", nil, nil, 0)
+		require.NoError(t, err)
+		tx, err := dag.NewTransactionSigner(keyStore, key, true).Sign(audit.TestContext(), unsignedTx, time.Now())
+		require.NoError(t, err)
+		err = didStore.Add(document, didstore.Transaction{
 			Clock:       tx.Clock(),
 			PayloadHash: tx.PayloadHash(),
 			Previous:    tx.Previous(),
@@ -1029,10 +1012,24 @@ func resetIntegrationTest(t *testing.T) {
 			SigningTime: tx.SigningTime(),
 		})
 		require.NoError(t, err)
+		bootstrapDIDDocumentTXs[subject] = bootstrapDIDDocumentTX{tx: tx, payload: docBytes}
 	}
 	writeDIDDocument("did:nuts:node1")
 	writeDIDDocument("did:nuts:node2")
 	writeDIDDocument("did:nuts:node3")
+}
+
+// addBootstrapDIDDocument adds the DID document transaction resetIntegrationTest created for
+// subject to n's own DAG, so it becomes a real prev that transactions n subsequently signs with
+// that document's kid (rather than an embedded key) can be verified against. Returns its ref,
+// which callers creating more than one such transaction should keep passing via
+// Template.WithAdditionalPrevs, since a transaction can only resolve a kid via a direct prev
+// (mirroring how vdr/didnuts and vcr/issuer always carry the signer's current
+// DocumentMetadata.SourceTransactions along as additional prevs).
+func addBootstrapDIDDocument(t *testing.T, n node, subject string) hash.SHA256Hash {
+	b := bootstrapDIDDocumentTXs[subject]
+	require.NoError(t, n.network.state.Add(context.Background(), b.tx, b.payload))
+	return b.tx.Ref()
 }
 
 func addTransactionAndWaitForItToArrive(t *testing.T, payload string, key nutsCrypto.Key, sender node, receivers ...string) bool {

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -467,8 +467,33 @@ func TestNetwork_CreateTransaction(t *testing.T) {
 			cxt.keyResolver.EXPECT().ResolveKeyAgreementKey(*sender).Return(senderKey.Public(), nil)
 			cxt.keyResolver.EXPECT().ResolveKeyAgreementKey(*receiver).Return(receiverKey.Public(), nil)
 
-			_, err = cxt.network.CreateTransaction(ctx, TransactionTemplate(payloadType, payload, key).WithPrivate([]did.DID{*sender, *receiver}))
+			senderSigningKey := crypto.NewTestKey("did:nuts:sender#signing-key")
+			_, err = cxt.network.CreateTransaction(ctx, TransactionTemplate(payloadType, payload, senderSigningKey).WithPrivate([]did.DID{*sender, *receiver}))
 			assert.NoError(t, err)
+		})
+		t.Run("error - embedded key", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			payload := []byte("Hello, World!")
+			cxt := createNetwork(t, ctrl)
+			err := cxt.start()
+			require.NoError(t, err)
+			cxt.network.nodeDID = *nodeDID
+
+			senderSigningKey := crypto.NewTestKey("did:nuts:sender#signing-key")
+			_, err = cxt.network.CreateTransaction(ctx, TransactionTemplate(payloadType, payload, senderSigningKey).WithAttachKey().WithPrivate([]did.DID{*sender, *receiver}))
+			assert.EqualError(t, err, "private transactions can't use an embedded key, keys must be identified by the RFC7515 `kid` header")
+		})
+		t.Run("error - kid is not a DID URL", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			payload := []byte("Hello, World!")
+			cxt := createNetwork(t, ctrl)
+			err := cxt.start()
+			require.NoError(t, err)
+			cxt.network.nodeDID = *nodeDID
+
+			plainKey := crypto.NewTestKey("signing-key")
+			_, err = cxt.network.CreateTransaction(ctx, TransactionTemplate(payloadType, payload, plainKey).WithPrivate([]did.DID{*sender, *receiver}))
+			assert.EqualError(t, err, "private transactions must be signed with a DID URL kid (did:<method>:<id>#<fragment>)")
 		})
 		t.Run("node DID not configured", func(t *testing.T) {
 			ctrl := gomock.NewController(t)

--- a/network/transport/v2/handlers.go
+++ b/network/transport/v2/handlers.go
@@ -153,6 +153,22 @@ func (p *protocol) handleTransactionPayloadQuery(ctx context.Context, connection
 				Warn("Peer requested private transaction over unauthenticated connection")
 			return connection.Send(p, &Envelope{Message: emptyResponse}, false)
 		}
+
+		// Only the node that authored this transaction may serve its payload. The payload store is
+		// keyed by content hash alone, with no binding to the transaction that's supposed to carry it,
+		// so PAL and payload hash on an inbound transaction are fully attacker-controlled. Requiring
+		// local authorship means the PAL being checked below is always the one this node itself
+		// encrypted, not one an attacker crafted to piggyback on someone else's stored payload.
+		authored := p.keyStore.Exists(ctx, tx.SigningKeyID())
+		if !authored {
+			log.Logger().
+				WithFields(peer.ToFields()).
+				WithField(core.LogFieldTransactionRef, tx.Ref()).
+				WithField(core.LogFieldKeyID, tx.SigningKeyID()).
+				Warn("Peer requested private payload via a transaction not authored by this node")
+			return connection.Send(p, &Envelope{Message: emptyResponse}, false)
+		}
+
 		epal := dag.EncryptedPAL(tx.PAL())
 
 		pal, err := p.decryptPAL(ctx, epal)

--- a/network/transport/v2/handlers_test.go
+++ b/network/transport/v2/handlers_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/nuts-foundation/nuts-node/network/dag/tree"
@@ -171,11 +172,24 @@ func TestProtocol_handleTransactionPayloadQuery(t *testing.T) {
 			assert.NoError(t, err)
 			assertEmptyPayloadResponse(t, tx, conns.Conn.SentMsgs[0])
 		})
+		t.Run("local node did not author the TX", func(t *testing.T) {
+			p, mocks := newTestProtocol(t, nodeDID)
+			mocks.State.EXPECT().GetTransaction(gomock.Any(), tx.Ref()).Return(tx, nil)
+			mocks.KeyStore.EXPECT().Exists(ctx, tx.SigningKeyID()).Return(false)
+			conns := grpc.NewStubConnectionList(authenticatedPeer)
+			p.connectionList = conns
+
+			err := p.handleTransactionPayloadQuery(ctx, conns.Conn, &Envelope{Message: &Envelope_TransactionPayloadQuery{&TransactionPayloadQuery{TransactionRef: tx.Ref().Slice()}}})
+
+			assert.NoError(t, err)
+			assertEmptyPayloadResponse(t, tx, conns.Conn.SentMsgs[0])
+		})
 		t.Run("local node is not a participant in the TX", func(t *testing.T) {
 			p, mocks := newTestProtocol(t, nodeDID)
 			mocks.State.EXPECT().GetTransaction(gomock.Any(), tx.Ref()).Return(tx, nil)
+			mocks.KeyStore.EXPECT().Exists(ctx, tx.SigningKeyID()).Return(true)
 			mocks.DocResolver.EXPECT().Resolve(*nodeDID, nil).Return(&didDocument, nil, nil)
-			mocks.Decrypter.EXPECT().Decrypt(ctx, keyDID.String(), gomock.Any()).Return(nil, errors.New("will return nil for PAL decryption")).Times(2)
+			mocks.KeyStore.EXPECT().Decrypt(ctx, keyDID.String(), gomock.Any()).Return(nil, errors.New("will return nil for PAL decryption")).Times(2)
 			conns := grpc.NewStubConnectionList(authenticatedPeer)
 			p.connectionList = conns
 
@@ -187,6 +201,7 @@ func TestProtocol_handleTransactionPayloadQuery(t *testing.T) {
 		t.Run("decoding of the PAL header failed (nodeDID not set)", func(t *testing.T) {
 			p, mocks := newTestProtocol(t, &did.DID{})
 			mocks.State.EXPECT().GetTransaction(gomock.Any(), tx.Ref()).Return(tx, nil)
+			mocks.KeyStore.EXPECT().Exists(ctx, tx.SigningKeyID()).Return(true)
 			conns := grpc.NewStubConnectionList(authenticatedPeer)
 			p.connectionList = conns
 
@@ -198,8 +213,9 @@ func TestProtocol_handleTransactionPayloadQuery(t *testing.T) {
 		t.Run("peer is not in PAL", func(t *testing.T) {
 			p, mocks := newTestProtocol(t, nodeDID)
 			mocks.State.EXPECT().GetTransaction(gomock.Any(), tx.Ref()).Return(tx, nil)
+			mocks.KeyStore.EXPECT().Exists(ctx, tx.SigningKeyID()).Return(true)
 			mocks.DocResolver.EXPECT().Resolve(*nodeDID, nil).Return(&didDocument, nil, nil)
-			mocks.Decrypter.EXPECT().Decrypt(ctx, keyDID.String(), gomock.Any()).Return([]byte(nodeDID.String()), nil)
+			mocks.KeyStore.EXPECT().Decrypt(ctx, keyDID.String(), gomock.Any()).Return([]byte(nodeDID.String()), nil)
 			conns := grpc.NewStubConnectionList(authenticatedPeer)
 			p.connectionList = conns
 
@@ -211,8 +227,10 @@ func TestProtocol_handleTransactionPayloadQuery(t *testing.T) {
 		t.Run("ok", func(t *testing.T) {
 			p, mocks := newTestProtocol(t, nodeDID)
 			mocks.State.EXPECT().GetTransaction(gomock.Any(), tx.Ref()).Return(tx, nil)
+			mocks.KeyStore.EXPECT().Exists(ctx, tx.SigningKeyID()).Return(true)
 			mocks.DocResolver.EXPECT().Resolve(*nodeDID, nil).Return(&didDocument, nil, nil)
-			mocks.Decrypter.EXPECT().Decrypt(ctx, keyDID.String(), gomock.Any()).Return([]byte(peerDID.String()), nil)
+			encodedPAL := strings.Join([]string{nodeDID.String(), peerDID.String()}, "\n")
+			mocks.KeyStore.EXPECT().Decrypt(ctx, keyDID.String(), gomock.Any()).Return([]byte(encodedPAL), nil)
 			mocks.State.EXPECT().ReadPayload(ctx, tx.PayloadHash()).Return([]byte{}, nil)
 			conns := grpc.NewStubConnectionList(authenticatedPeer)
 			p.connectionList = conns

--- a/network/transport/v2/protocol.go
+++ b/network/transport/v2/protocol.go
@@ -75,7 +75,7 @@ func New(
 	nodeDID did.DID,
 	state dag.State,
 	docResolver vdr.DocResolver,
-	decrypter crypto.Decrypter,
+	keyStore crypto.KeyStore,
 	diagnosticsProvider func() transport.Diagnostics,
 	dagStore stoabs.KVStore,
 ) transport.Protocol {
@@ -86,7 +86,7 @@ func New(
 		ctx:         ctx,
 		state:       state,
 		nodeDID:     nodeDID,
-		decrypter:   decrypter,
+		keyStore:    keyStore,
 		docResolver: docResolver,
 		dagStore:    dagStore,
 	}
@@ -103,7 +103,7 @@ type protocol struct {
 	routines               *sync.WaitGroup
 	docResolver            vdr.DocResolver
 	privatePayloadReceiver dag.Notifier
-	decrypter              crypto.Decrypter
+	keyStore               crypto.KeyStore
 	connectionList         grpc.ConnectionList
 	nodeDID                did.DID
 	connectionManager      transport.ConnectionManager
@@ -291,6 +291,18 @@ func (p *protocol) handlePrivateTxRetry(ctx context.Context, event dag.Event) (b
 		return true, nil
 	}
 
+	// Decrypting an entry only proves we hold a key that unlocks it, not that the plaintext actually
+	// names us: anyone can encrypt arbitrary participant claims to our public keyAgreement key, since
+	// it's public. Without this, that would let anyone redirect this node into broadcasting
+	// TransactionPayloadQuery at DIDs of their choosing.
+	if !pal.Contains(p.nodeDID) {
+		log.Logger().
+			WithField(core.LogFieldTransactionRef, event.Hash.String()).
+			Warn("Decrypted PAL does not contain the local node's DID, ignoring")
+		// stop retrying
+		return true, nil
+	}
+
 	// Broadcast query to all TX participants we've got a connection to
 	sent := false
 	for _, curr := range pal {
@@ -370,7 +382,7 @@ func (p *protocol) decryptPAL(ctx context.Context, encrypted [][]byte) (dag.PAL,
 
 	epal := dag.EncryptedPAL(encrypted)
 
-	return epal.Decrypt(ctx, keyAgreementIDs, p.decrypter)
+	return epal.Decrypt(ctx, keyAgreementIDs, p.keyStore)
 }
 
 type protocolServer struct {

--- a/network/transport/v2/protocol_test.go
+++ b/network/transport/v2/protocol_test.go
@@ -51,7 +51,7 @@ type protocolMocks struct {
 	State            *dag.MockState
 	PayloadScheduler *dag.MockNotifier
 	DocResolver      *vdr.MockDocResolver
-	Decrypter        *crypto.MockDecrypter
+	KeyStore         *crypto.MockKeyStore
 	Gossip           *gossip.MockManager
 	ConnectionList   *grpc.MockConnectionList
 	Sender           *MockmessageSender
@@ -80,7 +80,7 @@ func newTestProtocol(t *testing.T, nodeDID *did.DID) (*protocol, protocolMocks) 
 	dirname := io.TestDirectory(t)
 
 	docResolver := vdr.NewMockDocResolver(ctrl)
-	decrypter := crypto.NewMockDecrypter(ctrl)
+	keyStore := crypto.NewMockKeyStore(ctrl)
 	state := dag.NewMockState(ctrl)
 	gMan := gossip.NewMockManager(ctrl)
 	payloadScheduler := dag.NewMockNotifier(ctrl)
@@ -90,7 +90,7 @@ func newTestProtocol(t *testing.T, nodeDID *did.DID) (*protocol, protocolMocks) 
 
 	cfg := DefaultConfig()
 	cfg.Datadir = dirname
-	proto := New(cfg, *nodeDID, state, docResolver, decrypter, nil, storage).(*protocol)
+	proto := New(cfg, *nodeDID, state, docResolver, keyStore, nil, storage).(*protocol)
 	proto.privatePayloadReceiver = payloadScheduler
 	proto.gManager = gMan
 	proto.cMan = newConversationManager(time.Second)
@@ -106,7 +106,7 @@ func newTestProtocol(t *testing.T, nodeDID *did.DID) (*protocol, protocolMocks) 
 		State:            state,
 		PayloadScheduler: payloadScheduler,
 		DocResolver:      docResolver,
-		Decrypter:        decrypter,
+		KeyStore:         keyStore,
 		Gossip:           gMan,
 		ConnectionList:   connectionList,
 		Sender:           sender,
@@ -351,13 +351,34 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 				{VerificationMethod: &did.VerificationMethod{ID: *keyDID}},
 			},
 		}, nil, nil)
-		mocks.Decrypter.EXPECT().Decrypt(ctx, keyDID.String(), []byte{1}).Return(nil, crypto.ErrPrivateKeyNotFound)
+		mocks.KeyStore.EXPECT().Decrypt(ctx, keyDID.String(), []byte{1}).Return(nil, crypto.ErrPrivateKeyNotFound)
 
 		finished, err := proto.handlePrivateTxRetry(ctx, event)
 
 		assert.False(t, finished)
 		assert.True(t, errors.As(err, new(dag.EventFatal)))
 		assert.EqualError(t, err, fmt.Sprintf("failed to decrypt PAL header (tx=%s): private key of DID keyAgreement not found (kid=%s)", txOk.Ref().String(), keyDID.String()))
+	})
+
+	t.Run("stops retrying when decrypted PAL doesn't name the local node", func(t *testing.T) {
+		// Decrypting an entry only proves we hold a key that unlocks it, not that the plaintext
+		// actually names us: anyone can encrypt arbitrary participant claims to our public
+		// keyAgreement key, since it's public.
+		proto, mocks := newTestProtocol(t, testDID)
+
+		mocks.State.EXPECT().IsPayloadPresent(context.Background(), txOk.PayloadHash()).Return(false, nil)
+		mocks.DocResolver.EXPECT().Resolve(*testDID, nil).Return(&did.Document{
+			KeyAgreement: []did.VerificationRelationship{
+				{VerificationMethod: &did.VerificationMethod{ID: *keyDID}},
+			},
+		}, nil, nil)
+		encodedPAL := strings.Join([]string{peerDID.String(), otherPeerDID.String()}, "\n")
+		mocks.KeyStore.EXPECT().Decrypt(ctx, keyDID.String(), []byte{1}).Return([]byte(encodedPAL), nil)
+
+		finished, err := proto.handlePrivateTxRetry(ctx, event)
+
+		assert.True(t, finished)
+		assert.NoError(t, err)
 	})
 
 	t.Run("valid transaction fails when there is no connection available to the node", func(t *testing.T) {
@@ -368,8 +389,11 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 				{VerificationMethod: &did.VerificationMethod{ID: *keyDID}},
 			},
 		}, nil, nil)
-		mocks.Decrypter.EXPECT().Decrypt(ctx, keyDID.String(), []byte{1}).Return([]byte(peerDID.String()), nil)
+		// PAL must have exactly 2 entries (local node + one peer) - see palEntryCount in network/dag/pal.go.
+		encodedPAL := strings.Join([]string{testDID.String(), peerDID.String()}, "\n")
+		mocks.KeyStore.EXPECT().Decrypt(ctx, keyDID.String(), []byte{1}).Return([]byte(encodedPAL), nil)
 		connectionList := grpc.NewMockConnectionList(mocks.Controller)
+		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*testDID), grpc.ByAuthenticated()).Return(nil)
 		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*peerDID), grpc.ByAuthenticated()).Return(nil)
 		proto.connectionList = connectionList
 
@@ -377,7 +401,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 
 		assert.False(t, finished)
 		assert.False(t, errors.As(err, new(dag.EventFatal)))
-		assert.EqualError(t, err, fmt.Sprintf("no authenticated connection to any of the participants (tx=%s, PAL=[did:nuts:peer])", txOk.Ref().String()))
+		assert.EqualError(t, err, fmt.Sprintf("no authenticated connection to any of the participants (tx=%s, PAL=[did:nuts:123 did:nuts:peer])", txOk.Ref().String()))
 	})
 
 	t.Run("valid transaction fails when sending the payload query errors", func(t *testing.T) {
@@ -388,7 +412,8 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 				{VerificationMethod: &did.VerificationMethod{ID: *keyDID}},
 			},
 		}, nil, nil)
-		mocks.Decrypter.EXPECT().Decrypt(ctx, keyDID.String(), []byte{1}).Return([]byte(peerDID.String()), nil)
+		encodedPAL := strings.Join([]string{testDID.String(), peerDID.String()}, "\n")
+		mocks.KeyStore.EXPECT().Decrypt(ctx, keyDID.String(), []byte{1}).Return([]byte(encodedPAL), nil)
 		conn := grpc.NewMockConnection(mocks.Controller)
 		conn.EXPECT().Peer()
 		conn.EXPECT().Send(proto, &Envelope{Message: &Envelope_TransactionPayloadQuery{
@@ -397,6 +422,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 			},
 		}}, false).Return(errors.New("random error"))
 		connectionList := grpc.NewMockConnectionList(mocks.Controller)
+		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*testDID), grpc.ByAuthenticated()).Return(nil)
 		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*peerDID), grpc.ByAuthenticated()).Return(conn)
 		proto.connectionList = connectionList
 
@@ -404,7 +430,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 
 		assert.False(t, finished)
 		assert.False(t, errors.As(err, new(dag.EventFatal)))
-		assert.EqualError(t, err, fmt.Sprintf("no authenticated connection to any of the participants (tx=%s, PAL=[did:nuts:peer])", txOk.Ref().String()))
+		assert.EqualError(t, err, fmt.Sprintf("no authenticated connection to any of the participants (tx=%s, PAL=[did:nuts:123 did:nuts:peer])", txOk.Ref().String()))
 	})
 
 	t.Run("valid transaction is handled successfully", func(t *testing.T) {
@@ -415,7 +441,8 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 				{VerificationMethod: &did.VerificationMethod{ID: *keyDID}},
 			},
 		}, nil, nil)
-		mocks.Decrypter.EXPECT().Decrypt(ctx, keyDID.String(), []byte{1}).Return([]byte(peerDID.String()), nil)
+		encodedPAL := strings.Join([]string{testDID.String(), peerDID.String()}, "\n")
+		mocks.KeyStore.EXPECT().Decrypt(ctx, keyDID.String(), []byte{1}).Return([]byte(encodedPAL), nil)
 		conn := grpc.NewMockConnection(mocks.Controller)
 		conn.EXPECT().Send(proto, &Envelope{Message: &Envelope_TransactionPayloadQuery{
 			TransactionPayloadQuery: &TransactionPayloadQuery{
@@ -423,6 +450,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 			},
 		}}, false).Return(nil)
 		connectionList := grpc.NewMockConnectionList(mocks.Controller)
+		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*testDID), grpc.ByAuthenticated()).Return(nil)
 		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*peerDID), grpc.ByAuthenticated()).Return(conn)
 		proto.connectionList = connectionList
 
@@ -433,7 +461,7 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("broadcasts to all participants (except local node)", func(t *testing.T) {
-		tx := dag.CreateSignedTestTransaction(1, time.Now(), [][]byte{{1}, {2}, {3}}, "text/plain", true)
+		tx := dag.CreateSignedTestTransaction(1, time.Now(), [][]byte{{1}, {2}}, "text/plain", true)
 		event := dag.Event{
 			Type:        dag.TransactionEventType,
 			Hash:        tx.Ref(),
@@ -449,8 +477,9 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 				{VerificationMethod: &did.VerificationMethod{ID: *keyDID}},
 			},
 		}, nil, nil)
-		encodedPAL := strings.Join([]string{nodeDID.String(), peerDID.String(), otherPeerDID.String()}, "\n")
-		mocks.Decrypter.EXPECT().Decrypt(ctx, keyDID.String(), []byte{1}).Return([]byte(encodedPAL), nil)
+		// PAL must have exactly 2 entries (local node + one peer) - see palEntryCount in network/dag/pal.go.
+		encodedPAL := strings.Join([]string{testDID.String(), peerDID.String()}, "\n")
+		mocks.KeyStore.EXPECT().Decrypt(ctx, keyDID.String(), []byte{1}).Return([]byte(encodedPAL), nil)
 		// Connection to peer
 		conn1 := grpc.NewMockConnection(mocks.Controller)
 		conn1.EXPECT().Send(proto, &Envelope{Message: &Envelope_TransactionPayloadQuery{
@@ -458,17 +487,9 @@ func TestProtocol_HandlePrivateTxRetry(t *testing.T) {
 				TransactionRef: tx.Ref().Slice(),
 			},
 		}}, false).Return(nil)
-		// Connection to other peer
-		conn2 := grpc.NewMockConnection(mocks.Controller)
-		conn2.EXPECT().Send(proto, &Envelope{Message: &Envelope_TransactionPayloadQuery{
-			TransactionPayloadQuery: &TransactionPayloadQuery{
-				TransactionRef: tx.Ref().Slice(),
-			},
-		}}, false).Return(nil)
 		connectionList := grpc.NewMockConnectionList(mocks.Controller)
-		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*nodeDID), grpc.ByAuthenticated()).Return(nil)
+		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*testDID), grpc.ByAuthenticated()).Return(nil)
 		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*peerDID), grpc.ByAuthenticated()).Return(conn1)
-		connectionList.EXPECT().Get(grpc.ByConnected(), grpc.ByNodeDID(*otherPeerDID), grpc.ByAuthenticated()).Return(conn2)
 		proto.connectionList = connectionList
 
 		finished, err := proto.handlePrivateTxRetry(ctx, event)
@@ -527,7 +548,7 @@ func TestProtocol_decryptPAL(t *testing.T) {
 				{VerificationMethod: &did.VerificationMethod{ID: *keyDID}},
 			},
 		}, nil, nil)
-		mocks.Decrypter.EXPECT().Decrypt(ctx, keyDID.String(), []byte{1}).Return(nil, crypto.ErrPrivateKeyNotFound)
+		mocks.KeyStore.EXPECT().Decrypt(ctx, keyDID.String(), []byte{1}).Return(nil, crypto.ErrPrivateKeyNotFound)
 
 		_, err := proto.decryptPAL(ctx, tx.PAL())
 		assert.EqualError(t, err, fmt.Sprintf("private key of DID keyAgreement not found (kid=%s)", keyDID.String()))
@@ -542,7 +563,7 @@ func TestProtocol_decryptPAL(t *testing.T) {
 				{VerificationMethod: &did.VerificationMethod{ID: *keyDID}},
 			},
 		}, nil, nil)
-		mocks.Decrypter.EXPECT().Decrypt(ctx, keyDID.String(), []byte{1}).Return(append(append([]byte(testDID.String()), '\n'), []byte(testDID2.String())...), nil)
+		mocks.KeyStore.EXPECT().Decrypt(ctx, keyDID.String(), []byte{1}).Return(append(append([]byte(testDID.String()), '\n'), []byte(testDID2.String())...), nil)
 
 		pal, err := proto.decryptPAL(ctx, tx.PAL())
 

--- a/network/transport/v2/transactionlist_handler_test.go
+++ b/network/transport/v2/transactionlist_handler_test.go
@@ -197,7 +197,7 @@ func TestProtocol_handleTransactionList(t *testing.T) {
 			},
 		}})
 
-		assert.EqualError(t, err, "received transaction is invalid: unable to parse transaction: invalid compact serialization format: invalid number of segments")
+		assert.EqualError(t, err, "received transaction is invalid: unable to parse transaction: JWS is not canonically encoded compact serialization")
 	})
 
 	t.Run("error - unknown conversationID", func(t *testing.T) {


### PR DESCRIPTION
Backports the 4 security fixes from #4476 to V5.4, plus release notes for v5.4.38.

Assisted by AI
