### PR TITLE
ci: skip test and e2e-test jobs for docs-only changes (backport #4455 to V6.2)

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -14,8 +14,37 @@ on:
 
 
 jobs:
+  # Docs-only changes (docs/, markdown, rst) can't affect the e2e tests. Detected once here so the
+  # (required) e2e-test job below can skip entirely on them: that keeps the check fast and avoids
+  # the cost of building/pushing images and running the full e2e suite for changes that can't have
+  # broken anything it tests. A job skipped via `if:` reports as a passing check, so this still
+  # satisfies the required status check, unlike skipping the workflow itself via a trigger-level
+  # path filter.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for non-doc changes
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.rst'
+
   e2e-test:
-    if: ${{ github.event.pull_request.merged || github.event.pull_request.head.repo.full_name == github.repository }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' && (github.event.pull_request.merged || github.event.pull_request.head.repo.full_name == github.repository) }}
     permissions:
       packages: write
 

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -8,7 +8,37 @@ on:
   pull_request:
 
 jobs:
+  # Docs-only changes (docs/, markdown, rst) can't affect Go tests. Detected once here so the
+  # (required) test job below can skip entirely on them: that keeps the check fast and avoids
+  # spending CI minutes (and hitting flaky tests) on changes that can't have broken anything it
+  # tests. A job skipped via `if:` reports as a passing check, so this still satisfies the
+  # required status check, unlike skipping the workflow itself via a trigger-level path filter.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Check for non-doc changes
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.rst'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Backport of #4455 to V6.2.

## What

`test` and `e2e-test` are required status checks. Both now check whether the PR/push diff touches anything outside `docs/`, `*.md` and `*.rst` (via `dorny/paths-filter`), and skip their actual work when it doesn't.

## Why

Docs-only changes can't affect Go code or e2e behavior, so there's nothing for either job to catch — but skipping them entirely at the workflow-trigger level (`paths-ignore`) would leave the required check stuck pending forever and block merging, since GitHub doesn't auto-satisfy a required check that never ran. Gating the *steps* (job, after a follow-up commit) instead of the *trigger* keeps the job itself running (so the required check resolves quickly with a pass) while skipping the actual test/build/e2e work.

## Scope

`.github/workflows/go-test.yaml` and `.github/workflows/e2e-tests.yaml` only. Action versions/pins are left as they are on V6.2 — later unrelated hardening/version-bump commits on master were not pulled in.

Assisted by AI