### PR TITLE
build: bump golang image to 1.27.1 and prepare code for Go 1.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # golang alpine
-FROM golang:1.26.6-alpine AS builder
+FROM golang:1.27.1-alpine AS builder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/auth/services/oauth/authz_server_test.go
+++ b/auth/services/oauth/authz_server_test.go
@@ -570,7 +570,8 @@ func TestService_parseAndValidateJwtBearerToken(t *testing.T) {
 		}
 		err = ctx.oauthService.parseAndValidateJwtBearerToken(tokenCtx2)
 		assert.Nil(t, tokenCtx.jwtBearerToken)
-		assert.Equal(t, "jws.ParseString: failed to parse string: jws.Parse: failed to parse compact format: failed to parse JOSE headers: invalid character '×' looking for beginning of value", err.Error())
+		// the rendering of the invalid character in the error message differs between Go versions
+		assert.ErrorContains(t, err, "jws.ParseString: failed to parse string: jws.Parse: failed to parse compact format: failed to parse JOSE headers: invalid character ")
 	})
 
 	t.Run("wrong signing algorithm", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/nats-io/nats-server/v2 v2.14.6
 	github.com/nats-io/nats.go v1.53.1
 	github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b
-	github.com/nuts-foundation/go-did v0.22.0
+	github.com/nuts-foundation/go-did v0.22.1-0.20260909100713-1eca5d101829
 	github.com/nuts-foundation/go-leia/v4 v4.3.0
 	github.com/nuts-foundation/go-stoabs v1.11.2
 	github.com/nuts-foundation/sqlite v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/nats-io/nats-server/v2 v2.14.6
 	github.com/nats-io/nats.go v1.53.1
 	github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b
-	github.com/nuts-foundation/go-did v0.22.1-0.20260909100713-1eca5d101829
+	github.com/nuts-foundation/go-did v0.22.1
 	github.com/nuts-foundation/go-leia/v4 v4.3.0
 	github.com/nuts-foundation/go-stoabs v1.11.2
 	github.com/nuts-foundation/sqlite v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAm
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
 github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b h1:80icUxWHwE1MrIOOEK5rxrtyKOgZeq5Iu1IjAEkggTY=
 github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b/go.mod h1:6YUioYirD6/8IahZkoS4Ypc8xbeJW76Xdk1QKcziNTM=
-github.com/nuts-foundation/go-did v0.22.0 h1:cjGbLv8S+MMlwlnuy9YD6wdBWDKguweCIem8sZ6neQw=
-github.com/nuts-foundation/go-did v0.22.0/go.mod h1:M6d7KaJLf3Ipl+ttRANc207S5MT9Kq5F0so1fPad/I0=
+github.com/nuts-foundation/go-did v0.22.1-0.20260909100713-1eca5d101829 h1:zb7rqDREENNUgMfwv42+uMK17O7aZy9YhWg7yEjYqWU=
+github.com/nuts-foundation/go-did v0.22.1-0.20260909100713-1eca5d101829/go.mod h1:f41gU3uIIVF9D1qeMeB3RUqMS7QoMnLckIzO5NbL3uI=
 github.com/nuts-foundation/go-leia/v4 v4.3.0 h1:R0qGISIeg2q/PCQTC9cuoBtA6cFu4WBV2DbmSOWKZyM=
 github.com/nuts-foundation/go-leia/v4 v4.3.0/go.mod h1:Gw6bXqJLOAmHSiXJJYbVoj+Mowp/PoBRywO0ZPsVzA0=
 github.com/nuts-foundation/go-stoabs v1.11.2 h1:cOYjtozhdmDQDPNS2STBly5hp0XomNIOv6TqUHKeEEg=

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAm
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
 github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b h1:80icUxWHwE1MrIOOEK5rxrtyKOgZeq5Iu1IjAEkggTY=
 github.com/nuts-foundation/crypto-ecies v0.0.0-20211207143025-5b84f9efce2b/go.mod h1:6YUioYirD6/8IahZkoS4Ypc8xbeJW76Xdk1QKcziNTM=
-github.com/nuts-foundation/go-did v0.22.1-0.20260909100713-1eca5d101829 h1:zb7rqDREENNUgMfwv42+uMK17O7aZy9YhWg7yEjYqWU=
-github.com/nuts-foundation/go-did v0.22.1-0.20260909100713-1eca5d101829/go.mod h1:f41gU3uIIVF9D1qeMeB3RUqMS7QoMnLckIzO5NbL3uI=
+github.com/nuts-foundation/go-did v0.22.1 h1:p3sNGkUX2bX1pikTGl2Yb/5uPpcuaH+8CLq5MjxTNl0=
+github.com/nuts-foundation/go-did v0.22.1/go.mod h1:tmCj71RvH8guVoQP9IbnpYQuQHZ7M7QPndCP5nijTAM=
 github.com/nuts-foundation/go-leia/v4 v4.3.0 h1:R0qGISIeg2q/PCQTC9cuoBtA6cFu4WBV2DbmSOWKZyM=
 github.com/nuts-foundation/go-leia/v4 v4.3.0/go.mod h1:Gw6bXqJLOAmHSiXJJYbVoj+Mowp/PoBRywO0ZPsVzA0=
 github.com/nuts-foundation/go-stoabs v1.11.2 h1:cOYjtozhdmDQDPNS2STBly5hp0XomNIOv6TqUHKeEEg=

--- a/pki/denylist_test.go
+++ b/pki/denylist_test.go
@@ -111,8 +111,17 @@ func testDenylist(url, trustedSigner string) (Denylist, error) {
 	return NewDenylist(cfg)
 }
 
-// Do not use this value outside of denylist_test.go
-const bannedCertIssuer = `CN=www.example.com,O=Internet Widgits Pty Ltd,L=Amsterdam,ST=Noord-Holland,C=NL,1.2.840.113549.1.9.1=#0c136578616d706c65406578616d706c652e636f6d`
+// Do not use this value outside of denylist_test.go.
+// The issuer string is derived from the certificate at runtime, since its formatting depends on the Go version:
+// before Go 1.27, pkix.Name.String() hex-encoded the emailAddress attribute (1.2.840.113549.1.9.1) in the DN.
+var bannedCertIssuer = func() string {
+	block, _ := pem.Decode([]byte(bannedTestCertificate))
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		panic(err)
+	}
+	return cert.Issuer.String()
+}()
 
 // Do not use this value outside of denylist_test.go
 const bannedCertSerialNumber = `352232997782095055661451877220413401771436182288`

--- a/vcr/credential/resolver_test.go
+++ b/vcr/credential/resolver_test.go
@@ -135,7 +135,8 @@ func TestPresentationSigner(t *testing.T) {
 				Proof: []interface{}{5},
 			})
 			actual, err := PresentationSigner(presentation)
-			assert.EqualError(t, err, "invalid LD-proof for presentation: json: cannot unmarshal number into Go value of type proof.LDProof")
+			assert.ErrorContains(t, err, "invalid LD-proof for presentation: json: cannot unmarshal number into ")
+			assert.ErrorContains(t, err, " of type proof.LDProof")
 			assert.Nil(t, actual)
 		})
 		t.Run("invalid DID in proof", func(t *testing.T) {

--- a/vcr/credential/util_test.go
+++ b/vcr/credential/util_test.go
@@ -157,7 +157,8 @@ func TestPresenterIsCredentialSubject(t *testing.T) {
 			},
 		})
 		is, err := PresenterIsCredentialSubject(vp)
-		assert.EqualError(t, err, "invalid LD-proof for presentation: json: cannot unmarshal bool into Go value of type proof.LDProof")
+		assert.ErrorContains(t, err, "invalid LD-proof for presentation: json: cannot unmarshal bool into ")
+		assert.ErrorContains(t, err, " of type proof.LDProof")
 		assert.Nil(t, is)
 	})
 	t.Run("too many proofs", func(t *testing.T) {

--- a/vcr/verifier/verifier_test.go
+++ b/vcr/verifier/verifier_test.go
@@ -759,7 +759,8 @@ func TestVerifier_VerifyVP(t *testing.T) {
 
 			vcs, err := ctx.verifier.VerifyVP(vp, false, false, validAt)
 
-			assert.EqualError(t, err, "presentation(s) or credential(s) verification failed: presenter is credential subject: invalid LD-proof for presentation: json: cannot unmarshal string into Go value of type proof.LDProof")
+			assert.ErrorContains(t, err, "presentation(s) or credential(s) verification failed: presenter is credential subject: invalid LD-proof for presentation: json: cannot unmarshal string into ")
+			assert.ErrorContains(t, err, " of type proof.LDProof")
 			assert.Empty(t, vcs)
 		})
 		t.Run("error - no proof", func(t *testing.T) {


### PR DESCRIPTION
Supersedes #4461 (same Dockerfile change) and includes the fixes needed to make it pass. The go-did fix has been released as v0.22.1, so this is ready for review.

## Why #4461 fails

Building with Go 1.27 changes two standard-library behaviours that the unit tests do not cover (the `test` job uses the go.mod toolchain, only the Docker build uses the image's Go):

1. `encoding/json` is now backed by `encoding/json/v2` ([release notes](https://go.dev/doc/go1.27)). go-did's `CredentialStatus.UnmarshalJSON` used `type alias *CredentialStatus`; the v2-backed decoder resolves the method through the pointer alias and recurses until `fatal error: stack overflow`. Every credential with a `credentialStatus` crashed the node, which is the `Empty reply from server` in the redis e2e job. Fixed in nuts-foundation/go-did#163, released in go-did v0.22.1.
2. `pkix.Name.String` now renders string attributes with unrecognized OIDs as text instead of hex (golang/go#33093). The denylist tests hardcoded the old hex form of the `emailAddress` attribute in the banned certificate's issuer, so `certificate is banned` was no longer returned in the tests. The production denylist currently has one entry with a CN-only issuer, so live matching is unaffected, but future entries whose issuer has such attributes will only match nodes on the same Go generation.

Two more differences are cosmetic: json prints an invalid byte as `\xd7` instead of `×`, and nested type errors say `into .0 of type` instead of `into Go value of type`. Those tests now assert on the stable parts of the message.

## Changes

- `Dockerfile`: golang 1.26.6-alpine -> 1.27.1-alpine (identical to #4461).
- `go.mod`: go-did v0.22.0 -> v0.22.1 (contains the `CredentialStatus` fix from nuts-foundation/go-did#163).
- `pki/denylist_test.go`: derive the banned issuer string from the certificate at runtime.
- `auth/services/oauth`, `vcr/credential`, `vcr/verifier` tests: assert on toolchain-independent parts of json error messages.

## Verification

`GOTOOLCHAIN=go1.27.1 go test ./...` and the Go 1.26.5 run both pass locally with go-did v0.22.1, except `TestNetwork_checkHealth`, which fails in my local environment on master as well. The e2e job on this PR is the actual check for the crash.

## Follow-up

V6.2 and V5.4 need go-did v0.22.1 on their pinned go-did lines before their Go image can move to 1.27.
