### PR TITLE
docs(deployment): document node-http-services-baseurl as a required setup step (backport of #4475 to V5.4)

### DIFF
--- a/docs/pages/deployment/configuration.rst
+++ b/docs/pages/deployment/configuration.rst
@@ -88,3 +88,42 @@ json-ld context can only be downloaded from trusted domains configured in ``json
 and the ``internalratelimiter`` is always on.
 
 Interacting with remote Nuts nodes requires HTTPS: it will refuse to connect to plain HTTP endpoints when in strict mode.
+
+.. _node-http-services-baseurl:
+
+Registering ``node-http-services-baseurl``
+********************************************
+
+``did:nuts`` DIDs receive private Verifiable Credentials via server-to-server issuance: the issuer's node pushes the credential directly to the holder's node over HTTP, at issuance time.
+If a node can't be reached for server-to-server issuance, delivery falls back to the older gRPC/Nuts network instead: it publishes a transaction (with the recipient list encrypted) referencing the credential to the whole network, and the holder fetches the actual credential separately over an authenticated connection - a mechanism we're moving away from in favor of server-to-server issuance.
+For a node to be reachable for server-to-server issuance (as issuer or holder), its ``did:nuts`` DID document needs a ``node-http-services-baseurl`` service endpoint, pointing other nodes at the public base URL where its HTTP services (including server-to-server issuance, and other ``/n2n`` endpoints) can be reached.
+Without this DID Document service endpoint, its server-to-server issuance endpoints can't be discovered, triggering the gRPC fallback described above (or an outright failure if that's disabled too).
+Given ``<base-url>`` and a DID, the endpoints it needs to be reachable at are:
+
+- ``<base-url>/n2n/identity/<did>/.well-known/openid-credential-issuer`` - credential issuer metadata
+- ``<base-url>/n2n/identity/<did>/.well-known/oauth-authorization-server`` - OAuth/provider metadata
+- ``<base-url>/n2n/identity/<did>/openid4vci/credential`` - credential endpoint (issuer side)
+- ``<base-url>/n2n/identity/<did>/openid4vci/credential_offer`` - credential offer endpoint (wallet/holder side)
+
+This isn't an exhaustive list to configure individually: any reverse proxy or firewall in front of the node must forward the entire ``/n2n`` path prefix to it, not just these specific paths.
+
+The DID Document service endpoint is added automatically when possible, to ease configuration: a background module, GoldenHammer, tests each hostname in the node's own TLS certificate with a ``HEAD`` request to ``https://<hostname>/n2n/identity/<did>/.well-known/openid-credential-issuer``, and registers the first hostname that responds with ``200 OK`` and ``Content-Type: application/json``.
+This can fail if the node can't reach itself that way - DNS, firewall, and reverse-proxy routing are the usual suspects - in which case the endpoint stays missing.
+
+You can also register the service endpoint manually via the DIDMan API, e.g. to have it in place immediately after setup rather than waiting for the next automatic check, or as a fallback if a subject DID's vendor reference can't be resolved automatically for any reason:
+
+.. code-block:: shell
+
+    $ curl -X POST https://internal.example.com/internal/didman/v1/did/<did>/endpoint \
+        -H "Content-Type: application/json" \
+        -d '{"type": "node-http-services-baseurl", "endpoint": "https://your-node.example.com"}'
+
+For a vendor DID document (the one whose ``NutsComm`` service is a concrete URL, e.g. ``grpc://host:5555``), register the node's actual public base URL as the ``endpoint`` value, as above.
+
+Any care-organization/subject DID document whose ``NutsComm`` service is instead a *reference* to that vendor DID should get a matching reference for ``node-http-services-baseurl``, rather than a duplicate concrete URL, so all subject DIDs of the same vendor stay in sync with a single registration:
+
+.. code-block:: shell
+
+    $ curl -X POST https://internal.example.com/internal/didman/v1/did/<subject-did>/endpoint \
+        -H "Content-Type: application/json" \
+        -d '{"type": "node-http-services-baseurl", "endpoint": "<vendor-did>/serviceEndpoint?type=node-http-services-baseurl"}'

--- a/docs/pages/deployment/recommended-deployment.rst
+++ b/docs/pages/deployment/recommended-deployment.rst
@@ -57,6 +57,7 @@ Interfaces/Endpoints
 
 * **HTTP /n2n**: for providing Nuts services to other nodes (e.g. creating access tokens).
   The local node also calls other nodes on their `/n2n` endpoint, these outgoing calls are subject to the same security requirements.
+  Server-to-server credential issuance for ``did:nuts`` DIDs also runs over this endpoint; see :ref:`Registering node-http-services-baseurl <node-http-services-baseurl>` for how nodes discover each other's `/n2n` base URL.
 
   *Users*: Nuts nodes of other SPs.
 


### PR DESCRIPTION
Backport of #4475 to V5.4.

Verified with a clean sphinx build (`docs/Dockerfile`) - zero new warnings.

Assisted by AI