### PR TITLE
test(discovery): fix second-boundary race in refresh error timestamp check (backport)

### DIFF
--- a/discovery/store_test.go
+++ b/discovery/store_test.go
@@ -372,6 +372,10 @@ func Test_sqlStore_setPresentationRefreshError(t *testing.T) {
 	t.Run("store", func(t *testing.T) {
 		c := setupStore(t, storageEngine.GetSQLDatabase())
 
+		// LastOccurrence is stored in whole seconds, so compare against a timestamp
+		// taken before the call instead of "now minus a second": the latter fails
+		// when the call and the assertion straddle a second boundary.
+		before := int(time.Now().Unix())
 		require.NoError(t, c.updatePresentationRefreshTime(testServiceID, aliceSubject, nil, to.Ptr(time.Now().Add(time.Second))))
 		require.NoError(t, c.setPresentationRefreshError(testServiceID, aliceSubject, assert.AnError))
 
@@ -379,7 +383,7 @@ func Test_sqlStore_setPresentationRefreshError(t *testing.T) {
 		refreshError := getPresentationRefreshError(t, c.db, testServiceID, aliceSubject)
 
 		assert.Equal(t, refreshError.Error, assert.AnError.Error())
-		assert.True(t, refreshError.LastOccurrence > int(time.Now().Add(-1*time.Second).Unix()))
+		assert.GreaterOrEqual(t, refreshError.LastOccurrence, before)
 	})
 	t.Run("deletePresentationRecord", func(t *testing.T) {
 		c := setupStore(t, storageEngine.GetSQLDatabase())


### PR DESCRIPTION
Backport of https://github.com/nuts-foundation/nuts-node/pull/4497 to V6.2, cherry-picked without conflicts. See that PR for the analysis.