### PR TITLE
test: fix flaky TestXorTreeRepair and private-transactions e2e test

### DIFF
--- a/e2e-tests/nuts-network/private-transactions/run-test.sh
+++ b/e2e-tests/nuts-network/private-transactions/run-test.sh
@@ -21,6 +21,33 @@ function searchAuthCredentials() {
   }' | curl -s -X POST "$1/internal/vcr/v2/search" -H "Content-Type: application/json" --data-binary @-
 }
 
+# waitForAuthCredentialCount polls the credential search on a node until it returns the expected number of
+# NutsAuthorizationCredentials. The transaction count reaching its expected value only means the transaction is
+# stored: the VCR applies the credential or revocation afterwards through an asynchronous subscriber.
+# Args: service name, node URL, expected number of credentials, timeout in seconds
+function waitForAuthCredentialCount() {
+  local service_name=$1
+  local url=$2
+  local expected=$3
+  local timeout=$4
+  local count=""
+  printf "Waiting for service '%s' to return %s NutsAuthorizationCredentials" "$service_name" "$expected"
+  local retry=0
+  while [ $retry -lt $timeout ]; do
+    count=$(searchAuthCredentials "$url" | jq ".verifiableCredentials | length")
+    if [ "$count" == "$expected" ]; then
+      echo ""
+      return 0
+    fi
+    printf "."
+    sleep 1
+    retry=$((retry+1))
+  done
+  echo ""
+  echo "FAILED: Service '$service_name' returned ${count:-no} NutsAuthorizationCredentials after ${timeout} seconds, expected $expected"
+  exitWithDockerLogs 1
+}
+
 echo "------------------------------------"
 echo "Cleaning up running Docker containers and volumes, and key material..."
 echo "------------------------------------"
@@ -75,15 +102,8 @@ printf "VC issued by node B: %s\n" "$vcNodeB"
 waitForTXCount "NodeA" "http://localhost:18081/status/diagnostics" 6 10
 waitForTXCount "NodeB" "http://localhost:28081/status/diagnostics" 6 10
 
-if [ $(searchAuthCredentials "http://localhost:18081" | jq ".verifiableCredentials[].verifiableCredential.id" | wc -l) -ne "2" ]; then
-  echo "failed to find NutsAuthorizationCredentials on Node-A"
-  exitWithDockerLogs 1
-fi
-
-if [ $(searchAuthCredentials "http://localhost:28081" | jq ".verifiableCredentials[].verifiableCredential.id" | wc -l) -ne "2" ]; then
-  echo "failed to find NutsAuthorizationCredentials on Node-B"
-  exitWithDockerLogs 1
-fi
+waitForAuthCredentialCount "NodeA" "http://localhost:18081" 2 10
+waitForAuthCredentialCount "NodeB" "http://localhost:28081" 2 10
 
 echo "------------------------------------"
 echo "Revoking NutsAuthorizationCredential..."
@@ -95,15 +115,9 @@ revokeCredential "http://localhost:28081" "${vcNodeB}"
 waitForTXCount "NodeA" "http://localhost:18081/status/diagnostics" 8 10
 waitForTXCount "NodeB" "http://localhost:28081/status/diagnostics" 8 10
 
-if [ $(searchAuthCredentials "http://localhost:18081" | jq ".verifiableCredentials[].verifiableCredential.id" | wc -l) -ne "0" ]; then
-  echo "NutsAuthorizationCredentials should have been revoked so they can't be resolved on Node-A"
-  exitWithDockerLogs 1
-fi
-
-if [ $(searchAuthCredentials "http://localhost:28081" | jq ".verifiableCredentials[].verifiableCredential.id" | wc -l) -ne "0" ]; then
-  echo "NutsAuthorizationCredentials should have been revoked so they can't be resolved on Node-B"
-  exitWithDockerLogs 1
-fi
+# The revocations must no longer resolve once the VCR has processed them
+waitForAuthCredentialCount "NodeA" "http://localhost:18081" 0 10
+waitForAuthCredentialCount "NodeB" "http://localhost:28081" 0 10
 
 echo "------------------------------------"
 echo "Stopping Docker containers..."

--- a/network/dag/consistency.go
+++ b/network/dag/consistency.go
@@ -42,6 +42,7 @@ const (
 // The loop checks a page (512 LC values) per 10 seconds and continues looping until the network layer signals all is ok again.
 type xorTreeRepair struct {
 	cancel       context.CancelFunc
+	loopDone     sync.WaitGroup
 	ticker       *time.Ticker
 	currentPage  uint32
 	state        *state
@@ -57,9 +58,15 @@ func newXorTreeRepair(state *state) *xorTreeRepair {
 }
 
 func (f *xorTreeRepair) start() {
+	if f.cancel != nil {
+		// already started; a second loop could not be stopped anymore, since its cancel func would replace this one
+		return
+	}
 	var ctx context.Context
 	ctx, f.cancel = context.WithCancel(context.Background())
+	f.loopDone.Add(1)
 	go func() {
+		defer f.loopDone.Done()
 		defer f.ticker.Stop()
 		for {
 			select {
@@ -72,9 +79,12 @@ func (f *xorTreeRepair) start() {
 	}()
 }
 
+// shutdown stops the repair loop and waits for a page check that is in progress to finish,
+// so the caller can safely close the underlying store afterwards.
 func (f *xorTreeRepair) shutdown() {
 	if f.cancel != nil {
 		f.cancel()
+		f.loopDone.Wait()
 	}
 }
 

--- a/network/dag/consistency_test.go
+++ b/network/dag/consistency_test.go
@@ -21,6 +21,7 @@ package dag
 import (
 	"context"
 	"encoding/binary"
+	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/nuts-node/v6/crypto/hash"
 	"github.com/nuts-foundation/nuts-node/v6/network/dag/tree"
 	"github.com/nuts-foundation/nuts-node/v6/storage"
@@ -30,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"path"
+	"sync"
 	"testing"
 	"time"
 )
@@ -120,6 +122,86 @@ func TestXorTreeRepair(t *testing.T) {
 			return hashRoot.Equals(expectedHash), nil
 		}, 5*time.Second, "xorTree not updated within wait period")
 	})
+}
+
+func TestXorTreeRepair_shutdownWaitsForRunningPageCheck(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	tx, _, _ := CreateTestTransaction(1)
+	txState := createXorTreeRepairState(t, tx)
+	require.NoError(t, txState.Start())
+
+	// Hold the DB write lock so the next page check blocks inside its transaction.
+	release := make(chan struct{})
+	releaseOnce := sync.OnceFunc(func() { close(release) })
+	t.Cleanup(releaseOnce)
+	lockHeld := make(chan struct{})
+	writeDone := make(chan struct{})
+	go func() {
+		defer close(writeDone)
+		_ = txState.graph.db.Write(context.Background(), func(_ stoabs.WriteTx) error {
+			close(lockHeld)
+			<-release
+			return nil
+		})
+	}()
+	<-lockHeld
+
+	// twice to set circuit to red, so the loop starts checking pages
+	txState.IncorrectStateDetected()
+	txState.IncorrectStateDetected()
+
+	// checkPage holds the repair mutex while it waits for the DB lock
+	test.WaitFor(t, func() (bool, error) {
+		if txState.xorTreeRepair.mutex.TryLock() {
+			txState.xorTreeRepair.mutex.Unlock()
+			return false, nil
+		}
+		return true, nil
+	}, time.Second, "page check did not start within wait period")
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		txState.xorTreeRepair.shutdown()
+		close(shutdownDone)
+	}()
+
+	select {
+	case <-shutdownDone:
+		t.Fatal("shutdown returned while a page check was still running")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	releaseOnce()
+	<-writeDone
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not return after the page check finished")
+	}
+}
+
+func TestXorTreeRepair_startIsIdempotent(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	tx, _, _ := CreateTestTransaction(1)
+	txState := createXorTreeRepairState(t, tx)
+
+	// State.Start() may be called more than once (e.g. by test helpers); only one repair loop must run,
+	// otherwise the first loop can no longer be stopped and shutdown would wait for it forever.
+	txState.xorTreeRepair.start()
+	txState.xorTreeRepair.start()
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		txState.xorTreeRepair.shutdown()
+		close(shutdownDone)
+	}()
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not return, a repair loop is still running")
+	}
 }
 
 func xorRootDate(s *state) hash.SHA256Hash {


### PR DESCRIPTION
Fixes two flakes that were observed on unrelated PRs (#4445, and the V5.4 push run of 2026-09-08).

## TestXorTreeRepair goroutine leak

`xorTreeRepair.shutdown()` cancelled the loop's context but returned without waiting for the loop goroutine to exit. When a page check was in progress, it kept running inside a DB write transaction after `State.Shutdown()` returned. In the test this trips the `goleak` check on slow runners; in production it races with closing the store.

- `shutdown()` now waits for the loop to finish.
- `start()` is idempotent. `State.Start()` is called twice in several tests (once by the `createState` helper and once by the test), which spawned a second loop whose cancel func replaced the first one. With the wait in place that deadlocked, and before it the first loop simply leaked.

Two new tests pin this: one blocks a page check on the DB write lock and asserts that `shutdown()` does not return until the check finishes, the other starts the loop twice and asserts that `shutdown()` still returns. Both fail on the previous code (the first on the assertion, the second by hanging).

## private-transactions e2e test

The script asserted the credential search result once, right after the transaction count reached 8. The count is updated when the DAG stores a transaction, but the VCR applies the revocation afterwards through an asynchronous subscriber, so the search could still return a revoked credential. The search is now polled until it returns the expected number of credentials, with the same 10 second budget as the transaction count waits. Verified locally against the published master image.

Backports: V6.2 and V5.4 PRs follow.
