### PR TITLE
ci: skip govulncheck on pull requests

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -9,11 +9,6 @@ on:
     branches:
       - 'master'
       - 'V*'
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches:
-      - 'master'
-      - 'V*'
 
 jobs:
   govulncheck_job:


### PR DESCRIPTION
Backport of #4482 to V6.2.

## Summary
- Remove the `pull_request` trigger from `govulncheck.yaml`
- govulncheck already runs automatically on a separate schedule (`govulncheck-cron-schedule.yaml`, weekdays + notifies Slack on failure), so running it again on every PR is redundant
- `push` trigger on master/V* branches is kept

Assisted by AI