### PR TITLE
fix(docs): import cmd package through the /v6 module path

### DIFF
--- a/docs/generate_docs_uptodate_test.go
+++ b/docs/generate_docs_uptodate_test.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/nuts-foundation/nuts-node/cmd"
+	"github.com/nuts-foundation/nuts-node/v6/cmd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
The docs up-to-date test backported in #4493 still imports `github.com/nuts-foundation/nuts-node/cmd` after #4487 moved the module path to `/v6`. The go-test workflow on V6.2 has failed on every push since that merge (`no required module provides package github.com/nuts-foundation/nuts-node/cmd`), and `go mod tidy` on the branch pulls in `nuts-node v1.1.0` as a dependency.

Verification: `go vet ./docs/...` compiles the test file again. Split out of #4510 so it can merge first and unblock #4507 and #4510.

Assisted-by: AI
