### PR TITLE
test(network): ack NATS messages before signalling test completion

### DIFF
--- a/events/integration_test.go
+++ b/events/integration_test.go
@@ -45,12 +45,13 @@ func Test_pub_sub(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close()
 		var found []byte
+		var ackErr error
 		foundMutex := sync.Mutex{}
 		err = stream.Subscribe(conn, "TEST", "TRANSACTIONS.tx", func(msg *nats.Msg) {
 			foundMutex.Lock()
 			defer foundMutex.Unlock()
 			found = msg.Data
-			err = msg.Ack()
+			ackErr = msg.Ack()
 		})
 
 		require.NoError(t, err)
@@ -64,7 +65,9 @@ func Test_pub_sub(t *testing.T) {
 			defer foundMutex.Unlock()
 			return bytes.Equal(found, []byte{1}), nil
 		}, 100*time.Millisecond, "timeout waiting for message")
-		require.NoError(t, err)
+		foundMutex.Lock()
+		defer foundMutex.Unlock()
+		require.NoError(t, ackErr)
 	})
 
 	t.Run("publish more than the subscriber can handle", func(t *testing.T) {

--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -561,7 +561,7 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 			defer foundMutex.Unlock()
 			found = msg.Data
 			err := msg.Ack()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		})
 
 		node1DID := node1.network.nodeDID
@@ -829,7 +829,7 @@ func TestNetworkIntegration_AddedTransactionsAsEvents(t *testing.T) {
 		defer foundMutex.Unlock()
 		found = msg.Data
 		err := msg.Ack()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 
 	// add a transaction

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -898,8 +898,11 @@ func TestNetwork_Reprocess(t *testing.T) {
 		err = events.NewDisposableStream("REPROCESS_test", []string{"REPROCESS.*"}, 10).Subscribe(conn, t.Name(), "REPROCESS.*", func(m *nats.Msg) {
 			foundMutex.Lock()
 			defer foundMutex.Unlock()
+			// Signal completion only after the ack: once wg.Done() releases the test,
+			// its cleanup shuts down the NATS server and the ack would fail with
+			// "nats: connection closed".
+			defer wg.Done()
 			*counter++
-			wg.Done()
 			err := m.Ack()
 			assert.NoError(t, err)
 		})


### PR DESCRIPTION
Fixes the flaky `TestNetwork_Reprocess` (seen on #4487 and earlier on an unrelated feature branch in July).

The message handler in the test called `wg.Done()` before `msg.Ack()`. `Done` releases the test's `wg.Wait()`, the subtest returns, its cleanup shuts down the embedded NATS server, and only then does the callback goroutine send the ack over a closed connection: `nats: connection closed`. On a fast machine the ack usually wins that race, on a loaded CI runner it sometimes loses. The fix defers `wg.Done()` so the ack always precedes it.

The other three NATS handlers in tests were checked for the same pattern. Two in `network_integration_test.go` are safe because they ack while holding the mutex the test polls on. Their `require.NoError` calls are changed to `assert.NoError`, since `require` calls `FailNow`, which must run on the test goroutine. The one in `events/integration_test.go` wrote the ack error into a variable shared with the test goroutine; it now uses a dedicated variable read under the mutex.

Verified with `go test -race -count=5` on the affected packages.

Backport to V6.2: follows as a separate PR.
