### PR TITLE
test(network): fix race in TestNetworkIntegration_PrivateTransaction/event_received (backport of #4512)

### DIFF
--- a/network/network_integration_test.go
+++ b/network/network_integration_test.go
@@ -560,14 +560,24 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 		conn, _, err := node2.network.eventPublisher.Pool().Acquire(context.Background())
 		require.NoError(t, err)
 		defer conn.Close()
-		var found []byte
+		// node2 emits an event for every transaction it receives: the bootstrap DID document and the private TX.
+		// Wait for the private TX specifically and record its ack result under the mutex, so the test does not
+		// return (closing conn) while a later message is still being acked on the callback goroutine.
+		// Do not assert inside the callback: it may run after the test has completed.
+		var found bool
+		var ackErr error
 		foundMutex := sync.Mutex{}
 		_ = stream.Subscribe(conn, "TEST", "TRANSACTIONS.tx", func(msg *nats.Msg) {
 			foundMutex.Lock()
 			defer foundMutex.Unlock()
-			found = msg.Data
-			err := msg.Ack()
-			require.NoError(t, err)
+			event := events.TransactionWithPayload{}
+			if err := json.Unmarshal(msg.Data, &event); err != nil || string(event.Payload) != "private TX" {
+				// not the transaction we are waiting for (e.g. the bootstrap DID document)
+				_ = msg.Ack()
+				return
+			}
+			ackErr = msg.Ack()
+			found = true
 		})
 
 		node1DID := node1.network.nodeDID
@@ -584,8 +594,11 @@ func TestNetworkIntegration_PrivateTransaction(t *testing.T) {
 		test.WaitFor(t, func() (bool, error) {
 			foundMutex.Lock()
 			defer foundMutex.Unlock()
-			return len(found) > 0, nil
-		}, 100*time.Millisecond, "timeout waiting for message")
+			return found, nil
+		}, defaultTimeout, "timeout waiting for private TX event")
+		foundMutex.Lock()
+		defer foundMutex.Unlock()
+		assert.NoError(t, ackErr)
 	})
 
 	t.Run("third node knows nothing", func(t *testing.T) {


### PR DESCRIPTION
Backport of #4512 to V5.4. Fixes the flaky `TestNetworkIntegration_PrivateTransaction/event_received` (`nats: connection closed` on `msg.Ack()` in the subscription callback), first seen on V6.2 in #4494. V5.4 has the same subtest with the same race.

node2 publishes a NATS event for every transaction it receives, so the subtest gets two messages: the bootstrap DID document transaction and the private TX. The subtest waited for any message, returned on the first one and closed the connection through the deferred `conn.Close()`. The second message's `msg.Ack()` then failed with `nats: connection closed`, and the callback called `require` against a test that had already completed.

The subtest now waits for the private TX event specifically, records its ack error under the mutex and asserts it on the test goroutine. Other messages are acked without asserting. The wait timeout is raised from 100ms to `defaultTimeout`. Applied by hand because the transaction setup differs from master. Verified with `go test -race -count=5` on `TestNetworkIntegration_PrivateTransaction`.
