### PR TITLE
build: harden docker image, fix latest tag, scan published images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,3 +59,75 @@ updates:
       interval: "weekly"
     # Allow up to 0 open pull requests for pip dependencies
     open-pull-requests-limit: 0
+
+  # Release branches: Dependabot only reads this file from the default branch
+  # and only targets that branch unless told otherwise. Keep the base image
+  # and Go modules on the supported release lines patched as well.
+  # Only patch-level Go module updates are proposed there.
+  - package-ecosystem: "docker"
+    directory: "/"
+    target-branch: "V6.2"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "23:00"
+      timezone: "Europe/Amsterdam"
+    groups:
+      docker:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "V6.2"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "23:00"
+      timezone: "Europe/Amsterdam"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    groups:
+      go-modules:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    target-branch: "V5.4"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "23:00"
+      timezone: "Europe/Amsterdam"
+    groups:
+      docker:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "V5.4"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "23:00"
+      timezone: "Europe/Amsterdam"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    groups:
+      go-modules:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -36,6 +36,9 @@ jobs:
           # the history back to the nearest tag, otherwise the stamp becomes
           # v6.0.0-<time>-<rev>, which sorts below every release and trips image
           # scanners. Pull request builds are not pushed, so they stay shallow.
+          # fetch-tags above does not cover this: at depth 1 the tag objects
+          # exist but the tagged commit is not an ancestor of HEAD, so go build
+          # still stamps v6.0.0-<time>-<rev>.
           fetch-depth: ${{ github.event_name == 'push' && github.ref_type == 'branch' && 0 || 1 }}
 
       - name: Set version params

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+          # all tags are needed to decide whether this build is the highest release
+          fetch-tags: true
 
       - name: Set version params
         id: version
@@ -38,10 +40,13 @@ jobs:
           echo "git_branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
           echo "git_version=$(git name-rev --tags --name-only $(git rev-parse HEAD))" >> $GITHUB_OUTPUT
 
-      - uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435 # v1
+      - name: Determine highest release tag
+        # Sort by version, not by creation date: a v5.4.x patch tagged after a
+        # v6.2.x patch must not become 'latest'.
         id: get-latest-tag
-        with:
-          semver_only: true
+        shell: bash
+        run: |
+          echo "tag=$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" >> $GITHUB_OUTPUT
 
       - name: Print version params
         env:

--- a/.github/workflows/image-scan-cron-schedule.yaml
+++ b/.github/workflows/image-scan-cron-schedule.yaml
@@ -1,0 +1,119 @@
+# Scans the published Docker images of every supported release line for known
+# vulnerabilities. This complements the scheduled govulncheck run, which only
+# looks at Go source: base image packages (alpine, curl, openssl) and the Go
+# toolchain the image was built with are only visible in the image itself.
+# Published images are not rebuilt between releases, so this is the signal
+# that a new patch release is needed.
+name: 'Scheduled image scan'
+
+on:
+  # run schedule every work day at 9:52 UTC, shortly after govulncheck
+  schedule:
+    - cron: '52 9 * * 1-5'
+  # allow manually triggering workflow
+  workflow_dispatch:
+
+# deny-all default; the job below grants only the scopes it needs
+permissions: {}
+
+jobs:
+  image_scan_job:
+    runs-on: ubuntu-latest
+    name: Scan published image
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Supported release lines. Pattern matching doesn't work, so we need to add relevant branches manually.
+        # 'master' scans the image built from the master branch; the others scan the highest v<line>.x release tag.
+        line:
+          - 'master'
+          - 'v5.4'
+          - 'v6.2'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          fetch-tags: true
+
+      - name: Resolve image tag
+        id: image
+        shell: bash
+        env:
+          LINE: ${{ matrix.line }}
+        run: |
+          set -euo pipefail
+          if [ "${LINE}" = "master" ]; then
+            hub_tag="master"
+          else
+            # highest release tag on this line, e.g. v6.2.11
+            git_tag=$(git tag --list "${LINE}.*" --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+            if [ -z "${git_tag}" ]; then
+              echo "no release tag found for line ${LINE}" >&2
+              exit 1
+            fi
+            # Docker Hub tags differ per line (v5.4.x is pushed as 'v5.4.x', v6.2.x as '6.2.x'); take whichever exists.
+            hub_tag=""
+            for candidate in "${git_tag}" "${git_tag#v}"; do
+              if curl -sf "https://hub.docker.com/v2/repositories/nutsfoundation/nuts-node/tags/${candidate}" > /dev/null; then
+                hub_tag="${candidate}"
+                break
+              fi
+            done
+            if [ -z "${hub_tag}" ]; then
+              echo "no Docker Hub image found for ${git_tag}" >&2
+              exit 1
+            fi
+          fi
+          echo "Scanning nutsfoundation/nuts-node:${hub_tag}"
+          echo "ref=nutsfoundation/nuts-node:${hub_tag}" >> $GITHUB_OUTPUT
+
+      - name: Scan image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ steps.image.outputs.ref }}
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          # a finding without an available fix is noise for a rebuild decision
+          ignore-unfixed: true
+          exit-code: '1'
+          format: table
+
+      - name: notify slack
+        # this uses our own 'Github notifications' app in slack
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        if: ${{ failure() }} # only run this steps if one of the previous steps has failed
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_NUTS_CORE_TEAM }} # webhook is linked to a specific slack channel
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "GitHub Action failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Vulnerabilities detected in a published Docker image* :rotating_light:\n Trivy found fixable HIGH or CRITICAL vulnerabilities in the ${{ matrix.line }} image.\n See workflow for more info."
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": ":github: Failed workflow"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # golang alpine
-FROM golang:1.26.6-alpine AS builder
+FROM golang:1.26.8-alpine AS builder
 
 ARG TARGETARCH
 ARG TARGETOS
@@ -22,7 +22,9 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s -X 'github.com/nu
 
 # alpine
 FROM alpine:3.24.1
-RUN apk update \
+# Upgrade all preinstalled packages so the image picks up security fixes
+# published after the base image was cut.
+RUN apk -U upgrade --no-cache \
   && apk add --no-cache \
              tzdata \
              curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,10 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s -X 'github.com/nu
 # alpine
 FROM alpine:3.24.1
 # Upgrade all preinstalled packages so the image picks up security fixes
-# published after the base image was cut.
+# published after the base image was cut. Alpine repos only serve the newest
+# package version, so pinning (hadolint DL3018) would break the build on
+# every upstream fix.
+# hadolint ignore=DL3018
 RUN apk -U upgrade --no-cache \
   && apk add --no-cache \
              tzdata \


### PR DESCRIPTION
Follow-up to a Trivy scan of the published `v5.4.38` and `6.2.11` images (49 and 54 fixable Alpine findings plus Go 1.26.5 stdlib CVEs). Companion PRs on the release branches: #4506 (V5.4) and #4507 (V6.2). Four independent commits:

**Dockerfile**: builder to `golang:1.26.8-alpine`, runtime stage runs `apk -U upgrade --no-cache` before installing tzdata and curl. Alpine point-release images lag the repos (3.24.1 ships older openssl than the 3.24 repo), so the tag bump alone never clears a scan.

**`latest` tag**: `actions-ecosystem/action-get-latest-tag` sorts tags by creation date, not version, so whichever release line is tagged last wins `latest`. v5.4.38 was tagged 50 minutes after v6.2.11 and `latest` on Docker Hub still points at the 5.4 image. Replaced with `git tag --sort=-v:refname`; checkout now fetches tags. The same change needs to land on V5.4 and V6.2 since the tag build runs the workflow from the tagged branch.

**Dependabot**: added `target-branch` entries for V6.2 and V5.4 (docker and gomod). Dependabot only reads this file from master and only targets master without them; the release branches never received bump PRs. Go module updates on release branches are limited to patch versions.

**Scheduled image scan**: new `image-scan-cron-schedule.yaml` runs Trivy against the published `master` image and the highest release tag of v5.4 and v6.2, fixable HIGH/CRITICAL only, and posts to the same Slack webhook as the govulncheck cron. Nothing is built; it scans Docker Hub directly. Hub tag naming differs per line (`v5.4.38` vs `6.2.11`), the resolve step tries both forms.

Verification: workflow YAML parses; the tag resolution and highest-tag logic were run locally against the current tag list (v5.4 -> `v5.4.38`, v6.2 -> `6.2.11`, highest -> `v6.2.11`). The scheduled scan will fail until the release branches are rebuilt with the companion PRs and the Go module bumps; that is the intended signal.
