### PR TITLE
test(network): fix race in TestNotifier_VariousFlows/Happy_flow

### DIFF
--- a/network/dag/notifier_test.go
+++ b/network/dag/notifier_test.go
@@ -455,18 +455,23 @@ func TestNotifier_VariousFlows(t *testing.T) {
 
 		s.Notify(event)
 
+		// counter.N is incremented by the receiver callback, but notifyNow persists
+		// the updated event (Retries) only after the callback returns, and the next
+		// retry follows within tens of milliseconds. Wait for the persisted retry
+		// count instead of the in-memory counter, otherwise the read may observe
+		// the event before the second retry is written.
+		var e *Event
 		test.WaitFor(t, func() (bool, error) {
-			return counter.N.Load() == 2, nil
-		}, time.Second, "timeout while waiting for receiver")
+			err := kvStore.ReadShelf(ctx, s.shelfName(), func(reader stoabs.Reader) error {
+				var err error
+				e, err = s.readEvent(reader, hash.EmptyHash())
+				return err
+			})
+			return err == nil && e != nil && e.Retries >= 2, nil
+		}, time.Second, "timeout while waiting for the retry to be persisted")
 
-		kvStore.ReadShelf(ctx, s.shelfName(), func(reader stoabs.Reader) error {
-			e, err := s.readEvent(reader, hash.EmptyHash())
-
-			assert.NoError(t, err)
-			assert.Equal(t, 2, e.Retries)
-
-			return nil
-		})
+		// every persisted retry was preceded by a receiver call
+		assert.GreaterOrEqual(t, counter.N.Load(), int64(e.Retries))
 	})
 
 	t.Run("notifier marks event as finished", func(t *testing.T) {


### PR DESCRIPTION
Fixes the flaky `TestNotifier_VariousFlows/Happy_flow` seen on #4487.

The subtest waited until the receiver callback had run twice and then read the persisted event, expecting two retries. `notifyNow` increments and writes the retry count only after the callback returns, and the next retry follows within tens of milliseconds, so on a loaded runner the read could land between the second callback and its write and observe one retry (expected 2, actual 1). It is the same race that #4274 fixed for `TestNotifier_Notify`; the other subtests in this function already wait on the persisted retry count.

The subtest now waits for the persisted retry count to reach 2 and checks that the callback ran at least that often. Verified with `go test -race -count=30` on the package.

Backports to V6.2 and V5.4 follow, both branches have the same subtest.
