### PR TITLE
ci: skip test, e2e-test, govulncheck, docker build, and CodeQL (go) on docs-only changes (backport #4455 and #4459 to V5.4)

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -12,7 +12,33 @@ on:
       - master
 
 jobs:
+  # Docs-only changes (docs/, markdown, rst) can't affect the built image, so building/pushing one
+  # is redundant. Detected once here so the job below can skip entirely on them.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check for non-doc changes
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.rst'
+
   docker:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     outputs:
       image_digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,8 +25,34 @@ on:
     - cron: '21 10 * * 2'
 
 jobs:
+  # Docs-only changes (docs/, markdown, rst) can't affect Go code, so CodeQL has nothing new to
+  # find. Detected once here so the job below can skip entirely on them.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check for non-doc changes
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.rst'
+
   analyze:
     name: Analyze
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -14,7 +14,37 @@ on:
 
 
 jobs:
+  # Docs-only changes (docs/, markdown, rst) can't affect the e2e tests. Detected once here so the
+  # (required) e2e-test job below can skip entirely on them: that keeps the check fast and avoids
+  # the cost of building/pushing images and running the full e2e suite for changes that can't have
+  # broken anything it tests. A job skipped via `if:` reports as a passing check, so this still
+  # satisfies the required status check, unlike skipping the workflow itself via a trigger-level
+  # path filter.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check for non-doc changes
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.rst'
+
   e2e-test:
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' && (github.event.pull_request.merged || github.event.pull_request.head.repo.full_name == github.repository) }}
     permissions:
       packages: write
 

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -8,7 +8,37 @@ on:
   pull_request:
 
 jobs:
+  # Docs-only changes (docs/, markdown, rst) can't affect Go tests. Detected once here so the
+  # (required) test job below can skip entirely on them: that keeps the check fast and avoids
+  # spending CI minutes (and hitting flaky tests) on changes that can't have broken anything it
+  # tests. A job skipped via `if:` reports as a passing check, so this still satisfies the
+  # required status check, unlike skipping the workflow itself via a trigger-level path filter.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Check for non-doc changes
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.rst'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -11,7 +11,33 @@ on:
       - 'V*'
 
 jobs:
+  # Docs-only changes (docs/, markdown, rst) can't affect Go code, so govulncheck has nothing new
+  # to find. Detected once here so the job below can skip entirely on them.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check for non-doc changes
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.rst'
+
   govulncheck_job:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     name: Run govulncheck
     steps:

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -4,6 +4,9 @@
 # For more information see https://go.dev/blog/vuln and https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck
 name: 'govulncheck'
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Backport of #4455 and #4459 to V5.4. Neither had been backported here before, so this brings both over in one PR.

- #4455: `test` and `e2e-test` (required status checks) skip their actual work on docs-only changes (docs/, `*.md`, `*.rst`), gated via a `dorny/paths-filter` `changes` job + job-level `if:`. A job skipped this way still reports as a passing check, unlike a trigger-level path filter, which would leave a required check stuck pending.
- #4459: extends the same pattern to `govulncheck.yaml`, `build-images.yaml` (docker), and `codeql-analysis.yml` (Analyze (go)). None of these three are required status checks, but they still burn CI time on changes that can't affect Go code or the built image.

Assisted by AI