### PR TITLE
fix(vcr): clarify network-publish error message names gRPC as the transport (backport to v5.4)

### DIFF
--- a/vcr/issuer/issuer.go
+++ b/vcr/issuer/issuer.go
@@ -145,7 +145,7 @@ func (i issuer) Issue(ctx context.Context, credentialOptions vc.VerifiableCreden
 			}
 		}
 		if err := i.networkPublisher.PublishCredential(ctx, *createdVC, public); err != nil {
-			return nil, fmt.Errorf("unable to publish the issued credential: %w", err)
+			return nil, fmt.Errorf("unable to publish the issued credential over gRPC network: %w", err)
 		}
 	}
 	return createdVC, nil

--- a/vcr/issuer/issuer_test.go
+++ b/vcr/issuer/issuer_test.go
@@ -367,7 +367,7 @@ func Test_issuer_Issue(t *testing.T) {
 			}
 
 			result, err := sut.Issue(ctx, credentialOptions, true, true)
-			assert.EqualError(t, err, "unable to publish the issued credential: b00m!")
+			assert.EqualError(t, err, "unable to publish the issued credential over gRPC network: b00m!")
 			assert.Nil(t, result)
 		})
 

--- a/vcr/test/openid4vci_integration_test.go
+++ b/vcr/test/openid4vci_integration_test.go
@@ -207,7 +207,7 @@ func TestOpenID4VCIDisabled(t *testing.T) {
 		vcrService := system.FindEngineByName("vcr").(vcr.VCR)
 		_, err := vcrService.Issuer().Issue(audit.TestContext(), credential, true, false)
 
-		assert.ErrorContains(t, err, "unable to publish the issued credential")
+		assert.ErrorContains(t, err, "unable to publish the issued credential over gRPC network")
 	})
 }
 


### PR DESCRIPTION
Backport of #4516 to v5.4.

Tracks #4517.

Assisted by AI