### PR TITLE
build(docker): cross-compile instead of emulating arm64 in the builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # golang alpine
-FROM golang:1.26.8-alpine AS builder
+# The builder runs on the build host platform and cross-compiles for
+# TARGETOS/TARGETARCH. Building arm64 under QEMU emulation instead took
+# about 20 minutes for go build alone.
+FROM --platform=$BUILDPLATFORM golang:1.26.8-alpine AS builder
 
 ARG TARGETARCH
 ARG TARGETOS


### PR DESCRIPTION
Multi-arch image builds on V5.4 take 20 to 27 minutes. The builder stage runs on the target platform, so the arm64 half is emulated under QEMU. From a recent master run:

| BuildKit step | amd64 | arm64 |
| --- | --- | --- |
| go build | 146 s | 1314 s |
| go mod download | 14 s | 107 s |

Pull request builds finish in about 2 minutes because they build amd64 only.

Change: the builder stage runs on `$BUILDPLATFORM` and cross-compiles for the `TARGETOS`/`TARGETARCH` the Dockerfile already passes to `go build`. V5.4 already sets `CGO_ENABLED=0` explicitly. Only the runtime stage still runs per platform, and that stage is just `apk` plus a `COPY`.

Verification: local cross-build of the builder stage on an arm64 host produces the expected binaries: amd64 (master Dockerfile) and arm/v7 (V5.4 Dockerfile), both with `CGO_ENABLED=0`, and `GOARM=7` for arm. go build took 25 s and 14 s. The published master image already reports `CGO_ENABLED=0` in its build info, so the binary does not change. hadolint reports nothing new (DL3029 does not fire for `$BUILDPLATFORM`).

The same change is proposed for master and V6.2.
