### PR TITLE
test(discovery): fix second-boundary race in refresh error timestamp check

### DIFF
--- a/discovery/store_test.go
+++ b/discovery/store_test.go
@@ -372,6 +372,10 @@ func Test_sqlStore_setPresentationRefreshError(t *testing.T) {
 	t.Run("store", func(t *testing.T) {
 		c := setupStore(t, storageEngine.GetSQLDatabase())
 
+		// LastOccurrence is stored in whole seconds, so compare against a timestamp
+		// taken before the call instead of "now minus a second": the latter fails
+		// when the call and the assertion straddle a second boundary.
+		before := int(time.Now().Unix())
 		require.NoError(t, c.updatePresentationRefreshTime(testServiceID, aliceSubject, nil, to.Ptr(time.Now().Add(time.Second))))
 		require.NoError(t, c.setPresentationRefreshError(testServiceID, aliceSubject, assert.AnError))
 
@@ -379,7 +383,7 @@ func Test_sqlStore_setPresentationRefreshError(t *testing.T) {
 		refreshError := getPresentationRefreshError(t, c.db, testServiceID, aliceSubject)
 
 		assert.Equal(t, refreshError.Error, assert.AnError.Error())
-		assert.True(t, refreshError.LastOccurrence > int(time.Now().Add(-1*time.Second).Unix()))
+		assert.GreaterOrEqual(t, refreshError.LastOccurrence, before)
 	})
 	t.Run("deletePresentationRecord", func(t *testing.T) {
 		c := setupStore(t, storageEngine.GetSQLDatabase())


### PR DESCRIPTION
Fixes a flaky assertion in `Test_sqlStore_setPresentationRefreshError/store`, seen on the CI run of #4492 (a PR that changes only shell scripts).

`LastOccurrence` is stored as `time.Now().Unix()`, whole seconds. The test asserted it is strictly greater than `time.Now().Add(-1*time.Second).Unix()`, also whole seconds. If the store lands at the end of second S and the assertion runs a few milliseconds later in second S+1, both sides truncate to S and `S > S` fails. The window is a few milliseconds per second, hence the low failure rate.

The test now captures `time.Now().Unix()` before the call and asserts `LastOccurrence >= before`, which holds regardless of where the second boundary falls. Verified with `-count=20`. The other two `Add(-time.Second).Unix()` uses in the repo construct expired credentials on purpose and are not affected.

Backport to V6.2 follows; V5.4 does not have this test.