### PR TITLE
build(docker): upgrade to alpine 3.23.5, go 1.26.8 and apk upgrade

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -31,10 +31,14 @@ jobs:
           echo "git_branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
           echo "git_version=$(git name-rev --tags --name-only $(git rev-parse HEAD))" >> $GITHUB_OUTPUT
 
-      - uses: actions-ecosystem/action-get-latest-tag@v1
+      - name: Determine highest release tag
+        # Sort by version, not by creation date: a v5.4.x patch tagged after a
+        # v6.2.x patch must not become 'latest'.
         id: get-latest-tag
-        with:
-          semver_only: true
+        shell: bash
+        run: |
+          git fetch --tags --force --quiet
+          echo "tag=$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" >> $GITHUB_OUTPUT
 
       - name: Print version params
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # golang alpine
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.8-alpine AS builder
 
 ARG TARGETARCH
 ARG TARGETOS
@@ -21,8 +21,10 @@ COPY . .
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s -X 'github.com/nuts-foundation/nuts-node/v6/core.GitCommit=${GIT_COMMIT}' -X 'github.com/nuts-foundation/nuts-node/v6/core.GitBranch=${GIT_BRANCH}' -X 'github.com/nuts-foundation/nuts-node/v6/core.GitVersion=${GIT_VERSION}'" -o /opt/nuts/nuts
 
 # alpine
-FROM alpine:3.23.4
-RUN apk update \
+FROM alpine:3.23.5
+# Upgrade all preinstalled packages so the image picks up security fixes
+# published after the base image was cut.
+RUN apk -U upgrade --no-cache \
   && apk add --no-cache \
              tzdata \
              curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,10 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s -X 'github.com/nu
 # alpine
 FROM alpine:3.23.5
 # Upgrade all preinstalled packages so the image picks up security fixes
-# published after the base image was cut.
+# published after the base image was cut. Alpine repos only serve the newest
+# package version, so pinning (hadolint DL3018) would break the build on
+# every upstream fix.
+# hadolint ignore=DL3018
 RUN apk -U upgrade --no-cache \
   && apk add --no-cache \
              tzdata \


### PR DESCRIPTION
A Trivy scan of the published `nutsfoundation/nuts-node:6.2.11` image reports 54 fixable Alpine findings (curl/libcurl 8.20.0 with 8 HIGH CVEs, libcrypto3/libssl3 3.5.6) and 8 Go stdlib CVEs that are fixed in Go 1.26.6.

Changes:

- Builder image `golang:1.26.5-alpine` to `golang:1.26.8-alpine` (latest Go 1.26 patch).
- Runtime image `alpine:3.23.4` to `alpine:3.23.5` (latest 3.23 point release).
- Runtime stage now runs `apk -U upgrade --no-cache` before installing tzdata and curl. The point-release image still ships libcrypto3 3.5.7-r0 while the repositories carry 3.5.8-r0, so the tag bump alone does not clear the scan.

Verification: a local amd64 build of this Dockerfile scanned with Trivy shows 0 Alpine findings and 0 stdlib findings. The remaining findings are Go module versions (x/crypto, x/net, echo, grpc, chi) and will be handled separately.

Not for release yet; part of the batch of fixes before the next 6.2 patch tag.

Also includes the `latest` tag fix from #4508: the tag build runs this branch's workflow, and `action-get-latest-tag` picks the most recently *created* tag, which is how v5.4.38 became `latest` over 6.2.11. The step now sorts by version.