### PR TITLE
fix(vcr): clarify network-publish error message names gRPC as the transport (backport to v6.2)

### DIFF
--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -196,7 +196,7 @@ func (i issuer) Issue(ctx context.Context, template vc.VerifiableCredential, opt
 			}
 		}
 		if err := i.networkPublisher.PublishCredential(ctx, *createdVC, options.Public); err != nil {
-			return nil, fmt.Errorf("unable to publish the issued credential: %w", err)
+			return nil, fmt.Errorf("unable to publish the issued credential over gRPC network: %w", err)
 		}
 	}
 	return createdVC, nil

--- a/vcr/issuer/issuer_test.go
+++ b/vcr/issuer/issuer_test.go
@@ -498,7 +498,7 @@ func Test_issuer_Issue(t *testing.T) {
 				Publish: true,
 				Public:  true,
 			})
-			assert.EqualError(t, err, "unable to publish the issued credential: b00m!")
+			assert.EqualError(t, err, "unable to publish the issued credential over gRPC network: b00m!")
 			assert.Nil(t, result)
 		})
 

--- a/vcr/test/openid4vci_integration_test.go
+++ b/vcr/test/openid4vci_integration_test.go
@@ -109,7 +109,7 @@ func TestOpenID4VCIDisabled(t *testing.T) {
 			Public:  false,
 		})
 
-		assert.ErrorContains(t, err, "unable to publish the issued credential")
+		assert.ErrorContains(t, err, "unable to publish the issued credential over gRPC network")
 	})
 }
 


### PR DESCRIPTION
Backport of #4516 to v6.2.

Tracks #4517.

Assisted by AI