### PR TITLE
ci: skip govulncheck, docker build, and CodeQL (go) on docs-only changes (backport #4459 to V6.2)

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -20,7 +20,33 @@ concurrency:
 permissions: {}
 
 jobs:
+  # Docs-only changes (docs/, markdown, rst) can't affect the built image, so building/pushing one
+  # is redundant. Detected once here so the job below can skip entirely on them.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check for non-doc changes
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.rst'
+
   docker:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,8 +23,34 @@ on:
     - 'V*'
 
 jobs:
+  # Docs-only changes (docs/, markdown, rst) can't affect Go code, so CodeQL has nothing new to
+  # find. Detected once here so the job below can skip entirely on them.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check for non-doc changes
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.rst'
+
   analyze:
     name: Analyze
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -11,7 +11,33 @@ on:
       - 'V*'
 
 jobs:
+  # Docs-only changes (docs/, markdown, rst) can't affect Go code, so govulncheck has nothing new
+  # to find. Detected once here so the job below can skip entirely on them.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check for non-doc changes
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.rst'
+
   govulncheck_job:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     name: Run govulncheck
     steps:


### PR DESCRIPTION
Backport of #4459 to V6.2.

test and e2e-test already skip on docs-only changes (#4495, backport of #4455). This extends the same pattern to the remaining workflows we control: `govulncheck.yaml`, `build-images.yaml` (docker), and `codeql-analysis.yml` (Analyze (go)). None of these are required status checks, but they still burn CI time on changes that can't affect Go code or the built image.

Assisted by AI