### PR TITLE
build(docker): update image maintainer label to info@nuts.nl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG GIT_COMMIT=0
 ARG GIT_BRANCH=master
 ARG GIT_VERSION=undefined
 
-LABEL maintainer="wout.slakhorst@nuts.nl"
+LABEL maintainer="info@nuts.nl"
 
 ENV GOPATH=/
 


### PR DESCRIPTION
## Summary
- Wout is no longer working on nuts-node, so update the Docker image maintainer label to a team address.

Assisted by AI