### PR TITLE
fix(vcr): name gRPC network transport in publish-failure error message

### DIFF
--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -196,7 +196,7 @@ func (i issuer) Issue(ctx context.Context, template vc.VerifiableCredential, opt
 			}
 		}
 		if err := i.networkPublisher.PublishCredential(ctx, *createdVC, options.Public); err != nil {
-			return nil, fmt.Errorf("unable to publish the issued credential: %w", err)
+			return nil, fmt.Errorf("unable to publish the issued credential over gRPC network: %w", err)
 		}
 	}
 	return createdVC, nil

--- a/vcr/issuer/issuer_test.go
+++ b/vcr/issuer/issuer_test.go
@@ -498,7 +498,7 @@ func Test_issuer_Issue(t *testing.T) {
 				Publish: true,
 				Public:  true,
 			})
-			assert.EqualError(t, err, "unable to publish the issued credential: b00m!")
+			assert.EqualError(t, err, "unable to publish the issued credential over gRPC network: b00m!")
 			assert.Nil(t, result)
 		})
 

--- a/vcr/test/openid4vci_integration_test.go
+++ b/vcr/test/openid4vci_integration_test.go
@@ -109,7 +109,7 @@ func TestOpenID4VCIDisabled(t *testing.T) {
 			Public:  false,
 		})
 
-		assert.ErrorContains(t, err, "unable to publish the issued credential")
+		assert.ErrorContains(t, err, "unable to publish the issued credential over gRPC network")
 	})
 }
 


### PR DESCRIPTION
## Problem

When credential issuance falls back from OpenID4VCI to the gRPC network publish and *that* also fails, the two errors are joined (#4470) so the caller sees both. But the network-publish message just says "unable to publish the issued credential" — identical in shape to the OpenID4VCI failure message, so a reader can't tell which failure is which without already knowing the code.

## Fix

Rename the network-publish error message to "unable to publish the issued credential over gRPC network", explicitly naming the transport.

Relates to nuts-foundation/nuts-node#4515 (comment): "Test whether a (helpful) message is returned by the IssueVC REST API operation when issuance over both OpenID4VCI and gRPC network fails. It should describe why both methods failed." Builds on #4470's error joining.

Assisted by AI